### PR TITLE
Fix enumerator size for String#each_char and String#each_byte

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -94,6 +94,11 @@ public:
         return self->as_string()->size(env);
     }
 
+    static Value bytesize_fn(Env *env, Value self, Args, Block *) {
+        auto bytesize = self->as_string()->bytesize();
+        return Value::integer(bytesize);
+    }
+
     const char *c_str() const { return m_string.c_str(); }
     size_t bytesize() const { return m_string.length(); }
     size_t length() const { return m_string.length(); }

--- a/spec/core/string/each_byte_spec.rb
+++ b/spec/core/string/each_byte_spec.rb
@@ -48,8 +48,7 @@ describe "String#each_byte" do
 
     describe "returned enumerator" do
       describe "size" do
-        # NATFIXME: Make Enumerator#size spec compliant
-        xit "should return the bytesize of the string" do
+        it "should return the bytesize of the string" do
           str = "hello"
           str.each_byte.size.should == str.bytesize
           str = "ola"

--- a/spec/core/string/each_char_spec.rb
+++ b/spec/core/string/each_char_spec.rb
@@ -1,0 +1,7 @@
+require_relative 'shared/chars'
+require_relative 'shared/each_char_without_block'
+
+describe "String#each_char" do
+  it_behaves_like :string_chars, :each_char
+  it_behaves_like :string_each_char_without_block, :each_char
+end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1641,9 +1641,8 @@ Value ArrayObject::reverse(Env *env) {
 
 Value ArrayObject::reverse_each(Env *env, Block *block) {
     if (!block) {
-        auto enumerator = send(env, "enum_for"_s, { "reverse_each"_s });
-        enumerator->ivar_set(env, "@size"_s, Value::integer(m_vector.size()));
-        return enumerator;
+        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        return send(env, "enum_for"_s, { "reverse_each"_s }, size_block);
     }
 
     for (size_t i = m_vector.size(); i > 0; --i) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -710,8 +710,10 @@ Value StringObject::bytes(Env *env, Block *block) {
 }
 
 Value StringObject::each_byte(Env *env, Block *block) {
-    if (!block)
-        return send(env, "enum_for"_s, { "each_byte"_s });
+    if (!block) {
+        Block *size_block = new Block { env, this, StringObject::bytesize_fn, 0 };
+        return send(env, "enum_for"_s, { "each_byte"_s }, size_block);
+    }
 
     for (size_t i = 0; i < length(); i++) {
         unsigned char c = c_str()[i];

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -38,14 +38,16 @@ StringView StringObject::next_char(Env *env, size_t *index) const {
 }
 
 Value StringObject::each_char(Env *env, Block *block) {
-    if (!block)
-        return send(env, "enum_for"_s, { "each_char"_s });
+    if (!block) {
+        Block *size_block = new Block { env, this, StringObject::size_fn, 0 };
+        return send(env, "enum_for"_s, { "each_char"_s }, size_block);
+    }
 
     for (auto c : *this) {
         Value args[] = { new StringObject { c, m_encoding } };
         NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
     }
-    return NilObject::the();
+    return this;
 }
 
 Value StringObject::chars(Env *env, Block *block) {


### PR DESCRIPTION
Return string size/byte size (not nil) as an enumerator size when `#each_char`/`#each_byte` are called without a block.

Example:

```ruby
enum = "abc".each_char
enum.size # => 3
```
