### PR TITLE
Add partial CSV headers parsing support, add CSV#each spec

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -99,7 +99,11 @@ class CSV
   end
 
   def headers
-    @writer&.headers
+    if @writer
+      @writer.headers
+    else
+      parser.headers
+    end
   end
 
   def liberal_parsing?

--- a/lib/csv/parser.rb
+++ b/lib/csv/parser.rb
@@ -22,6 +22,29 @@ class CSV
     end
 
     def next_line
+      line = consume_line
+
+      if @lineno == 1 && @options[:headers]
+        # We have just read the headers line
+        @headers = line
+
+        line = consume_line
+      end
+
+      if @headers && line
+        Row.new(@headers, line)
+      else
+        line
+      end
+    end
+
+    def headers
+      return nil unless @options[:headers]
+
+      @headers || true
+    end
+
+    def consume_line
       @line = @input.gets
       return nil unless @line
       @current_col = 0

--- a/spec/library/csv/each_spec.rb
+++ b/spec/library/csv/each_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require 'csv'
+
+describe "CSV#each" do
+  it "yields each row" do
+    c = CSV.new("1,2,3")
+    yielded = []
+    c.each { |x| yielded << x }
+
+    yielded.should == [["1", "2", "3"]]
+  end
+
+  it "yields nothing for empty file" do
+    c = CSV.new("")
+    yielded = []
+    c.each { |x| yielded << x }
+
+    yielded.should == []
+  end
+end

--- a/spec/library/csv/each_spec.rb
+++ b/spec/library/csv/each_spec.rb
@@ -17,4 +17,27 @@ describe "CSV#each" do
 
     yielded.should == []
   end
+
+  context "with headers: true" do
+    it "yields nothing for file with only headers" do
+      c = CSV.new("a,b,c", headers: true)
+      yielded = []
+      c.each { |x| yielded << x }
+
+      yielded.should == []
+    end
+
+    it "yields instances of CSV::Row with headers" do
+      c = CSV.new("a,b,c\n1,2,3", headers: true)
+      yielded = []
+      c.each { |x| yielded << x }
+
+      yielded.count.should == 1
+
+      row = yielded.first
+
+      row.headers.should == ["a", "b", "c"]
+      row.fields.should == ["1", "2", "3"]
+    end
+  end
 end

--- a/spec/library/csv/headers_spec.rb
+++ b/spec/library/csv/headers_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+require 'csv'
+
+describe "CSV#headers" do
+  it "is nil if headers will not be used" do
+    csv = CSV.new("a,b,c\n1,2,3", headers: false)
+
+    csv.headers.should == nil
+  end
+
+  it "is true if headers will but not yet have been read" do
+    csv = CSV.new("a,b,c\n1,2,3", headers: true)
+
+    csv.headers.should == true
+  end
+
+  it "is the actual headers after they have been read" do
+    csv = CSV.new("a,b,c\n1,2,3", headers: true)
+
+    csv.readline
+
+    csv.headers.should == ["a", "b", "c"]
+  end
+end


### PR DESCRIPTION
Adds `each` and `headers` specs for #551.

Also adds basic support for headers when parsing csv. Most notably, `ruby/csv` allows setting separate converters for headers which is not implemented in this PR.