### PR TITLE
Delay building an exception backtrace array

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "natalie/array_object.hpp"
+#include "natalie/backtrace.hpp"
 #include "natalie/binding_object.hpp"
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"

--- a/include/natalie/backtrace.hpp
+++ b/include/natalie/backtrace.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "natalie/forward.hpp"
+#include "natalie/gc.hpp"
+#include "tm/hashmap.hpp"
+
+namespace Natalie {
+class Backtrace : public Cell {
+public:
+    struct Item {
+        const ManagedString *source_location;
+        const char *file;
+        size_t line;
+    };
+
+    void add_item(Env *env, const char *file, size_t line) {
+        // NATFIXME: Ideally we could store the env and delay building the code location name
+        m_items.push(Item { env->build_code_location_name(), file, line });
+    }
+    ArrayObject *to_ruby_array();
+
+    virtual void visit_children(Visitor &visitor) override final {
+        for (auto item : m_items) {
+            visitor.visit(item.source_location);
+        }
+    }
+
+    virtual void gc_inspect(char *buf, size_t len) const override {
+        snprintf(buf, len, "<Backtrace %p size=%ld>", this, m_items.size());
+    }
+
+private:
+    Vector<Item> m_items;
+};
+
+}

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -40,7 +40,7 @@ public:
     Value global_set(SymbolObject *, Value);
 
     Method *current_method();
-    const ManagedString *build_code_location_name(Env *);
+    const ManagedString *build_code_location_name();
 
     Value var_get(const char *, size_t);
     Value var_set(const char *, size_t, bool, Value);
@@ -124,7 +124,7 @@ public:
     void set_exception(ExceptionObject *exception) { m_exception = exception; }
     void clear_exception() { m_exception = nullptr; }
 
-    ArrayObject *backtrace();
+    Backtrace *backtrace();
 
     bool is_main() { return this == GlobalEnv::the()->main_env(); }
 

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -41,7 +41,7 @@ public:
         return m_message;
     }
 
-    const ArrayObject *backtrace() { return m_backtrace; }
+    Backtrace *backtrace() { return m_backtrace; }
     void build_backtrace(Env *env) { m_backtrace = env->backtrace(); }
     Value backtrace(Env *);
 
@@ -64,8 +64,10 @@ public:
     void set_break_point(nat_int_t break_point) { m_break_point = break_point; }
 
 private:
+    ArrayObject *generate_backtrace();
+
     StringObject *m_message { nullptr };
-    ArrayObject *m_backtrace { nullptr };
+    Backtrace *m_backtrace { nullptr };
     nat_int_t m_break_point { 0 };
     Env *m_local_jump_error_env { nullptr };
     LocalJumpErrorType m_local_jump_error_type { LocalJumpErrorType::None };

--- a/include/natalie/forward.hpp
+++ b/include/natalie/forward.hpp
@@ -5,6 +5,7 @@
 namespace Natalie {
 
 class ArrayObject;
+class Backtrace;
 class Block;
 class ClassObject;
 class EncodingObject;

--- a/src/backtrace.cpp
+++ b/src/backtrace.cpp
@@ -1,0 +1,11 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+ArrayObject *Backtrace::to_ruby_array() {
+    ArrayObject *generated = new ArrayObject { m_items.size() };
+    for (auto item : m_items) {
+        generated->push(StringObject::format("{}:{}:in `{}'", item.file, item.line, item.source_location));
+    }
+    return generated;
+}
+}

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -20,7 +20,10 @@ Value ExceptionObject::inspect(Env *env) {
 }
 
 Value ExceptionObject::backtrace(Env *env) {
-    return m_backtrace ? m_backtrace->dup(env) : NilObject::the();
+    if (m_backtrace)
+        return m_backtrace->to_ruby_array();
+
+    return NilObject::the();
 }
 
 Value ExceptionObject::match_rescue_array(Env *env, Value ary) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -54,7 +54,8 @@ Value KernelModule::binding(Env *env) {
 }
 
 Value KernelModule::caller(Env *env) {
-    auto ary = env->backtrace();
+    auto backtrace = env->backtrace();
+    auto ary = backtrace->to_ruby_array();
     ary->shift(); // remove the frame for Kernel#caller itself
     ary->shift(); // remove the frame for the call site of Kernel#caller
     return ary;

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -280,7 +280,7 @@ void run_at_exit_handlers(Env *env) {
 void print_exception_with_backtrace(Env *env, ExceptionObject *exception) {
     IoObject *_stderr = env->global_get("$stderr"_s)->as_io();
     int fd = _stderr->fileno();
-    const ArrayObject *backtrace = exception->backtrace();
+    ArrayObject *backtrace = exception->backtrace()->to_ruby_array();
     if (backtrace && backtrace->size() > 0) {
         dprintf(fd, "Traceback (most recent call last):\n");
         for (int i = backtrace->size() - 1; i > 0; i--) {


### PR DESCRIPTION
Previously, we were building a backtrace array when initializing an
exception object. Sometimes though we do not want to print the backtrace
which makes generating it useless.

This patch tries to delay building the backtrace array, until it will
actually be used.

This should impact a lot of code slightly, because exceptions are
sometimes used for control-flow in the language itself (LocalJumpError
for example).

Benchmark:

```ruby
10000.times do |n|
  begin
    raise Exception, 'message'
  rescue Exception
  end
end
```

On MRI: 
```
real    0m0.100s
user    0m0.080s
sys     0m0.020s
```

On Natalie (master):
```
real    0m0.247s
user    0m0.237s
sys     0m0.010s
```

On Natalie (with this patch):
```
real    0m0.190s
user    0m0.189s
sys     0m0.000s
```