### PR TITLE
Float `to_i` should raise a `FloatDomainError` when `NaN`

### DIFF
--- a/spec/core/float/shared/to_i.rb
+++ b/spec/core/float/shared/to_i.rb
@@ -1,5 +1,6 @@
 describe :float_to_i, shared: true do
   it "returns self truncated to an Integer" do
+    -> { (0.0 / 0.0).send(@method) }.should raise_error(FloatDomainError)
     899.2.send(@method).should eql(899)
     -1.122256e-45.send(@method).should eql(0)
     5_213_451.9201.send(@method).should eql(5213451)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -191,6 +191,7 @@ Value FloatObject::coerce(Env *env, Value arg) {
 }
 
 Value FloatObject::to_i(Env *env) const {
+    if (is_nan()) env->raise("FloatDomainError", "NaN");
     if (is_infinity()) {
         env->raise("FloatDomainError", to_s()->as_string()->string());
     }


### PR DESCRIPTION
Float `to_i` should raise a `FloatDomainError` when `NaN`

There is no test for this in the `to_i` example in spec/core . I added one and will then try upstream it to `ruby/spec`

I notice that the change recommended for the stack allocated Float has been fixed by a similar commit so did not include it

It was:
```
auto significand = Value::floatingpoint(std::frexp(arg, &exponent));
Value x = significand.send(env, "*"_s, { y })->as_float()->to_i(env);
```

vs what is now in master