### PR TITLE
Experiment with building shared object instead of static archive

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -190,8 +190,10 @@ class Runner
         Natalie::VM.new(compiler.instructions, path: source_path).run
       else
         compiler.compile
+        build_dir = File.expand_path('../build', __dir__)
+        env = { 'LD_LIBRARY_PATH' => "#{build_dir}:#{build_dir}/onigmo/lib" }
         begin
-          pid = spawn(out.path, *ARGV)
+          pid = spawn(env, out.path, *ARGV)
           Process.wait(pid)
           exit $?.exitstatus || 1
         ensure
@@ -215,7 +217,7 @@ class Runner
       rescue Natalie::Compiler2::CompileError => e
         puts e
       else
-        pid = spawn(out.path, *ARGV)
+        pid = spawn(env, out.path, *ARGV)
         Process.wait(pid)
       end
       print 'Edit again? [Yn] '

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -18,8 +18,15 @@ module Natalie
       File.join(BUILD_DIR, 'onigmo/include'),
       File.join(BUILD_DIR, 'natalie_parser/include'),
     ]
-    LIB_PATHS = [BUILD_DIR]
-    LIBRARIES = %W[-lnatalie]
+    LIB_PATHS = [
+      BUILD_DIR,
+      File.join(BUILD_DIR, 'onigmo/lib'),
+    ]
+    LIBRARIES = %w[
+      -lnatalie_base
+      -lnatalie_parser
+      -lonigmo
+    ]
 
     RB_LIB_PATH = File.expand_path('..', __dir__)
 
@@ -71,7 +78,7 @@ module Natalie
     end
 
     def check_build
-      unless File.file?(File.join(BUILD_DIR, 'libnatalie.a'))
+      unless File.file?(File.join(BUILD_DIR, 'libnatalie_base.so'))
         puts 'please run: rake'
         exit 1
       end


### PR DESCRIPTION
The idea would be to use a shared object when running a script directly.

It seems to speed up compilation when you don't care about the temporary
binary.

TODO: When using `-c out` we will still need to use the static-compilation
method so that the binary is fully self-contained.