### PR TITLE
Implement Integer#bit_length and try to optimize BigInt

### DIFF
--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -124,6 +124,7 @@ public:
     double to_double() const;
     TM::String to_string() const;
 
+    Integer bit_length() const;
     // TM::String to_binary() const;
 
     ~Integer() {

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -76,6 +76,7 @@ public:
     Value bitwise_and(Env *, Value);
     Value bitwise_or(Env *, Value);
     Value bitwise_xor(Env *, Value);
+    Value bit_length(Env *);
     Value left_shift(Env *, Value);
     Value right_shift(Env *, Value);
     Value pred(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -583,6 +583,7 @@ gen.binding('Integer', '==', 'IntegerObject', 'eq', argc: 1, pass_env: true, pas
 gen.binding('Integer', '===', 'IntegerObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Integer', '^', 'IntegerObject', 'bitwise_xor', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'abs', 'IntegerObject', 'abs', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Integer', 'bit_length', 'IntegerObject', 'bit_length', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'chr', 'IntegerObject', 'chr', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'ceil', 'IntegerObject', 'ceil', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'coerce', 'IntegerObject', 'coerce', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/integer/bit_length_spec.rb
+++ b/spec/core/integer/bit_length_spec.rb
@@ -1,0 +1,80 @@
+require_relative '../../spec_helper'
+
+describe "Integer#bit_length" do
+  context "fixnum" do
+    it "returns the position of the leftmost bit of a positive number" do
+      0.bit_length.should == 0
+      1.bit_length.should == 1
+      2.bit_length.should == 2
+      3.bit_length.should == 2
+      4.bit_length.should == 3
+      n = fixnum_max.bit_length
+      fixnum_max[n].should == 0
+      fixnum_max[n - 1].should == 1
+
+      0.bit_length.should == 0
+      1.bit_length.should == 1
+      0xff.bit_length.should == 8
+      0x100.bit_length.should == 9
+      (2**12 - 1).bit_length.should == 12
+      (2**12).bit_length.should == 13
+      (2**12 + 1).bit_length.should == 13
+    end
+
+    it "returns the position of the leftmost 0 bit of a negative number" do
+      -1.bit_length.should == 0
+      -2.bit_length.should == 1
+      -3.bit_length.should == 2
+      -4.bit_length.should == 2
+      -5.bit_length.should == 3
+      n = fixnum_min.bit_length
+      fixnum_min[n].should == 1
+      fixnum_min[n - 1].should == 0
+
+      (-2**12 - 1).bit_length.should == 13
+      (-2**12).bit_length.should == 12
+      (-2**12 + 1).bit_length.should == 12
+      -0x101.bit_length.should == 9
+      -0x100.bit_length.should == 8
+      -0xff.bit_length.should == 8
+      -2.bit_length.should == 1
+      -1.bit_length.should == 0
+    end
+  end
+
+  context "bignum" do
+    it "returns the position of the leftmost bit of a positive number" do
+      (2**1000-1).bit_length.should == 1000
+      (2**1000).bit_length.should == 1001
+      (2**1000+1).bit_length.should == 1001
+
+      # NATFIXME: Improve BigInt speed to let this run in reasonable time
+      # (2**10000-1).bit_length.should == 10000
+      # (2**10000).bit_length.should == 10001
+      # (2**10000+1).bit_length.should == 10001
+
+      (1 << 100).bit_length.should == 101
+      (1 << 100).succ.bit_length.should == 101
+      (1 << 100).pred.bit_length.should == 100
+      # NATFIXME: Improve BigInt speed to let this run in reasonable time
+      # (1 << 10000).bit_length.should == 10001
+    end
+
+    it "returns the position of the leftmost 0 bit of a negative number" do
+      # NATFIXME: Improve BigInt speed to let this run in reasonable time
+      # (-2**10000-1).bit_length.should == 10001
+      # (-2**10000).bit_length.should == 10000
+      # (-2**10000+1).bit_length.should == 10000
+
+      (-2**1000-1).bit_length.should == 1001
+      (-2**1000).bit_length.should == 1000
+      (-2**1000+1).bit_length.should == 1000
+
+      ((-1 << 100)-1).bit_length.should == 101
+      ((-1 << 100)-1).succ.bit_length.should == 100
+      ((-1 << 100)-1).pred.bit_length.should == 101
+      # NATFIXME: Improve BigInt speed to let this run in reasonable time
+      # ((-1 << 10000)-1).bit_length.should == 10001
+    end
+  end
+end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -813,7 +813,7 @@ bool operator>=(const TM::String &lhs, const BigInt &rhs) {
 */
 
 BigInt abs(const BigInt &num) {
-    return num < 0 ? -num : num;
+    return num.is_negative() ? -num : num;
 }
 
 /*

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -1813,12 +1813,14 @@ TM::String BigInt::to_binary() const {
     }
 
     while (copy_num > 0) {
-        if (copy_num % 2 == 1) {
+        auto quotient = copy_num.c_div(2);
+        auto remainder = copy_num - quotient * 2;
+        if (remainder == 1) {
             binary_num.prepend_char('1');
         } else {
             binary_num.prepend_char('0');
         }
-        copy_num /= 2;
+        copy_num = quotient;
     }
 
     if (*this < 0) {

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -1232,14 +1232,27 @@ std::tuple<BigInt, BigInt> divide(const BigInt &dividend, const BigInt &divisor)
 
     temp = divisor;
     quotient = 1;
+    unsigned long long iterations = 0;
     while (temp < dividend) {
-        quotient++;
         temp += divisor;
+        iterations++;
+        if (iterations == LLONG_MAX) {
+            quotient += iterations;
+            iterations = 0;
+        }
     }
+    quotient += iterations;
+    iterations = 0;
+
     if (temp > dividend) {
-        quotient--;
+        iterations++;
+        if (iterations == LLONG_MAX) {
+            quotient -= iterations;
+            iterations = 0;
+        }
         remainder = dividend - (temp - divisor);
     }
+    quotient -= iterations;
 
     return std::make_tuple(quotient, remainder);
 }

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -1067,7 +1067,7 @@ BigInt BigInt::operator+(const BigInt &num) const {
     // add the two values
     for (long i = larger.size() - 1; i >= 0; i--) {
         sum = larger[i] - '0' + smaller[i] - '0' + carry;
-        result.value.prepend(sum % 10);
+        result.value.prepend_char((sum % 10) + '0');
         carry = sum / (short)10;
     }
     if (carry)
@@ -1118,7 +1118,7 @@ BigInt BigInt::operator-(const BigInt &num) const {
     add_leading_zeroes(smaller, larger.size() - smaller.size());
 
     result.value = ""; // the value is cleared as the digits will be appended
-    short difference;
+    char difference;
     long i, j;
     // subtract the two values
     for (i = larger.size() - 1; i >= 0; i--) {
@@ -1137,7 +1137,7 @@ BigInt BigInt::operator-(const BigInt &num) const {
             }
             difference += 10; // add the borrow
         }
-        result.value.prepend(difference);
+        result.value.prepend_char(difference + '0');
     }
     strip_leading_zeroes(result.value);
 

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -346,6 +346,20 @@ TM::String Integer::to_string() const {
     return TM::String(to_nat_int_t());
 }
 
+Integer Integer::bit_length() const {
+    // If it is equal to NAT_MAX_FIXNUM we cannot increment it later, instead we have to use the
+    // bignum branch.
+    if (is_bignum() || to_nat_int_t() == NAT_MAX_FIXNUM) {
+        auto binary = to_bigint().to_binary();
+        for (size_t i = 0; i < binary.length(); ++i)
+            if (binary[i] == (to_bigint().is_negative() ? '0' : '1'))
+                return (nat_int_t)(binary.length() - i);
+    }
+
+    auto nat_int = to_nat_int_t();
+    return ceil(log2(nat_int < 0 ? -nat_int : nat_int + 1));
+}
+
 Integer operator+(const long long &lhs, const Integer &rhs) {
     return Integer(lhs) + rhs;
 }

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -284,9 +284,8 @@ Integer Integer::operator<<(const Integer &other) const {
     auto pow_result = pow(2, other.to_nat_int_t());
     if (pow_result.is_bignum())
         return to_bigint() << other.to_nat_int_t();
-    else if (will_multiplication_overflow(to_nat_int_t(), pow_result.to_nat_int_t())) {
+    else if (will_multiplication_overflow(to_nat_int_t(), pow_result.to_nat_int_t()))
         return to_bigint() << other.to_nat_int_t();
-    }
 
     return to_nat_int_t() << other.to_nat_int_t();
 }
@@ -297,7 +296,7 @@ Integer Integer::operator>>(const Integer &other) const {
     if (is_bignum())
         return to_bigint() >> other.to_nat_int_t();
 
-    if (other.to_nat_int_t() > (nat_int_t)sizeof(nat_int_t))
+    if (other.to_nat_int_t() >= (nat_int_t)sizeof(nat_int_t) * 8)
         return is_negative() ? -1 : 0;
 
     return to_nat_int_t() >> other.to_nat_int_t();

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -426,6 +426,10 @@ Value IntegerObject::bitwise_xor(Env *env, Value arg) {
     return create(m_integer ^ argument);
 }
 
+Value IntegerObject::bit_length(Env *env) {
+    return create(m_integer.bit_length());
+}
+
 Value IntegerObject::left_shift(Env *env, Value arg) {
     nat_int_t nat_int;
     if (arg.is_fast_integer()) {


### PR DESCRIPTION
Integer#bit_length uses conversion from BigInts zu a binary string. Sadly this is very slow on large numbers (like 2**10000) that the specs are using. I tried to improve performance of different BigInt operators used by `BigInt::to_binary` but it is not good enough to handle those large numbers yet.