### PR TITLE
Fix remaining clang-tidy warnings and configure warnings as errors in clang-tidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV LLVM_CONFIG=/usr/lib/llvm-11/bin/llvm-config
 WORKDIR natalie
 COPY .git/ .git/
 COPY .gitmodules .gitmodules
+COPY .clang-tidy .clang-tidy
 RUN git submodule update --init
 
 COPY Gemfile Gemfile.lock /natalie/ 

--- a/Rakefile
+++ b/Rakefile
@@ -375,7 +375,7 @@ file "build/libnatalie_parser.#{SO_EXT}" => "build/natalie_parser.#{SO_EXT}" do 
 end
 
 task :tidy_internal do
-  sh "clang-tidy #{PRIMARY_SOURCES.exclude('src/dtoa.c')}"
+  sh "clang-tidy --warnings-as-errors='*' #{PRIMARY_SOURCES.exclude('src/dtoa.c')}"
 end
 
 task :gc_lint_internal do

--- a/include/natalie/backtrace.hpp
+++ b/include/natalie/backtrace.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "natalie/env.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/gc.hpp"
 #include "tm/hashmap.hpp"
@@ -9,13 +10,14 @@ class Backtrace : public Cell {
 public:
     struct Item {
         String source_location;
-        const char *file;
+        String file;
         size_t line;
     };
 
-    void add_item(Env *env, const char *file, size_t line) {
+    void add_item(Env *env, String file, size_t line) {
         // NATFIXME: Ideally we could store the env and delay building the code location name
-        m_items.push(Item { env->build_code_location_name(), file, line });
+        auto name = env->build_code_location_name();
+        m_items.push(Item { name, file, line });
     }
     ArrayObject *to_ruby_array();
 

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -30,14 +30,14 @@ public:
     Value asctime(Env *);
     Value cmp(Env *, Value);
     bool eql(Env *, Value);
-    Value hour(Env *);
+    Value hour(Env *) const;
     Value inspect(Env *);
     bool is_utc(Env *) const { return m_mode == Mode::UTC; }
-    Value mday(Env *);
-    Value min(Env *);
-    Value month(Env *);
+    Value mday(Env *) const;
+    Value min(Env *) const;
+    Value month(Env *) const;
     Value nsec(Env *);
-    Value sec(Env *);
+    Value sec(Env *) const;
     Value strftime(Env *, Value);
     Value subsec(Env *);
     Value to_f(Env *);
@@ -45,9 +45,9 @@ public:
     Value to_r(Env *);
     Value to_s(Env *);
     Value usec(Env *);
-    Value wday(Env *);
-    Value yday(Env *);
-    Value year(Env *);
+    Value wday(Env *) const;
+    Value yday(Env *) const;
+    Value year(Env *) const;
 
     virtual void visit_children(Visitor &visitor) override {
         Object::visit_children(visitor);

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1736,7 +1736,7 @@ Value ArrayObject::find_index(Env *env, Value object, Block *block, bool search_
                 return Value::integer(index);
         } else {
             Value args[] = { item };
-            auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr); // NOLINT FIXME: Called C++ object pointer is null
+            auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
             length = static_cast<nat_int_t>(size());
             if (result->is_truthy())
                 return Value::integer(index);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -43,7 +43,7 @@ String Env::build_code_location_name() {
         return String::format("block in {}", outer_name);
     }
     // fall back to just "block" if we don't know where this block came from
-    return new String("block");
+    return String("block");
 }
 
 void Env::raise(ClassObject *klass, StringObject *message) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -226,7 +226,7 @@ Value Env::var_set(const char *name, size_t index, bool allocate, Value val) {
             abort();
         }
     }
-    m_vars->at(index) = val; // NOLINT FIXME: Called C++ object pointer is null
+    m_vars->at(index) = val;
     return val;
 }
 

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -292,7 +292,10 @@ Integer Integer::operator<<(const Integer &other) const {
     else if (will_multiplication_overflow(to_nat_int_t(), pow_result.to_nat_int_t()))
         return to_bigint() << other.to_nat_int_t();
 
-    return to_nat_int_t() << other.to_nat_int_t(); // NOLINT FIXME: The result of the left shift is undefined because the right operand is negative
+    if (other.to_nat_int_t() < 0)
+        return to_nat_int_t() >> ::abs(other.to_nat_int_t());
+
+    return to_nat_int_t() << other.to_nat_int_t();
 }
 
 Integer Integer::operator>>(const Integer &other) const {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -464,12 +464,12 @@ String ModuleObject::inspect_str() {
         if (owner() && owner() != GlobalEnv::the()->Object()) {
             return String::format("{}::{}", owner()->inspect_str(), m_class_name.value());
         } else {
-            return new String(m_class_name.value());
+            return String(m_class_name.value());
         }
     } else if (is_class()) {
         return String::format("#<Class:{}>", pointer_id());
     } else if (is_module() && m_class_name) {
-        return new String(m_class_name.value());
+        return String(m_class_name.value());
     } else {
         return String::format("#<{}:{}>", klass()->inspect_str(), pointer_id());
     }

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -137,7 +137,7 @@ bool TimeObject::eql(Env *env, Value other) {
     return false;
 }
 
-Value TimeObject::hour(Env *) {
+Value TimeObject::hour(Env *) const {
     return Value::integer(m_time.tm_hour);
 }
 
@@ -168,15 +168,15 @@ Value TimeObject::inspect(Env *env) {
     return result;
 }
 
-Value TimeObject::mday(Env *) {
+Value TimeObject::mday(Env *) const {
     return Value::integer(m_time.tm_mday);
 }
 
-Value TimeObject::min(Env *) {
+Value TimeObject::min(Env *) const {
     return Value::integer(m_time.tm_min);
 }
 
-Value TimeObject::month(Env *) {
+Value TimeObject::month(Env *) const {
     return Value::integer(m_time.tm_mon + 1);
 }
 
@@ -188,7 +188,7 @@ Value TimeObject::nsec(Env *env) {
     }
 }
 
-Value TimeObject::sec(Env *) {
+Value TimeObject::sec(Env *) const {
     return Value::integer(m_time.tm_sec);
 }
 
@@ -236,15 +236,15 @@ Value TimeObject::usec(Env *env) {
     }
 }
 
-Value TimeObject::wday(Env *) {
+Value TimeObject::wday(Env *) const {
     return Value::integer(m_time.tm_wday);
 }
 
-Value TimeObject::yday(Env *) {
+Value TimeObject::yday(Env *) const {
     return Value::integer(m_time.tm_yday + 1);
 }
 
-Value TimeObject::year(Env *) {
+Value TimeObject::year(Env *) const {
     return Value::integer(m_time.tm_year + 1900);
 }
 

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -162,7 +162,7 @@ Value TimeObject::inspect(Env *env) {
         result->append(" UTC");
     } else {
         char buffer[7];
-        auto length = ::strftime(buffer, 7, " %z", &m_time);
+        ::strftime(buffer, 7, " %z", &m_time);
         result->append(buffer);
     }
     return result;


### PR DESCRIPTION
This fixes #592 and a few more warnings that have popped up since that issue was created.

When I added the clang-tidy linter, I didn't realize it would not fail the build for warnings. So, this PR configures clang-tidy to treat warnings as errors, so they should fail the build from now on.