### PR TITLE
Implement comparison between Integer and Rational objects

### DIFF
--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -219,7 +219,7 @@ Value IntegerObject::powmod(Env *env, Value exponent, Value mod) {
 
 Value IntegerObject::cmp(Env *env, Value arg) {
     auto is_comparable_with = [](Value arg) -> bool {
-        return arg->is_integer() || arg->is_float();
+        return arg->is_integer() || arg->is_float() || arg->is_rational();
     };
 
     // Check if we might want to coerce the value
@@ -243,11 +243,13 @@ bool IntegerObject::eq(Env *env, Value other) {
     if (other->is_float())
         return m_integer == other->as_float()->to_double();
 
-    if (!other->is_integer())
-        other = Natalie::coerce(env, other, this).second;
-
     if (other->is_integer())
         return m_integer == other->as_integer()->integer();
+
+    if (other->respond_to(env, "coerce"_s)) {
+        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
+        return result.first->send(env, "=="_s, { result.second })->is_truthy();
+    }
 
     return other->send(env, "=="_s, { this })->is_truthy();
 }
@@ -256,11 +258,13 @@ bool IntegerObject::lt(Env *env, Value other) {
     if (other->is_float())
         return m_integer < other->as_float()->to_double();
 
-    if (!other->is_integer())
-        other = Natalie::coerce(env, other, this).second;
-
     if (other->is_integer())
         return m_integer < other->as_integer()->integer();
+
+    if (other->respond_to(env, "coerce"_s)) {
+        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
+        return result.first->send(env, "<"_s, { result.second })->is_truthy();
+    }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
@@ -269,11 +273,13 @@ bool IntegerObject::lte(Env *env, Value other) {
     if (other->is_float())
         return m_integer <= other->as_float()->to_double();
 
-    if (!other->is_integer())
-        other = Natalie::coerce(env, other, this).second;
-
     if (other->is_integer())
         return m_integer <= other->as_integer()->integer();
+
+    if (other->respond_to(env, "coerce"_s)) {
+        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
+        return result.first->send(env, "<="_s, { result.second })->is_truthy();
+    }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
@@ -282,11 +288,13 @@ bool IntegerObject::gt(Env *env, Value other) {
     if (other->is_float())
         return m_integer > other->as_float()->to_double();
 
-    if (!other->is_integer())
-        other = Natalie::coerce(env, other, this).second;
-
     if (other->is_integer())
         return m_integer > other->as_integer()->integer();
+
+    if (other->respond_to(env, "coerce"_s)) {
+        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
+        return result.first->send(env, ">"_s, { result.second })->is_truthy();
+    }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
@@ -295,11 +303,13 @@ bool IntegerObject::gte(Env *env, Value other) {
     if (other->is_float())
         return m_integer >= other->as_float()->to_double();
 
-    if (!other->is_integer())
-        other = Natalie::coerce(env, other, this).second;
-
     if (other->is_integer())
         return m_integer >= other->as_integer()->integer();
+
+    if (other->respond_to(env, "coerce"_s)) {
+        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
+        return result.first->send(env, ">="_s, { result.second })->is_truthy();
+    }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }

--- a/test/natalie/integer_test.rb
+++ b/test/natalie/integer_test.rb
@@ -125,13 +125,29 @@ describe 'integer' do
   end
 
   describe '==' do
-    (2 == 2).should == true
-    (2 == 3).should == false
+    it 'works for integers' do
+      (2 == 2).should == true
+      (2 == 3).should == false
+    end
+
+    it 'works for rationals' do
+      (0 == Rational(1, 2)).should == false
+      (1 == Rational(1, 2)).should == false
+      (1 == Rational(1, 1)).should == true
+    end
   end
 
   describe 'eql?' do
     (2.eql?(2)).should == true
     (2.eql?(3)).should == false
+  end
+
+  describe '<=>' do
+    it 'works for rationals' do
+      (0 <=> Rational(1, 2)).should == -1
+      (1 <=> Rational(1, 2)).should == 1
+      (1 <=> Rational(1, 1)).should == 0
+    end
   end
 
   describe '<' do
@@ -143,6 +159,12 @@ describe 'integer' do
       (1 < 1).should == false
       (11 < 10).should == false
       (2 < 1).should == false
+    end
+
+    it 'works for rationals' do
+      (0 < Rational(1, 2)).should == true
+      (1 < Rational(1, 2)).should == false
+      (1 < Rational(1, 1)).should == false
     end
   end
 
@@ -156,6 +178,12 @@ describe 'integer' do
       (11 <= 10).should == false
       (2 <= 1).should == false
     end
+
+    it 'works for rationals' do
+      (0 <= Rational(1, 2)).should == true
+      (1 <= Rational(1, 2)).should == false
+      (1 <= Rational(1, 1)).should == true
+    end
   end
 
   describe '>' do
@@ -168,6 +196,12 @@ describe 'integer' do
       (10 > 11).should == false
       (1 > 2).should == false
     end
+
+    it 'works for rationals' do
+      (0 > Rational(1, 2)).should == false
+      (1 > Rational(1, 2)).should == true
+      (1 > Rational(1, 1)).should == false
+    end
   end
 
   describe '>=' do
@@ -179,6 +213,12 @@ describe 'integer' do
     it 'returns false if we are less than the given integer' do
       (10 >= 11).should == false
       (1 >= 2).should == false
+    end
+
+    it 'works for rationals' do
+      (0 >= Rational(1, 2)).should == false
+      (1 >= Rational(1, 2)).should == true
+      (1 >= Rational(1, 1)).should == true
     end
   end
 


### PR DESCRIPTION
This makes expressions like `0 < Rational(1, 2)` and `0 <=> Rational(1, 2)` correct/compliant—comparison in this direction doesn't appear to be covered by ruby/spec yet, so I've added tests to `test/natalie/integer_test.rb`