### PR TITLE
Fix subsecond formatting in Time#inspect

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -64,7 +64,6 @@ private:
     static TimeObject *create(Env *, RationalObject *, Mode);
 
     Value build_string(Env *, const char *);
-    Value inspect_usec(Env *);
     void set_subsec(Env *, long);
     void set_subsec(Env *, IntegerObject *);
     void set_subsec(Env *, RationalObject *);

--- a/test/natalie/time_test.rb
+++ b/test/natalie/time_test.rb
@@ -147,6 +147,16 @@ describe 'Time' do
         time = Time.utc(1985, 4, 12, 23, 20, 50, 520_000)
         time.inspect.should == '1985-04-12 23:20:50.52 UTC'
       end
+
+      it 'preserves nanoseconds' do
+        time = Time.utc(1970, nil, nil, nil, nil, nil, Rational(1, 1000))
+        time.inspect.should == '1970-01-01 00:00:00.000000001 UTC'
+      end
+
+      it 'includes microseconds with leading zeroes' do
+        time = Time.utc(1970, nil, nil, nil, nil, nil, 1)
+        time.inspect.should == '1970-01-01 00:00:00.000001 UTC'
+      end
     end
   end
 

--- a/test/natalie/time_test.rb
+++ b/test/natalie/time_test.rb
@@ -69,6 +69,22 @@ describe 'Time' do
         t.sec.should == 1
       end
     end
+
+    context 'with an Integer microseconds argument' do
+      it 'returns a time' do
+        t = Time.utc(1970, 1, 1, 0, 0, 0, 1)
+        t.should be_an_instance_of(Time)
+        t.nsec.should == 1000
+      end
+    end
+
+    context 'with a Rational microseconds argument' do
+      it 'returns a time' do
+        t = Time.utc(1970, 1, 1, 0, 0, 0, Rational(1, 1000))
+        t.should be_an_instance_of(Time)
+        t.nsec.should == 1
+      end
+    end
   end
 
   describe '#+' do


### PR DESCRIPTION
This fixes Time#inspect for nanosecond values and subsecond values that require padding with leading zeroes.