### PR TITLE
Implement Kernel#initialize_dup

### DIFF
--- a/spec/core/kernel/initialize_dup_spec.rb
+++ b/spec/core/kernel/initialize_dup_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+describe "Kernel#initialize_dup" do
+  it "is a private instance method" do
+    Kernel.should have_private_instance_method(:initialize_dup)
+  end
+
+  it "returns the receiver" do
+    a = Object.new
+    b = Object.new
+    a.send(:initialize_dup, b).should == a
+  end
+
+  it "calls #initialize_copy" do
+    a = Object.new
+    b = Object.new
+    a.should_receive(:initialize_copy).with(b)
+    a.send(:initialize_dup, b)
+  end
+end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -19,6 +19,12 @@ module Kernel
   end
   alias to_enum enum_for
 
+  def initialize_dup(other)
+    initialize_copy(other)
+    self
+  end
+  private :initialize_dup
+
   def rand(*args)
     Random::DEFAULT.rand(*args)
   end


### PR DESCRIPTION
Following on from #530 this implements the Kernel#initialize_dup method. Further work required to call this method from `Object::dup` to make that spec compliant.