### PR TITLE
FIX: Docker build fails when git submodules not initialised

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY .git/ .git/
 COPY .gitmodules .gitmodules
 RUN git submodule update --init
 
-COPY Gemfile* . 
+COPY Gemfile Gemfile.lock /natalie/ 
 RUN bundle install
 
 ARG CC=gcc


### PR DESCRIPTION
Hey @seven1m! :)

This PR fixes the following issue when attempting to build the `Docker` image for `natalie` caused by git modules not being initialised as part of the `Dockerfile`.

- Copy `.git` folder & `.gitmodules` files into container
- Initialise `gitmodules`
- Small refactor to simplify copy layers when in the same working directory

![Docker Error](https://i.imgur.com/Ntbh3M5.png)  

