### PR TITLE
Add arm64-darwin-20 platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     stackprof (0.2.21)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
Bundler adds this every time I run `bundle` (via `rake` or directly)