### PR TITLE
Require once is now checked at runtime

### DIFF
--- a/test/natalie/require_test.rb
+++ b/test/natalie/require_test.rb
@@ -31,4 +31,11 @@ describe 'require' do
     File.directory?('./test').should be_true
     `#{ruby} -e "require './test'" 2>&1`.should =~ /cannot load such file.*test/
   end
+
+  it 'returns true when require loads a file and false when it\'s already loaded' do
+    ruby = RUBY_ENGINE == 'natalie' ? 'bin/natalie' : 'ruby'
+
+    `#{ruby} -e "p require 'tempfile'"`.should =~ /true/
+    `#{ruby} -e "require 'tempfile'; p require 'tempfile'"`.should =~ /false/
+  end
 end


### PR DESCRIPTION
This is a follow-up to #218 . The idea here is to mimic MRI's behaviour far more closely and check if a script has already been required (when require_once = true) at runtime, rather than compile time.