### PR TITLE
Teaching the compiler about internal Floats and fixing them up

### DIFF
--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -160,7 +160,6 @@ public:
     }
 
     static bool optimized_method(SymbolObject *);
-
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<FloatObject %p float=%f>", this, m_double);
     }

--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -28,8 +28,10 @@ public:
         : Object { Object::Type::Float, other.klass() }
         , m_double { other.m_double } { }
 
-    static FloatObject *nan(Env *env) {
-        return new FloatObject { 0.0 / 0.0 };
+    static FloatObject *nan() {
+        if (!s_nan)
+            s_nan = new FloatObject { 0.0 / 0.0 };
+        return s_nan;
     }
 
     static FloatObject *positive_infinity(Env *env) {
@@ -136,11 +138,11 @@ public:
     bool gte(Env *, Value);
 
     Value uminus() const {
-        return Value { -m_double };
+        return Value::floatingpoint(-m_double);
     }
 
     Value uplus() const {
-        return Value { m_double };
+        return Value::floatingpoint(m_double);
     }
 
     static void build_constants(Env *env, ClassObject *klass) {
@@ -154,8 +156,7 @@ public:
         klass->const_set("MIN"_s, FloatObject::min(env));
         klass->const_set("MIN_10_EXP"_s, new FloatObject { double { DBL_MIN_10_EXP } });
         klass->const_set("MIN_EXP"_s, new FloatObject { double { DBL_MIN_EXP } });
-        klass->const_set("NAN"_s, FloatObject::nan(env));
-        klass->const_set("NAN"_s, FloatObject::nan(env));
+        klass->const_set("NAN"_s, FloatObject::nan());
         klass->const_set("RADIX"_s, new FloatObject { double { std::numeric_limits<double>::radix } });
     }
 
@@ -166,6 +167,7 @@ public:
 
 private:
     inline static Hashmap<SymbolObject *> s_optimized_methods {};
+    inline static FloatObject *s_nan { nullptr };
 
     double m_double { 0.0 };
 };

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -62,13 +62,9 @@ public:
         if (is_fast_integer()) {
             if (other.is_fast_integer())
                 return get_fast_integer() == other.get_fast_integer();
-            if (other.is_fast_float())
-                return get_fast_integer() == other.get_fast_float();
             return false;
         }
         if (is_fast_float()) {
-            if (other.is_fast_integer())
-                return get_fast_integer() == other.get_fast_integer();
             if (other.is_fast_float())
                 return get_fast_float() == other.get_fast_float();
             return false;
@@ -77,21 +73,7 @@ public:
     }
 
     bool operator!=(Value other) const {
-        if (is_fast_integer()) {
-            if (other.is_fast_integer())
-                return get_fast_integer() != other.get_fast_integer();
-            if (other.is_fast_float())
-                return get_fast_integer() != other.get_fast_float();
-            return true;
-        }
-        if (is_fast_float()) {
-            if (other.is_fast_integer())
-                return get_fast_integer() != other.get_fast_integer();
-            if (other.is_fast_float())
-                return get_fast_float() != other.get_fast_float();
-            return true;
-        }
-        return m_object != other.object();
+        return !(*this == other);
     }
 
     bool is_null() const { return m_type == Type::Pointer && !m_object; }

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -28,22 +28,13 @@ public:
     explicit Value(nat_int_t integer)
         : m_type { Type::Integer }
         , m_integer { integer } { }
-    explicit Value(double value)
-        : m_type { Type::Double }
-        , m_double { value } { }
 
     static Value integer(nat_int_t integer) {
         // This is required, beacause initialization by a literal is often
         // ambiguous.
         return Value { integer };
     }
-    static Value floatingpoint(double value) {
-        // This is used in the code gen
-        // auto v =  Value { value };
-        // v.hydrate();
-        // return v;
-        return Value { value };
-    }
+    static Value floatingpoint(double value);
 
     Object &operator*() {
         auto_hydrate();
@@ -154,6 +145,10 @@ public:
     }
 
 private:
+    explicit Value(double value)
+        : m_type { Type::Double }
+        , m_double { value } { }
+
     void auto_hydrate() {
         if (m_guarded) {
             printf("%p is a guarded Value, which means you must call unguard() on it before using the arrow operator.\n", this);

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -28,15 +28,21 @@ public:
     explicit Value(nat_int_t integer)
         : m_type { Type::Integer }
         , m_integer { integer } { }
-
     explicit Value(double value)
         : m_type { Type::Double }
         , m_double { value } { }
 
     static Value integer(nat_int_t integer) {
-        // This is still required, beacause initialization by a literal is often
+        // This is required, beacause initialization by a literal is often
         // ambiguous.
         return Value { integer };
+    }
+    static Value floatingpoint(double value) {
+        // This is used in the code gen
+        // auto v =  Value { value };
+        // v.hydrate();
+        // return v;
+        return Value { value };
     }
 
     Object &operator*() {
@@ -80,7 +86,21 @@ public:
     }
 
     bool operator!=(Value other) const {
-        return !(*this == other);
+        if (is_fast_integer()) {
+            if (other.is_fast_integer())
+                return get_fast_integer() != other.get_fast_integer();
+            if (other.is_fast_float())
+                return get_fast_integer() != other.get_fast_float();
+            return true;
+        }
+        if (is_fast_float()) {
+            if (other.is_fast_integer())
+                return get_fast_integer() != other.get_fast_integer();
+            if (other.is_fast_float())
+                return get_fast_float() != other.get_fast_float();
+            return true;
+        }
+        return m_object != other.object();
     }
 
     bool is_null() const { return m_type == Type::Pointer && !m_object; }

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -499,7 +499,7 @@ module Natalie
         lit = exp.last
         case lit
         when Float
-          exp.new(:new, :FloatObject, lit)
+          exp.new(:'Value::floatingpoint', lit)
         when Integer
           if lit > MAX_FIXNUM || lit < MIN_FIXNUM
             str = lit.to_s

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -682,6 +682,7 @@ module Natalie
         fn, *args = exp
 
         return "Value::integer(#{args.map { |a| process_atom(a) }.join(', ')})" if fn == :'Value::integer'
+        return "Value::floatingpoint(#{args.map { |a| process_atom(a) }.join(', ')})" if fn == :'Value::integer'
 
         if VOID_FUNCTIONS.include?(fn)
           if METHODS.include?(fn)

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -204,7 +204,7 @@ module Natalie
         cast_value_from_cpp = ->(v, t) do
           case t
           when 'double'
-            "Value { #{v} }"
+            "Value::floatingpoint(#{v})"
           else
             raise "I don't yet know how to cast return type #{t}"
           end
@@ -682,7 +682,7 @@ module Natalie
         fn, *args = exp
 
         return "Value::integer(#{args.map { |a| process_atom(a) }.join(', ')})" if fn == :'Value::integer'
-        return "Value::floatingpoint(#{args.map { |a| process_atom(a) }.join(', ')})" if fn == :'Value::integer'
+        return "Value::floatingpoint(#{args.map { |a| process_atom(a) }.join(', ')})" if fn == :'Value::floatingpoint'
 
         if VOID_FUNCTIONS.include?(fn)
           if METHODS.include?(fn)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -68,7 +68,7 @@ bool FloatObject::eql(Value other) const {
             env->raise("FloatDomainError", this->inspect_str(env));              \
                                                                                  \
         if (is_infinity())                                                       \
-            return Value { m_double };                                           \
+            return Value::floatingpoint(m_double);                               \
                                                                                  \
         FloatObject *result;                                                     \
         if (precision == 0)                                                      \
@@ -77,7 +77,7 @@ bool FloatObject::eql(Value other) const {
         double f = ::pow(10, precision);                                         \
         double rounded = ::libm_name(m_double * f) / f;                          \
         if (isinf(f) || isinf(rounded)) {                                        \
-            return Value { m_double };                                           \
+            return Value::floatingpoint(m_double);                               \
         }                                                                        \
         if (precision < 0)                                                       \
             return f_to_i_or_bigint(rounded);                                    \
@@ -239,10 +239,10 @@ Value FloatObject::to_i(Env *env) const {
 
 Value FloatObject::add(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
-        return Value { m_double + rhs.get_fast_integer() };
+        return Value::floatingpoint(m_double + rhs.get_fast_integer());
     }
     if (rhs.is_fast_float()) {
-        return Value { m_double + rhs.get_fast_float() };
+        return Value::floatingpoint(m_double + rhs.get_fast_float());
     }
     rhs.unguard();
 
@@ -259,15 +259,15 @@ Value FloatObject::add(Env *env, Value rhs) {
 
     double addend1 = to_double();
     double addend2 = rhs->as_float()->to_double();
-    return Value { addend1 + addend2 };
+    return Value::floatingpoint(addend1 + addend2);
 }
 
 Value FloatObject::sub(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
-        return Value { m_double - rhs.get_fast_integer() };
+        return Value::floatingpoint(m_double - rhs.get_fast_integer());
     }
     if (rhs.is_fast_float()) {
-        return Value { m_double - rhs.get_fast_float() };
+        return Value::floatingpoint(m_double - rhs.get_fast_float());
     }
     rhs.unguard();
 
@@ -284,15 +284,15 @@ Value FloatObject::sub(Env *env, Value rhs) {
 
     double minuend = to_double();
     double subtrahend = rhs->as_float()->to_double();
-    return Value { minuend - subtrahend };
+    return Value::floatingpoint(minuend - subtrahend);
 }
 
 Value FloatObject::mul(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
-        return Value { m_double * rhs.get_fast_integer() };
+        return Value::floatingpoint(m_double * rhs.get_fast_integer());
     }
     if (rhs.is_fast_float()) {
-        return Value { m_double * rhs.get_fast_float() };
+        return Value::floatingpoint(m_double * rhs.get_fast_float());
     }
     rhs.unguard();
 
@@ -309,15 +309,15 @@ Value FloatObject::mul(Env *env, Value rhs) {
 
     double multiplicand = to_double();
     double multiplier = rhs->as_float()->to_double();
-    return Value { multiplicand * multiplier };
+    return Value::floatingpoint(multiplicand * multiplier);
 }
 
 Value FloatObject::div(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
-        return Value { m_double / rhs.get_fast_integer() };
+        return Value::floatingpoint(m_double / rhs.get_fast_integer());
     }
     if (rhs.is_fast_float()) {
-        return Value { m_double / rhs.get_fast_float() };
+        return Value::floatingpoint(m_double / rhs.get_fast_float());
     }
     rhs.unguard();
 
@@ -335,18 +335,18 @@ Value FloatObject::div(Env *env, Value rhs) {
     double dividend = to_double();
     double divisor = rhs->as_float()->to_double();
 
-    return Value { dividend / divisor };
+    return Value::floatingpoint(dividend / divisor);
 }
 
 Value FloatObject::mod(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
         if (rhs.get_fast_integer() == 0) env->raise("ZeroDivisionError", "divided by 0");
-        return Value { fmod(m_double, rhs.get_fast_integer()) };
+        return Value::floatingpoint(fmod(m_double, rhs.get_fast_integer()));
     }
     if (rhs.is_fast_float()) {
         if (rhs.get_fast_float() == 0) env->raise("ZeroDivisionError", "divided by 0");
         if (rhs.get_fast_float() == -INFINITY) return rhs;
-        return Value { fmod(m_double, rhs.get_fast_float()) };
+        return Value::floatingpoint(fmod(m_double, rhs.get_fast_float()));
     }
     rhs.unguard();
 
@@ -376,7 +376,7 @@ Value FloatObject::mod(Env *env, Value rhs) {
         result += divisor;
     }
 
-    return Value { result };
+    return Value::floatingpoint(result);
 }
 
 Value FloatObject::divmod(Env *env, Value arg) {
@@ -387,7 +387,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
         if (arg.get_fast_integer() == 0) env->raise("ZeroDivisionError", "divided by 0");
         return new ArrayObject {
             Value { f_to_i_or_bigint(::floor(m_double / arg.get_fast_integer())) },
-            Value { ::fmod(m_double, arg.get_fast_integer()) }
+            Value::floatingpoint(::fmod(m_double, arg.get_fast_integer()))
         };
     }
     if (arg.is_fast_float()) {
@@ -395,7 +395,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
         if (isnan(arg.get_fast_float())) env->raise("FloatDomainError", "NaN");
         return new ArrayObject {
             Value { f_to_i_or_bigint(::floor(m_double / arg.get_fast_float())) },
-            Value { arg.get_fast_float() == -INFINITY ? -INFINITY : ::fmod(m_double, arg.get_fast_integer()) }
+            Value::floatingpoint(arg.get_fast_float() == -INFINITY ? -INFINITY : ::fmod(m_double, arg.get_fast_integer()))
         };
     }
     arg.unguard();
@@ -416,10 +416,10 @@ Value FloatObject::divmod(Env *env, Value arg) {
 
 Value FloatObject::pow(Env *env, Value rhs) {
     if (rhs.is_fast_integer()) {
-        return Value { ::pow(m_double, rhs.get_fast_integer()) };
+        return Value::floatingpoint(::pow(m_double, rhs.get_fast_integer()));
     }
     if (rhs.is_fast_float()) {
-        return Value { ::pow(m_double, rhs.get_fast_float()) };
+        return Value::floatingpoint(::pow(m_double, rhs.get_fast_float()));
     }
     rhs.unguard();
 
@@ -437,19 +437,19 @@ Value FloatObject::pow(Env *env, Value rhs) {
     double base = to_double();
     double exponent = rhs->as_float()->to_double();
 
-    return Value { ::pow(base, exponent) };
+    return Value::floatingpoint(::pow(base, exponent));
 }
 
 Value FloatObject::abs(Env *env) const {
-    return Value { fabs(m_double) };
+    return Value::floatingpoint(fabs(m_double));
 }
 
 Value FloatObject::next_float(Env *env) const {
-    return Value { ::nextafter(to_double(), HUGE_VAL) };
+    return Value::floatingpoint(::nextafter(to_double(), HUGE_VAL));
 }
 
 Value FloatObject::prev_float(Env *env) const {
-    return Value { ::nextafter(to_double(), -HUGE_VAL) };
+    return Value::floatingpoint(::nextafter(to_double(), -HUGE_VAL));
 }
 
 Value FloatObject::arg(Env *env) {

--- a/src/math.rb
+++ b/src/math.rb
@@ -186,7 +186,7 @@ module Math
       }
       int exponent;
       auto significand = std::frexp(value->to_double(), &exponent);
-      return new ArrayObject { { Value { significand }, Value::integer(exponent) } };
+      return new ArrayObject { { Value::floatingpoint(significand), Value::integer(exponent) } };
     END
 
     __function__('::tgamma', ['double'], 'double')

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -784,6 +784,9 @@ void Object::assert_not_frozen(Env *env) {
 bool Object::equal(Value other) {
     if (is_integer() && other->is_integer())
         return as_integer()->to_nat_int_t() == other->as_integer()->to_nat_int_t();
+    // We still need the pointer compare for the identical NaN equality
+    if (is_float() && other->is_float())
+        return this == other.object() || as_float()->to_double() == other->as_float()->to_double();
 
     return other == this;
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -2,6 +2,12 @@
 
 namespace Natalie {
 
+Value Value::floatingpoint(double value) {
+    if (isnan(value))
+        return FloatObject::nan();
+    return Value { value };
+}
+
 #define PROFILED_SEND(type)                                                                     \
     static auto is_profiled = NativeProfiler::the()->enabled();                                 \
     NativeProfilerEvent *event;                                                                 \


### PR DESCRIPTION
I temporarily removed the previous implementation of it, to narrow down on some errors.

Current errors include:
* [X] `Kernel.Float: returns the identical Float for numeric Floats   1.12 should be equal to 1.12 (line 9)`
* [x] `Kernel.Float: returns the identical NaN if to_f is called and it returns NaN   NaN should be equal to NaN (line 281)`
* [x] `Float#divmod: returns an [quotient, modulus] from dividing self by other  -Infinity should be within 3.0e-05 of 2.8284 (line 10)`
