### PR TITLE
Add Time#usec spec

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -62,6 +62,7 @@ public:
 
 private:
     static struct tm build_time_struct(Env *, Value, Value, Value, Value, Value, Value);
+    static RationalObject *convert_rational(Env *, Value);
     static TimeObject *create(Env *, RationalObject *, Mode);
 
     Value build_string(Env *, const char *);

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -61,11 +61,11 @@ public:
     }
 
 private:
-    static struct tm build_time_struct(Env *, Value, Value, Value, Value, Value, Value);
     static RationalObject *convert_rational(Env *, Value);
     static TimeObject *create(Env *, RationalObject *, Mode);
 
     Value build_string(Env *, const char *);
+    void build_time(Env *, Value, Value, Value, Value, Value, Value);
     void set_subsec(Env *, long);
     void set_subsec(Env *, IntegerObject *);
     void set_subsec(Env *, RationalObject *);

--- a/spec/core/time/usec_spec.rb
+++ b/spec/core/time/usec_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../../spec_helper'
+
+describe "Time#usec" do
+  it "returns 0 for a Time constructed with a whole number of seconds" do
+    Time.at(100).usec.should == 0
+  end
+
+  it "returns the microseconds part of a Time constructed with a Float number of seconds" do
+    Time.at(10.75).usec.should == 750_000
+  end
+
+  it "returns the microseconds part of a Time constructed with an Integer number of microseconds" do
+    Time.at(0, 999_999).usec.should == 999_999
+  end
+
+  it "returns the microseconds part of a Time constructed with an Float number of microseconds > 1" do
+    Time.at(0, 3.75).usec.should == 3
+  end
+
+  it "returns 0 for a Time constructed with an Float number of microseconds < 1" do
+    Time.at(0, 0.75).usec.should == 0
+  end
+
+  it "returns the microseconds part of a Time constructed with a Rational number of seconds" do
+    Time.at(Rational(3, 2)).usec.should == 500_000
+  end
+
+  it "returns the microseconds part of a Time constructed with an Rational number of microseconds > 1" do
+    Time.at(0, Rational(99, 10)).usec.should == 9
+  end
+
+  it "returns 0 for a Time constructed with an Rational number of microseconds < 1" do
+    Time.at(0, Rational(9, 10)).usec.should == 0
+  end
+
+  it "returns the microseconds for time created by Time#local" do
+    Time.local(1,2,3,4,5,Rational(6.78)).usec.should == 780000
+  end
+
+  it "returns a positive value for dates before the epoch" do
+    Time.utc(1969, 11, 12, 13, 18, 57, 404240).usec.should == 404240
+  end
+end

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -294,7 +294,7 @@ void TimeObject::build_time(Env *env, Value year, Value month, Value mday, Value
         m_time.tm_hour = hour->as_integer()->to_nat_int_t();
     if (min && min->is_integer())
         m_time.tm_min = min->as_integer()->to_nat_int_t();
-    if (sec) {
+    if (sec && !sec->is_nil()) {
         if (sec->is_integer()) {
             m_time.tm_sec = sec->as_integer()->to_nat_int_t();
         } else {

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -13,10 +13,9 @@ TimeObject *TimeObject::at(Env *env, Value time, Value subsec) {
 }
 
 TimeObject *TimeObject::local(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec, Value usec) {
-    struct tm time = build_time_struct(env, year, month, mday, hour, min, sec);
-    int seconds = mktime(&time);
     TimeObject *result = new TimeObject {};
-    result->m_time = time;
+    result->build_time(env, year, month, mday, hour, min, sec);
+    int seconds = mktime(&result->m_time);
     result->m_mode = Mode::Localtime;
     result->m_integer = Value::integer(seconds);
     if (usec && usec->is_integer()) {
@@ -42,11 +41,10 @@ TimeObject *TimeObject::now(Env *env) {
 }
 
 TimeObject *TimeObject::utc(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec, Value subsec) {
-    struct tm time = build_time_struct(env, year, month, mday, hour, min, sec);
-    time.tm_gmtoff = 0;
-    int seconds = timegm(&time);
     TimeObject *result = new TimeObject {};
-    result->m_time = time;
+    result->build_time(env, year, month, mday, hour, min, sec);
+    result->m_time.tm_gmtoff = 0;
+    int seconds = timegm(&result->m_time);
     result->m_mode = Mode::UTC;
     result->m_integer = Value::integer(seconds);
     if (subsec) {
@@ -243,28 +241,6 @@ Value TimeObject::year(Env *) const {
     return Value::integer(m_time.tm_year + 1900);
 }
 
-struct tm TimeObject::build_time_struct(Env *, Value year, Value month, Value mday, Value hour, Value min, Value sec) {
-    struct tm time = { 0 };
-    time.tm_year = year->as_integer()->to_nat_int_t() - 1900;
-    time.tm_mon = 0;
-    time.tm_mday = 1;
-    time.tm_hour = 0;
-    time.tm_min = 0;
-    time.tm_sec = 0;
-    if (month && month->is_integer())
-        time.tm_mon = month->as_integer()->to_nat_int_t() - 1;
-    if (mday && mday->is_integer())
-        time.tm_mday = mday->as_integer()->to_nat_int_t();
-    if (hour && hour->is_integer())
-        time.tm_hour = hour->as_integer()->to_nat_int_t();
-    if (min && min->is_integer())
-        time.tm_min = min->as_integer()->to_nat_int_t();
-    if (sec && sec->is_integer())
-        time.tm_sec = sec->as_integer()->to_nat_int_t();
-    time.tm_isdst = -1;
-    return time;
-}
-
 RationalObject *TimeObject::convert_rational(Env *env, Value value) {
     if (value->is_integer()) {
         return RationalObject::create(env, value->as_integer(), new IntegerObject { 1 });
@@ -299,6 +275,35 @@ TimeObject *TimeObject::create(Env *env, RationalObject *rational, Mode mode) {
     result->m_integer = integer;
     result->set_subsec(env, subseconds);
     return result;
+}
+
+void TimeObject::build_time(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec) {
+    m_time = { 0 };
+    m_time.tm_year = year->as_integer()->to_nat_int_t() - 1900;
+    m_time.tm_mon = 0;
+    m_time.tm_mday = 1;
+    m_time.tm_hour = 0;
+    m_time.tm_min = 0;
+    m_time.tm_sec = 0;
+    m_time.tm_isdst = -1;
+    if (month && month->is_integer())
+        m_time.tm_mon = month->as_integer()->to_nat_int_t() - 1;
+    if (mday && mday->is_integer())
+        m_time.tm_mday = mday->as_integer()->to_nat_int_t();
+    if (hour && hour->is_integer())
+        m_time.tm_hour = hour->as_integer()->to_nat_int_t();
+    if (min && min->is_integer())
+        m_time.tm_min = min->as_integer()->to_nat_int_t();
+    if (sec) {
+        if (sec->is_integer()) {
+            m_time.tm_sec = sec->as_integer()->to_nat_int_t();
+        } else {
+            RationalObject *rational = convert_rational(env, sec);
+            auto divmod = rational->send(env, "divmod"_s, { Value::integer(1) })->as_array();
+            m_time.tm_sec = divmod->first()->as_integer()->to_nat_int_t();
+            set_subsec(env, divmod->last()->as_rational());
+        }
+    }
 }
 
 void TimeObject::set_subsec(Env *env, long nsec) {

--- a/test/natalie/time_test.rb
+++ b/test/natalie/time_test.rb
@@ -49,6 +49,14 @@ describe 'Time' do
         t.nsec.should == 1
       end
     end
+
+    context 'with a Float microseconds argument' do
+      it 'returns a time' do
+        t = Time.at(0, 3.75)
+        t.should be_an_instance_of(Time)
+        t.nsec.should == 3750
+      end
+    end
   end
 
   describe '.local' do


### PR DESCRIPTION
Time#usec is already implemented, but a couple of changes required to get the spec passing:

* Float microseconds argument to `Time.at` e.g. `Time.at(0, 3.75)`
* Rational second argument to `Time.local` e.g. `Time.local(1,2,3,4,5,Rational(6.78))`
  (second argument is documented as integer, but the implementation accepts other numeric values)

I've added `TimeObject::convert_rational` to handle the repeated type conversion logic, and changed the `TimeObject::build_time_struct` helper function so that it can store the subseconds.