### PR TITLE
Implement Encoding::default_internal (and it's setter)

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -56,6 +56,8 @@ public:
     static EncodingObject *find(Env *, Value);
     static ArrayObject *list(Env *env);
     static const TM::Hashmap<Encoding, EncodingObject *> &encodings() { return EncodingObject::s_encoding_list; }
+    static EncodingObject *default_internal() { return s_default_internal; }
+    static EncodingObject *set_default_internal(Env *, Value);
 
     virtual void visit_children(Visitor &) override final;
 
@@ -68,6 +70,7 @@ private:
     Encoding m_num;
 
     static inline TM::Hashmap<Encoding, EncodingObject *> s_encoding_list {};
+    static inline EncodingObject *s_default_internal = nullptr;
 };
 
 EncodingObject *encoding(Env *env, Encoding num, ArrayObject *names);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -422,6 +422,8 @@ gen.binding('Class', 'superclass', 'ClassObject', 'superclass', argc: 0, pass_en
 gen.binding('Class', 'singleton_class?', 'ClassObject', 'is_singleton', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 
 gen.static_binding('Encoding', 'aliases', 'EncodingObject', 'aliases', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Encoding', 'default_internal', 'EncodingObject', 'default_internal', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.static_binding('Encoding', 'default_internal=', 'EncodingObject', 'set_default_internal', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Encoding', 'find', 'EncodingObject', 'find', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Encoding', 'list', 'EncodingObject', 'list', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Encoding', 'inspect', 'EncodingObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/encoding/default_internal_spec.rb
+++ b/spec/core/encoding/default_internal_spec.rb
@@ -1,0 +1,78 @@
+require_relative '../../spec_helper'
+
+describe "Encoding.default_internal" do
+  before :each do
+    @original_encoding = Encoding.default_internal
+  end
+
+  after :each do
+    Encoding.default_internal = @original_encoding
+  end
+
+  it "is nil by default" do
+    Encoding.default_internal.should be_nil
+  end
+
+  # NATFIXME: Implement Encoding::ASCII
+  xit "returns an Encoding object if a default internal encoding is set" do
+    Encoding.default_internal = Encoding::ASCII
+    Encoding.default_internal.should be_an_instance_of(Encoding)
+  end
+
+  it "returns nil if no default internal encoding is set" do
+    Encoding.default_internal = nil
+    Encoding.default_internal.should be_nil
+  end
+
+  it "returns the default internal encoding" do
+    Encoding.default_internal = Encoding::BINARY
+    Encoding.default_internal.should == Encoding::BINARY
+  end
+end
+
+describe "Encoding.default_internal=" do
+  before :each do
+    @original_encoding = Encoding.default_internal
+  end
+
+  after :each do
+    Encoding.default_internal = @original_encoding
+  end
+
+  # NATFIXME: Implement Encoding::SHIFT_JIS
+  xit "sets the default internal encoding" do
+    Encoding.default_internal = Encoding::SHIFT_JIS
+    Encoding.default_internal.should == Encoding::SHIFT_JIS
+  end
+
+  # NATFIXME: Implement Encoding::SHIFT_JIS
+  xit "can accept a name of an encoding as a String" do
+    Encoding.default_internal = 'Shift_JIS'
+    Encoding.default_internal.should == Encoding::SHIFT_JIS
+  end
+
+  # NATFIXME: Implement Encoding::ASCII
+  xit "calls #to_str to convert an object to a String" do
+    obj = mock('string')
+    obj.should_receive(:to_str).at_least(1).times.and_return('ascii')
+
+    Encoding.default_internal = obj
+    Encoding.default_internal.should == Encoding::ASCII
+  end
+
+  it "raises a TypeError if #to_str does not return a String" do
+    obj = mock('string')
+    obj.should_receive(:to_str).at_least(1).times.and_return(1)
+
+    -> { Encoding.default_internal = obj }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError when passed an object not providing #to_str" do
+    -> { Encoding.default_internal = mock("encoding") }.should raise_error(TypeError)
+  end
+
+  it "accepts an argument of nil to unset the default internal encoding" do
+    Encoding.default_internal = nil
+    Encoding.default_internal.should be_nil
+  end
+end

--- a/spec/core/integer/chr_spec.rb
+++ b/spec/core/integer/chr_spec.rb
@@ -27,7 +27,6 @@ describe "Integer#chr without argument" do
 
       it "returns a String encoding self interpreted as a US-ASCII codepoint" do
         (0..127).each do |c|
-          p c.chr.bytes
           c.chr.bytes.to_a.should == [c]
         end
       end
@@ -53,8 +52,7 @@ describe "Integer#chr without argument" do
     end
   end
 
-  # FIXME: Implement Encoding.default_internal
-  xdescribe "when Encoding.default_internal is not nil" do
+  describe "when Encoding.default_internal is not nil" do
     before do
       @default_internal = Encoding.default_internal
     end
@@ -63,7 +61,8 @@ describe "Integer#chr without argument" do
       Encoding.default_internal = @default_internal
     end
 
-    describe "and self is between 0 and 127 (inclusive)" do
+    # NATFIXME: Implement Encoding::US_ASCII and Encoding::SHIFT_JIS
+    xdescribe "and self is between 0 and 127 (inclusive)" do
       it "returns a US-ASCII String" do
         (0..127).each do |c|
           Encoding.default_internal = Encoding::UTF_8
@@ -91,8 +90,9 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.encoding.should == Encoding::BINARY
 
-          Encoding.default_internal = Encoding::SHIFT_JIS
-          c.chr.encoding.should == Encoding::BINARY
+          # NATFIXME: Implement Encoding::SHIFT_JIS
+          # Encoding.default_internal = Encoding::SHIFT_JIS
+          # c.chr.encoding.should == Encoding::BINARY
         end
       end
 
@@ -101,8 +101,9 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.bytes.to_a.should == [c]
 
-          Encoding.default_internal = Encoding::SHIFT_JIS
-          c.chr.bytes.to_a.should == [c]
+          # NATFIXME: Implement Encoding::SHIFT_JIS
+          # Encoding.default_internal = Encoding::SHIFT_JIS
+          # c.chr.bytes.to_a.should == [c]
         end
       end
     end
@@ -113,12 +114,14 @@ describe "Integer#chr without argument" do
         0x0100.chr.encoding.should == Encoding::UTF_8
         0x3000.chr.encoding.should == Encoding::UTF_8
 
-        Encoding.default_internal = Encoding::SHIFT_JIS
-        0x8140.chr.encoding.should == Encoding::SHIFT_JIS
-        0xFC4B.chr.encoding.should == Encoding::SHIFT_JIS
+        # NATFIXME: Implement Encoding::SHIFT_JIS
+        # Encoding.default_internal = Encoding::SHIFT_JIS
+        # 0x8140.chr.encoding.should == Encoding::SHIFT_JIS
+        # 0xFC4B.chr.encoding.should == Encoding::SHIFT_JIS
       end
 
-      it "returns a String encoding self interpreted as a codepoint in the default internal encoding" do
+      # NATFIXME: Implement multibyte characters and Encoding::SHIFT_JIS
+      xit "returns a String encoding self interpreted as a codepoint in the default internal encoding" do
         Encoding.default_internal = Encoding::UTF_8
         0x0100.chr.bytes.to_a.should == [0xC4, 0x80]
         0x3000.chr.bytes.to_a.should == [0xE3, 0x80, 0x80]
@@ -128,14 +131,15 @@ describe "Integer#chr without argument" do
         0xFC4B.chr.bytes.to_a.should == [0xFC, 0x4B] # Largest assigned CP932 codepoint
       end
 
+      # NATFIXME: Implement various encodings
       # #5864
       it "raises RangeError if self is invalid as a codepoint in the default internal encoding" do
-        [ [0x0100, "US-ASCII"],
+        [ #[0x0100, "US-ASCII"],
           [0x0100, "BINARY"],
-          [0x0100, "EUC-JP"],
-          [0xA1A0, "EUC-JP"],
-          [0x0100, "ISO-8859-9"],
-          [620,    "TIS-620"]
+          #[0x0100, "EUC-JP"],
+          #[0xA1A0, "EUC-JP"],
+          #[0x0100, "ISO-8859-9"],
+          #[620,    "TIS-620"]
         ].each do |integer, encoding_name|
           Encoding.default_internal = Encoding.find(encoding_name)
           -> { integer.chr }.should raise_error(RangeError)

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -21,6 +21,19 @@ HashObject *EncodingObject::aliases(Env *env) {
     return aliases;
 }
 
+EncodingObject *EncodingObject::set_default_internal(Env *env, Value arg) {
+    if (arg->is_encoding()) {
+        s_default_internal = arg->as_encoding();
+    } else if (arg->is_nil()) {
+        s_default_internal = nullptr;
+    } else {
+        auto name = arg->to_str(env);
+        s_default_internal = find(env, name);
+    }
+
+    return default_internal();
+}
+
 EncodingObject *EncodingObject::find(Env *env, Value name) {
     for (auto value : *list(env)) {
         auto encoding = value->as_encoding();

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -581,16 +581,17 @@ Value IntegerObject::chr(Env *env, Value encoding) const {
             encoding->assert_type(env, Type::String, "String");
             encoding = EncodingObject::find(env, encoding);
         }
-    } else {
-        if (m_integer > 255)
-            env->raise("RangeError", "{} out of char range", m_integer.to_string());
-
+    } else if (m_integer < 256) {
         Value Encoding = GlobalEnv::the()->Object()->const_fetch("Encoding"_s);
         if (m_integer <= 127) {
             NAT_NOT_YET_IMPLEMENTED();
         } else {
             encoding = Encoding->const_fetch("BINARY"_s);
         }
+    } else if (EncodingObject::default_internal()) {
+        encoding = EncodingObject::default_internal();
+    } else {
+        env->raise("RangeError", "{} out of char range", m_integer.to_string());
     }
 
     auto encoding_obj = encoding->as_encoding();


### PR DESCRIPTION
Those are needed for various methods and objects. Right now only
Integer#chr supports Encoding::default_internal.