### PR TITLE
Add possibility to profile Natalie's compiler using StackProf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gem 'minitest-reporters'
 gem 'minitest-parallel_fork'
 gem 'rake'
 
+group :development do
+  gem 'stackprof'
+end
+
 group :run_all_specs, optional: true do
   gem 'concurrent-ruby'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       ruby-progressbar
     rake (13.0.6)
     ruby-progressbar (1.11.0)
+    stackprof (0.2.21)
 
 PLATFORMS
   arm64-darwin-21
@@ -24,6 +25,7 @@ DEPENDENCIES
   minitest-parallel_fork
   minitest-reporters
   rake
+  stackprof
 
 BUNDLED WITH
-   2.2.32
+   2.2.33

--- a/bin/natalie
+++ b/bin/natalie
@@ -5,7 +5,7 @@ require 'tempfile'
 
 require_relative '../lib/natalie'
 
-options = { load_path: [], require: [], profile: false }
+options = { load_path: [], require: [], profile: false, transform_only: false }
 OptionParser.new do |opts|
   opts.banner = 'Usage: natalie [options] file.rb'
 
@@ -18,6 +18,7 @@ OptionParser.new do |opts|
     options: {
       '{p1,p1,p3,p4}' => 'print intermediate AST from individual compiler pass',
       'cpp'           => 'print generated C++',
+      'transform'     => 'only transform the code to C++ without outputting it (can be used for profiling the compiler)',
       'cc-cmd'        => 'show the gcc/clang compiler command that will be run',
       'valgrind'      => 'run the resulting binary with valgrind',
       'kcachegrind'   => 'run the resulting binary with valgrind (callgrind) and open the profile in kcachegrind',
@@ -32,6 +33,8 @@ OptionParser.new do |opts|
     when 'gdb', 'lldb'
       options[:debug] = type
       options[:keep_cpp] = true
+    when 'transform'
+      options[:transform_only] = true
     else
       puts "Unrecognized -d argument: #{type.inspect}"
       exit 1
@@ -43,8 +46,25 @@ OptionParser.new do |opts|
     options[:execute] = e
   end
 
-  opts.on('-p', '--profile', 'Profile a Natalie application with the embedded profiler') do
-    options[:profile] = true
+  opts.on(
+    '-p [type]', '--profile [type]',
+    'Start profiling an application or the compiler.',
+    options: {
+      'app'       => 'Execute the script and profile it using the embedded profiler.',
+      'compiler'  => 'Profile the compilation process using StackProf.'
+    }
+  ) do |type|
+    case type
+    when true, 'app'
+      options[:profile] = :app
+    when 'compiler'
+      options[:profile] = :compiler
+      options[:transform_only] = true
+    else
+      puts "Unrecognized -p argument: #{type.inspect}"
+      exit 1
+    end
+    options[:expecting_script] = true
   end
 
   opts.on('--ast', 'Show AST rather than compiling') do |ast|
@@ -138,6 +158,8 @@ class Runner
       show_assembly
     elsif options[:debug] == 'edit'
       edit_compile_run_loop
+    elsif options[:transform_only]
+      compiler.send(:transform)
     else
       compile_and_run
     end
@@ -149,7 +171,7 @@ class Runner
     out = Tempfile.create("natalie#{extension}")
     out.close
     compiler.out_path = out.path
-    if options[:profile]
+    if options[:profile] == :app
       compiler.cxx_flags << '-DNAT_NATIVE_PROFILER'
     end
     if options[:print_objects]


### PR DESCRIPTION
This patch adds two new options to bin/natalie:

`--transform-only` - Only transform the given ruby code to cpp code without writing it to a file. This is useful for measuring the time needed by the compiler to transform ruby code to cpp.

`-pc` - Profiles the compiler using the stackprof gem. When speedscope is installed, the profile will be opened using speedscope!

Let me know what you think. We could definitely add more here. I'm thinking profiling the different passes for example.