### PR TITLE
Implement Time#+

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -26,6 +26,7 @@ public:
     static TimeObject *now(Env *);
     static TimeObject *utc(Env *, Value, Value, Value, Value, Value, Value, Value);
 
+    Value add(Env *, Value);
     Value asctime(Env *);
     bool eql(Env *, Value);
     Value hour(Env *);
@@ -49,6 +50,7 @@ public:
 
 private:
     static struct tm build_time_struct(Env *, Value, Value, Value, Value, Value, Value);
+    static TimeObject *create(Env *, RationalObject *, Mode);
 
     Value build_string(Env *, const char *);
     Value inspect_usec(Env *);

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -48,11 +48,13 @@ public:
     Value year(Env *);
 
 private:
-    static TimeObject *build_time_object(Env *, Value, Value, Value, Value, Value, Value, Value);
     static struct tm build_time_struct(Env *, Value, Value, Value, Value, Value, Value);
 
     Value build_string(Env *, const char *);
     Value inspect_usec(Env *);
+    void set_subsec(Env *, long);
+    void set_subsec(Env *, IntegerObject *);
+    void set_subsec(Env *, RationalObject *);
     Value strip_zeroes(StringObject *);
 
     Value m_integer;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -961,6 +961,7 @@ gen.static_binding('Time', 'local', 'TimeObject', 'local', argc: 1..7, pass_env:
 gen.static_binding('Time', 'new', 'TimeObject', 'create', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'now', 'TimeObject', 'now', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'utc', 'TimeObject', 'utc', argc: 1..7, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Time', '+', 'TimeObject', 'add', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'asctime', 'TimeObject', 'asctime', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'eql?', 'TimeObject', 'eql', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Time', 'hour', 'TimeObject', 'hour', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/test/natalie/time_test.rb
+++ b/test/natalie/time_test.rb
@@ -27,6 +27,44 @@ describe 'Time' do
     end
   end
 
+  describe '#+' do
+    context 'with an Integer argument' do
+      it 'returns a time' do
+        t = Time.at(0) + 100
+        t.should be_an_instance_of(Time)
+        t.to_i.should == 100
+      end
+    end
+
+    context 'with a Rational argument' do
+      it 'returns a time' do
+        t = Time.at(Rational(11, 10)) + Rational(9, 10)
+        t.should be_an_instance_of(Time)
+        t.to_i.should == 2
+      end
+    end
+
+    context 'with a Time argument' do
+      it 'raises an error' do
+        -> { time + time }.should raise_error(TypeError)
+      end
+    end
+
+    context 'with a nil argument' do
+      it 'raises an error' do
+        -> { time + nil }.should raise_error(TypeError)
+      end
+    end
+
+    context 'with a utc time' do
+      it 'returns a utc time' do
+        t = Time.utc(2012) + 10
+        t.should be_an_instance_of(Time)
+        t.utc?.should be_true
+      end
+    end
+  end
+
   describe '#asctime' do
     it 'returns a string' do
       time.asctime.should == 'Fri Apr 12 23:20:50 1985'


### PR DESCRIPTION
Implements addition for time objects:

    $ bin/natalie
    nat> Time.utc(1970) + 3723
    1970-01-01 01:02:03 UTC

Further work required to make it fully spec compliant (floats, fixed offsets, zones, Time#<=>).