### PR TITLE
Use Object::to_str(Env *) for implicit conversion to String

### DIFF
--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -897,10 +897,9 @@ Value ArrayObject::join(Env *env, Value joiner) {
 
             auto to_str = "to_str"_s;
             auto to_s = "to_s"_s;
-            if (!joiner->is_string() && joiner->respond_to(env, to_str))
-                joiner = joiner->send(env, to_str);
+            if (!joiner->is_string())
+                joiner = joiner->to_str(env);
 
-            joiner->assert_type(env, Object::Type::String, "String");
             StringObject *out = new StringObject {};
             for (size_t i = 0; i < size(); i++) {
                 Value item = (*this)[i];
@@ -959,10 +958,9 @@ Value ArrayObject::cmp(Env *env, Value other) {
 }
 
 Value ArrayObject::pack(Env *env, Value directives) {
-    if (!directives->is_string() && directives->respond_to(env, "to_str"_s))
-        directives = directives->send(env, "to_str"_s);
+    if (!directives->is_string())
+        directives = directives->to_str(env);
 
-    directives->assert_type(env, Object::Type::String, "String");
     auto directives_string = directives->as_string()->string();
 
     if (directives_string.is_empty())

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -22,9 +22,8 @@ Value KernelModule::abort_method(Env *env, Value message) {
     ExceptionObject *exception;
 
     if (message) {
-        auto to_str = "to_str"_s;
-        if (!message->is_string() && message->respond_to(env, to_str))
-            message = message->send(env, to_str);
+        if (!message->is_string())
+            message = message->to_str(env);
 
         message->assert_type(env, Type::String, "String");
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -133,7 +133,7 @@ Value StringObject::center(Env *env, Value length, Value padstr) {
     }
 
     if (pad.is_empty())
-        env->raise("ArgumentError", "padstr can't be empty");
+        env->raise("ArgumentError", "zero width padding");
 
     if (length_i <= (nat_int_t)m_string.size())
         return this;
@@ -570,7 +570,7 @@ Value StringObject::concat(Env *env, Args args) {
         if (arg->is_string()) {
             str_obj = arg->as_string();
         } else if (arg->is_integer() && arg->as_integer()->to_nat_int_t() < 0) {
-            env->raise("RangeError", "less than 0");
+            env->raise("RangeError", "{} out of char range", arg->as_integer()->to_s(env)->as_string()->string());
         } else if (arg->is_integer()) {
             str_obj = arg.send(env, "chr"_s, { m_encoding })->as_string();
         } else {
@@ -644,7 +644,7 @@ Value StringObject::prepend(Env *env, Args args) {
         if (arg->is_string()) {
             str_obj = arg->as_string();
         } else if (arg->is_integer() && arg->as_integer()->to_nat_int_t() < 0) {
-            env->raise("RangeError", "less than 0");
+            env->raise("RangeError", "{} out of char range", arg->as_integer()->to_s(env)->as_string()->string());
         } else if (arg->is_integer()) {
             str_obj = arg.send(env, "chr"_s, { m_encoding })->as_string();
         } else {


### PR DESCRIPTION
Changes:
- fixed an error message when implicit conversion to String fails because `#to_str` doesn't return String
- fixed several other (not related) error messages (unfortunately they aren't covered with specs)

A common pattern to convert an argument to String:

```ruby
    auto to_str = "to_str"_s;
    if (!arg->is_string() && arg->respond_to(env, to_str))
        arg = arg->send(env, to_str);
    arg->assert_type(env, Object::Type::String, "String");
```

leads to an error message

```
(repl):3:in `include?': no implicit conversion of Integer into String (TypeError)
```

But expected message usually is the following:

```
(irb):59:in `include?': can't convert Object to String (Object#to_str gives Integer) (TypeError)
```

Source code to reproduce the issue (for `String#include?`):

```ruby
a = Object.new
def a.to_str() 1 end
"".include?(a)
```