### PR TITLE
Use spec compliant message for Fiber#resume exception

### DIFF
--- a/spec/core/fiber/resume_spec.rb
+++ b/spec/core/fiber/resume_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/fiber/resume'
+
+describe "Fiber#resume" do
+  it_behaves_like :fiber_resume, :resume
+end
+
+describe "Fiber#resume" do
+  it "runs until Fiber.yield" do
+    obj = mock('obj')
+    obj.should_not_receive(:do)
+    fiber = Fiber.new { 1 + 2; Fiber.yield; obj.do }
+    fiber.resume
+  end
+
+  it "resumes from the last call to Fiber.yield on subsequent invocations" do
+    fiber = Fiber.new { Fiber.yield :first; :second }
+    fiber.resume.should == :first
+    fiber.resume.should == :second
+  end
+
+  it "sets the block parameters to its arguments on the first invocation" do
+    first = mock('first')
+    first.should_receive(:arg).with(:first).twice
+
+    fiber = Fiber.new { |arg| first.arg arg; Fiber.yield; first.arg arg; }
+    fiber.resume :first
+    fiber.resume :second
+  end
+
+  ruby_version_is '3.0' do
+    it "raises a FiberError if the Fiber tries to resume itself" do
+      fiber = Fiber.new { fiber.resume }
+      -> { fiber.resume }.should raise_error(FiberError, /current fiber/)
+    end
+  end
+
+  ruby_version_is '' ... '3.0' do
+    it "raises a FiberError if the Fiber tries to resume itself" do
+      fiber = Fiber.new { fiber.resume }
+      -> { fiber.resume }.should raise_error(FiberError, /double resume/)
+    end
+  end
+
+  it "returns control to the calling Fiber if called from one" do
+    fiber1 = Fiber.new { :fiber1 }
+    fiber2 = Fiber.new { fiber1.resume; :fiber2 }
+    fiber2.resume.should == :fiber2
+  end
+
+  # Redmine #595
+  it "executes the ensure clause" do
+    code = <<-RUBY
+      f = Fiber.new do
+        begin
+          Fiber.yield
+        ensure
+          puts "ensure executed"
+        end
+      end
+
+      # The apparent issue is that when Fiber.yield executes, control
+      # "leaves" the "ensure block" and so the ensure clause should run. But
+      # control really does NOT leave the ensure block when Fiber.yield
+      # executes. It merely pauses there. To require ensure to run when a
+      # Fiber is suspended then makes ensure-in-a-Fiber-context different
+      # than ensure-in-a-Thread-context and this would be very confusing.
+      f.resume
+
+      # When we execute the second #resume call, the ensure block DOES exit,
+      # the ensure clause runs.
+      f.resume
+
+      exit 0
+    RUBY
+
+    ruby_exe(code).should == "ensure executed\n"
+  end
+end

--- a/spec/shared/fiber/resume.rb
+++ b/spec/shared/fiber/resume.rb
@@ -1,0 +1,59 @@
+describe :fiber_resume, shared: true do
+  it "can be invoked from the root Fiber" do
+   fiber = Fiber.new { :fiber }
+   fiber.send(@method).should == :fiber
+  end
+
+  # NATFIXME: no threads
+  xit "raises a FiberError if invoked from a different Thread" do
+    fiber = Fiber.new { 42 }
+    Thread.new do
+      -> {
+        fiber.send(@method)
+      }.should raise_error(FiberError)
+    end.join
+
+    # Check the Fiber can still be used
+    fiber.send(@method).should == 42
+  end
+
+  it "passes control to the beginning of the block on first invocation" do
+    invoked = false
+    fiber = Fiber.new { invoked = true }
+    fiber.send(@method)
+    invoked.should be_true
+  end
+
+  it "returns the last value encountered on first invocation" do
+    fiber = Fiber.new { 1+1; true }
+    fiber.send(@method).should be_true
+  end
+
+  it "runs until the end of the block" do
+    obj = mock('obj')
+    obj.should_receive(:do).once
+    fiber = Fiber.new { 1 + 2; a = "glark"; obj.do }
+    fiber.send(@method)
+  end
+
+  it "accepts any number of arguments" do
+    fiber = Fiber.new { |a| }
+    -> { fiber.send(@method, *(1..10).to_a) }.should_not raise_error
+  end
+
+  it "raises a FiberError if the Fiber is dead" do
+    fiber = Fiber.new { true }
+    fiber.send(@method)
+    -> { fiber.send(@method) }.should raise_error(FiberError)
+  end
+
+  it "raises a LocalJumpError if the block includes a return statement" do
+    fiber = Fiber.new { return; }
+    -> { fiber.send(@method) }.should raise_error(LocalJumpError)
+  end
+
+  it "raises a LocalJumpError if the block includes a break statement" do
+    fiber = Fiber.new { break; }
+    -> { fiber.send(@method) }.should raise_error(LocalJumpError)
+  end
+end

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -40,7 +40,7 @@ Value FiberObject::resume(Env *env, Args args) {
     if (m_status == Status::Terminated)
         env->raise("FiberError", "dead fiber called");
     if (m_previous_fiber)
-        env->raise("FiberError", "double resume");
+        env->raise("FiberError", "attempt to resume the current fiber");
     auto previous_fiber = FiberObject::current();
     m_previous_fiber = s_current;
     s_current = this;

--- a/test/natalie/fiber_test.rb
+++ b/test/natalie/fiber_test.rb
@@ -52,7 +52,7 @@ describe 'Fiber' do
 
     f = Fiber.new { f2.resume(f) }
 
-    -> { f.resume }.should raise_error(FiberError, /double resume/)
+    -> { f.resume }.should raise_error(FiberError, /attempt to resume the current fiber/)
   end
 
   it 'raises an error when attempting to yield from the main fiber' do


### PR DESCRIPTION
The exception message changed in Ruby 3.0.0: https://github.com/ruby/ruby/commit/bf3b2a43741e4f72be21bc6acf24d37e7fcff61c