### PR TITLE
Implement Time#to_r

### DIFF
--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -15,6 +15,10 @@ public:
 
     static RationalObject *create(Env *env, IntegerObject *numerator, IntegerObject *denominator);
 
+    bool is_zero() const {
+        return m_numerator->is_zero();
+    }
+
     Value add(Env *, Value);
     Value cmp(Env *, Value);
     Value coerce(Env *, Value);

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -40,6 +40,7 @@ public:
     Value subsec(Env *);
     Value to_f(Env *);
     Value to_i(Env *) const { return m_integer; }
+    Value to_r(Env *);
     Value to_s(Env *);
     Value usec(Env *);
     Value wday(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -974,6 +974,7 @@ gen.binding('Time', 'strftime', 'TimeObject', 'strftime', argc: 1, pass_env: tru
 gen.binding('Time', 'subsec', 'TimeObject', 'subsec', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'to_f', 'TimeObject', 'to_f', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'to_i', 'TimeObject', 'to_i', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Time', 'to_r', 'TimeObject', 'to_r', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'to_s', 'TimeObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'usec', 'TimeObject', 'usec', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'wday', 'TimeObject', 'wday', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/time/to_r_spec.rb
+++ b/spec/core/time/to_r_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "Time#to_r" do
+  it "returns the a Rational representing seconds and subseconds since the epoch" do
+    Time.at(Rational(11, 10)).to_r.should eql(Rational(11, 10))
+  end
+
+  it "returns a Rational even for a whole number of seconds" do
+    Time.at(2).to_r.should eql(Rational(2))
+  end
+end

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -148,6 +148,14 @@ Value TimeObject::to_f(Env *env) {
     return result;
 }
 
+Value TimeObject::to_r(Env *env) {
+    Value result = RationalObject::create(env, m_integer->as_integer(), new IntegerObject { 1 });
+    if (m_subsec) {
+        result = result->as_rational()->add(env, m_subsec->as_rational());
+    }
+    return result;
+}
+
 Value TimeObject::to_s(Env *env) {
     if (is_utc(env)) {
         return build_string(env, "%Y-%m-%d %H:%M:%S UTC");

--- a/test/natalie/time_test.rb
+++ b/test/natalie/time_test.rb
@@ -5,6 +5,28 @@ describe 'Time' do
     Time.utc(1985, 4, 12, 23, 20, 50)
   end
 
+  describe '.at' do
+    context 'with a Rational argument' do
+      it 'returns a time' do
+        t = Time.at(Rational(1_486_570_508_539_759, 1_000_000))
+        t.should be_an_instance_of(Time)
+        t.usec.should == 539_759
+      end
+    end
+
+    context 'with a String argument' do
+      it 'raises an error' do
+        -> { Time.at('') }.should raise_error(TypeError)
+      end
+    end
+
+    context 'with a nil argument' do
+      it 'raises an error' do
+        -> { Time.at(nil) }.should raise_error(TypeError)
+      end
+    end
+  end
+
   describe '#asctime' do
     it 'returns a string' do
       time.asctime.should == 'Fri Apr 12 23:20:50 1985'


### PR DESCRIPTION
First commit adds support for `Rational` arguments to `Time.at` which is necessary for `spec/core/time/to_r_spec.rb`
