### PR TITLE
Implement Range#step and Range#%

### DIFF
--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -15,8 +15,8 @@ public:
     ArithmeticSequenceObject()
         : ArithmeticSequenceObject { GlobalEnv::the()->Object()->const_fetch("Enumerator"_s)->const_fetch("ArithmeticSequence"_s)->as_class() } { }
 
-    static ArithmeticSequenceObject *from_range(Env *env, Value begin, Value end, Value step, bool exclude_end) {
-        return new ArithmeticSequenceObject { env, Origin::Range, begin, end, step, exclude_end };
+    static ArithmeticSequenceObject *from_range(Env *env, const TM::String &origin_method, Value begin, Value end, Value step, bool exclude_end) {
+        return new ArithmeticSequenceObject { env, Origin::Range, origin_method, begin, end, step, exclude_end };
     }
 
     static ArithmeticSequenceObject *from_numeric(Env *env, Value begin, Value end, Value step) {
@@ -57,6 +57,7 @@ private:
     };
 
     ArithmeticSequenceObject(Env *, Origin, Value, Value, Value, bool);
+    ArithmeticSequenceObject(Env *, Origin, const TM::String &, Value, Value, Value, bool);
     static Value enum_block(Env *, Value, Args, Block *);
 
     bool ascending(Env *env) {
@@ -75,6 +76,7 @@ private:
     Value maybe_to_f(Env *, Value);
 
     Origin m_origin;
+    TM::String m_range_origin_method {};
     Value m_begin { nullptr };
     Value m_end { nullptr };
     Value m_step { nullptr };

--- a/include/natalie/natalie_parser/natalie_creator.hpp
+++ b/include/natalie/natalie_parser/natalie_creator.hpp
@@ -64,7 +64,7 @@ public:
     }
 
     virtual void append_range(long long first, long long last, bool exclude_end) override {
-        m_sexp->push(new RangeObject(Value::integer(first), Value::integer(last), exclude_end));
+        m_sexp->push(RangeObject::create(m_env, Value::integer(first), Value::integer(last), exclude_end));
     }
 
     virtual void append_regexp(TM::String &pattern, int options) override {

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -37,7 +37,7 @@ public:
     bool eql(Env *, Value);
     bool include(Env *, Value);
     Value bsearch(Env *, Block *);
-    Value step(Env *, Value);
+    Value step(Env *, Value, Block *);
 
     static Value size_fn(Env *env, Value self, Args, Block *) {
         return Value::integer(self->as_range()->to_a(env)->as_array()->size());

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -19,13 +19,7 @@ public:
     RangeObject(ClassObject *klass)
         : Object { Object::Type::Range, klass } { }
 
-    RangeObject(Value begin, Value end, bool exclude_end)
-        : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s)->as_class() }
-        , m_begin { begin }
-        , m_end { end }
-        , m_exclude_end { exclude_end } {
-        freeze();
-    }
+    static RangeObject *create(Env *, Value, Value, bool);
 
     Value begin() { return m_begin; }
     Value end() { return m_end; }
@@ -62,6 +56,14 @@ public:
     }
 
 private:
+    RangeObject(Value begin, Value end, bool exclude_end)
+        : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s)->as_class() }
+        , m_begin { begin }
+        , m_end { end }
+        , m_exclude_end { exclude_end } { }
+
+    static void assert_no_bad_value(Env *, Value, Value);
+
     Value m_begin { nullptr };
     Value m_end { nullptr };
     bool m_exclude_end { false };

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -816,7 +816,7 @@ gen.binding('Range', 'initialize', 'RangeObject', 'initialize', argc: 2..3, pass
 gen.binding('Range', 'inspect', 'RangeObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Range', 'last', 'RangeObject', 'last', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Range', 'member?', 'RangeObject', 'include', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
-gen.binding('Range', 'step', 'RangeObject', 'step', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Range', 'step', 'RangeObject', 'step', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Range', 'to_a', 'RangeObject', 'to_a', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Range', 'to_s', 'RangeObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -803,6 +803,7 @@ gen.binding('Random', 'initialize', 'RandomObject', 'initialize', argc: 0..1, pa
 gen.binding('Random', 'rand', 'RandomObject', 'rand', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Random', 'seed', 'RandomObject', 'seed', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 
+gen.binding('Range', '%', 'RangeObject', 'step', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Range', '==', 'RangeObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Range', 'begin', 'RangeObject', 'begin', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Range', 'bsearch', 'RangeObject', 'bsearch', argc: 0, pass_env: true, pass_block: true, return_type: :Object)

--- a/lib/natalie/compiler/instructions/push_range_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_range_instruction.rb
@@ -16,7 +16,7 @@ module Natalie
       def generate(transform)
         beginning = transform.pop
         ending = transform.pop
-        transform.exec_and_push(:range, "Value(new RangeObject(#{beginning}, #{ending}, #{@exclude_end}))")
+        transform.exec_and_push(:range, "Value(RangeObject::create(env, #{beginning}, #{ending}, #{@exclude_end}))")
       end
 
       def execute(vm)

--- a/spec/core/range/percent_spec.rb
+++ b/spec/core/range/percent_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+
+describe "Range#%" do
+  it "works as a Range#step" do
+    aseq = (1..10) % 2
+    aseq.class.should == Enumerator::ArithmeticSequence
+    aseq.begin.should == 1
+    aseq.end.should == 10
+    aseq.step.should == 2
+    aseq.to_a.should == [1, 3, 5, 7, 9]
+  end
+
+  it "produces an arithmetic sequence with a percent sign in #inspect" do
+    ((1..10) % 2).inspect.should == "((1..10).%(2))"
+  end
+end

--- a/spec/core/range/step_spec.rb
+++ b/spec/core/range/step_spec.rb
@@ -1,0 +1,514 @@
+require_relative '../../spec_helper'
+
+describe "Range#step" do
+  before :each do
+    ScratchPad.record []
+  end
+
+  it "returns self" do
+    r = 1..2
+    r.step { }.should equal(r)
+  end
+
+  it "raises TypeError if step" do
+    obj = mock("mock")
+    -> { (1..10).step(obj) { } }.should raise_error(TypeError)
+  end
+
+  it "calls #to_int to coerce step to an Integer" do
+    obj = mock("Range#step")
+    obj.should_receive(:to_int).and_return(1)
+
+    (1..2).step(obj) { |x| ScratchPad << x }
+    ScratchPad.recorded.should eql([1, 2])
+  end
+
+  it "raises a TypeError if step does not respond to #to_int" do
+    obj = mock("Range#step non-integer")
+
+    -> { (1..2).step(obj) { } }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    obj = mock("Range#step non-integer")
+    obj.should_receive(:to_int).and_return("1")
+
+    -> { (1..2).step(obj) { } }.should raise_error(TypeError)
+  end
+
+  it "coerces the argument to integer by invoking to_int" do
+    (obj = mock("2")).should_receive(:to_int).and_return(2)
+    res = []
+    (1..10).step(obj) {|x| res << x}
+    res.should == [1, 3, 5, 7, 9]
+  end
+
+  it "raises a TypeError if the first element does not respond to #succ" do
+    obj = mock("Range#step non-comparable")
+    obj.should_receive(:<=>).with(obj).and_return(1)
+
+    -> { (obj..obj).step { |x| x } }.should raise_error(TypeError)
+  end
+
+  it "raises an ArgumentError if step is 0" do
+    -> { (-1..1).step(0) { |x| x } }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if step is 0.0" do
+    -> { (-1..1).step(0.0) { |x| x } }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if step is negative" do
+    -> { (-1..1).step(-2) { |x| x } }.should raise_error(ArgumentError)
+  end
+
+  describe "with inclusive end" do
+    describe "and Integer values" do
+      it "yields Integer values incremented by 1 and less than or equal to end when not passed a step" do
+        (-2..2).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2, -1, 0, 1, 2])
+      end
+
+      it "yields Integer values incremented by an Integer step" do
+        (-5..5).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5, -3, -1, 1, 3, 5])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-2..2).step(1.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -0.5, 1.0])
+      end
+    end
+
+    describe "and Float values" do
+      it "yields Float values incremented by 1 and less than or equal to end when not passed a step" do
+        (-2.0..2.0).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0, 2.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5.0..5.0).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0, 5.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-1.0..1.0).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5, 1.0])
+      end
+
+      it "returns Float values of 'step * n + begin <= end'" do
+        (1.0..6.4).step(1.8) { |x| ScratchPad << x }
+        (1.0..12.7).step(1.3) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([1.0, 2.8, 4.6, 6.4, 1.0, 2.3, 3.6,
+                                       4.9, 6.2, 7.5, 8.8, 10.1, 11.4, 12.7])
+      end
+
+      it "handles infinite values at either end" do
+        (-Float::INFINITY..0.0).step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([-Float::INFINITY, -Float::INFINITY, -Float::INFINITY])
+
+        ScratchPad.record []
+        (0.0..Float::INFINITY).step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([0.0, 2.0, 4.0])
+      end
+    end
+
+    describe "and Integer, Float values" do
+      it "yields Float values incremented by 1 and less than or equal to end when not passed a step" do
+        (-2..2.0).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0, 2.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5..5.0).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0, 5.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-1..1.0).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5, 1.0])
+      end
+    end
+
+    describe "and Float, Integer values" do
+      it "yields Float values incremented by 1 and less than or equal to end when not passed a step" do
+        (-2.0..2).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0, 2.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5.0..5).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0, 5.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-1.0..1).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5, 1.0])
+      end
+    end
+
+    describe "and String values" do
+      it "yields String values incremented by #succ and less than or equal to end when not passed a step" do
+        ("A".."E").step { |x| ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "B", "C", "D", "E"]
+      end
+
+      it "yields String values incremented by #succ called Integer step times" do
+        ("A".."G").step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "C", "E", "G"]
+      end
+
+      it "raises a TypeError when passed a Float step" do
+        -> { ("A".."G").step(2.0) { } }.should raise_error(TypeError)
+      end
+
+      it "calls #succ on begin and each element returned by #succ" do
+        obj = mock("Range#step String start")
+        obj.should_receive(:<=>).exactly(3).times.and_return(-1, -1, -1, 0)
+        obj.should_receive(:succ).exactly(2).times.and_return(obj)
+
+        (obj..obj).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should == [obj, obj, obj]
+      end
+    end
+  end
+
+  describe "with exclusive end" do
+    describe "and Integer values" do
+      it "yields Integer values incremented by 1 and less than end when not passed a step" do
+        (-2...2).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2, -1, 0, 1])
+      end
+
+      it "yields Integer values incremented by an Integer step" do
+        (-5...5).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5, -3, -1, 1, 3])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-2...2).step(1.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -0.5, 1.0])
+      end
+    end
+
+    describe "and Float values" do
+      it "yields Float values incremented by 1 and less than end when not passed a step" do
+        (-2.0...2.0).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5.0...5.0).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-1.0...1.0).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5])
+      end
+
+      it "returns Float values of 'step * n + begin < end'" do
+        (1.0...6.4).step(1.8) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([1.0, 2.8, 4.6])
+      end
+
+      ruby_version_is '3.1' do
+        it "correctly handles values near the upper limit" do # https://bugs.ruby-lang.org/issues/16612
+          (1.0...55.6).step(18.2) { |x| ScratchPad << x }
+          ScratchPad.recorded.should eql([1.0, 19.2, 37.4, 55.599999999999994])
+
+          (1.0...55.6).step(18.2).size.should == 4
+        end
+      end
+
+      it "handles infinite values at either end" do
+        (-Float::INFINITY...0.0).step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([-Float::INFINITY, -Float::INFINITY, -Float::INFINITY])
+
+        ScratchPad.record []
+        (0.0...Float::INFINITY).step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([0.0, 2.0, 4.0])
+      end
+    end
+
+    describe "and Integer, Float values" do
+      it "yields Float values incremented by 1 and less than end when not passed a step" do
+        (-2...2.0).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5...5.0).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0])
+      end
+
+      it "yields an Float and then Float values incremented by a Float step" do
+        (-1...1.0).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5])
+      end
+    end
+
+    describe "and Float, Integer values" do
+      it "yields Float values incremented by 1 and less than end when not passed a step" do
+        (-2.0...2).step { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        (-5.0...5).step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        (-1.0...1).step(0.5) { |x| ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5])
+      end
+    end
+
+    describe "and String values" do
+      it "yields String values incremented by #succ and less than or equal to end when not passed a step" do
+        ("A"..."E").step { |x| ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "B", "C", "D"]
+      end
+
+      it "yields String values incremented by #succ called Integer step times" do
+        ("A"..."G").step(2) { |x| ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "C", "E"]
+      end
+
+      it "raises a TypeError when passed a Float step" do
+        -> { ("A"..."G").step(2.0) { } }.should raise_error(TypeError)
+      end
+    end
+  end
+
+  describe "with an endless range" do
+    describe "and Integer values" do
+      it "yield Integer values incremented by 1 when not passed a step" do
+        eval("(-2..)").step { |x| break if x > 2; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2, -1, 0, 1, 2])
+
+        ScratchPad.record []
+        eval("(-2...)").step { |x| break if x > 2; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2, -1, 0, 1, 2])
+      end
+
+      it "yields Integer values incremented by an Integer step" do
+        eval("(-5..)").step(2) { |x| break if x > 3; ScratchPad << x }
+        ScratchPad.recorded.should eql([-5, -3, -1, 1, 3])
+
+        ScratchPad.record []
+        eval("(-5...)").step(2) { |x| break if x > 3; ScratchPad << x }
+        ScratchPad.recorded.should eql([-5, -3, -1, 1, 3])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        eval("(-2..)").step(1.5) { |x| break if x > 1.0; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -0.5, 1.0])
+
+        ScratchPad.record []
+        eval("(-2..)").step(1.5) { |x| break if x > 1.0; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -0.5, 1.0])
+      end
+    end
+
+    describe "and Float values" do
+      it "yields Float values incremented by 1 and less than end when not passed a step" do
+        eval("(-2.0..)").step { |x| break if x > 1.5; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0])
+
+        ScratchPad.record []
+        eval("(-2.0...)").step { |x| break if x > 1.5; ScratchPad << x }
+        ScratchPad.recorded.should eql([-2.0, -1.0, 0.0, 1.0])
+      end
+
+      it "yields Float values incremented by an Integer step" do
+        eval("(-5.0..)").step(2) { |x| break if x > 3.5; ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0])
+
+        ScratchPad.record []
+        eval("(-5.0...)").step(2) { |x| break if x > 3.5; ScratchPad << x }
+        ScratchPad.recorded.should eql([-5.0, -3.0, -1.0, 1.0, 3.0])
+      end
+
+      it "yields Float values incremented by a Float step" do
+        eval("(-1.0..)").step(0.5) { |x| break if x > 0.6; ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5])
+
+        ScratchPad.record []
+        eval("(-1.0...)").step(0.5) { |x| break if x > 0.6; ScratchPad << x }
+        ScratchPad.recorded.should eql([-1.0, -0.5, 0.0, 0.5])
+      end
+
+      it "handles infinite values at the start" do
+        eval("(-Float::INFINITY..)").step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([-Float::INFINITY, -Float::INFINITY, -Float::INFINITY])
+
+        ScratchPad.record []
+        eval("(-Float::INFINITY...)").step(2) { |x| ScratchPad << x; break if ScratchPad.recorded.size == 3 }
+        ScratchPad.recorded.should eql([-Float::INFINITY, -Float::INFINITY, -Float::INFINITY])
+      end
+    end
+
+    describe "and String values" do
+      it "yields String values incremented by #succ and less than or equal to end when not passed a step" do
+        eval("('A'..)").step { |x| break if x > "D"; ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "B", "C", "D"]
+
+        ScratchPad.record []
+        eval("('A'...)").step { |x| break if x > "D"; ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "B", "C", "D"]
+      end
+
+      it "yields String values incremented by #succ called Integer step times" do
+        eval("('A'..)").step(2) { |x| break if x > "F"; ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "C", "E"]
+
+        ScratchPad.record []
+        eval("('A'...)").step(2) { |x| break if x > "F"; ScratchPad << x }
+        ScratchPad.recorded.should == ["A", "C", "E"]
+      end
+
+      it "raises a TypeError when passed a Float step" do
+        -> { eval("('A'..)").step(2.0) { } }.should raise_error(TypeError)
+        -> { eval("('A'...)").step(2.0) { } }.should raise_error(TypeError)
+      end
+    end
+  end
+
+  describe "when no block is given" do
+    ruby_version_is "3.0" do
+      it "raises an ArgumentError if step is 0" do
+        -> { (-1..1).step(0) }.should raise_error(ArgumentError)
+      end
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        ruby_version_is ""..."3.0" do
+          it "raises a TypeError if step does not respond to #to_int" do
+            obj = mock("Range#step non-integer")
+            enum = (1..2).step(obj)
+            -> { enum.size }.should raise_error(TypeError)
+          end
+
+          it "raises a TypeError if #to_int does not return an Integer" do
+            obj = mock("Range#step non-integer")
+            obj.should_receive(:to_int).and_return("1")
+            enum = (1..2).step(obj)
+
+            -> { enum.size }.should raise_error(TypeError)
+          end
+        end
+
+        ruby_version_is "3.0" do
+          it "raises a TypeError if step does not respond to #to_int" do
+            obj = mock("Range#step non-integer")
+            -> { (1..2).step(obj) }.should raise_error(TypeError)
+          end
+
+          it "raises a TypeError if #to_int does not return an Integer" do
+            obj = mock("Range#step non-integer")
+            obj.should_receive(:to_int).and_return("1")
+            -> { (1..2).step(obj) }.should raise_error(TypeError)
+          end
+        end
+
+        ruby_version_is ""..."3.0" do
+          it "returns Float::INFINITY for zero step" do
+            (-1..1).step(0).size.should == Float::INFINITY
+            (-1..1).step(0.0).size.should == Float::INFINITY
+          end
+        end
+
+        it "returns the ceil of range size divided by the number of steps" do
+          (1..10).step(4).size.should == 3
+          (1..10).step(3).size.should == 4
+          (1..10).step(2).size.should == 5
+          (1..10).step(1).size.should == 10
+          (-5..5).step(2).size.should == 6
+          (1...10).step(4).size.should == 3
+          (1...10).step(3).size.should == 3
+          (1...10).step(2).size.should == 5
+          (1...10).step(1).size.should == 9
+          (-5...5).step(2).size.should == 5
+        end
+
+        it "returns the ceil of range size divided by the number of steps even if step is negative" do
+          (-1..1).step(-1).size.should == 0
+          (1..-1).step(-1).size.should == 3
+        end
+
+        it "returns the correct number of steps when one of the arguments is a float" do
+          (-1..1.0).step(0.5).size.should == 5
+          (-1.0...1.0).step(0.5).size.should == 4
+        end
+
+        it "returns the range size when there's no step_size" do
+          (-2..2).step.size.should == 5
+          (-2.0..2.0).step.size.should == 5
+          (-2..2.0).step.size.should == 5
+          (-2.0..2).step.size.should == 5
+          (1.0..6.4).step(1.8).size.should == 4
+          (1.0..12.7).step(1.3).size.should == 10
+          (-2...2).step.size.should == 4
+          (-2.0...2.0).step.size.should == 4
+          (-2...2.0).step.size.should == 4
+          (-2.0...2).step.size.should == 4
+          (1.0...6.4).step(1.8).size.should == 3
+        end
+
+        it "returns nil with begin and end are String" do
+          ("A".."E").step(2).size.should == nil
+          ("A"..."E").step(2).size.should == nil
+          ("A".."E").step.size.should == nil
+          ("A"..."E").step.size.should == nil
+        end
+
+        it "return nil and not raises a TypeError if the first element does not respond to #succ" do
+          obj = mock("Range#step non-comparable")
+          obj.should_receive(:<=>).with(obj).and_return(1)
+          enum = (obj..obj).step
+          -> { enum.size }.should_not raise_error
+          enum.size.should == nil
+        end
+      end
+
+      describe "type" do
+        context "when both begin and end are numerics" do
+          it "returns an instance of Enumerator::ArithmeticSequence" do
+            (1..10).step.class.should == Enumerator::ArithmeticSequence
+          end
+        end
+
+        context "when begin is not defined and end is numeric" do
+          it "returns an instance of Enumerator::ArithmeticSequence" do
+            (..10).step.class.should == Enumerator::ArithmeticSequence
+          end
+        end
+
+        context "when range is endless" do
+          it "returns an instance of Enumerator::ArithmeticSequence when begin is numeric" do
+            (1..).step.class.should == Enumerator::ArithmeticSequence
+          end
+
+          it "returns an instance of Enumerator when begin is not numeric" do
+            ("a"..).step.class.should == Enumerator
+          end
+        end
+
+        context "when range is beginless and endless" do
+          it "returns an instance of Enumerator" do
+            Range.new(nil, nil).step.class.should == Enumerator
+          end
+        end
+
+        context "when begin and end are not numerics" do
+          it "returns an instance of Enumerator" do
+            ("a".."z").step.class.should == Enumerator
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -155,7 +155,7 @@ Value ArithmeticSequenceObject::hash(Env *env) {
 Value ArithmeticSequenceObject::inspect(Env *env) {
     switch (m_origin) {
     case Origin::Range: {
-        auto range_inspect = RangeObject(m_begin, m_end, m_exclude_end).inspect_str(env);
+        auto range_inspect = RangeObject::create(env, m_begin, m_end, m_exclude_end)->inspect_str(env);
         auto string = StringObject::format("(({}).step", range_inspect);
 
         if (has_step()) {

--- a/src/range.rb
+++ b/src/range.rb
@@ -42,13 +42,6 @@ class Range
 
     result = true
 
-    if self.end && self.begin
-      compare_result = self.begin <=> self.end
-      if !compare_result || compare_result == 1 || (exclude_end? && compare_result == 0)
-        return false
-      end
-    end
-
     if self.begin
       result &&= greater_than_begin.()
     end

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -349,7 +349,7 @@ Value RangeObject::step(Env *env, Value n, Block *block) {
     if (m_begin->is_numeric() || m_end->is_numeric()) {
         auto begin = m_begin;
         auto end = m_end;
-        auto enumerator = Enumerator::ArithmeticSequenceObject::from_range(env, m_begin, m_end, n, m_exclude_end);
+        auto enumerator = Enumerator::ArithmeticSequenceObject::from_range(env, env->current_method()->name(), m_begin, m_end, n, m_exclude_end);
 
         if (block) {
             if (enumerator->step().send(env, "<"_s, { Value::integer(0) })->is_true())

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -3,11 +3,22 @@
 
 namespace Natalie {
 
+RangeObject *RangeObject::create(Env *env, Value begin, Value end, bool exclude_end) {
+    assert_no_bad_value(env, begin, end);
+    auto range = new RangeObject(begin, end, exclude_end);
+    range->freeze();
+    return range;
+}
+
+void RangeObject::assert_no_bad_value(Env *env, Value begin, Value end) {
+    if (!begin->is_nil() && !end->is_nil() && begin->send(env, "<=>"_s, { end })->is_nil())
+        env->raise("ArgumentError", "bad value for range");
+}
+
 Value RangeObject::initialize(Env *env, Value begin, Value end, Value exclude_end_value) {
     assert_not_frozen(env);
 
-    if (!begin->is_nil() && !end->is_nil() && begin->send(env, "<=>"_s, { end })->is_nil())
-        env->raise("ArgumentError", "bad value for range");
+    assert_no_bad_value(env, begin, end);
 
     m_begin = begin;
     m_end = end;
@@ -21,16 +32,9 @@ template <typename Function>
 Value RangeObject::iterate_over_range(Env *env, Function &&func) {
     Value item = m_begin;
 
-    // According to the spec, this call MUST happen before the #succ check.
-    // See core/range/each_spec.rb "raises a TypeError if the first element does not respond to #succ"
-    auto compare_result = item.send(env, "<=>"_s, { m_end });
-
     auto succ = "succ"_s;
     if (!m_begin->respond_to(env, succ))
         env->raise("TypeError", "can't iterate from {}", m_begin->klass()->inspect_str());
-
-    if (compare_result->equal(Value::integer(1)))
-        return nullptr;
 
     if (m_begin->is_string() && m_end->is_string())
         return iterate_over_string_range(env, func);
@@ -41,6 +45,15 @@ Value RangeObject::iterate_over_range(Env *env, Function &&func) {
     // If we exclude the end, the loop should not be entered if m_begin (item) == m_end.
     bool done = m_exclude_end ? item.send(env, "=="_s, { m_end })->is_truthy() : false;
     while (!done) {
+        if (!m_end->is_nil()) {
+            auto compare_result = item.send(env, cmp, { m_end })->to_int(env)->integer();
+            // We are done if we reached the end element.
+            done = compare_result == 0;
+            // If we exclude the end we break instantly, otherwise we yield the item once again. We also break if item is bigger than end.
+            if ((done && m_exclude_end) || compare_result == 1)
+                break;
+        }
+
         if constexpr (std::is_void_v<std::invoke_result_t<Function, Value>>) {
             func(item);
         } else {
@@ -48,17 +61,10 @@ Value RangeObject::iterate_over_range(Env *env, Function &&func) {
                 return ptr;
         }
 
-        if (!item->respond_to(env, "succ"_s))
-            break;
-        item = item.send(env, succ);
-
-        if (!m_end->is_nil()) {
-            auto compare_result = item.send(env, cmp, { m_end })->to_int(env)->integer();
-            // If range excludes the end,
-            //  we are done if item is bigger than or equal to m_end
-            // else
-            //  we are done if item is bigger than m_end.
-            done = compare_result > (m_exclude_end ? -1 : 0);
+        if (!done) {
+            if (!item->respond_to(env, "succ"_s))
+                break;
+            item = item.send(env, succ);
         }
     }
 
@@ -67,6 +73,9 @@ Value RangeObject::iterate_over_range(Env *env, Function &&func) {
 
 template <typename Function>
 Value RangeObject::iterate_over_string_range(Env *env, Function &&func) {
+    if (m_begin.send(env, "<=>"_s, { m_end })->equal(Value::integer(1)))
+        return nullptr;
+
     TM::Optional<TM::String> current;
     auto end = m_end->as_string()->string();
     auto iterator = StringUptoIterator(m_begin->as_string()->string(), end, m_exclude_end);
@@ -85,6 +94,9 @@ Value RangeObject::iterate_over_string_range(Env *env, Function &&func) {
 
 template <typename Function>
 Value RangeObject::iterate_over_symbol_range(Env *env, Function &&func) {
+    if (m_begin.send(env, "<=>"_s, { m_end })->equal(Value::integer(1)))
+        return nullptr;
+
     TM::Optional<TM::String> current;
     auto end = m_end->as_symbol()->string();
     auto iterator = StringUptoIterator(m_begin->as_symbol()->string(), end, m_exclude_end);

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -797,6 +797,14 @@ class Stub
 
   def and_return(*results)
     @results.concat(results)
+
+    # Update count restrictions if results' size exceeds it
+    if @count_restriction.is_a?(Range) && @count_restriction.end && @results.size > @count_restriction.end
+      @count_restriction = (@count_restriction.first..@results.size)
+    elsif @count_restriction.is_a?(Integer) && @results.size > @count_restriction
+      @count_restriction = @results.size
+    end
+
     self
   end
 


### PR DESCRIPTION
This also fixes a bug in Range construction with the (x..y)-syntax. We were not checking if constructing the Range should be possible.

[#555]