### PR TITLE
Make Range#to_a spec-compliant

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -55,6 +55,7 @@
 #include "natalie/regexp_object.hpp"
 #include "natalie/sexp_object.hpp"
 #include "natalie/string_object.hpp"
+#include "natalie/string_upto_iterator.hpp"
 #include "natalie/symbol_object.hpp"
 #include "natalie/true_object.hpp"
 #include "natalie/types.hpp"

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -63,6 +63,12 @@ private:
 
     template <typename Function>
     Value iterate_over_range(Env *env, Function &&f);
+
+    template <typename Function>
+    Value iterate_over_string_range(Env *env, Function &&f);
+
+    template <typename Function>
+    Value iterate_over_symbol_range(Env *env, Function &&f);
 };
 
 }

--- a/include/natalie/string_upto_iterator.hpp
+++ b/include/natalie/string_upto_iterator.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "tm/string.hpp"
+
+namespace Natalie {
+class StringUptoIterator {
+public:
+    StringUptoIterator(const TM::String string)
+        : m_string(string) {
+        if (string.contains_only_digits())
+            m_treat_like_integer = true;
+    }
+
+    const TM::String next();
+    const TM::String peek() const;
+
+private:
+    TM::String m_string;
+    bool m_treat_like_integer { false };
+};
+}

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -1169,7 +1169,7 @@ public:
      * assert_str_eq("d000", String("c999").successive());
      * ```
      */
-    String successive() {
+    String successive() const {
         auto result = String { *this };
         assert(m_length > 0);
         size_t index = size() - 1;

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -1145,6 +1145,13 @@ public:
      */
     bool is_empty() const { return m_length == 0; }
 
+    bool contains_only_digits() const {
+        for (size_t i = 0; i < m_length; ++i)
+            if (at(i) < '0' || at(i) > '9')
+                return false;
+        return true;
+    }
+
     /**
      * Returns a new String that is the result of incrementing
      * the last character of this String. If the the last character

--- a/spec/core/range/shared/cover_and_include.rb
+++ b/spec/core/range/shared/cover_and_include.rb
@@ -58,7 +58,9 @@ describe :range_cover_and_include, shared: true do
     (20..30).send(@method, 28).should be_true
     ('e'..'h').send(@method, 'g').should be_true
     # NATFIXME: Implement custom String#succ logic ("\u09B9".succ should be "\u09B6\u09B6")
-    if @method != :include?
+    # After that the iteration should abort because "\u09B6\u09B6".length > "\u{9999}".length
+    # Also this seems to be a ruby/spec bug because there is no expectation set on the expression below?
+    if @method == :cover?
       ("\u{999}".."\u{9999}").send @method, "\u{9995}"
     end
   end

--- a/spec/core/range/to_a_spec.rb
+++ b/spec/core/range/to_a_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../spec_helper'
+
+describe "Range#to_a" do
+  it "converts self to an array" do
+    (-5..5).to_a.should == [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]
+    ('A'..'D').to_a.should == ['A','B','C','D']
+    ('A'...'D').to_a.should == ['A','B','C']
+    (0xfffd...0xffff).to_a.should == [0xfffd,0xfffe]
+    -> { (0.5..2.4).to_a }.should raise_error(TypeError)
+  end
+
+  it "returns empty array for descending-ordered" do
+    (5..-5).to_a.should == []
+    ('D'..'A').to_a.should == []
+    ('D'...'A').to_a.should == []
+    (0xffff...0xfffd).to_a.should == []
+  end
+
+  it "works with Ranges of 64-bit integers" do
+    large = 1 << 40
+    (large..large+1).to_a.should == [1099511627776, 1099511627777]
+  end
+
+  it "works with Ranges of Symbols" do
+    (:A..:z).to_a.size.should == 58
+  end
+
+  it "works for non-ASCII ranges" do
+    ('Σ'..'Ω').to_a.should == ["Σ", "Τ", "Υ", "Φ", "Χ", "Ψ", "Ω"]
+  end
+
+  it "throws an exception for endless ranges" do
+    -> { eval("(1..)").to_a }.should raise_error(RangeError)
+  end
+
+  it "throws an exception for beginless ranges" do
+    -> { (..1).to_a }.should raise_error(TypeError)
+  end
+end

--- a/src/string_upto_iterator.cpp
+++ b/src/string_upto_iterator.cpp
@@ -10,6 +10,7 @@ const TM::String StringUptoIterator::peek() const {
     if (m_treat_like_integer)
         return TM::String((Integer(m_string) + 1).to_nat_int_t());
 
+    // special handling for single characters
     if (m_string == "9")
         return ":";
     else if (m_string == "Z")

--- a/src/string_upto_iterator.cpp
+++ b/src/string_upto_iterator.cpp
@@ -1,0 +1,22 @@
+#include "natalie/string_upto_iterator.hpp"
+#include "natalie/integer.hpp"
+
+namespace Natalie {
+const TM::String StringUptoIterator::next() {
+    return m_string = peek();
+}
+
+const TM::String StringUptoIterator::peek() const {
+    if (m_treat_like_integer)
+        return TM::String((Integer(m_string) + 1).to_nat_int_t());
+
+    if (m_string == "9")
+        return ":";
+    else if (m_string == "Z")
+        return "[";
+    else if (m_string == "z")
+        return "{";
+
+    return m_string.successive();
+}
+}


### PR DESCRIPTION
I don't know about the code-duplication in #iterate_over_string_range and #iterate_over_symbol_range. We could add some kind of macro or maybe there is another idea?

I also was not sure about the location of StringUptoIterator. I decided for a new class but am open to other suggestions. If we decided on the approach we can adjust String#upto to use the iterator as well.

[#555]