### PR TITLE
Try to fix Array#bsearch

### DIFF
--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1450,27 +1450,29 @@ Value ArrayObject::bsearch_index(Env *env, Block *block) {
         }
 
         if (outcome->is_numeric()) {
+            // Find-any mode
             auto result = (outcome->is_integer() ? outcome->as_integer()->to_nat_int_t()
                                                  : floor(outcome->as_float()->to_double()));
             if (result == 0) {
                 last_index = i;
                 break;
             }
+
             if (result < 0)
-                --right;
-            ++left;
+                right = i - 1;
+            else
+                left = i + 1;
         } else {
+            // Find-minimum mode
             if (outcome->is_true()) {
                 last_index = i;
-                --right;
+                right = i - 1;
                 continue;
             }
-            if (last_index >= 0) {
-                break;
-            }
-            ++left;
+
+            left = i + 1;
         }
-    } while (left < right);
+    } while (left <= right);
 
     if (last_index < 0)
         return NilObject::the();

--- a/test/natalie/array_test.rb
+++ b/test/natalie/array_test.rb
@@ -1902,4 +1902,10 @@ describe 'array' do
       end
     end
   end
+
+  describe '#bsearch' do
+    it 'should match last element' do
+      [0, 1, 2, 3, 4].bsearch { |x| x == 4 }.should == 4
+    end
+  end
 end


### PR DESCRIPTION
I feel like (correct me if I'm wrong) that the previous implementation
wasn't a binary search. It just moved the window used to determine the
middle of the array by one. However a binary search should continue it's
search in the left/right half of the array. This change also improves
performance of the bsearch method:

```ruby
p (0..100_000).to_a.bsearch { |x| x >= 73 }
```

master:
```
$ time ./find-min
73

real    0m0.524s
user    0m0.513s
sys     0m0.011s
```

with fix:
```
$ time ./find-min-2
73

real    0m0.455s
user    0m0.414s
sys     0m0.041s
```

When measuring the iteration count in the while-loop we can see that it
dropped from 99856 using master to only 17.