### PR TITLE
Make Range#include? spec compliant

### DIFF
--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -787,6 +787,7 @@ gen.binding('Range', 'to_a', 'RangeObject', 'to_a', argc: 0, pass_env: true, pas
 gen.binding('Range', 'each', 'RangeObject', 'each', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Range', 'first', 'RangeObject', 'first', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Range', 'inspect', 'RangeObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Range', 'member?', 'RangeObject', 'include', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Range', '==', 'RangeObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Range', '===', 'RangeObject', 'eqeqeq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Range', 'include?', 'RangeObject', 'include', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/spec/core/range/include_spec.rb
+++ b/spec/core/range/include_spec.rb
@@ -1,0 +1,10 @@
+# -*- encoding: binary -*-
+require_relative '../../spec_helper'
+require_relative 'shared/cover_and_include'
+require_relative 'shared/include'
+require_relative 'shared/cover'
+
+describe "Range#include?" do
+  it_behaves_like :range_cover_and_include, :include?
+  it_behaves_like :range_include, :include?
+end

--- a/spec/core/range/member_spec.rb
+++ b/spec/core/range/member_spec.rb
@@ -1,0 +1,10 @@
+# -*- encoding: binary -*-
+require_relative '../../spec_helper'
+require_relative 'shared/cover_and_include'
+require_relative 'shared/include'
+require_relative 'shared/cover'
+
+describe "Range#member?" do
+  it_behaves_like :range_cover_and_include, :member?
+  it_behaves_like :range_include, :member?
+end

--- a/spec/core/range/shared/cover_and_include.rb
+++ b/spec/core/range/shared/cover_and_include.rb
@@ -57,7 +57,10 @@ describe :range_cover_and_include, shared: true do
   it "returns true if argument is less than the last value of the range and greater than the first value" do
     (20..30).send(@method, 28).should be_true
     ('e'..'h').send(@method, 'g').should be_true
-    ("\u{999}".."\u{9999}").send @method, "\u{9995}"
+    # NATFIXME: Implement custom String#succ logic ("\u09B9".succ should be "\u09B6\u09B6")
+    if @method != :include?
+      ("\u{999}".."\u{9999}").send @method, "\u{9995}"
+    end
   end
 
   it "returns true if argument is sole element in the range" do

--- a/spec/core/range/shared/include.rb
+++ b/spec/core/range/shared/include.rb
@@ -1,0 +1,92 @@
+# -*- encoding: binary -*-
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :range_include, shared: true do
+  describe "on string elements" do
+    it "returns true if other is matched by element.succ" do
+      ('a'..'c').send(@method, 'b').should be_true
+      ('a'...'c').send(@method, 'b').should be_true
+    end
+
+    it "returns false if other is not matched by element.succ" do
+      ('a'..'c').send(@method, 'bc').should be_false
+      ('a'...'c').send(@method, 'bc').should be_false
+    end
+  end
+
+  describe "with weird succ" do
+    describe "when included end value" do
+      before :each do
+        @range = RangeSpecs::TenfoldSucc.new(1)..RangeSpecs::TenfoldSucc.new(99)
+      end
+
+      it "returns false if other is less than first element" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(0)).should be_false
+      end
+
+      it "returns true if other is equal as first element" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(1)).should be_true
+      end
+
+      it "returns true if other is matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(10)).should be_true
+      end
+
+      it "returns false if other is not matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(2)).should be_false
+      end
+
+      it "returns false if other is equal as last element but not matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(99)).should be_false
+      end
+
+      it "returns false if other is greater than last element but matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(100)).should be_false
+      end
+    end
+
+    describe "when excluded end value" do
+      before :each do
+        @range = RangeSpecs::TenfoldSucc.new(1)...RangeSpecs::TenfoldSucc.new(99)
+      end
+
+      it "returns false if other is less than first element" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(0)).should be_false
+      end
+
+      it "returns true if other is equal as first element" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(1)).should be_true
+      end
+
+      it "returns true if other is matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(10)).should be_true
+      end
+
+      it "returns false if other is not matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(2)).should be_false
+      end
+
+      it "returns false if other is equal as last element but not matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(99)).should be_false
+      end
+
+      it "returns false if other is greater than last element but matched by element.succ" do
+        @range.send(@method, RangeSpecs::TenfoldSucc.new(100)).should be_false
+      end
+    end
+  end
+
+  # NATFIXME: Implement Time
+  xdescribe "with Time endpoints" do
+    it "uses cover? logic" do
+      now = Time.now
+      range = (now..(now + 60))
+
+      range.include?(now).should == true
+      range.include?(now - 1).should == false
+      range.include?(now + 60).should == true
+      range.include?(now + 61).should == false
+    end
+  end
+end

--- a/test/natalie/range_test.rb
+++ b/test/natalie/range_test.rb
@@ -245,5 +245,12 @@ describe 'range' do
       r.include?(11).should == false
       r.include?(10.1).should == false
     end
+
+    it 'checks for endless ranges correctly' do
+      (1..).include?(-1).should == false
+      (1..).include?(10).should == true
+      (..1).include?(-1).should == true
+      (..1).include?(10).should == false
+    end
   end
 end


### PR DESCRIPTION
This revealed a small bug in our `String#succ` method that I was not able to fix. Maybe somebody has an idea:
```ruby
"\u09b9".succ
# => MRI: "\u09b6\u09b6"
# => Natalie: "\u09ba"
```

[#555]