### PR TITLE
Add support for `include_str!` macro

### DIFF
--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -19,6 +19,7 @@ module Natalie
         eval
         nat_ignore_require_relative
         nat_ignore_require
+        include_str!
       ].freeze
 
       def expand
@@ -155,6 +156,18 @@ module Natalie
 
       def macro_nat_ignore_require_relative(expr:, current_path:)
         s(:false) # Script has not been loaded
+      end
+
+      def macro_include_str!(expr:, current_path:)
+        args = expr[3..]
+        node = args.first
+        raise ArgumentError, "Expected a String, but got #{node.inspect}" unless node.sexp_type == :str
+        name = node[1]
+        if (full_path = find_full_path(name, base: File.dirname(current_path), search: false))
+          s(:str, File.read(full_path))
+        else
+          raise IOError, "cannot find file #{name} at #{node.file}##{node.line}"
+        end
       end
 
       def interpret?


### PR DESCRIPTION
Open to feedback on the name of the macro (borrowed the name from Rust since Ruby allows `!` in method names I thought it looked cool), but this is fully functional.

**Usage:**
```rb
html = include_str! './public/index.html'

puts html
```

It will get the contents of the file at compile time (relative to the current file) and include the contents as a string inside of the resulting binary.

**Generated C++:**
<img width="1223" alt="CleanShot 2022-09-01 at 15 14 57@2x" src="https://user-images.githubusercontent.com/41837763/187936141-6c0d9a1a-473f-434f-a1db-73f5bbc940e8.png">
