### PR TITLE
Implement Float#to_r

### DIFF
--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -129,6 +129,7 @@ public:
     Value sub(Env *, Value);
     Value to_f() const { return Value::floatingpoint(m_double); }
     Value to_i(Env *) const;
+    Value to_r(Env *) const;
     Value to_s() const;
     Value truncate(Env *, Value);
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -521,6 +521,7 @@ gen.binding('Float', 'round', 'FloatObject', 'round', argc: 0..1, pass_env: true
 gen.binding('Float', 'to_f', 'FloatObject', 'to_f', argc: 0, pass_env: false, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Float', 'to_i', 'FloatObject', 'to_i', argc: 0, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Float', 'to_int', 'FloatObject', 'to_i', argc: 0, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
+gen.binding('Float', 'to_r', 'FloatObject', 'to_r', argc: 0, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Float', 'to_s', 'FloatObject', 'to_s', argc: 0, pass_env: false, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Float', 'truncate', 'FloatObject', 'truncate', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Float', 'zero?', 'FloatObject', 'is_zero', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -200,6 +200,10 @@ Value FloatObject::to_i(Env *env) const {
     return f_to_i_or_bigint(num);
 }
 
+Value FloatObject::to_r(Env *env) const {
+    return KernelModule::Rational(env, m_double);
+}
+
 Value FloatObject::add(Env *env, Value rhs) {
     Value lhs = this;
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -489,8 +489,8 @@ RationalObject *KernelModule::Rational(Env *env, double arg) {
     Value y = radix.pow(env, Value::integer(DBL_MANT_DIG));
 
     int exponent;
-    FloatObject significand { std::frexp(arg, &exponent) };
-    Value x = significand.mul(env, y)->as_float()->to_i(env);
+    FloatObject *significand = new FloatObject { std::frexp(arg, &exponent) };
+    Value x = significand->mul(env, y)->as_float()->to_i(env);
 
     IntegerObject two { 2 };
     if (exponent < 0) {

--- a/test/natalie/float_test.rb
+++ b/test/natalie/float_test.rb
@@ -17,4 +17,14 @@ describe 'float' do
       (2.2 ** 3).should be_close(10.648, TOLERANCE)
     end
   end
+
+  describe '#to_r' do
+    it 'returns a rational' do
+      2.0.to_r.should == Rational(2, 1)
+      2.5.to_r.should == Rational(5, 2)
+      -0.75.to_r.should == Rational(-3, 4)
+      0.0.to_r.should == Rational(0, 1)
+      0.3.to_r.should == Rational(5404319552844595, 18014398509481984)
+    end
+  end
 end


### PR DESCRIPTION
There isn't any spec coverage provided by `spec/core/float/to_r_spec.rb` so I've added some examples from Ruby's Float#to_r documentation to `test/natalie/float_test.rb` for now

I had to change how `KernelModule::Rational` constructed the float object to get it to work—without any change that was resulting in the "This object is stack allocated..." failure from `NAT_GC_GUARD_VALUE`