### PR TITLE
Add Array#pack directives 'V' and 'v'

### DIFF
--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -57,6 +57,12 @@ namespace ArrayPacker {
             case 's':
                 pack_s();
                 break;
+            case 'v':
+                pack_v();
+                break;
+            case 'V':
+                pack_V();
+                break;
             default: {
                 char buf[2] = { d, '\0' };
                 env->raise("ArgumentError", "unknown directive in string: {}", buf);
@@ -195,6 +201,29 @@ namespace ArrayPacker {
             auto size = m_token.native_size ? sizeof(signed short) : 2;
             append_bytes((const char *)&source, size);
         }
+
+        void pack_V() {
+            m_token.endianness = Endianness::Little;
+            auto size = 4;
+            if (m_source->is_bignum()) {
+                pack_bignum(size * 8);
+            } else {
+                auto source = (unsigned long long)m_source->to_nat_int_t();
+                append_bytes((const char *)(&source), size);
+            }
+        }
+
+        void pack_v() {
+            m_token.endianness = Endianness::Little;
+            auto size = 2;
+            if (m_source->is_bignum()) {
+                pack_bignum(size * 8);
+            } else {
+                auto source = (long long)m_source->to_nat_int_t();
+                append_bytes((const char *)(&source), size);
+            }
+        }
+
 
         // NOTE: We probably don't need this monster method, but I could not figure out
         // how to pack 'j'/'J' using the modulus trick. ¯\_(ツ)_/¯

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -94,7 +94,9 @@ namespace ArrayPacker {
                 case 'n':
                 case 'S':
                 case 's':
-                case 'U': {
+                case 'U': 
+                case 'V':
+                case 'v':{
                     pack_with_loop(env, token, [&]() {
                         auto integer = m_source->at(m_index)->to_int(env);
                         auto packer = IntegerHandler { integer, token };

--- a/spec/core/array/pack/v_spec.rb
+++ b/spec/core/array/pack/v_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../../spec_helper'
 require_relative '../fixtures/classes'
 require_relative 'shared/basic'


### PR DESCRIPTION
This PR adds the Array#pack directives 'V' and 'v'. Related to issue #195.

The pack directives 'v' and 'V' pack an array of integers into 16-bit unsigned and 32-bit unsigned little endian byte order respectively. I tested my code with different inputs in the Natalie REPL and compared the outputs with the `irb`. It seems that everything is working fine.

Before merging this, I would like to confess that a spec gets skipped when I try to run the `v_spec.rb` file. 

![image](https://user-images.githubusercontent.com/51860725/198311857-124987b7-8e7d-4801-946a-23d50ea6916d.png)

## Debugging
I did some debugging in `test/support/spec.rb` and placed some inspections. It seems like the spec `encodes a Float truncated as an Integer` gets skipped because the `fn` for it is `nil`. Does this mean that this particular spec hasn't been implemented for 'v' and 'V' directives? 

This is my first time ever working on compilers and would like some inputs. I'm fairly confused on this one.


