### PR TITLE
Fix missing GC visits of member variables and add GC linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Test
 
 on:
   push:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format Code
+name: Format
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,11 @@ jobs:
         run: git submodule update --init --recursive
       - name: run clang-tidy
         run: rake docker_tidy
+  gc-lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: checkout submodules
+        run: git submodule update --init --recursive
+      - name: run gc-lint
+        run: rake docker_gc_lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ARG IMAGE=ruby:3.0
 FROM $IMAGE
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov clang-tidy python3 python3-pip ccache
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov clang-tidy libclang-dev python3 python3-pip ccache
 RUN pip3 install compiledb
 RUN gem install bundler --no-doc
 
-ENV LC_ALL C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LLVM_CONFIG=/usr/lib/llvm-11/bin/llvm-config
 
 WORKDIR natalie
 COPY .git/ .git/

--- a/Rakefile
+++ b/Rakefile
@@ -111,6 +111,9 @@ end
 desc 'Run clang-tidy'
 task tidy: %i[build tidy_internal]
 
+desc 'Lint GC visiting code'
+task gc_lint: %i[build gc_lint_internal]
+
 # # # # Docker Tasks (used for CI) # # # #
 
 DOCKER_FLAGS =
@@ -157,6 +160,10 @@ end
 
 task docker_tidy: :docker_build_clang do
   sh "docker run #{DOCKER_FLAGS} --rm --entrypoint rake natalie_clang tidy"
+end
+
+task docker_gc_lint: :docker_build_clang do
+  sh "docker run #{DOCKER_FLAGS} --rm --entrypoint rake natalie_clang gc_lint"
 end
 
 # # # # Build Compile Database # # # #
@@ -369,6 +376,10 @@ end
 
 task :tidy_internal do
   sh "clang-tidy #{PRIMARY_SOURCES.exclude('src/dtoa.c')}"
+end
+
+task :gc_lint_internal do
+  sh "ruby test/gc_lint.rb"
 end
 
 task :bundle_install do

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -19,6 +19,7 @@
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"
 #include "natalie/complex_object.hpp"
+#include "natalie/constant.hpp"
 #include "natalie/encoding/ascii_8bit_encoding_object.hpp"
 #include "natalie/encoding/us_ascii_encoding_object.hpp"
 #include "natalie/encoding/utf8_encoding_object.hpp"

--- a/include/natalie/abstract_method_object.hpp
+++ b/include/natalie/abstract_method_object.hpp
@@ -19,6 +19,15 @@ public:
     Method *method() { return m_method; }
     int arity() { return m_method->arity(); }
 
+    virtual void visit_children(Visitor &visitor) override {
+        Object::visit_children(visitor);
+        visitor.visit(m_method);
+    }
+
+    virtual void gc_inspect(char *buf, size_t len) const override {
+        snprintf(buf, len, "<AbstractMethodObject %p>", this);
+    }
+
 protected:
     Method *m_method { nullptr };
 

--- a/include/natalie/args.hpp
+++ b/include/natalie/args.hpp
@@ -69,7 +69,7 @@ public:
 
 private:
     // Args cannot be heap-allocated, because the GC is not aware of it.
-    void *operator new(size_t size) { TM_UNREACHABLE(); };
+    void *operator new(size_t size) = delete;
 
     size_t m_size { 0 };
     const Value *m_data { nullptr };

--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -9,7 +9,7 @@ namespace Natalie {
 
 namespace ArrayPacker {
 
-    class IntegerHandler {
+    class IntegerHandler : public Cell {
     public:
         IntegerHandler(IntegerObject *source, Token token)
             : m_source { source }
@@ -40,6 +40,10 @@ namespace ArrayPacker {
             }
 
             return m_packed;
+        }
+
+        virtual void visit_children(Visitor &visitor) override {
+            visitor.visit(m_source);
         }
 
     private:

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -12,7 +12,7 @@ namespace Natalie {
 
 namespace ArrayPacker {
 
-    class Packer {
+    class Packer : public Cell {
     public:
         Packer(ArrayObject *source, String directives)
             : m_source { source }
@@ -103,6 +103,11 @@ namespace ArrayPacker {
                 }
             }
             return new StringObject { m_packed, m_encoding };
+        }
+
+        virtual void visit_children(Visitor &visitor) override {
+            visitor.visit(m_source);
+            visitor.visit(m_encoding);
         }
 
     private:

--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -53,10 +53,6 @@
 #include "tm/string.hpp"
 
 class BigInt {
-    // FIXME: members should be prefixed with m_
-    TM::String value;
-    char sign;
-
 public:
     // Constructors:
     BigInt();
@@ -158,7 +154,7 @@ public:
     BigInt operator<<(const size_t &num) const;
     BigInt operator>>(const size_t &num) const;
 
-    bool is_negative() const { return sign == '-'; }
+    bool is_negative() const { return m_sign == '-'; }
 
     // Conversion functions:
     TM::String to_string() const;
@@ -169,6 +165,10 @@ public:
 
     // Random number generating functions:
     friend BigInt big_random(size_t);
+
+private:
+    TM::String m_value;
+    char m_sign;
 };
 
 BigInt pow(const BigInt &base, long long exp);

--- a/include/natalie/binding_object.hpp
+++ b/include/natalie/binding_object.hpp
@@ -13,6 +13,10 @@ public:
 
     Env *env() { return &m_env; }
 
+    virtual void visit_children(Visitor &visitor) override final {
+        visitor.visit(&m_env);
+    }
+
 private:
     Env m_env;
 };

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -42,7 +42,7 @@ public:
 
     virtual void visit_children(Visitor &visitor) override final {
         visitor.visit(m_env);
-        // visitor.visit(m_calling_env); memory access bug :-(
+        visitor.visit(m_calling_env);
         visitor.visit(m_self);
     }
 

--- a/include/natalie/constant.hpp
+++ b/include/natalie/constant.hpp
@@ -16,9 +16,7 @@ public:
     bool is_deprecated() const { return m_deprecated; }
     void set_deprecated(bool is_deprecated) { this->m_deprecated = is_deprecated; }
 
-    void visit_children(Visitor &visitor) {
-        visitor.visit(m_value);
-    }
+    void visit_children(Visitor &visitor);
 
 private:
     SymbolObject *m_name;

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -51,9 +51,6 @@ public:
         snprintf(buf, len, "<ExceptionObject %p message='%s'>", this, m_message->c_str());
     }
 
-    void set_local_jump_error_env(Env *env) { m_local_jump_error_env = env; }
-    Env *local_jump_error_env() { return m_local_jump_error_env; }
-
     void set_local_jump_error_type(LocalJumpErrorType type) { m_local_jump_error_type = type; }
     LocalJumpErrorType local_jump_error_type() { return m_local_jump_error_type; }
 
@@ -69,7 +66,6 @@ private:
     StringObject *m_message { nullptr };
     Backtrace *m_backtrace { nullptr };
     nat_int_t m_break_point { 0 };
-    Env *m_local_jump_error_env { nullptr };
     LocalJumpErrorType m_local_jump_error_type { LocalJumpErrorType::None };
 };
 

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -87,7 +87,7 @@ public:
         s_current = fiber;
     }
 
-    const int STACK_SIZE = 1024 * 1024;
+    constexpr static int STACK_SIZE = 1024 * 1024;
 
     FiberObject *initialize(Env *env, Block *block);
 

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -19,9 +19,9 @@ class Heap {
 public:
     NAT_MAKE_NONCOPYABLE(Heap);
 
-    const int initial_blocks_per_allocator = 10;
-    const int min_percent_free_triggers_collection = 5;
-    const int min_percent_free_after_collection = 20;
+    constexpr static int initial_blocks_per_allocator = 10;
+    constexpr static int min_percent_free_triggers_collection = 5;
+    constexpr static int min_percent_free_after_collection = 20;
 
     static Heap &the() {
         if (s_instance)

--- a/include/natalie/gc/heap_block.hpp
+++ b/include/natalie/gc/heap_block.hpp
@@ -107,6 +107,9 @@ public:
         }
 
     private:
+        // cannot be heap-allocated, because the GC is not aware of it.
+        void *operator new(size_t size) = delete;
+
         HeapBlock *m_block;
         Cell *m_ptr { nullptr };
         size_t m_index { 0 };

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -140,6 +140,9 @@ public:
         }
 
     private:
+        // cannot be heap-allocated, because the GC is not aware of it.
+        void *operator new(size_t size) = delete;
+
         Key *m_key;
         const HashObject *m_hash;
     };

--- a/include/natalie/method_info.hpp
+++ b/include/natalie/method_info.hpp
@@ -31,6 +31,8 @@ public:
     bool is_defined() const { return !m_undefined && m_method; }
 
 private:
+    // WARNING: do not add more members to this object without making sure
+    // they are visited by ModuleObject::visit_children().
     MethodVisibility m_visibility { MethodVisibility::Public };
     Method *m_method { nullptr };
     bool m_undefined { false };

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -17,8 +17,6 @@ using namespace TM;
 
 class StringObject : public Object {
 public:
-    const int STRING_GROW_FACTOR = 2;
-
     StringObject(ClassObject *klass)
         : Object { Object::Type::String, klass }
         , m_encoding { EncodingObject::get(Encoding::ASCII_8BIT) } {

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -314,6 +314,9 @@ public:
         }
 
     private:
+        // cannot be heap-allocated, because the GC is not aware of it.
+        void *operator new(size_t size) = delete;
+
         const StringObject *m_string;
         StringView m_view;
     };

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -275,6 +275,10 @@ public:
 
     virtual String dbg_inspect() const override;
 
+    virtual void visit_children(Visitor &visitor) override final {
+        visitor.visit(m_encoding);
+    }
+
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<StringObject %p str='%s'>", this, m_string.c_str());
     }

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -66,6 +66,11 @@ public:
 
     virtual String dbg_inspect() const override;
 
+    virtual void visit_children(Visitor &visitor) override {
+        Object::visit_children(visitor);
+        visitor.visit(m_string);
+    }
+
     virtual void gc_inspect(char *buf, size_t len) const override {
         // NOTE: this won't properly print the null character '\0', but since this is only used
         // for debugging, we probably don't care.

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -155,15 +155,15 @@ BigInt big_random(size_t num_digits = 0) {
         num_digits = 1 + rand_generator() % MAX_RANDOM_LENGTH;
 
     BigInt big_rand;
-    big_rand.value = ""; // clear value to append digits
+    big_rand.m_value = ""; // clear value to append digits
 
     // ensure that the first digit is non-zero
-    big_rand.value.append((size_t)(1 + rand_generator() % 9));
+    big_rand.m_value.append((size_t)(1 + rand_generator() % 9));
 
-    while (big_rand.value.size() < num_digits)
-        big_rand.value.append((size_t)rand_generator());
-    if (big_rand.value.size() != num_digits)
-        big_rand.value.truncate(num_digits); // erase extra digits
+    while (big_rand.m_value.size() < num_digits)
+        big_rand.m_value.append((size_t)rand_generator());
+    if (big_rand.m_value.size() != num_digits)
+        big_rand.m_value.truncate(num_digits); // erase extra digits
 
     return big_rand;
 }
@@ -180,8 +180,8 @@ BigInt big_random(size_t num_digits = 0) {
 */
 
 BigInt::BigInt() {
-    value = "0";
-    sign = '+';
+    m_value = "0";
+    m_sign = '+';
 }
 
 /*
@@ -190,8 +190,8 @@ BigInt::BigInt() {
 */
 
 BigInt::BigInt(const BigInt &num) {
-    value = num.value;
-    sign = num.sign;
+    m_value = num.m_value;
+    m_sign = num.m_sign;
 }
 
 /*
@@ -200,11 +200,11 @@ BigInt::BigInt(const BigInt &num) {
 */
 
 BigInt::BigInt(const long long &num) {
-    value = TM::String(std::abs(num));
+    m_value = TM::String(std::abs(num));
     if (num < 0)
-        sign = '-';
+        m_sign = '-';
     else
-        sign = '+';
+        m_sign = '+';
 }
 
 /*
@@ -213,11 +213,11 @@ BigInt::BigInt(const long long &num) {
 */
 
 BigInt::BigInt(const int &num) {
-    value = TM::String(std::abs(num));
+    m_value = TM::String(std::abs(num));
     if (num < 0)
-        sign = '-';
+        m_sign = '-';
     else
-        sign = '+';
+        m_sign = '+';
 }
 
 /*
@@ -228,12 +228,12 @@ BigInt::BigInt(const int &num) {
 BigInt::BigInt(const double &num) {
     assert(floor(num) == num);
 
-    value = TM::String(std::abs(num), 1);
-    value.truncate(value.size() - 2);
+    m_value = TM::String(std::abs(num), 1);
+    m_value.truncate(m_value.size() - 2);
     if (num < 0)
-        sign = '-';
+        m_sign = '-';
     else
-        sign = '+';
+        m_sign = '+';
 }
 
 /*
@@ -246,15 +246,15 @@ BigInt::BigInt(const TM::String &num) {
         TM::String magnitude = num.substring(1);
         // Expected an integer, got num
         assert(is_valid_number(magnitude));
-        value = magnitude;
-        sign = num[0];
+        m_value = magnitude;
+        m_sign = num[0];
     } else { // if no sign is specified
         // Expected an integer, got num
         assert(is_valid_number(num));
-        value = num;
-        sign = '+'; // positive by default
+        m_value = num;
+        m_sign = '+'; // positive by default
     }
-    strip_leading_zeroes(value);
+    strip_leading_zeroes(m_value);
 }
 
 /*
@@ -271,12 +271,12 @@ BigInt::BigInt(const TM::String &num) {
 
 TM::String BigInt::to_string() const {
     // prefix with sign if negative
-    if (this->sign == '-') {
-        auto copy = this->value;
-        copy.prepend_char(this->sign);
+    if (m_sign == '-') {
+        auto copy = m_value;
+        copy.prepend_char(m_sign);
         return copy;
     } else {
-        return this->value;
+        return m_value;
     }
 }
 
@@ -334,8 +334,8 @@ double BigInt::to_double() const {
 BigInt &BigInt::operator=(const BigInt &num) {
     if (num == *this) return *this;
 
-    value = num.value;
-    sign = num.sign;
+    m_value = num.m_value;
+    m_sign = num.m_sign;
 
     return *this;
 }
@@ -347,8 +347,8 @@ BigInt &BigInt::operator=(const BigInt &num) {
 
 BigInt &BigInt::operator=(const long long &num) {
     BigInt temp(num);
-    value = temp.value;
-    sign = temp.sign;
+    m_value = temp.m_value;
+    m_sign = temp.m_sign;
 
     return *this;
 }
@@ -360,8 +360,8 @@ BigInt &BigInt::operator=(const long long &num) {
 
 BigInt &BigInt::operator=(const TM::String &num) {
     BigInt temp(num);
-    value = temp.value;
-    sign = temp.sign;
+    m_value = temp.m_value;
+    m_sign = temp.m_sign;
 
     return *this;
 }
@@ -393,12 +393,12 @@ BigInt BigInt::operator+() const {
 BigInt BigInt::operator-() const {
     BigInt temp;
 
-    temp.value = value;
-    if (value != "0") {
-        if (sign == '+')
-            temp.sign = '-';
+    temp.m_value = m_value;
+    if (m_value != "0") {
+        if (m_sign == '+')
+            temp.m_sign = '-';
         else
-            temp.sign = '+';
+            temp.m_sign = '+';
     }
 
     return temp;
@@ -417,7 +417,7 @@ BigInt BigInt::operator-() const {
 */
 
 bool BigInt::operator==(const BigInt &num) const {
-    return (sign == num.sign) and (value == num.value);
+    return (m_sign == num.m_sign) and (m_value == num.m_value);
 }
 
 /*
@@ -435,16 +435,16 @@ bool BigInt::operator!=(const BigInt &num) const {
 */
 
 bool BigInt::operator<(const BigInt &num) const {
-    if (sign == num.sign) {
-        if (sign == '+') {
-            if (value.length() == num.value.length())
-                return value < num.value;
+    if (m_sign == num.m_sign) {
+        if (m_sign == '+') {
+            if (m_value.length() == num.m_value.length())
+                return m_value < num.m_value;
             else
-                return value.length() < num.value.length();
+                return m_value.length() < num.m_value.length();
         } else
             return -(*this) > -num;
     } else
-        return sign == '-';
+        return m_sign == '-';
 }
 
 /*
@@ -1053,35 +1053,35 @@ const long long FLOOR_SQRT_LLONG_MAX = 3037000499;
 
 BigInt BigInt::operator+(const BigInt &num) const {
     // if the operands are of opposite signs, perform subtraction
-    if (this->sign == '+' and num.sign == '-') {
+    if (m_sign == '+' and num.m_sign == '-') {
         BigInt rhs = num;
-        rhs.sign = '+';
+        rhs.m_sign = '+';
         return *this - rhs;
-    } else if (this->sign == '-' and num.sign == '+') {
+    } else if (m_sign == '-' and num.m_sign == '+') {
         BigInt lhs = *this;
-        lhs.sign = '+';
+        lhs.m_sign = '+';
         return -(lhs - num);
     }
 
     // identify the numbers as `larger` and `smaller`
     TM::String larger, smaller;
-    std::tie(larger, smaller) = get_larger_and_smaller(this->value, num.value);
+    std::tie(larger, smaller) = get_larger_and_smaller(m_value, num.m_value);
 
     BigInt result; // the resultant sum
-    result.value = ""; // the value is cleared as the digits will be appended
+    result.m_value = ""; // the value is cleared as the digits will be appended
     short carry = 0, sum;
     // add the two values
     for (long i = larger.size() - 1; i >= 0; i--) {
         sum = larger[i] - '0' + smaller[i] - '0' + carry;
-        result.value.prepend_char((sum % 10) + '0');
+        result.m_value.prepend_char((sum % 10) + '0');
         carry = sum / (short)10;
     }
     if (carry)
-        result.value.prepend(carry);
+        result.m_value.prepend(carry);
 
     // if the operands are negative, the result is negative
-    if (this->sign == '-' and result.value != "0")
-        result.sign = '-';
+    if (m_sign == '-' and result.m_value != "0")
+        result.m_sign = '-';
 
     return result;
 }
@@ -1094,13 +1094,13 @@ BigInt BigInt::operator+(const BigInt &num) const {
 
 BigInt BigInt::operator-(const BigInt &num) const {
     // if the operands are of opposite signs, perform addition
-    if (this->sign == '+' and num.sign == '-') {
+    if (m_sign == '+' and num.m_sign == '-') {
         BigInt rhs = num;
-        rhs.sign = '+';
+        rhs.m_sign = '+';
         return *this + rhs;
-    } else if (this->sign == '-' and num.sign == '+') {
+    } else if (m_sign == '-' and num.m_sign == '+') {
         BigInt lhs = *this;
-        lhs.sign = '+';
+        lhs.m_sign = '+';
         return -(lhs + num);
     }
 
@@ -1108,22 +1108,22 @@ BigInt BigInt::operator-(const BigInt &num) const {
     // identify the numbers as `larger` and `smaller`
     TM::String larger, smaller;
     if (abs(*this) > abs(num)) {
-        larger = this->value;
-        smaller = num.value;
+        larger = m_value;
+        smaller = num.m_value;
 
-        if (this->sign == '-') // -larger - -smaller = -result
-            result.sign = '-';
+        if (m_sign == '-') // -larger - -smaller = -result
+            result.m_sign = '-';
     } else {
-        larger = num.value;
-        smaller = this->value;
+        larger = num.m_value;
+        smaller = m_value;
 
-        if (num.sign == '+') // smaller - larger = -result
-            result.sign = '-';
+        if (num.m_sign == '+') // smaller - larger = -result
+            result.m_sign = '-';
     }
     // pad the smaller number with zeroes
     add_leading_zeroes(smaller, larger.size() - smaller.size());
 
-    result.value = ""; // the value is cleared as the digits will be appended
+    result.m_value = ""; // the value is cleared as the digits will be appended
     signed char difference;
     long i, j;
     // subtract the two values
@@ -1143,13 +1143,13 @@ BigInt BigInt::operator-(const BigInt &num) const {
             }
             difference += 10; // add the borrow
         }
-        result.value.prepend_char(difference + '0');
+        result.m_value.prepend_char(difference + '0');
     }
-    strip_leading_zeroes(result.value);
+    strip_leading_zeroes(result.m_value);
 
     // if the result is 0, set its sign as +
-    if (result.value == "0")
-        result.sign = '+';
+    if (result.m_value == "0")
+        result.m_sign = '+';
 
     return result;
 }
@@ -1171,19 +1171,19 @@ BigInt BigInt::operator*(const BigInt &num) const {
 
     BigInt product;
     if (abs(*this) <= FLOOR_SQRT_LLONG_MAX and abs(num) <= FLOOR_SQRT_LLONG_MAX)
-        product = strtoll(this->value.c_str(), NULL, 10) * strtoll(num.value.c_str(), NULL, 10);
-    else if (is_power_of_10(this->value)) { // if LHS is a power of 10 do optimised operation
-        product.value = num.value;
-        if (this->value.length() > 1)
-            product.value.append(this->value.substring(1));
-    } else if (is_power_of_10(num.value)) { // if RHS is a power of 10 do optimised operation
-        product.value = this->value;
-        if (num.value.length() > 1)
-            product.value.append(num.value.substring(1));
+        product = strtoll(m_value.c_str(), NULL, 10) * strtoll(num.m_value.c_str(), NULL, 10);
+    else if (is_power_of_10(m_value)) { // if LHS is a power of 10 do optimised operation
+        product.m_value = num.m_value;
+        if (m_value.length() > 1)
+            product.m_value.append(m_value.substring(1));
+    } else if (is_power_of_10(num.m_value)) { // if RHS is a power of 10 do optimised operation
+        product.m_value = m_value;
+        if (num.m_value.length() > 1)
+            product.m_value.append(num.m_value.substring(1));
     } else {
         // identify the numbers as `larger` and `smaller`
         TM::String larger, smaller;
-        std::tie(larger, smaller) = get_larger_and_smaller(this->value, num.value);
+        std::tie(larger, smaller) = get_larger_and_smaller(m_value, num.m_value);
 
         size_t half_length = larger.size() / 2;
         auto half_length_ceil = (size_t)ceil(larger.size() / 2.0);
@@ -1196,10 +1196,10 @@ BigInt BigInt::operator*(const BigInt &num) const {
         num2_high = smaller.substring(0, half_length);
         num2_low = smaller.substring(half_length);
 
-        strip_leading_zeroes(num1_high.value);
-        strip_leading_zeroes(num1_low.value);
-        strip_leading_zeroes(num2_high.value);
-        strip_leading_zeroes(num2_low.value);
+        strip_leading_zeroes(num1_high.m_value);
+        strip_leading_zeroes(num1_low.m_value);
+        strip_leading_zeroes(num2_high.m_value);
+        strip_leading_zeroes(num2_low.m_value);
 
         BigInt prod_high, prod_mid, prod_low;
         prod_high = num1_high * num2_high;
@@ -1207,21 +1207,21 @@ BigInt BigInt::operator*(const BigInt &num) const {
         prod_mid = (num1_high + num1_low) * (num2_high + num2_low)
             - prod_high - prod_low;
 
-        add_trailing_zeroes(prod_high.value, 2 * half_length_ceil);
-        add_trailing_zeroes(prod_mid.value, half_length_ceil);
+        add_trailing_zeroes(prod_high.m_value, 2 * half_length_ceil);
+        add_trailing_zeroes(prod_mid.m_value, half_length_ceil);
 
-        strip_leading_zeroes(prod_high.value);
-        strip_leading_zeroes(prod_mid.value);
-        strip_leading_zeroes(prod_low.value);
+        strip_leading_zeroes(prod_high.m_value);
+        strip_leading_zeroes(prod_mid.m_value);
+        strip_leading_zeroes(prod_low.m_value);
 
         product = prod_high + prod_mid + prod_low;
     }
-    strip_leading_zeroes(product.value);
+    strip_leading_zeroes(product.m_value);
 
-    if (this->sign == num.sign)
-        product.sign = '+';
+    if (m_sign == num.m_sign)
+        product.m_sign = '+';
     else
-        product.sign = '-';
+        product.m_sign = '-';
 
     return product;
 }
@@ -1283,46 +1283,46 @@ BigInt BigInt::c_div(const BigInt &num) const {
 
     BigInt quotient;
     if (abs_dividend <= LLONG_MAX and abs_divisor <= LLONG_MAX)
-        quotient = strtoll(abs_dividend.value.c_str(), NULL, 10) / strtoll(abs_divisor.value.c_str(), NULL, 10);
+        quotient = strtoll(abs_dividend.m_value.c_str(), NULL, 10) / strtoll(abs_divisor.m_value.c_str(), NULL, 10);
     else if (abs_dividend == abs_divisor)
         quotient = 1;
-    else if (is_power_of_10(abs_divisor.value)) { // if divisor is a power of 10 do optimised calculation
-        size_t digits_in_quotient = abs_dividend.value.size() - abs_divisor.value.size() + 1;
-        quotient.value = abs_dividend.value.substring(0, digits_in_quotient);
+    else if (is_power_of_10(abs_divisor.m_value)) { // if divisor is a power of 10 do optimised calculation
+        size_t digits_in_quotient = abs_dividend.m_value.size() - abs_divisor.m_value.size() + 1;
+        quotient.m_value = abs_dividend.m_value.substring(0, digits_in_quotient);
     } else {
-        quotient.value = ""; // the value is cleared as digits will be appended
+        quotient.m_value = ""; // the value is cleared as digits will be appended
         BigInt chunk, chunk_quotient, chunk_remainder;
         size_t chunk_index = 0;
-        chunk_remainder.value = abs_dividend.value.substring(chunk_index, abs_divisor.value.size() - 1);
-        chunk_index = abs_divisor.value.size() - 1;
-        while (chunk_index < abs_dividend.value.size()) {
-            chunk_remainder.value.append(1, abs_dividend.value[chunk_index]);
-            chunk.value = chunk_remainder.value;
+        chunk_remainder.m_value = abs_dividend.m_value.substring(chunk_index, abs_divisor.m_value.size() - 1);
+        chunk_index = abs_divisor.m_value.size() - 1;
+        while (chunk_index < abs_dividend.m_value.size()) {
+            chunk_remainder.m_value.append(1, abs_dividend.m_value[chunk_index]);
+            chunk.m_value = chunk_remainder.m_value;
             chunk_index++;
             while (chunk < abs_divisor) {
-                quotient.value.append_char('0');
-                if (chunk_index < abs_dividend.value.size()) {
-                    chunk.value.append(1, abs_dividend.value[chunk_index]);
+                quotient.m_value.append_char('0');
+                if (chunk_index < abs_dividend.m_value.size()) {
+                    chunk.m_value.append(1, abs_dividend.m_value[chunk_index]);
                     chunk_index++;
                 } else
                     break;
             }
             if (chunk == abs_divisor) {
-                quotient.value.append_char('1');
+                quotient.m_value.append_char('1');
                 chunk_remainder = 0;
             } else if (chunk > abs_divisor) {
-                strip_leading_zeroes(chunk.value);
+                strip_leading_zeroes(chunk.m_value);
                 std::tie(chunk_quotient, chunk_remainder) = divide(chunk, abs_divisor);
-                quotient.value.append(chunk_quotient.value.c_str());
+                quotient.m_value.append(chunk_quotient.m_value.c_str());
             }
         }
     }
-    strip_leading_zeroes(quotient.value);
+    strip_leading_zeroes(quotient.m_value);
 
-    if (this->sign == num.sign)
-        quotient.sign = '+';
+    if (m_sign == num.m_sign)
+        quotient.m_sign = '+';
     else
-        quotient.sign = '-';
+        quotient.m_sign = '-';
 
     return quotient;
 }
@@ -1356,21 +1356,21 @@ BigInt BigInt::c_mod(const BigInt &num) const {
 
     BigInt remainder;
     if (abs_dividend <= LLONG_MAX and abs_divisor <= LLONG_MAX)
-        remainder = strtoll(abs_dividend.value.c_str(), NULL, 10) % strtoll(abs_divisor.value.c_str(), NULL, 10);
+        remainder = strtoll(abs_dividend.m_value.c_str(), NULL, 10) % strtoll(abs_divisor.m_value.c_str(), NULL, 10);
     else if (abs_dividend < abs_divisor)
         remainder = abs_dividend;
-    else if (is_power_of_10(num.value)) { // if num is a power of 10 use optimised calculation
-        size_t no_of_zeroes = num.value.size() - 1;
-        remainder.value = abs_dividend.value.substring(abs_dividend.value.size() - no_of_zeroes);
+    else if (is_power_of_10(num.m_value)) { // if num is a power of 10 use optimised calculation
+        size_t no_of_zeroes = num.m_value.size() - 1;
+        remainder.m_value = abs_dividend.m_value.substring(abs_dividend.m_value.size() - no_of_zeroes);
     } else {
         BigInt quotient = abs_dividend / abs_divisor;
         remainder = abs_dividend - quotient * abs_divisor;
     }
-    strip_leading_zeroes(remainder.value);
+    strip_leading_zeroes(remainder.m_value);
 
-    remainder.sign = this->sign;
-    if (remainder.value == "0")
-        remainder.sign = '+';
+    remainder.m_sign = m_sign;
+    if (remainder.m_value == "0")
+        remainder.m_sign = '+';
 
     return remainder;
 }
@@ -1385,7 +1385,7 @@ BigInt BigInt::c_mod(const BigInt &num) const {
 BigInt BigInt::operator%(const BigInt &num) const {
     BigInt remainder = c_mod(num);
 
-    if (remainder != 0 && num.sign != remainder.sign)
+    if (remainder != 0 && num.m_sign != remainder.m_sign)
         remainder += num;
 
     return remainder;

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -1,0 +1,10 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+void Constant::visit_children(Visitor &visitor) {
+    visitor.visit(m_name);
+    visitor.visit(m_value);
+}
+
+}

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -86,12 +86,8 @@ void Env::raise_local_jump_error(Value exit_value, LocalJumpErrorType type, nat_
     exception->ivar_set(this, "@exit_value"_s, exit_value);
     if (break_point != 0)
         exception->set_break_point(break_point);
-    if (type == LocalJumpErrorType::Break) {
+    if (type == LocalJumpErrorType::Break)
         assert(m_this_block);
-        exception->set_local_jump_error_env(m_this_block->calling_env());
-    } else {
-        exception->set_local_jump_error_env(this);
-    }
     this->raise_exception(exception);
 }
 

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -58,6 +58,7 @@ void ExceptionObject::visit_children(Visitor &visitor) {
     Object::visit_children(visitor);
     visitor.visit(m_message);
     visitor.visit(m_backtrace);
+    visitor.visit(m_local_jump_error_env);
 }
 
 }

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -58,7 +58,6 @@ void ExceptionObject::visit_children(Visitor &visitor) {
     Object::visit_children(visitor);
     visitor.visit(m_message);
     visitor.visit(m_backtrace);
-    visitor.visit(m_local_jump_error_env);
 }
 
 }

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -38,17 +38,25 @@ void GlobalEnv::visit_children(Visitor &visitor) {
         visitor.visit(pair.first);
         visitor.visit(pair.second);
     }
+    for (size_t i = 0; i < EncodingCount; i++)
+        visitor.visit(m_Encodings[i]);
     visitor.visit(m_Array);
+    visitor.visit(m_Binding);
     visitor.visit(m_Class);
+    visitor.visit(m_Complex);
+    visitor.visit(m_Float);
     visitor.visit(m_Hash);
     visitor.visit(m_Integer);
     visitor.visit(m_Module);
     visitor.visit(m_Object);
     visitor.visit(m_Random);
+    visitor.visit(m_Rational);
     visitor.visit(m_Regexp);
     visitor.visit(m_String);
     visitor.visit(m_Symbol);
+    visitor.visit(m_Time);
     visitor.visit(m_main_obj);
+    visitor.visit(m_main_env);
 }
 
 }

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -20,10 +20,11 @@ Value Method::call(Env *env, Value self, Args args, Block *block) {
 
     auto call_fn = [&](Args args) {
         if (block && !block->calling_env()) {
+            Defer clear_calling_env([&]() {
+                block->clear_calling_env();
+            });
             block->set_calling_env(env);
-            auto result = m_fn(&e, self, args, block);
-            block->clear_calling_env();
-            return result;
+            return m_fn(&e, self, args, block);
         } else {
             return m_fn(&e, self, args, block);
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -923,6 +923,7 @@ Value Object::enum_for(Env *env, const char *method, Args args) {
 }
 
 void Object::visit_children(Visitor &visitor) {
+    visitor.visit(m_klass);
     visitor.visit(m_singleton_class);
     visitor.visit(m_owner);
     if (m_ivars) {

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -1,0 +1,223 @@
+SKIP_CLASS_MEMBERS = { 
+  # NOTE: our smart pointer type gets visited by everything else
+  'Natalie::Value' => '*',
+
+  # NOTE: Args cannot be heap-allocated, so pointers inside are seen on the stack
+  'Natalie::Args' => '*',
+
+  # NOTE: visited via ModuleObject
+  'Natalie::MethodInfo' => '*',
+
+  # NOTE: each key is already visited via m_hashmap
+  'Natalie::HashObject' => %w[m_key_list],
+
+  # NOTE: iterators aren't heap-allocated
+  'Natalie::HashObject::iterator' => '*',
+  'Natalie::HeapBlock::iterator' => '*',
+  'Natalie::StringObject::iterator' => '*',
+
+  # FIXME: members aren't properly named with m_ prefix
+  'Natalie::BigInt' => '*',
+
+  # FIXME: memory access bug when visiting m_calling_env
+  # (probably leaving m_calling_env behind after call when we shouldn't be)
+  'Natalie::Block' => %w[m_calling_env],
+}
+
+KNOWN_UNCOLLECTABLE_TYPES = [
+  'bool',
+  'char',
+  'double',
+  'fiber_stack_struct',
+  'int',
+  'long',
+  'long long',
+  'Natalie::Allocator',
+  'Natalie::ArrayPacker::Token',
+  'Natalie::Backtrace::Item',
+  'Natalie::Encoding',
+  'Natalie::Enumerator::ArithmeticSequenceObject::Origin',
+  'Natalie::FiberObject::Status',
+  'Natalie::HeapBlock',
+  'Natalie::HeapBlock::FreeCellNode',
+  'Natalie::Integer',
+  'Natalie::LocalJumpErrorType',
+  'Natalie::MethodInfo',
+  'Natalie::MethodMissingReason',
+  'Natalie::MethodVisibility',
+  'Natalie::NativeProfilerEvent',
+  'Natalie::NativeProfilerEvent::Type',
+  'Natalie::ObjectType',
+  'Natalie::ProcObject::ProcType',
+  'Natalie::TimeObject::Mode',
+  'TM::Hashmap',
+  'TM::Optional',
+  'TM::String',
+  'TM::Vector',
+  'tm',
+  'unsigned long',
+  'void',
+]
+
+# I can't get libclang to give good type info for these templates
+TEMPLATE_TYPES = {
+  'ManagedVector<T>' => { canonical_name: 'Natalie::ManagedVector', superclass: 'Natalie::Cell' },
+}
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'ffi-clang'
+end
+
+@classes = {}
+
+def get_canonical_class_name(cursor)
+  if (override = TEMPLATE_TYPES[cursor.display_name])
+    return override[:canonical_name]
+  end
+  name = cursor.type.canonical.spelling
+  if name != ''
+    name
+  else
+    # cursor_class_template doesn't give us the canonical name, but this works :-/
+    klass = cursor.display_name.sub(/<.*>/, '')
+    klass = '(anon)' if klass == ''
+    parent = cursor
+    while (parent = parent.semantic_parent) && parent.display_name != '' && parent.display_name !~ /\/|\./
+      klass = "#{parent.display_name}::#{klass}"
+    end
+    klass
+  end
+end
+
+def get_class_details_for_path(path)
+  code = File.read(path)
+  code_lines = code.split(/\n/)
+  index = FFI::Clang::Index.new
+  translation_unit = index.parse_translation_unit(path, ['-I', 'include', '-std=c++17'])
+  cursor = translation_unit.cursor
+
+  cursor.visit_children do |cursor, parent|
+    if cursor.location&.file == path
+      #p([cursor.kind, cursor.location&.line, cursor&.display_name])  
+      if %i[cursor_class_decl cursor_class_template cursor_struct cursor_union].include?(cursor.kind) && cursor.definition?
+        line = code_lines[cursor.location.line - 1]
+        if line =~ /:/
+          base = cursor.type.declaration.filter { |c| c.kind == :cursor_cxx_base_specifier }.first&.spelling
+          if base =~ /^class (.+)/
+            superclass = $1
+          elsif cursor.kind == :cursor_class_template
+            superclass = TEMPLATE_TYPES[cursor.display_name][:superclass]
+          else
+            raise 'could not get base class'
+          end
+        else
+          superclass = nil
+        end
+        klass = get_canonical_class_name(cursor)
+        @classes[klass] = {
+          kind: cursor.kind,
+          name: klass,
+          path: path,
+          location: cursor.location,
+          superclass: superclass,
+          members: [],
+          visit_children_method: nil,
+        }
+      elsif cursor.kind == :cursor_cxx_method && cursor.display_name =~ /^visit_children\(/
+        lines = code[cursor.extent.start.offset..cursor.extent.end.offset].split("\n")
+        klass = get_canonical_class_name(cursor.semantic_parent)
+        @classes[klass][:visit_children_method] = lines[1...-1]
+      elsif cursor.kind == :cursor_field_decl
+        klass = get_canonical_class_name(cursor.semantic_parent)
+        @classes[klass][:members] << {
+          type: cursor.type.canonical.spelling,
+          name: cursor.display_name,
+        }
+      end
+    end
+    :recurse
+  end
+end
+
+def garbage_collected?(type)
+  type = lookup_type(type)
+  if %w[Natalie::Cell Natalie::Object Natalie::Value].include?(type)
+    true
+  elsif (klass = @classes[type])
+    if %w[Natalie::Cell Natalie::Object Natalie::Value].include?(klass[:superclass])
+      true
+    elsif (superclass = @classes[klass[:superclass]])
+      garbage_collected?(superclass[:name])
+    else
+      binding.irb if klass[:name].strip =~ /.*Object$/
+      false
+    end
+  else
+    false
+  end
+end
+
+def lookup_type(type)
+  type
+    .sub(/const /, '')
+    .sub(/\s*\*?\s*(\[\d*\])?$/, '') # * and []
+    .strip
+end
+
+def verify_visited(klass, type, name)
+  type = type.sub(/const /, '').strip
+  details = @classes.fetch(klass)
+  if garbage_collected?(type)
+    if (method_lines = details[:visit_children_method])
+      visits_directly = method_lines.grep(/^\s*visitor\.visit\(&?#{name}/).any?
+      loops_over = method_lines.grep(/for\s*\(.*:\s*\*?#{name}\)/).any?
+      unless visits_directly || loops_over
+        puts "FAIL: #{klass}'s visit_children() method does not visit #{name} (type #{type})!"
+        exit 2
+      end
+    else
+      location = details[:location]
+      puts "FAIL: #{klass} (#{location.file}##{location.line}) does not have a visit_children() method!"
+      exit 1
+    end
+  elsif !KNOWN_UNCOLLECTABLE_TYPES.include?(lookup_type(type))
+    puts "CHECK - not a Natalie class? : #{type} (found in #{klass})"
+  end
+end
+
+paths = (Dir['include/natalie/**/*.hpp'] + Dir['src/**/*.cpp']).to_a
+#paths = ['include/natalie/env.hpp', 'include/natalie/managed_vector.hpp', 'src/env.cpp']
+paths.each_with_index do |path, index|
+  puts "processing file #{index + 1} of #{paths.size} : #{path}"
+  next if path =~ /natalie_parser/
+  get_class_details_for_path(path)
+end
+
+@classes.each do |klass, details|
+  next if SKIP_CLASS_MEMBERS[klass] == '*'
+
+  next if %i[cursor_struct cursor_union].include?(details[:kind])
+
+  details[:members].each do |member|
+    next if SKIP_CLASS_MEMBERS.fetch(klass, []).include?(member[:name])
+
+    if member[:type] =~ /^[:\w\*]+ \(\*\)\(.*\)$/
+      # looks like a function pointer type
+      next
+    end
+
+    types = []
+    if member[:type] =~ /<(.*)>/
+      types << member[:type].split('<').first
+      types += $1.split(/\s*,\s*/)
+    else
+      types = [member[:type]]
+    end
+    types.each do |t|
+      verify_visited(klass, t, member[:name])
+    end
+  end
+end

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -19,10 +19,9 @@ SKIP_CLASS_MEMBERS = {
   # FIXME: members aren't properly named with m_ prefix
   'Natalie::BigInt' => '*',
 
-  # FIXME: memory access bug when visiting these Envs
-  # (probably leaving an env behind after a call or break when we shouldn't be)
+  # FIXME: memory access bug when visiting this Env
+  # (probably leaving an env behind after a call when we shouldn't be)
   'Natalie::Block' => %w[m_calling_env],
-  'Natalie::ExceptionObject' => %w[m_local_jump_error_env],
 }
 
 KNOWN_UNCOLLECTABLE_TYPES = [

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -15,9 +15,6 @@ SKIP_CLASS_MEMBERS = {
   'Natalie::HashObject::iterator' => '*',
   'Natalie::HeapBlock::iterator' => '*',
   'Natalie::StringObject::iterator' => '*',
-
-  # FIXME: members aren't properly named with m_ prefix
-  'Natalie::BigInt' => '*',
 }
 
 KNOWN_UNCOLLECTABLE_TYPES = [

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -145,7 +145,7 @@ def garbage_collected?(type)
     elsif (superclass = @classes[klass[:superclass]])
       garbage_collected?(superclass[:name])
     else
-      binding.irb if klass[:name].strip =~ /.*Object$/
+      raise 'unlikely' if klass[:name].strip =~ /.*Object$/
       false
     end
   else

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -18,10 +18,6 @@ SKIP_CLASS_MEMBERS = {
 
   # FIXME: members aren't properly named with m_ prefix
   'Natalie::BigInt' => '*',
-
-  # FIXME: memory access bug when visiting this Env
-  # (probably leaving an env behind after a call when we shouldn't be)
-  'Natalie::Block' => %w[m_calling_env],
 }
 
 KNOWN_UNCOLLECTABLE_TYPES = [

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -19,9 +19,10 @@ SKIP_CLASS_MEMBERS = {
   # FIXME: members aren't properly named with m_ prefix
   'Natalie::BigInt' => '*',
 
-  # FIXME: memory access bug when visiting m_calling_env
-  # (probably leaving m_calling_env behind after call when we shouldn't be)
+  # FIXME: memory access bug when visiting these Envs
+  # (probably leaving an env behind after a call or break when we shouldn't be)
   'Natalie::Block' => %w[m_calling_env],
+  'Natalie::ExceptionObject' => %w[m_local_jump_error_env],
 }
 
 KNOWN_UNCOLLECTABLE_TYPES = [


### PR DESCRIPTION
We have a bad habit of adding class member variables without informing the GC how to visit those members. This bit of (hacky) linter code should help us catch those mistakes earlier in the future.

In fact, I was able to find quite a few GC bugs with it, so *worth it!* :100: 