### PR TITLE
Implement symbolize_names argument for JSON.parse

### DIFF
--- a/lib/json.rb
+++ b/lib/json.rb
@@ -2,9 +2,9 @@ module JSON
   class JSONError < StandardError; end
   class ParserError < JSONError; end
 
-  def self.parse(string)
+  def self.parse(string, **options)
     tokens = Lexer.new(string).tokens
-    Parser.new(tokens).parse
+    Parser.new(tokens, **options).parse
   end
 
   class Lexer
@@ -137,8 +137,9 @@ module JSON
   end
 
   class Parser
-    def initialize(tokens)
+    def initialize(tokens, symbolize_names: false)
       @tokens = tokens
+      @symbolize_names = symbolize_names
     end
 
     def parse
@@ -212,6 +213,7 @@ module JSON
       case token
       when String
         key = token
+        key = key.to_sym if @symbolize_names
         token = @tokens.shift
         raise ParserError, ':' unless token == :':'
         token = @tokens.shift

--- a/test/natalie/json_test.rb
+++ b/test/natalie/json_test.rb
@@ -91,5 +91,12 @@ describe 'JSON' do
         }
       }
     end
+
+    context 'with symbolize_names argument' do
+      it 'returns symbol keys' do
+        JSON.parse('{"foo":"bar"}', symbolize_names: true).should == { foo: 'bar' }
+        JSON.parse('{"1":"foo","2":"bar"}', symbolize_names: true).should == { :'1' => 'foo', :'2' => 'bar' }
+      end
+    end
   end
 end


### PR DESCRIPTION
Useful for compatibility with existing code.