### PR TITLE
Make Range#clone spec-compliant

### DIFF
--- a/spec/core/range/clone_spec.rb
+++ b/spec/core/range/clone_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+
+describe "Range#clone" do
+  it "duplicates the range" do
+    original = (1..3)
+    copy = original.clone
+    copy.begin.should == 1
+    copy.end.should == 3
+    copy.should_not.exclude_end?
+    copy.should_not.equal? original
+
+    original = ("a"..."z")
+    copy = original.clone
+    copy.begin.should == "a"
+    copy.end.should == "z"
+    copy.should.exclude_end?
+    copy.should_not.equal? original
+  end
+
+  it "maintains the frozen state" do
+    (1..2).clone.frozen?.should == (1..2).frozen?
+    (1..).clone.frozen?.should == (1..).frozen?
+    Range.new(1, 2).clone.frozen?.should == Range.new(1, 2).frozen?
+    Class.new(Range).new(1, 2).clone.frozen?.should == Class.new(Range).new(1, 2).frozen?
+  end
+end

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -745,6 +745,9 @@ Value Object::clone(Env *env) {
         duplicate->set_singleton_class(s_class->clone(env)->as_class());
     }
 
+    if (is_frozen())
+        duplicate->freeze();
+
     return duplicate;
 }
 


### PR DESCRIPTION
This uses the underlying implementation of Object#clone.

Object#clone should freeze the duplicate if the original was frozen too.

[#555]