### PR TITLE
Fix clang-tidy warnings (and add clang-tidy to CI)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,4 +8,5 @@ Checks: |
   readability-avoid-const-params-in-decls,
   -clang-analyzer-valist.Uninitialized,
   -clang-analyzer-core.CallAndMessage,
+  -readability-braces-around-statements,
 FormatStyle: file

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: git submodule update --init --recursive
+    - run: sudo apt-get install -y -q build-essential autoconf libtool clang lcov ruby-dev
+    - run: sudo gem install bundler --no-doc
+    - run: rake
+    - uses: pajlada/clang-tidy-review@526cbfb043719639f1ebdeedae0cc1eacd219d8f
+      id: review
+    - if: steps.review.outputs.total_comments > 0
+      run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,21 @@
 name: Lint
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  DOCKER_FLAGS: ""
+  CI: 1
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - run: git submodule update --init --recursive
-    - run: sudo apt-get install -y -q build-essential autoconf libtool clang lcov ruby-dev
-    - run: sudo gem install bundler --no-doc
-    - run: rake
-    - uses: pajlada/clang-tidy-review@526cbfb043719639f1ebdeedae0cc1eacd219d8f
-      id: review
-    - if: steps.review.outputs.total_comments > 0
-      run: exit 1
+      - uses: actions/checkout@v1
+      - name: checkout submodules
+        run: git submodule update --init --recursive
+      - name: run clang-tidy
+        run: rake docker_tidy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG IMAGE=ruby:3.0
 FROM $IMAGE
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov clang-tidy python3 python3-pip ccache
+RUN pip3 install compiledb
 RUN gem install bundler --no-doc
 
 ENV LC_ALL C.UTF-8

--- a/Rakefile
+++ b/Rakefile
@@ -131,8 +131,8 @@ task :docker_build_clang do
      '.'
 end
 
-task docker_bash: :docker_build do
-  sh 'docker run -it --rm --entrypoint bash natalie'
+task docker_bash: :docker_build_clang do
+  sh 'docker run -it --rm --entrypoint bash natalie_clang'
 end
 
 task :docker_build_ruby27 do
@@ -152,6 +152,10 @@ end
 # NOTE: this tests that Natalie can be hosted by MRI 2.7 -- not Natalie under Ruby 3 specs
 task docker_test_ruby27: :docker_build_ruby27 do
   sh "docker run -e RUBYOPT=-W:no-experimental #{DOCKER_FLAGS} --rm --entrypoint rake natalie_ruby27 test"
+end
+
+task docker_tidy: :docker_build_clang do
+  sh "docker run #{DOCKER_FLAGS} --rm --entrypoint rake natalie_clang tidy"
 end
 
 # # # # Build Compile Database # # # #
@@ -355,8 +359,7 @@ file "build/libnatalie_parser.#{SO_EXT}" => "build/natalie_parser.#{SO_EXT}" do 
 end
 
 task :tidy_internal do
-  # FIXME: excluding big_int.cpp for now since clang-tidy thinks it has memory leaks (need to check that).
-  sh "clang-tidy --fix #{HEADERS} #{PRIMARY_SOURCES.exclude('src/dtoa.c', 'src/big_int.cpp')}"
+  sh "clang-tidy #{PRIMARY_SOURCES.exclude('src/dtoa.c')}"
 end
 
 task :bundle_install do

--- a/include/natalie/string_upto_iterator.hpp
+++ b/include/natalie/string_upto_iterator.hpp
@@ -11,8 +11,8 @@ public:
             m_treat_like_integer = true;
     }
 
-    const TM::String next();
-    const TM::String peek() const;
+    TM::String next();
+    TM::String peek() const;
 
 private:
     TM::String m_string;

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -229,7 +229,10 @@ public:
      * ```
      */
     String &operator=(const String &other) {
-        set_str(other.c_str(), other.size());
+        if (m_str == other.m_str)
+            m_length = other.m_length;
+        else
+            set_str(other.c_str(), other.size());
         return *this;
     }
 

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -112,6 +112,10 @@ public:
      * ```
      */
     String(size_t length, char c) {
+        if (length == 0) {
+            set_str("", 0);
+            return;
+        }
         char buf[length];
         memset(buf, c, sizeof(char) * length);
         set_str(buf, length);
@@ -481,13 +485,11 @@ public:
      */
     void set_str(const char *str) {
         assert(str);
-        auto old_str = m_str;
         m_length = strlen(str);
         m_capacity = m_length;
+        delete[] m_str;
         m_str = new char[m_length + 1];
         memcpy(m_str, str, sizeof(char) * (m_length + 1));
-        if (old_str)
-            delete[] old_str;
     }
 
     /**
@@ -508,14 +510,12 @@ public:
      */
     void set_str(const char *str, size_t length) {
         assert(str);
-        auto old_str = m_str;
+        delete[] m_str;
         m_str = new char[length + 1];
         memcpy(m_str, str, sizeof(char) * length);
         m_str[length] = 0;
         m_length = length;
         m_capacity = length;
-        if (old_str)
-            delete[] old_str;
     }
 
     /**

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1751,7 +1751,7 @@ Value ArrayObject::find_index(Env *env, Value object, Block *block, bool search_
                 return Value::integer(index);
         } else {
             Value args[] = { item };
-            auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+            auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr); // NOLINT FIXME: Called C++ object pointer is null
             length = static_cast<nat_int_t>(size());
             if (result->is_truthy())
                 return Value::integer(index);

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -332,6 +332,8 @@ double BigInt::to_double() const {
 */
 
 BigInt &BigInt::operator=(const BigInt &num) {
+    if (num == *this) return *this;
+
     value = num.value;
     sign = num.sign;
 
@@ -813,7 +815,9 @@ bool operator>=(const TM::String &lhs, const BigInt &rhs) {
 */
 
 BigInt abs(const BigInt &num) {
-    return num.is_negative() ? -num : num;
+    if (num.is_negative())
+        return -num;
+    return num;
 }
 
 /*
@@ -839,7 +843,9 @@ BigInt pow(const BigInt &base, long long exp) {
     if (exp < 0) {
         // Cannot divide by zero
         assert(base != 0);
-        return abs(base) == 1 ? base : 0;
+        if (abs(base) == 1)
+            return base;
+        return 0;
     }
     if (exp == 0) {
         // Zero cannot be raised to zero

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -47,7 +47,6 @@ EncodingObject *EncodingObject::find(Env *env, Value name) {
 }
 
 ArrayObject *EncodingObject::list(Env *) {
-    Value Encoding = GlobalEnv::the()->Object()->const_fetch("Encoding"_s);
     auto ary = new ArrayObject {};
     for (auto pair : s_encoding_list)
         ary->push(pair.second);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -231,7 +231,7 @@ Value Env::var_set(const char *name, size_t index, bool allocate, Value val) {
             abort();
         }
     }
-    m_vars->at(index) = val;
+    m_vars->at(index) = val; // NOLINT FIXME: Called C++ object pointer is null
     return val;
 }
 

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -292,7 +292,7 @@ Integer Integer::operator<<(const Integer &other) const {
     else if (will_multiplication_overflow(to_nat_int_t(), pow_result.to_nat_int_t()))
         return to_bigint() << other.to_nat_int_t();
 
-    return to_nat_int_t() << other.to_nat_int_t();
+    return to_nat_int_t() << other.to_nat_int_t(); // NOLINT FIXME: The result of the left shift is undefined because the right operand is negative
 }
 
 Integer Integer::operator>>(const Integer &other) const {

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -427,7 +427,9 @@ Integer pow(Integer lhs, Integer rhs) {
         --rhs;
     }
 
-    return negative ? -result : result;
+    if (negative)
+        return -result;
+    return result;
 }
 
 Integer abs(const Integer &other) {

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -382,14 +382,14 @@ void arg_spread(Env *env, Args args, const char *arrangement, ...) {
             optional = true;
             break;
         case 'o': {
-            Object **obj_ptr = va_arg(va_args, Object **);
+            Object **obj_ptr = va_arg(va_args, Object **); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Object *obj = args[arg_index++].object();
             *obj_ptr = obj;
             break;
         }
         case 'i': {
-            int *int_ptr = va_arg(va_args, int *);
+            int *int_ptr = va_arg(va_args, int *); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
             obj->assert_type(env, Object::Type::Integer, "Integer");
@@ -397,7 +397,7 @@ void arg_spread(Env *env, Args args, const char *arrangement, ...) {
             break;
         }
         case 's': {
-            const char **str_ptr = va_arg(va_args, const char **);
+            const char **str_ptr = va_arg(va_args, const char **); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
             if (obj == NilObject::the()) {
@@ -409,14 +409,14 @@ void arg_spread(Env *env, Args args, const char *arrangement, ...) {
             break;
         }
         case 'b': {
-            bool *bool_ptr = va_arg(va_args, bool *);
+            bool *bool_ptr = va_arg(va_args, bool *); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
             *bool_ptr = obj->is_truthy();
             break;
         }
         case 'v': {
-            void **void_ptr = va_arg(va_args, void **);
+            void **void_ptr = va_arg(va_args, void **); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
             obj = obj->ivar_get(env, "@_ptr"_s);

--- a/src/string_upto_iterator.cpp
+++ b/src/string_upto_iterator.cpp
@@ -2,11 +2,11 @@
 #include "natalie/integer.hpp"
 
 namespace Natalie {
-const TM::String StringUptoIterator::next() {
+TM::String StringUptoIterator::next() {
     return m_string = peek();
 }
 
-const TM::String StringUptoIterator::peek() const {
+TM::String StringUptoIterator::peek() const {
     if (m_treat_like_integer)
         return TM::String((Integer(m_string) + 1).to_nat_int_t());
 


### PR DESCRIPTION
I was able to fix a few warnings, and a few of the others I had to ignore for now.

The main point was to get clang-tidy in our CI workflow so that we can catch new bad habits before they land in `master`. 😄 