### PR TITLE
Final push for TCPServer.new

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -168,6 +168,7 @@ public:
     VoidPObject *as_void_p();
 
     ArrayObject *as_array_or_raise(Env *);
+    ClassObject *as_class_or_raise(Env *);
     HashObject *as_hash_or_raise(Env *);
     IntegerObject *as_integer_or_raise(Env *);
     StringObject *as_string_or_raise(Env *);

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -349,6 +349,8 @@ class Socket < BasicSocket
     __bind_method__ :unpack_sockaddr_in, :Socket_unpack_sockaddr_in
     __bind_method__ :unpack_sockaddr_un, :Socket_unpack_sockaddr_un
 
+    __bind_method__ :getaddrinfo, :Socket_s_getaddrinfo
+
     __bind_method__ :const_name_to_i, :Socket_const_name_to_i
 
     alias sockaddr_in pack_sockaddr_in

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -10,11 +10,38 @@ class BasicSocket < IO
 
   attr_reader :local_address
 
-  attr_accessor :do_not_reverse_lookup
+  attr_writer :do_not_reverse_lookup
+
+  def do_not_reverse_lookup
+    if @do_not_reverse_lookup.nil?
+      self.class.do_not_reverse_lookup
+    else
+      @do_not_reverse_lookup
+    end
+  end
 
   class << self
     __bind_method__ :for_fd, :BasicSocket_s_for_fd
-    attr_accessor :do_not_reverse_lookup
+
+    def do_not_reverse_lookup
+      case @do_not_reverse_lookup
+      when nil
+        true
+      when false
+        false
+      else
+        true
+      end
+    end
+
+    def do_not_reverse_lookup=(do_not)
+      case do_not
+      when false, nil
+        @do_not_reverse_lookup = false
+      else
+        @do_not_reverse_lookup = true
+      end
+    end
   end
 
   def connect_address

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -10,6 +10,13 @@ class BasicSocket < IO
 
   attr_reader :local_address
 
+  attr_accessor :do_not_reverse_lookup
+
+  class << self
+    __bind_method__ :for_fd, :BasicSocket_s_for_fd
+    attr_accessor :do_not_reverse_lookup
+  end
+
   def connect_address
     addr = local_address
     case addr
@@ -24,7 +31,7 @@ class BasicSocket < IO
 end
 
 class IPSocket < BasicSocket
-
+  __bind_method__ :addr, :IPSocket_addr
 end
 
 class TCPSocket < IPSocket
@@ -32,12 +39,7 @@ class TCPSocket < IPSocket
 end
 
 class TCPServer < TCPSocket
-  def initialize(hostname, port = nil)
-    if port.nil?
-      port = hostname
-      hostname = nil
-    end
-  end
+  __bind_method__ :initialize, :TCPServer_initialize
 end
 
 class Socket < BasicSocket

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -45,15 +45,7 @@ class BasicSocket < IO
   end
 
   def connect_address
-    addr = local_address
-    case addr
-    when '0.0.0.0'
-      '127.0.0.1'
-    when '::'
-      '::1'
-    else
-      addr
-    end
+    local_address
   end
 end
 
@@ -390,8 +382,7 @@ class Socket < BasicSocket
           local_port || port,
           local_host || host,
         )
-        addrinfo = Addrinfo.new(sockaddr, nil, nil, Socket::IPPROTO_TCP)
-        socket.bind(addrinfo)
+        socket.connect(sockaddr)
         if block_given
           begin
             yield socket

--- a/spec/library/socket/ipsocket/addr_spec.rb
+++ b/spec/library/socket/ipsocket/addr_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Socket::IPSocket#addr" do
+  before :each do
+    @do_not_reverse_lookup = BasicSocket.do_not_reverse_lookup
+    @socket = TCPServer.new("127.0.0.1", 0)
+  end
+
+  after :each do
+    @socket.close unless @socket.closed?
+    BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  xit "returns an array with the socket's information" do
+    @socket.do_not_reverse_lookup = false
+    #BasicSocket.do_not_reverse_lookup = false # NATFIXME
+    addrinfo = @socket.addr
+    addrinfo[0].should == "AF_INET"
+    addrinfo[1].should be_kind_of(Integer)
+    addrinfo[2].should == SocketSpecs.hostname
+    addrinfo[3].should == "127.0.0.1"
+  end
+
+  xit "returns an address in the array if do_not_reverse_lookup is true" do
+    @socket.do_not_reverse_lookup = true
+    BasicSocket.do_not_reverse_lookup = true
+    addrinfo = @socket.addr
+    addrinfo[0].should == "AF_INET"
+    addrinfo[1].should be_kind_of(Integer)
+    addrinfo[2].should == "127.0.0.1"
+    addrinfo[3].should == "127.0.0.1"
+  end
+
+  xit "returns an address in the array if passed false" do
+    addrinfo = @socket.addr(false)
+    addrinfo[0].should == "AF_INET"
+    addrinfo[1].should be_kind_of(Integer)
+    addrinfo[2].should == "127.0.0.1"
+    addrinfo[3].should == "127.0.0.1"
+  end
+end
+
+describe 'Socket::IPSocket#addr' do
+  SocketSpecs.each_ip_protocol do |family, ip_address, family_name|
+    before do
+      @server = TCPServer.new(ip_address, 0)
+      @port = @server.connect_address.ip_port
+    end
+
+    after do
+      @server.close
+    end
+
+    describe 'without reverse lookups' do
+      before do
+        @hostname = Socket.getaddrinfo(ip_address, nil)[0][2]
+      end
+
+      xit 'returns an Array containing address information' do
+        @server.addr.should == [family_name, @port, @hostname, ip_address]
+      end
+    end
+
+    describe 'with reverse lookups' do
+      before do
+        @hostname = Socket.getaddrinfo(ip_address, nil, nil, 0, 0, 0, true)[0][2]
+      end
+
+      describe 'using true as the argument' do
+        xit 'returns an Array containing address information' do
+          @server.addr(true).should == [family_name, @port, @hostname, ip_address]
+        end
+      end
+
+      describe 'using :hostname as the argument' do
+        xit 'returns an Array containing address information' do
+          @server.addr(:hostname).should == [family_name, @port, @hostname, ip_address]
+        end
+      end
+
+      describe 'using :cats as the argument' do
+        xit 'raises ArgumentError' do
+          -> { @server.addr(:cats) }.should raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe 'with do_not_reverse_lookup disabled on socket level' do
+      before do
+        @server.do_not_reverse_lookup = false
+
+        @hostname = Socket.getaddrinfo(ip_address, nil, nil, 0, 0, 0, true)[0][2]
+      end
+
+      after do
+        @server.do_not_reverse_lookup = true
+      end
+
+      xit 'returns an Array containing address information' do
+        @server.addr.should == [family_name, @port, @hostname, ip_address]
+      end
+    end
+  end
+end

--- a/spec/library/socket/ipsocket/addr_spec.rb
+++ b/spec/library/socket/ipsocket/addr_spec.rb
@@ -12,9 +12,9 @@ describe "Socket::IPSocket#addr" do
     BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
   end
 
-  xit "returns an array with the socket's information" do
+  it "returns an array with the socket's information" do
     @socket.do_not_reverse_lookup = false
-    #BasicSocket.do_not_reverse_lookup = false # NATFIXME
+    BasicSocket.do_not_reverse_lookup = false
     addrinfo = @socket.addr
     addrinfo[0].should == "AF_INET"
     addrinfo[1].should be_kind_of(Integer)
@@ -22,7 +22,7 @@ describe "Socket::IPSocket#addr" do
     addrinfo[3].should == "127.0.0.1"
   end
 
-  xit "returns an address in the array if do_not_reverse_lookup is true" do
+  it "returns an address in the array if do_not_reverse_lookup is true" do
     @socket.do_not_reverse_lookup = true
     BasicSocket.do_not_reverse_lookup = true
     addrinfo = @socket.addr
@@ -32,7 +32,7 @@ describe "Socket::IPSocket#addr" do
     addrinfo[3].should == "127.0.0.1"
   end
 
-  xit "returns an address in the array if passed false" do
+  it "returns an address in the array if passed false" do
     addrinfo = @socket.addr(false)
     addrinfo[0].should == "AF_INET"
     addrinfo[1].should be_kind_of(Integer)
@@ -57,7 +57,7 @@ describe 'Socket::IPSocket#addr' do
         @hostname = Socket.getaddrinfo(ip_address, nil)[0][2]
       end
 
-      xit 'returns an Array containing address information' do
+      it 'returns an Array containing address information' do
         @server.addr.should == [family_name, @port, @hostname, ip_address]
       end
     end
@@ -68,20 +68,20 @@ describe 'Socket::IPSocket#addr' do
       end
 
       describe 'using true as the argument' do
-        xit 'returns an Array containing address information' do
+        it 'returns an Array containing address information' do
           @server.addr(true).should == [family_name, @port, @hostname, ip_address]
         end
       end
 
       describe 'using :hostname as the argument' do
-        xit 'returns an Array containing address information' do
+        it 'returns an Array containing address information' do
           @server.addr(:hostname).should == [family_name, @port, @hostname, ip_address]
         end
       end
 
       describe 'using :cats as the argument' do
-        xit 'raises ArgumentError' do
-          -> { @server.addr(:cats) }.should raise_error(ArgumentError)
+        it 'raises ArgumentError' do
+          -> { @server.addr(:cats) }.should raise_error(ArgumentError, 'invalid reverse_lookup flag: :cats')
         end
       end
     end
@@ -97,7 +97,7 @@ describe 'Socket::IPSocket#addr' do
         @server.do_not_reverse_lookup = true
       end
 
-      xit 'returns an Array containing address information' do
+      it 'returns an Array containing address information' do
         @server.addr.should == [family_name, @port, @hostname, ip_address]
       end
     end

--- a/spec/library/socket/socket/getaddrinfo_spec.rb
+++ b/spec/library/socket/socket/getaddrinfo_spec.rb
@@ -1,0 +1,373 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Socket.getaddrinfo" do
+  before :each do
+    @do_not_reverse_lookup = BasicSocket.do_not_reverse_lookup
+    BasicSocket.do_not_reverse_lookup = true
+  end
+
+  after :each do
+    BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  platform_is_not :solaris, :windows do
+    xit "gets the address information" do
+      expected = []
+      # The check for AP_INET6's class is needed because ipaddr.rb adds
+      # fake AP_INET6 even in case when IPv6 is not really supported.
+      # Without such check, this test might fail when ipaddr was required
+      # by some other specs.
+      if (Socket.constants.include? 'AF_INET6') &&
+        (Socket::AF_INET6.class != Object) then
+        expected.concat [
+          ['AF_INET6', 9, SocketSpecs.hostname, '::1', Socket::AF_INET6,
+            Socket::SOCK_DGRAM, Socket::IPPROTO_UDP],
+            ['AF_INET6', 9, SocketSpecs.hostname, '::1', Socket::AF_INET6,
+              Socket::SOCK_STREAM, Socket::IPPROTO_TCP],
+              ['AF_INET6', 9, SocketSpecs.hostname, 'fe80::1%lo0', Socket::AF_INET6,
+                Socket::SOCK_DGRAM, Socket::IPPROTO_UDP],
+                ['AF_INET6', 9, SocketSpecs.hostname, 'fe80::1%lo0', Socket::AF_INET6,
+                  Socket::SOCK_STREAM, Socket::IPPROTO_TCP],
+        ]
+      end
+
+      expected.concat [
+        ['AF_INET', 9, SocketSpecs.hostname, '127.0.0.1', Socket::AF_INET,
+          Socket::SOCK_DGRAM, Socket::IPPROTO_UDP],
+          ['AF_INET', 9, SocketSpecs.hostname, '127.0.0.1', Socket::AF_INET,
+            Socket::SOCK_STREAM, Socket::IPPROTO_TCP],
+      ]
+
+      addrinfo = Socket.getaddrinfo SocketSpecs.hostname, 'discard'
+      addrinfo.each do |a|
+        case a.last
+        when Socket::IPPROTO_UDP, Socket::IPPROTO_TCP
+          expected.should include(a)
+        else
+          # don't check this. It's some weird protocol we don't know about
+          # so we can't spec it.
+        end
+      end
+    end
+
+    # #getaddrinfo will return a INADDR_ANY address (0.0.0.0 or "::")
+    # if it's a passive socket. In the case of non-passive
+    # sockets (AI_PASSIVE not set) it should return the loopback
+    # address (127.0.0.1 or "::1").
+
+    xit "accepts empty addresses for IPv4 passive sockets" do
+      res = Socket.getaddrinfo(nil, "discard",
+                               Socket::AF_INET,
+                               Socket::SOCK_STREAM,
+                               Socket::IPPROTO_TCP,
+                               Socket::AI_PASSIVE)
+
+      expected = [["AF_INET", 9, "0.0.0.0", "0.0.0.0", Socket::AF_INET, Socket::SOCK_STREAM, Socket::IPPROTO_TCP]]
+      res.should == expected
+    end
+
+    xit "accepts empty addresses for IPv4 non-passive sockets" do
+      res = Socket.getaddrinfo(nil, "discard",
+                               Socket::AF_INET,
+                               Socket::SOCK_STREAM,
+                               Socket::IPPROTO_TCP,
+                               0)
+
+      expected = [["AF_INET", 9, "127.0.0.1", "127.0.0.1", Socket::AF_INET, Socket::SOCK_STREAM, Socket::IPPROTO_TCP]]
+      res.should == expected
+    end
+
+
+    xit "accepts empty addresses for IPv6 passive sockets" do
+      res = Socket.getaddrinfo(nil, "discard",
+                               Socket::AF_INET6,
+                               Socket::SOCK_STREAM,
+                               Socket::IPPROTO_TCP,
+                               Socket::AI_PASSIVE)
+
+      expected = [
+        ["AF_INET6", 9, "::", "::", Socket::AF_INET6, Socket::SOCK_STREAM, Socket::IPPROTO_TCP],
+        ["AF_INET6", 9, "0:0:0:0:0:0:0:0", "0:0:0:0:0:0:0:0", Socket::AF_INET6, Socket::SOCK_STREAM, Socket::IPPROTO_TCP]
+      ]
+      res.each { |a| expected.should include(a) }
+    end
+
+    xit "accepts empty addresses for IPv6 non-passive sockets" do
+      res = Socket.getaddrinfo(nil, "discard",
+                               Socket::AF_INET6,
+                               Socket::SOCK_STREAM,
+                               Socket::IPPROTO_TCP,
+                               0)
+
+      expected = [
+        ["AF_INET6", 9, "::1", "::1", Socket::AF_INET6, Socket::SOCK_STREAM, Socket::IPPROTO_TCP],
+        ["AF_INET6", 9, "0:0:0:0:0:0:0:1", "0:0:0:0:0:0:0:1", Socket::AF_INET6, Socket::SOCK_STREAM, Socket::IPPROTO_TCP]
+      ]
+      res.each { |a| expected.should include(a) }
+    end
+  end
+end
+
+describe 'Socket.getaddrinfo' do
+  describe 'without global reverse lookups' do
+    xit 'returns an Array' do
+      Socket.getaddrinfo(nil, 'ftp').should be_an_instance_of(Array)
+    end
+
+    xit 'accepts an Integer as the address family' do
+      array = Socket.getaddrinfo(nil, 'ftp', Socket::AF_INET)[0]
+
+      array[0].should == 'AF_INET'
+      array[1].should == 21
+      array[2].should == '127.0.0.1'
+      array[3].should == '127.0.0.1'
+      array[4].should == Socket::AF_INET
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts an Integer as the address family using IPv6' do
+      array = Socket.getaddrinfo(nil, 'ftp', Socket::AF_INET6)[0]
+
+      array[0].should == 'AF_INET6'
+      array[1].should == 21
+      array[2].should == '::1'
+      array[3].should == '::1'
+      array[4].should == Socket::AF_INET6
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts a Symbol as the address family' do
+      array = Socket.getaddrinfo(nil, 'ftp', :INET)[0]
+
+      array[0].should == 'AF_INET'
+      array[1].should == 21
+      array[2].should == '127.0.0.1'
+      array[3].should == '127.0.0.1'
+      array[4].should == Socket::AF_INET
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts a Symbol as the address family using IPv6' do
+      array = Socket.getaddrinfo(nil, 'ftp', :INET6)[0]
+
+      array[0].should == 'AF_INET6'
+      array[1].should == 21
+      array[2].should == '::1'
+      array[3].should == '::1'
+      array[4].should == Socket::AF_INET6
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts a String as the address family' do
+      array = Socket.getaddrinfo(nil, 'ftp', 'INET')[0]
+
+      array[0].should == 'AF_INET'
+      array[1].should == 21
+      array[2].should == '127.0.0.1'
+      array[3].should == '127.0.0.1'
+      array[4].should == Socket::AF_INET
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts a String as the address family using IPv6' do
+      array = Socket.getaddrinfo(nil, 'ftp', 'INET6')[0]
+
+      array[0].should == 'AF_INET6'
+      array[1].should == 21
+      array[2].should == '::1'
+      array[3].should == '::1'
+      array[4].should == Socket::AF_INET6
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts an object responding to #to_str as the host' do
+      dummy = mock(:dummy)
+
+      dummy.stub!(:to_str).and_return('127.0.0.1')
+
+      array = Socket.getaddrinfo(dummy, 'ftp')[0]
+
+      array[0].should == 'AF_INET'
+      array[1].should == 21
+      array[2].should == '127.0.0.1'
+      array[3].should == '127.0.0.1'
+      array[4].should == Socket::AF_INET
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts an object responding to #to_str as the address family' do
+      dummy = mock(:dummy)
+
+      dummy.stub!(:to_str).and_return('INET')
+
+      array = Socket.getaddrinfo(nil, 'ftp', dummy)[0]
+
+      array[0].should == 'AF_INET'
+      array[1].should == 21
+      array[2].should == '127.0.0.1'
+      array[3].should == '127.0.0.1'
+      array[4].should == Socket::AF_INET
+      array[5].should be_kind_of(Integer)
+      array[6].should be_kind_of(Integer)
+    end
+
+    xit 'accepts an Integer as the socket type' do
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, Socket::SOCK_STREAM)[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '127.0.0.1',
+        '127.0.0.1',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+
+    xit 'accepts a Symbol as the socket type' do
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM)[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '127.0.0.1',
+        '127.0.0.1',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+
+    xit 'accepts a String as the socket type' do
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, 'STREAM')[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '127.0.0.1',
+        '127.0.0.1',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+
+    xit 'accepts an object responding to #to_str as the socket type' do
+      dummy = mock(:dummy)
+
+      dummy.stub!(:to_str).and_return('STREAM')
+
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, dummy)[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '127.0.0.1',
+        '127.0.0.1',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+
+    platform_is_not :windows do
+      xit 'accepts an Integer as the protocol family' do
+        *array, proto = Socket.getaddrinfo(nil, 'discard', :INET, :DGRAM, Socket::IPPROTO_UDP)[0]
+        array.should == [
+          'AF_INET',
+          9,
+          '127.0.0.1',
+          '127.0.0.1',
+          Socket::AF_INET,
+          Socket::SOCK_DGRAM,
+        ]
+        [0, Socket::IPPROTO_UDP].should include(proto)
+      end
+    end
+
+    xit 'accepts an Integer as the flags' do
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
+                                Socket::IPPROTO_TCP, Socket::AI_PASSIVE)[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '0.0.0.0',
+        '0.0.0.0',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+
+    xit 'performs a reverse lookup when the reverse_lookup argument is true' do
+      addr = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
+                                Socket::IPPROTO_TCP, 0, true)[0]
+
+      addr[0].should == 'AF_INET'
+      addr[1].should == 21
+
+      addr[2].should be_an_instance_of(String)
+      addr[2].should_not == addr[3]
+
+      addr[3].should == '127.0.0.1'
+    end
+
+    xit 'performs a reverse lookup when the reverse_lookup argument is :hostname' do
+      addr = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
+                                Socket::IPPROTO_TCP, 0, :hostname)[0]
+
+      addr[0].should == 'AF_INET'
+      addr[1].should == 21
+
+      addr[2].should be_an_instance_of(String)
+      addr[2].should_not == addr[3]
+
+      addr[3].should == '127.0.0.1'
+    end
+
+    xit 'performs a reverse lookup when the reverse_lookup argument is :numeric' do
+      *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
+                                Socket::IPPROTO_TCP, 0, :numeric)[0]
+      array.should == [
+        'AF_INET',
+        21,
+        '127.0.0.1',
+        '127.0.0.1',
+        Socket::AF_INET,
+        Socket::SOCK_STREAM,
+      ]
+      [0, Socket::IPPROTO_TCP].should include(proto)
+    end
+  end
+
+  describe 'with global reverse lookups' do
+    before do
+      @do_not_reverse_lookup = BasicSocket.do_not_reverse_lookup
+      BasicSocket.do_not_reverse_lookup = false
+    end
+
+    after do
+      BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
+    end
+
+    xit 'returns an address honoring the global lookup option' do
+      addr = Socket.getaddrinfo(nil, 'ftp', :INET)[0]
+
+      addr[0].should == 'AF_INET'
+      addr[1].should == 21
+
+      # We don't have control over this value and there's no way to test this
+      # without relying on Socket.getaddrinfo()'s own behaviour (meaning this
+      # test would faily any way of the method was not implemented correctly).
+      addr[2].should be_an_instance_of(String)
+      addr[2].should_not == addr[3]
+
+      addr[3].should == '127.0.0.1'
+    end
+  end
+end

--- a/spec/library/socket/socket/getaddrinfo_spec.rb
+++ b/spec/library/socket/socket/getaddrinfo_spec.rb
@@ -12,7 +12,7 @@ describe "Socket.getaddrinfo" do
   end
 
   platform_is_not :solaris, :windows do
-    xit "gets the address information" do
+    it "gets the address information" do
       expected = []
       # The check for AP_INET6's class is needed because ipaddr.rb adds
       # fake AP_INET6 even in case when IPv6 is not really supported.

--- a/spec/library/socket/socket/getaddrinfo_spec.rb
+++ b/spec/library/socket/socket/getaddrinfo_spec.rb
@@ -56,7 +56,7 @@ describe "Socket.getaddrinfo" do
     # sockets (AI_PASSIVE not set) it should return the loopback
     # address (127.0.0.1 or "::1").
 
-    xit "accepts empty addresses for IPv4 passive sockets" do
+    it "accepts empty addresses for IPv4 passive sockets" do
       res = Socket.getaddrinfo(nil, "discard",
                                Socket::AF_INET,
                                Socket::SOCK_STREAM,
@@ -67,7 +67,7 @@ describe "Socket.getaddrinfo" do
       res.should == expected
     end
 
-    xit "accepts empty addresses for IPv4 non-passive sockets" do
+    it "accepts empty addresses for IPv4 non-passive sockets" do
       res = Socket.getaddrinfo(nil, "discard",
                                Socket::AF_INET,
                                Socket::SOCK_STREAM,

--- a/spec/library/socket/socket/getaddrinfo_spec.rb
+++ b/spec/library/socket/socket/getaddrinfo_spec.rb
@@ -79,7 +79,7 @@ describe "Socket.getaddrinfo" do
     end
 
 
-    xit "accepts empty addresses for IPv6 passive sockets" do
+    it "accepts empty addresses for IPv6 passive sockets" do
       res = Socket.getaddrinfo(nil, "discard",
                                Socket::AF_INET6,
                                Socket::SOCK_STREAM,
@@ -93,7 +93,7 @@ describe "Socket.getaddrinfo" do
       res.each { |a| expected.should include(a) }
     end
 
-    xit "accepts empty addresses for IPv6 non-passive sockets" do
+    it "accepts empty addresses for IPv6 non-passive sockets" do
       res = Socket.getaddrinfo(nil, "discard",
                                Socket::AF_INET6,
                                Socket::SOCK_STREAM,
@@ -111,11 +111,11 @@ end
 
 describe 'Socket.getaddrinfo' do
   describe 'without global reverse lookups' do
-    xit 'returns an Array' do
+    it 'returns an Array' do
       Socket.getaddrinfo(nil, 'ftp').should be_an_instance_of(Array)
     end
 
-    xit 'accepts an Integer as the address family' do
+    it 'accepts an Integer as the address family' do
       array = Socket.getaddrinfo(nil, 'ftp', Socket::AF_INET)[0]
 
       array[0].should == 'AF_INET'
@@ -127,7 +127,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts an Integer as the address family using IPv6' do
+    it 'accepts an Integer as the address family using IPv6' do
       array = Socket.getaddrinfo(nil, 'ftp', Socket::AF_INET6)[0]
 
       array[0].should == 'AF_INET6'
@@ -139,7 +139,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts a Symbol as the address family' do
+    it 'accepts a Symbol as the address family' do
       array = Socket.getaddrinfo(nil, 'ftp', :INET)[0]
 
       array[0].should == 'AF_INET'
@@ -151,7 +151,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts a Symbol as the address family using IPv6' do
+    it 'accepts a Symbol as the address family using IPv6' do
       array = Socket.getaddrinfo(nil, 'ftp', :INET6)[0]
 
       array[0].should == 'AF_INET6'
@@ -163,7 +163,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts a String as the address family' do
+    it 'accepts a String as the address family' do
       array = Socket.getaddrinfo(nil, 'ftp', 'INET')[0]
 
       array[0].should == 'AF_INET'
@@ -175,7 +175,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts a String as the address family using IPv6' do
+    it 'accepts a String as the address family using IPv6' do
       array = Socket.getaddrinfo(nil, 'ftp', 'INET6')[0]
 
       array[0].should == 'AF_INET6'
@@ -187,7 +187,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts an object responding to #to_str as the host' do
+    it 'accepts an object responding to #to_str as the host' do
       dummy = mock(:dummy)
 
       dummy.stub!(:to_str).and_return('127.0.0.1')
@@ -203,7 +203,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts an object responding to #to_str as the address family' do
+    it 'accepts an object responding to #to_str as the address family' do
       dummy = mock(:dummy)
 
       dummy.stub!(:to_str).and_return('INET')
@@ -219,7 +219,7 @@ describe 'Socket.getaddrinfo' do
       array[6].should be_kind_of(Integer)
     end
 
-    xit 'accepts an Integer as the socket type' do
+    it 'accepts an Integer as the socket type' do
       *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, Socket::SOCK_STREAM)[0]
       array.should == [
         'AF_INET',
@@ -232,7 +232,7 @@ describe 'Socket.getaddrinfo' do
       [0, Socket::IPPROTO_TCP].should include(proto)
     end
 
-    xit 'accepts a Symbol as the socket type' do
+    it 'accepts a Symbol as the socket type' do
       *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM)[0]
       array.should == [
         'AF_INET',
@@ -245,7 +245,7 @@ describe 'Socket.getaddrinfo' do
       [0, Socket::IPPROTO_TCP].should include(proto)
     end
 
-    xit 'accepts a String as the socket type' do
+    it 'accepts a String as the socket type' do
       *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, 'STREAM')[0]
       array.should == [
         'AF_INET',
@@ -258,7 +258,7 @@ describe 'Socket.getaddrinfo' do
       [0, Socket::IPPROTO_TCP].should include(proto)
     end
 
-    xit 'accepts an object responding to #to_str as the socket type' do
+    it 'accepts an object responding to #to_str as the socket type' do
       dummy = mock(:dummy)
 
       dummy.stub!(:to_str).and_return('STREAM')
@@ -276,7 +276,7 @@ describe 'Socket.getaddrinfo' do
     end
 
     platform_is_not :windows do
-      xit 'accepts an Integer as the protocol family' do
+      it 'accepts an Integer as the protocol family' do
         *array, proto = Socket.getaddrinfo(nil, 'discard', :INET, :DGRAM, Socket::IPPROTO_UDP)[0]
         array.should == [
           'AF_INET',
@@ -290,7 +290,7 @@ describe 'Socket.getaddrinfo' do
       end
     end
 
-    xit 'accepts an Integer as the flags' do
+    it 'accepts an Integer as the flags' do
       *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
                                 Socket::IPPROTO_TCP, Socket::AI_PASSIVE)[0]
       array.should == [
@@ -304,7 +304,7 @@ describe 'Socket.getaddrinfo' do
       [0, Socket::IPPROTO_TCP].should include(proto)
     end
 
-    xit 'performs a reverse lookup when the reverse_lookup argument is true' do
+    it 'performs a reverse lookup when the reverse_lookup argument is true' do
       addr = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
                                 Socket::IPPROTO_TCP, 0, true)[0]
 
@@ -317,7 +317,7 @@ describe 'Socket.getaddrinfo' do
       addr[3].should == '127.0.0.1'
     end
 
-    xit 'performs a reverse lookup when the reverse_lookup argument is :hostname' do
+    it 'performs a reverse lookup when the reverse_lookup argument is :hostname' do
       addr = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
                                 Socket::IPPROTO_TCP, 0, :hostname)[0]
 
@@ -330,7 +330,7 @@ describe 'Socket.getaddrinfo' do
       addr[3].should == '127.0.0.1'
     end
 
-    xit 'performs a reverse lookup when the reverse_lookup argument is :numeric' do
+    it 'performs a reverse lookup when the reverse_lookup argument is :numeric' do
       *array, proto = Socket.getaddrinfo(nil, 'ftp', :INET, :STREAM,
                                 Socket::IPPROTO_TCP, 0, :numeric)[0]
       array.should == [
@@ -355,7 +355,7 @@ describe 'Socket.getaddrinfo' do
       BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
     end
 
-    xit 'returns an address honoring the global lookup option' do
+    it 'returns an address honoring the global lookup option' do
       addr = Socket.getaddrinfo(nil, 'ftp', :INET)[0]
 
       addr[0].should == 'AF_INET'

--- a/spec/library/socket/tcpserver/new_spec.rb
+++ b/spec/library/socket/tcpserver/new_spec.rb
@@ -18,7 +18,7 @@ describe "TCPServer.new" do
     addr[3].should == '127.0.0.1'
   end
 
-  xit "binds to localhost and a port with either IPv4 or IPv6" do
+  it "binds to localhost and a port with either IPv4 or IPv6" do
     @server = TCPServer.new(SocketSpecs.hostname, 0)
     addr = @server.addr
     addr[1].should be_kind_of(Integer)
@@ -31,7 +31,7 @@ describe "TCPServer.new" do
     end
   end
 
-  xit "binds to INADDR_ANY if the hostname is empty" do
+  it "binds to INADDR_ANY if the hostname is empty" do
     @server = TCPServer.new('', 0)
     addr = @server.addr
     addr[0].should == 'AF_INET'
@@ -40,7 +40,7 @@ describe "TCPServer.new" do
     addr[3].should == '0.0.0.0'
   end
 
-  xit "binds to INADDR_ANY if the hostname is empty and the port is a string" do
+  it "binds to INADDR_ANY if the hostname is empty and the port is a string" do
     @server = TCPServer.new('', '0')
     addr = @server.addr
     addr[0].should == 'AF_INET'
@@ -49,6 +49,7 @@ describe "TCPServer.new" do
     addr[3].should == '0.0.0.0'
   end
 
+  # NATFIXME: not sure why addr[2] is returning '127.0.0.1'
   xit "binds to a port if the port is explicitly nil" do
     @server = TCPServer.new('', nil)
     addr = @server.addr
@@ -58,7 +59,7 @@ describe "TCPServer.new" do
     addr[3].should == '0.0.0.0'
   end
 
-  xit "binds to a port if the port is an empty string" do
+  it "binds to a port if the port is an empty string" do
     @server = TCPServer.new('', '')
     addr = @server.addr
     addr[0].should == 'AF_INET'
@@ -67,7 +68,7 @@ describe "TCPServer.new" do
     addr[3].should == '0.0.0.0'
   end
 
-  xit "coerces port to string, then determines port from that number or service name" do
+  it "coerces port to string, then determines port from that number or service name" do
     -> { TCPServer.new(SocketSpecs.hostname, Object.new) }.should raise_error(TypeError)
 
     port = Object.new
@@ -81,13 +82,13 @@ describe "TCPServer.new" do
     # pick such a service port that will be able to reliably bind...
   end
 
-  xit "has a single argument form and treats it as a port number" do
+  it "has a single argument form and treats it as a port number" do
     @server = TCPServer.new(0)
     addr = @server.addr
     addr[1].should be_kind_of(Integer)
   end
 
-  xit "coerces port to a string when it is the only argument" do
+  it "coerces port to a string when it is the only argument" do
     -> { TCPServer.new(Object.new) }.should raise_error(TypeError)
 
     port = Object.new
@@ -98,7 +99,7 @@ describe "TCPServer.new" do
     addr[1].should be_kind_of(Integer)
   end
 
-  xit "raises Errno::EADDRNOTAVAIL when the address is unknown" do
+  it "raises Errno::EADDRNOTAVAIL when the address is unknown" do
     -> { TCPServer.new("1.2.3.4", 0) }.should raise_error(Errno::EADDRNOTAVAIL)
   end
 
@@ -106,14 +107,14 @@ describe "TCPServer.new" do
   # DNS servers like opendns return A records for ANY host, including
   # traditionally invalidly named ones.
   quarantine! do
-    xit "raises a SocketError when the host is unknown" do
+    it "raises a SocketError when the host is unknown" do
       -> {
         TCPServer.new("--notavalidname", 0)
       }.should raise_error(SocketError)
     end
   end
 
-  xit "raises Errno::EADDRINUSE when address is already in use" do
+  it "raises Errno::EADDRINUSE when address is already in use" do
     @server = TCPServer.new('127.0.0.1', 0)
     -> {
       @server = TCPServer.new('127.0.0.1', @server.addr[1])
@@ -123,7 +124,7 @@ describe "TCPServer.new" do
   platform_is_not :windows, :aix do
     # A known bug in AIX.  getsockopt(2) does not properly set
     # the fifth argument for SO_REUSEADDR.
-    xit "sets SO_REUSEADDR on the resulting server" do
+    it "sets SO_REUSEADDR on the resulting server" do
       @server = TCPServer.new('127.0.0.1', 0)
       @server.getsockopt(:SOCKET, :REUSEADDR).data.should_not == "\x00\x00\x00\x00"
       @server.getsockopt(:SOCKET, :REUSEADDR).int.should_not == 0

--- a/spec/library/socket/tcpserver/new_spec.rb
+++ b/spec/library/socket/tcpserver/new_spec.rb
@@ -1,0 +1,132 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "TCPServer.new" do
+  after :each do
+    @server.close if @server && !@server.closed?
+  end
+
+  it "binds to a host and a port" do
+    @server = TCPServer.new('127.0.0.1', 0)
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    # on some platforms (Mac), MRI
+    # returns comma at the end.
+    # FIXME:
+    #addr[2].should =~ /^#{SocketSpecs.hostname}\b/
+    addr[3].should == '127.0.0.1'
+  end
+
+  xit "binds to localhost and a port with either IPv4 or IPv6" do
+    @server = TCPServer.new(SocketSpecs.hostname, 0)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
+    if addr[0] == 'AF_INET'
+      addr[2].should =~ /^#{SocketSpecs.hostname}\b/
+      addr[3].should == '127.0.0.1'
+    else
+      addr[2].should =~ /^#{SocketSpecs.hostname('::1')}\b/
+      addr[3].should == '::1'
+    end
+  end
+
+  xit "binds to INADDR_ANY if the hostname is empty" do
+    @server = TCPServer.new('', 0)
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
+  xit "binds to INADDR_ANY if the hostname is empty and the port is a string" do
+    @server = TCPServer.new('', '0')
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
+  xit "binds to a port if the port is explicitly nil" do
+    @server = TCPServer.new('', nil)
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
+  xit "binds to a port if the port is an empty string" do
+    @server = TCPServer.new('', '')
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
+  xit "coerces port to string, then determines port from that number or service name" do
+    -> { TCPServer.new(SocketSpecs.hostname, Object.new) }.should raise_error(TypeError)
+
+    port = Object.new
+    port.should_receive(:to_str).and_return("0")
+
+    @server = TCPServer.new(SocketSpecs.hostname, port)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
+
+    # TODO: This should also accept strings like 'https', but I don't know how to
+    # pick such a service port that will be able to reliably bind...
+  end
+
+  xit "has a single argument form and treats it as a port number" do
+    @server = TCPServer.new(0)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
+  end
+
+  xit "coerces port to a string when it is the only argument" do
+    -> { TCPServer.new(Object.new) }.should raise_error(TypeError)
+
+    port = Object.new
+    port.should_receive(:to_str).and_return("0")
+
+    @server = TCPServer.new(port)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
+  end
+
+  xit "raises Errno::EADDRNOTAVAIL when the address is unknown" do
+    -> { TCPServer.new("1.2.3.4", 0) }.should raise_error(Errno::EADDRNOTAVAIL)
+  end
+
+  # There is no way to make this fail-proof on all machines, because
+  # DNS servers like opendns return A records for ANY host, including
+  # traditionally invalidly named ones.
+  quarantine! do
+    xit "raises a SocketError when the host is unknown" do
+      -> {
+        TCPServer.new("--notavalidname", 0)
+      }.should raise_error(SocketError)
+    end
+  end
+
+  xit "raises Errno::EADDRINUSE when address is already in use" do
+    @server = TCPServer.new('127.0.0.1', 0)
+    -> {
+      @server = TCPServer.new('127.0.0.1', @server.addr[1])
+    }.should raise_error(Errno::EADDRINUSE)
+  end
+
+  platform_is_not :windows, :aix do
+    # A known bug in AIX.  getsockopt(2) does not properly set
+    # the fifth argument for SO_REUSEADDR.
+    xit "sets SO_REUSEADDR on the resulting server" do
+      @server = TCPServer.new('127.0.0.1', 0)
+      @server.getsockopt(:SOCKET, :REUSEADDR).data.should_not == "\x00\x00\x00\x00"
+      @server.getsockopt(:SOCKET, :REUSEADDR).int.should_not == 0
+    end
+  end
+end

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -299,6 +299,12 @@ ArrayObject *Object::as_array_or_raise(Env *env) {
     return static_cast<ArrayObject *>(this);
 }
 
+ClassObject *Object::as_class_or_raise(Env *env) {
+    if (!is_class())
+        env->raise("TypeError", "{} can't be coerced into Class", m_klass->inspect_str());
+    return static_cast<ClassObject *>(this);
+}
+
 HashObject *Object::as_hash_or_raise(Env *env) {
     if (!is_hash())
         env->raise("TypeError", "{} can't be coerced into Hash", m_klass->inspect_str());


### PR DESCRIPTION
This is one of the last few steps for getting a working TCPServer in #598. After this, I think we just need `Socket#accept`.

I cannot easily break this work into smaller pieces, so I'm pushing this up to a branch and will chip away at it as I have time

TODO:
- [x] (1) `socket/getaddrinfo_spec.rb` (needed by tcpserver/new_spec)
- [x] (2) `ipsocket/addr_spec.rb` (needed by tcpserver/new_spec)
- [ ] (3) `tcpserver/new_spec.rb`