### PR TITLE
Implement Range#min, #max and #minmax

### DIFF
--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -47,6 +47,8 @@ public:
     }
 
     Object *object() {
+        if (m_type == Type::Pointer)
+            return m_object;
         auto_hydrate();
         return m_object;
     }
@@ -115,6 +117,8 @@ public:
         assert(m_type == Type::Double);
         return m_double;
     }
+
+    bool guarded() const { return m_guarded; }
 
     Value guard() {
         m_guarded = true;

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -611,7 +611,8 @@ module Natalie
           args_name, args_count = process_atom(args).split(':')
           decl "Value #{result_name} = super(env, self, #{args_count}, #{args_name}, #{block || 'nullptr'});"
         else
-          decl "Value #{result_name} = super(env, self, argc, args, #{block || 'nullptr'});"
+          block = block && block != 'nullptr' ? block : 'block'
+          decl "Value #{result_name} = super(env, self, argc, args, #{block});"
         end
         result_name
       end

--- a/spec/core/range/max_spec.rb
+++ b/spec/core/range/max_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../../spec_helper'
+
+describe "Range#max" do
+  it "returns the maximum value in the range when called with no arguments" do
+    (1..10).max.should == 10
+    (1...10).max.should == 9
+    (0...2**64).max.should == 18446744073709551615
+    ('f'..'l').max.should == 'l'
+    ('a'...'f').max.should == 'e'
+  end
+
+  it "returns the maximum value in the Float range when called with no arguments" do
+    (303.20..908.1111).max.should == 908.1111
+  end
+
+  it "raises TypeError when called on an exclusive range and a non Integer value" do
+    -> { (303.20...908.1111).max }.should raise_error(TypeError)
+  end
+
+  it "returns nil when the endpoint is less than the start point" do
+    (100..10).max.should be_nil
+    ('z'..'l').max.should be_nil
+  end
+
+  it "returns nil when the endpoint equals the start point and the range is exclusive" do
+    (5...5).max.should be_nil
+  end
+
+  it "returns the endpoint when the endpoint equals the start point and the range is inclusive" do
+    (5..5).max.should equal(5)
+  end
+
+  it "returns nil when the endpoint is less than the start point in a Float range" do
+    (3003.20..908.1111).max.should be_nil
+  end
+
+  # NATFIXME: Implement Time
+  xit "returns end point when the range is Time..Time(included end point)" do
+    time_start = Time.now
+    time_end = Time.now + 1.0
+    (time_start..time_end).max.should equal(time_end)
+  end
+
+  # NATFIXME: Implement Time
+  xit "raises TypeError when called on a Time...Time(excluded end point)" do
+    time_start = Time.now
+    time_end = Time.now + 1.0
+    -> { (time_start...time_end).max  }.should raise_error(TypeError)
+  end
+
+  it "raises RangeError when called on an endless range" do
+    -> { eval("(1..)").max }.should raise_error(RangeError)
+  end
+
+  ruby_version_is "3.0" do
+    it "returns the end point for beginless ranges" do
+      (..1).max.should == 1
+      (..1.0).max.should == 1.0
+    end
+
+    it "raises for an exclusive beginless range" do
+      -> {
+        (...1).max
+      }.should raise_error(TypeError, 'cannot exclude end value with non Integer begin value')
+    end
+  end
+end
+
+describe "Range#max given a block" do
+  it "passes each pair of values in the range to the block" do
+    acc = []
+    (1..10).max {|a,b| acc << [a,b]; a }
+    acc.flatten!
+    (1..10).each do |value|
+      acc.include?(value).should be_true
+    end
+  end
+
+  it "passes each pair of elements to the block in reversed order" do
+    acc = []
+    (1..5).max {|a,b| acc << [a,b]; a }
+    acc.should == [[2,1],[3,2], [4,3], [5, 4]]
+  end
+
+  it "calls #> and #< on the return value of the block" do
+    obj = mock('obj')
+    obj.should_receive(:>).exactly(2).times
+    obj.should_receive(:<).exactly(2).times
+    (1..3).max {|a,b| obj }
+  end
+
+  it "returns the element the block determines to be the maximum" do
+    (1..3).max {|a,b| -3 }.should == 1
+  end
+
+  it "returns nil when the endpoint is less than the start point" do
+    (100..10).max {|x,y| x <=> y}.should be_nil
+    ('z'..'l').max {|x,y| x <=> y}.should be_nil
+    (5...5).max {|x,y| x <=> y}.should be_nil
+  end
+
+  it "raises RangeError when called with custom comparison method on an beginless range" do
+    -> { (..1).max {|a, b| a} }.should raise_error(RangeError)
+  end
+end

--- a/spec/core/range/min_spec.rb
+++ b/spec/core/range/min_spec.rb
@@ -1,0 +1,90 @@
+require_relative '../../spec_helper'
+
+describe "Range#min" do
+  it "returns the minimum value in the range when called with no arguments" do
+    (1..10).min.should == 1
+    ('f'..'l').min.should == 'f'
+  end
+
+  it "returns the minimum value in the Float range when called with no arguments" do
+    (303.20..908.1111).min.should == 303.20
+  end
+
+  it "returns nil when the start point is greater than the endpoint" do
+    (100..10).min.should be_nil
+    ('z'..'l').min.should be_nil
+  end
+
+  it "returns nil when the endpoint equals the start point and the range is exclusive" do
+    (7...7).min.should be_nil
+  end
+
+  it "returns the start point when the endpoint equals the start point and the range is inclusive" do
+    (7..7).min.should equal(7)
+  end
+
+  it "returns nil when the start point is greater than the endpoint in a Float range" do
+    (3003.20..908.1111).min.should be_nil
+  end
+
+  # NATFIXME: Implement Time
+  xit "returns start point when the range is Time..Time(included end point)" do
+    time_start = Time.now
+    time_end = Time.now + 1.0
+    (time_start..time_end).min.should equal(time_start)
+  end
+
+  # NATFIXME: Implement Time
+  xit "returns start point when the range is Time...Time(excluded end point)" do
+    time_start = Time.now
+    time_end = Time.now + 1.0
+    (time_start...time_end).min.should equal(time_start)
+  end
+
+  it "returns the start point for endless ranges" do
+    eval("(1..)").min.should == 1
+    eval("(1.0...)").min.should == 1.0
+  end
+
+  it "raises RangeError when called on an beginless range" do
+    -> { (..1).min }.should raise_error(RangeError)
+  end
+end
+
+describe "Range#min given a block" do
+  it "passes each pair of values in the range to the block" do
+    acc = []
+    (1..10).min {|a,b| acc << [a,b]; a }
+    acc.flatten!
+    (1..10).each do |value|
+      acc.include?(value).should be_true
+    end
+  end
+
+  it "passes each pair of elements to the block where the first argument is the current element, and the last is the first element" do
+    acc = []
+    (1..5).min {|a,b| acc << [a,b]; a }
+    acc.should == [[2, 1], [3, 1], [4, 1], [5, 1]]
+  end
+
+  it "calls #> and #< on the return value of the block" do
+    obj = mock('obj')
+    obj.should_receive(:>).exactly(2).times
+    obj.should_receive(:<).exactly(2).times
+    (1..3).min {|a,b| obj }
+  end
+
+  it "returns the element the block determines to be the minimum" do
+    (1..3).min {|a,b| -3 }.should == 3
+  end
+
+  it "returns nil when the start point is greater than the endpoint" do
+    (100..10).min {|x,y| x <=> y}.should be_nil
+    ('z'..'l').min {|x,y| x <=> y}.should be_nil
+    (7...7).min {|x,y| x <=> y}.should be_nil
+  end
+
+  it "raises RangeError when called with custom comparison method on an endless range" do
+    -> { eval("(1..)").min {|a, b| a} }.should raise_error(RangeError)
+  end
+end

--- a/spec/core/range/minmax_spec.rb
+++ b/spec/core/range/minmax_spec.rb
@@ -1,0 +1,132 @@
+require_relative '../../spec_helper'
+
+describe 'Range#minmax' do
+  before(:each) do
+    @x = mock('x')
+    @y = mock('y')
+
+    @x.should_receive(:<=>).with(@y).any_number_of_times.and_return(-1) # x < y
+    @x.should_receive(:<=>).with(@x).any_number_of_times.and_return(0) # x == x
+    @y.should_receive(:<=>).with(@x).any_number_of_times.and_return(1) # y > x
+    @y.should_receive(:<=>).with(@y).any_number_of_times.and_return(0) # y == y
+  end
+
+  describe 'on an inclusive range' do
+    it 'should raise RangeError on an endless range without iterating the range' do
+      @x.should_not_receive(:succ)
+
+      range = (@x..)
+
+      -> { range.minmax }.should raise_error(RangeError, 'cannot get the maximum of endless range')
+    end
+
+    it 'raises RangeError or ArgumentError on a beginless range' do
+      range = (..@x)
+
+      -> { range.minmax }.should raise_error(StandardError) { |e|
+        if RangeError === e
+          # error from #min
+          -> { raise e }.should raise_error(RangeError, 'cannot get the minimum of beginless range')
+        else
+          # error from #max
+          -> { raise e }.should raise_error(ArgumentError, 'comparison of NilClass with MockObject failed')
+        end
+      }
+    end
+
+    it 'should return beginning of range if beginning and end are equal without iterating the range' do
+      @x.should_not_receive(:succ)
+
+      (@x..@x).minmax.should == [@x, @x]
+    end
+
+    it 'should return nil pair if beginning is greater than end without iterating the range' do
+      @y.should_not_receive(:succ)
+
+      (@y..@x).minmax.should == [nil, nil]
+    end
+
+    it 'should return the minimum and maximum values for a non-numeric range without iterating the range' do
+      @x.should_not_receive(:succ)
+
+      (@x..@y).minmax.should == [@x, @y]
+    end
+
+    it 'should return the minimum and maximum values for a numeric range' do
+      (1..3).minmax.should == [1, 3]
+    end
+
+    it 'should return the minimum and maximum values for a numeric range without iterating the range' do
+      # We cannot set expectations on integers,
+      # so we "prevent" iteration by picking a value that would iterate until the spec times out.
+      range_end = Float::INFINITY
+
+      (1..range_end).minmax.should == [1, range_end]
+    end
+
+    it 'should return the minimum and maximum values according to the provided block by iterating the range' do
+      @x.should_receive(:succ).once.and_return(@y)
+
+      (@x..@y).minmax { |x, y| - (x <=> y) }.should == [@y, @x]
+    end
+  end
+
+  describe 'on an exclusive range' do
+    it 'should raise RangeError on an endless range' do
+      @x.should_not_receive(:succ)
+      range = (@x...)
+
+      -> { range.minmax }.should raise_error(RangeError, 'cannot get the maximum of endless range')
+    end
+
+    it 'should raise RangeError on a beginless range' do
+      range = (...@x)
+
+      -> { range.minmax }.should raise_error(RangeError,
+        /cannot get the maximum of beginless range with custom comparison method|cannot get the minimum of beginless range/)
+    end
+
+    ruby_bug "#17014", ""..."3.0" do
+      it 'should return nil pair if beginning and end are equal without iterating the range' do
+        @x.should_not_receive(:succ)
+
+        (@x...@x).minmax.should == [nil, nil]
+      end
+
+      it 'should return nil pair if beginning is greater than end without iterating the range' do
+        @y.should_not_receive(:succ)
+
+        (@y...@x).minmax.should == [nil, nil]
+      end
+
+      it 'should return the minimum and maximum values for a non-numeric range by iterating the range' do
+        @x.should_receive(:succ).once.and_return(@y)
+
+        (@x...@y).minmax.should == [@x, @x]
+      end
+    end
+
+    it 'should return the minimum and maximum values for a numeric range' do
+      (1...3).minmax.should == [1, 2]
+    end
+
+    it 'should return the minimum and maximum values for a numeric range without iterating the range' do
+      # We cannot set expectations on integers,
+      # so we "prevent" iteration by picking a value that would iterate until the spec times out.
+      range_end = bignum_value
+
+      (1...range_end).minmax.should == [1, range_end - 1]
+    end
+
+    it 'raises TypeError if the end value is not an integer' do
+      range = (0...Float::INFINITY)
+      -> { range.minmax }.should raise_error(TypeError, 'cannot exclude non Integer end value')
+    end
+
+    it 'should return the minimum and maximum values according to the provided block by iterating the range' do
+      @x.should_receive(:succ).once.and_return(@y)
+
+      (@x...@y).minmax { |x, y| - (x <=> y) }.should == [@x, @x]
+    end
+  end
+end

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -390,6 +390,7 @@ module Enumerable
     has_block = block_given?
     cmp = ->(result) do
       raise ArgumentError, 'bad result from block' unless result.respond_to?(:>)
+      result < 2 # Ruby requires a call to :<?
       result > 0
     end
     if n

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -452,6 +452,7 @@ module Enumerable
     has_block = block_given?
     cmp = ->(result) do
       raise ArgumentError, 'bad result from block' unless result.respond_to?(:<)
+      result > -2 # Ruby requires a call to :>?
       result < 0
     end
     if n

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -16,6 +16,9 @@ Value Env::global_get(SymbolObject *name) {
 }
 
 Value Env::global_set(SymbolObject *name, Value val) {
+    if (val.guarded())
+        TM_UNREACHABLE();
+
     return GlobalEnv::the()->global_set(this, name, val);
 }
 
@@ -226,6 +229,9 @@ Value Env::var_get(const char *key, size_t index) {
 }
 
 Value Env::var_set(const char *name, size_t index, bool allocate, Value val) {
+    if (val.guarded())
+        TM_UNREACHABLE();
+
     size_t needed = index + 1;
     size_t current_size = m_vars ? m_vars->size() : 0;
     if (needed > current_size) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -424,6 +424,9 @@ Value Object::ivar_set(Env *env, SymbolObject *name, Value val) {
     if (!name->is_ivar_name())
         env->raise_name_error(name, "`{}' is not allowed as an instance variable name", name->c_str());
 
+    if (val.guarded())
+        TM_UNREACHABLE();
+
     m_ivars.put(name, val.object(), env);
     return val;
 }

--- a/src/range.rb
+++ b/src/range.rb
@@ -61,6 +61,42 @@ class Range
   end
   alias === cover?
 
+  def max(n = nil)
+    raise RangeError, 'cannot get maximum of endless range' unless self.end
+
+    if block_given?
+      raise RangeError, 'cannot get the maximum of beginless range with custom comparison method' unless self.begin
+
+      return super
+    end
+
+    if n
+      return last(n)
+    end
+
+    # If end is not a numeric and the range excludes it's end, we cannot calculate the max value without iterating
+    if exclude_end? && !self.end.is_a?(Numeric)
+      return super
+    end
+
+    max =
+      if exclude_end?
+        raise TypeError, 'cannot exclude end value with non Integer begin value' unless self.begin
+
+        if self.end.is_a?(Integer)
+          self.end - 1
+        else
+          raise TypeError, 'cannot exclude non Integer end value'
+        end
+      else
+        self.end
+      end
+
+    if !self.begin || max >= self.begin
+      max
+    end
+  end
+
   def size
     return Float::INFINITY if self.begin.nil?
     return unless self.begin.is_a?(Numeric)

--- a/src/range.rb
+++ b/src/range.rb
@@ -97,6 +97,29 @@ class Range
     end
   end
 
+  def min(n = nil)
+    raise RangeError, 'cannot get the minimum of beginless range' unless self.begin
+
+    if block_given?
+      raise RangeError, 'cannot get the minimum of endless range with custom comparison method' unless self.end
+
+      return super
+    end
+
+    if n
+      return first(n)
+    end
+
+    min = first
+    return min if !self.end
+
+    if exclude_end?
+      return min if min < self.end
+    else
+      return min if min <= self.end
+    end
+  end
+
   def size
     return Float::INFINITY if self.begin.nil?
     return unless self.begin.is_a?(Numeric)

--- a/src/range.rb
+++ b/src/range.rb
@@ -62,7 +62,7 @@ class Range
   alias === cover?
 
   def max(n = nil)
-    raise RangeError, 'cannot get maximum of endless range' unless self.end
+    raise RangeError, 'cannot get the maximum of endless range' unless self.end
 
     if block_given?
       raise RangeError, 'cannot get the maximum of beginless range with custom comparison method' unless self.begin
@@ -92,7 +92,7 @@ class Range
         self.end
       end
 
-    if !self.begin || max >= self.begin
+    if !self.begin || (max == self.begin || (self.begin <=> max) == -1)
       max
     end
   end
@@ -116,8 +116,16 @@ class Range
     if exclude_end?
       return min if min < self.end
     else
-      return min if min <= self.end
+      return min if min == self.end || (min <=> self.end) == -1
     end
+  end
+
+  def minmax(&block)
+    if block_given?
+      return super
+    end
+
+    [min, max]
   end
 
   def size

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -44,13 +44,17 @@ Value Value::public_send(Env *env, SymbolObject *name, size_t argc, Value *args,
         if (argc > 0 && args[0].is_fast_integer())
             args[0].guard();
         auto synthesized = IntegerObject { m_integer };
-        return synthesized.public_send(env, name, argc, args, block);
+        auto wrapper = Value { &synthesized };
+        wrapper.guard();
+        return wrapper.public_send(env, name, argc, args, block);
     }
     if (m_type == Type::Double && FloatObject::optimized_method(name)) {
         if (argc > 0 && args[0].is_fast_float())
             args[0].guard();
         auto synthesized = FloatObject { m_double };
-        return synthesized.public_send(env, name, argc, args, block);
+        auto wrapper = Value { &synthesized };
+        wrapper.guard();
+        return wrapper.public_send(env, name, argc, args, block);
     }
 
     return object()->public_send(env, name, argc, args, block);
@@ -62,13 +66,17 @@ Value Value::send(Env *env, SymbolObject *name, size_t argc, Value *args, Block 
         if (argc > 0 && args[0].is_fast_integer())
             args[0].guard();
         auto synthesized = IntegerObject { m_integer };
-        return synthesized.send(env, name, argc, args, block);
+        auto wrapper = Value { &synthesized };
+        wrapper.guard();
+        return wrapper.send(env, name, argc, args, block);
     }
     if (m_type == Type::Double && FloatObject::optimized_method(name)) {
         if (argc > 0 && args[0].is_fast_float())
             args[0].guard();
         auto synthesized = FloatObject { m_double };
-        return synthesized.send(env, name, argc, args, block);
+        auto wrapper = Value { &synthesized };
+        wrapper.guard();
+        return wrapper.send(env, name, argc, args, block);
     }
 
     return object()->send(env, name, argc, args, block);

--- a/test/natalie/range_test.rb
+++ b/test/natalie/range_test.rb
@@ -253,4 +253,31 @@ describe 'range' do
       (..1).include?(10).should == false
     end
   end
+
+  describe 'min' do
+    it 'returns beginning if end and begin are equal' do
+      x = mock('x')
+      (x..x).min.should == x
+    end
+
+    it 'uses <=> to compare end and min' do
+      x = mock('x')
+      x.should_receive(:<=>).and_return(1)
+      (x..2).min.should == nil
+    end
+  end
+
+  describe 'max' do
+    it 'returns end if begin and end are equal' do
+      x = mock('x')
+      (x..x).max.should == x
+    end
+
+    it 'uses <=> to compare begin and max' do
+      x = mock('x')
+      y = mock('y')
+      y.should_receive(:<=>).and_return(1)
+      (y..x).max.should == nil
+    end
+  end
 end

--- a/test/natalie/super_test.rb
+++ b/test/natalie/super_test.rb
@@ -25,6 +25,10 @@ class Greeter
     "Hello, #{name}."
   end
 
+  def greet_by_block_implicitly
+    "Hello, #{yield}."
+  end
+
   def greet_in_rescue
     'Hello.'
   end
@@ -63,6 +67,10 @@ class PirateGreeter < Greeter
 
   def greet_by_name_implicitly(name)
     "ARRRR. #{super}"
+  end
+
+  def greet_by_block_implicitly
+    "ARRR. #{super}"
   end
 
   def greet_in_rescue
@@ -105,6 +113,11 @@ describe 'super' do
   it 'works with implicit args' do
     greeter = PirateGreeter.new
     greeter.greet_by_name_implicitly('Tim').should == 'ARRRR. Hello, Tim.'
+  end
+
+  it 'works with implicit blocks' do
+    greeter = PirateGreeter.new
+    greeter.greet_by_block_implicitly { 'Tim' }.should == 'ARRR. Hello, Tim.'
   end
 
   it 'works with explicit empty args' do

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -833,7 +833,12 @@ class Stub
 
   def validate!
     unless @count_restriction == nil || @count_restriction === @count
-      raise SpecFailedException, "#{@subject.inspect} should have received #{@message}"
+      message = "#{@subject.inspect} should have received ##{@message}"
+      if @count_restriction != nil
+        message << " #{@count_restriction} time(s) but received #{@count} time(s)"
+      end
+
+      raise SpecFailedException, message
     end
   end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1139,8 +1139,9 @@ def run_specs
           end
         end
         $stub_registry.reset
-        context.each { |con| con.before_each.each { |b| b.call } }
         $expectations = []
+        context.each { |con| con.before_each.each { |b| b.call } }
+
         fn.call
 
         $expectations.each { |expectation| expectation.validate! }


### PR DESCRIPTION
This also fixes some issues with our spec library and a bug with implicit block passing for `super`.

[#555]