### PR TITLE
Make `String#clone` spec compliant

### DIFF
--- a/spec/core/string/clone_spec.rb
+++ b/spec/core/string/clone_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "String#clone" do
+  before :each do
+    ScratchPad.clear
+    @obj = StringSpecs::InitializeString.new "string"
+  end
+
+  it "calls #initialize_copy on the new instance" do
+    clone = @obj.clone
+    ScratchPad.recorded.should_not == @obj.object_id
+    ScratchPad.recorded.should == clone.object_id
+  end
+
+  it "copies instance variables" do
+    clone = @obj.clone
+    clone.ivar.should == 1
+  end
+
+  it "copies singleton methods" do
+    def @obj.special() :the_one end
+    clone = @obj.clone
+    clone.special.should == :the_one
+  end
+
+  it "copies modules included in the singleton class" do
+    class << @obj
+      include StringSpecs::StringModule
+    end
+
+    clone = @obj.clone
+    clone.repr.should == 1
+  end
+
+  it "copies constants defined in the singleton class" do
+    class << @obj
+      CLONE = :clone
+    end
+
+    clone = @obj.clone
+    (class << clone; CLONE; end).should == :clone
+  end
+
+  it "copies frozen state" do
+    @obj.freeze.clone.frozen?.should be_true
+    "".freeze.clone.frozen?.should be_true
+  end
+
+  it "does not modify the original string when changing cloned string" do
+    orig = "string"[0..100]
+    clone = orig.clone
+    orig[0] = 'x'
+    orig.should == "xtring"
+    clone.should == "string"
+  end
+end

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -680,13 +680,19 @@ Value Object::dup(Env *env) {
 
 Value Object::clone(Env *env) {
     auto duplicate = this->dup(env);
-    if (this->is_frozen()) {
-        duplicate->freeze();
-    }
     auto s_class = singleton_class();
     if (s_class) {
         duplicate->set_singleton_class(s_class->clone(env)->as_class());
     }
+    
+    if (duplicate->respond_to(env, "initialize_copy"_s)) {
+        duplicate->send(env, "initialize_copy"_s, { duplicate });
+    }
+
+    if (this->is_frozen()) {
+        duplicate->freeze();
+    }
+
     return duplicate;
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -680,6 +680,9 @@ Value Object::dup(Env *env) {
 
 Value Object::clone(Env *env) {
     auto duplicate = this->dup(env);
+    if (this->is_frozen()) {
+        duplicate->freeze();
+    }
     auto s_class = singleton_class();
     if (s_class) {
         duplicate->set_singleton_class(s_class->clone(env)->as_class());


### PR DESCRIPTION
Related to #217.

This will actually help pass some other specs too that also test the `#clone` method I imagine - I haven't identified them though.