### PR TITLE
Memoize label of a compiler instruction

### DIFF
--- a/lib/natalie/compiler/env_builder.rb
+++ b/lib/natalie/compiler/env_builder.rb
@@ -16,7 +16,7 @@ module Natalie
       def process
         while @ip < @instructions.size
           instruction = @instructions[@ip]
-          method = "process_#{instruction.label}"
+          method = "process_#{instruction.class.label}"
           method << "_#{instruction.matching_label}" if instruction.matching_label
 
           @instruction_stack << instruction if instruction.has_body?

--- a/lib/natalie/compiler/instruction_manager.rb
+++ b/lib/natalie/compiler/instruction_manager.rb
@@ -83,7 +83,7 @@ module Natalie
           instructions << instruction
           break if instruction.is_a?(until_instruction)
 
-          instructions += fetch_block(expected_label: instruction.label) if instruction.has_body?
+          instructions += fetch_block(expected_label: instruction.class.label) if instruction.has_body?
         end
 
         unless expected_label.nil? || instruction.matching_label == expected_label

--- a/lib/natalie/compiler/instructions/base_instruction.rb
+++ b/lib/natalie/compiler/instructions/base_instruction.rb
@@ -6,9 +6,9 @@ module Natalie
         false
       end
 
-      def label
+      def self.label
         @label ||=
-          underscore(self.class.name.sub(/Instruction$/, '')).to_sym
+          self.underscore(self.name.sub(/Instruction$/, '')).to_sym
       end
 
       def matching_label
@@ -19,7 +19,7 @@ module Natalie
 
       private
 
-      def underscore(name)
+      def self.underscore(name)
         name.split('::').last.gsub(/[A-Z]/) { |c| '_' + c.downcase }.sub(/^_/, '')
       end
     end

--- a/lib/natalie/compiler/instructions/base_instruction.rb
+++ b/lib/natalie/compiler/instructions/base_instruction.rb
@@ -7,7 +7,8 @@ module Natalie
       end
 
       def label
-        underscore(self.class.name.sub(/Instruction$/, '')).to_sym
+        @label ||=
+          underscore(self.class.name.sub(/Instruction$/, '')).to_sym
       end
 
       def matching_label

--- a/lib/natalie/compiler/pass2.rb
+++ b/lib/natalie/compiler/pass2.rb
@@ -21,7 +21,7 @@ module Natalie
 
       def transform
         @instructions.walk do |instruction|
-          method = "transform_#{instruction.label}"
+          method = "transform_#{instruction.class.label}"
           send(method, instruction) if respond_to?(method, true)
         end
       end

--- a/lib/natalie/compiler/pass3.rb
+++ b/lib/natalie/compiler/pass3.rb
@@ -25,7 +25,7 @@ module Natalie
 
       def transform
         @instructions.walk do |instruction|
-          method = "transform_#{instruction.label}"
+          method = "transform_#{instruction.class.label}"
           method << "_#{instruction.matching_label}" if instruction.matching_label
           @env = instruction.env
           if respond_to?(method, true)

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -19,7 +19,7 @@ module Natalie
 
       def transform
         @instructions.walk do |instruction|
-          method = "transform_#{instruction.label}"
+          method = "transform_#{instruction.class.label}"
           method << "_#{instruction.matching_label}" if instruction.matching_label
           @env = instruction.env
           if respond_to?(method, true)


### PR DESCRIPTION
This reduces transformation time by ~50%

Before:
![image](https://user-images.githubusercontent.com/61323346/192120429-5ef21c33-2fe8-4f61-9da7-b27a898ce04a.png)

After:
![image](https://user-images.githubusercontent.com/61323346/192120439-58c4981d-1cc7-4025-88ea-7d060668d0ad.png)

With label as class method:

![image](https://user-images.githubusercontent.com/61323346/192139298-b5c20324-06b7-4fb6-be7d-e7bed80309b4.png)
