### PR TITLE
Add Float Infinity expectation & unskip related tests

### DIFF
--- a/spec/core/float/divide_spec.rb
+++ b/spec/core/float/divide_spec.rb
@@ -8,19 +8,19 @@ describe "Float#/" do
   it "returns self divided by other" do
     (5.75 / -2).should be_close(-2.875,TOLERANCE)
     (451.0 / 9.3).should be_close(48.494623655914,TOLERANCE)
-    #(91.1 / -0xffffffff).should be_close(-2.12108716418061e-08, TOLERANCE)
+    (91.1 / -0xffffffff).should be_close(-2.12108716418061e-08, TOLERANCE)
   end
 
   it "properly coerces objects" do
     (5.0 / FloatSpecs::CanCoerce.new(5)).should be_close(0, TOLERANCE)
   end
 
-  xit "returns +Infinity when dividing non-zero by zero of the same sign" do
+  it "returns +Infinity when dividing non-zero by zero of the same sign" do
     (1.0 / 0.0).should be_positive_infinity
     (-1.0 / -0.0).should be_positive_infinity
   end
 
-  xit "returns -Infinity when dividing non-zero by zero of opposite sign" do
+  it "returns -Infinity when dividing non-zero by zero of opposite sign" do
     (-1.0 / 0.0).should be_negative_infinity
     (1.0 / -0.0).should be_negative_infinity
   end
@@ -35,5 +35,9 @@ describe "Float#/" do
   it "raises a TypeError when given a non-Numeric" do
     -> { 13.0 / "10"    }.should raise_error(TypeError)
     -> { 13.0 / :symbol }.should raise_error(TypeError)
+  end
+
+  it "divides correctly by Rational numbers" do
+    (1.2345678901234567 / Rational(1, 10000000000000000000)).should == 1.2345678901234567e+19
   end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -541,6 +541,27 @@ class BeNanExpectation
   end
 end
 
+class BeInfinityExpectation
+  def initialize(sign_of_infinity)
+    @sign_of_infinity = sign_of_infinity
+  end
+
+  def match(subject)
+    raise SpecFailedException, "#{subject.inspect} should be #{"-" if negative?}Infinity" unless expected_infinity?(subject)
+  end
+
+  private
+
+  def expected_infinity?(subject)
+    subject.kind_of?(Float) && subject.infinite? == @sign_of_infinity
+  end
+
+  def negative?
+    @sign_of_infinity == -1
+  end
+end
+
+
 class OutputExpectation
   def initialize(expected)
     @expected = expected
@@ -1034,6 +1055,14 @@ class Object
 
   def be_positive_zero
     EqlExpectation.new(0.0)
+  end
+
+  def be_positive_infinity
+    BeInfinityExpectation.new(1)
+  end
+
+  def be_negative_infinity
+    BeInfinityExpectation.new(-1)
   end
 
   def be_true


### PR DESCRIPTION
Hi all! Love what you are building here! Wanted to help get more specs green.

I noticed a couple of skipped / failing specs on `divide_spec` for Float. Fixed by adding the missing matchers (inspired by https://github.com/ruby/mspec/blob/master/lib/mspec/matchers/infinity.rb) and updated the spec to the latest from `ruby/spec` (https://github.com/ruby/spec/blob/master/core/float/divide_spec.rb)

