### PR TITLE
Fix Matcher spec class

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -343,6 +343,8 @@ class Matcher
       raise SpecFailedException, "#{@subject.inspect} should not be #{method}#{than}" if @subject.send(method, *args)
     end
   end
+
+  undef_method :equal?
 end
 
 class BeNilExpectation


### PR DESCRIPTION
There are some specs in ruby/spec with expectations like `a.should.equal?(b)` which as-is will always pass.

For example, with the following code in `spec/example_spec.rb`:

    require_relative 'spec_helper'

    describe 'Matcher#equal?' do
      it 'always passes' do
        1.should.equal?(1)
        1.should.equal?(2)
      end
    end

The second expectation should fail, but the spec passes:

    $ bin/natalie spec/example_spec.rb
    .

    1 spec(s) passed.

Fixing by undefining the #equal? method on the Matcher class so that Matcher#method_missing is called, which implements the correct behavior for testing.