### PR TITLE
Add Array#pack directives 'X' and 'x'

### DIFF
--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -128,9 +128,33 @@ namespace ArrayPacker {
                     });
                     break;
                 }
-                case 'x':
-                    // TODO
+                case 'x': {
+                    // Asterisks have no effect on this directive.
+                    if (token.star)
+                        break;
+
+                    auto null_byte_count = (token.count < 0) ? 1: token.count;
+                    for (int count = 0; count < null_byte_count; count++) {
+                        m_packed.append_char('\0');
+                    }
                     break;
+                }
+                case 'X': {
+                    // Asterisks have no effect on this directive.
+                    if (token.star)
+                        break;
+
+                    auto amount_of_truncated_bytes = (token.count < 0) ? 1: token.count;
+
+                    // If the packed string is empty or if the amount of bytes to be truncated 
+                    // is greater than the packed string's current length, 
+                    // then we can't truncate it. Raise ArgumentError.
+                    if (m_packed.length() == 0 || (int)m_packed.length() < amount_of_truncated_bytes) {
+                        env->raise("ArgumentError", "X outside of the string");
+                    }
+                    m_packed.truncate(m_packed.length() - amount_of_truncated_bytes);
+                    break;
+                }
                 case '@': {
                     auto count = (token.count < 0) ? 1 : token.count;
                     auto missing_chars = static_cast<nat_int_t>(count) - static_cast<nat_int_t>(m_packed.size());

--- a/spec/core/array/pack/x_spec.rb
+++ b/spec/core/array/pack/x_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 # -*- encoding: binary -*-
 require_relative '../../../spec_helper'
 require_relative '../fixtures/classes'


### PR DESCRIPTION
This PR implements array pack directives 'X' and 'x'. Related to issue #195.

## 'x' directive
The 'x' directive packs `count` amount of null bytes. Null bytes are packed irrespective of the length of the array.

```ruby
nat> [1,2,3].pack('xxxx')
"\x00\x00\x00\x00"
nat>
```


## 'X' directive
The 'X' directive pops the rightmost `count` amount of characters from the string. `count` is 1 by default.

```ruby
# Pack all integers as characters and remove the rightmost two
nat> [65,66,67].pack('C*X2')
"A"
nat>
```

Asterisk modifiers have no effect on either of the directives. 

## Specs
All specs seem to pass! :)

![image](https://user-images.githubusercontent.com/51860725/198709645-2673a268-0859-40e7-a3d2-9c3d63a4501c.png)
