### PR TITLE
Fix Addrinfo.new with packed sockaddr string argument

### DIFF
--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -2,6 +2,21 @@ require_relative '../spec_helper'
 
 require 'socket'
 
+describe 'Addrinfo' do
+  describe '.new' do
+    it 'works with packed sockaddr strings' do
+      addrinfo = Addrinfo.new(Socket.pack_sockaddr_in(80, '127.0.0.1'))
+      addrinfo.afamily.should == Socket::AF_INET
+
+      addrinfo = Addrinfo.new(Socket.pack_sockaddr_in('smtp', '2001:DB8::1'))
+      addrinfo.afamily.should == Socket::AF_INET6
+
+      addrinfo = Addrinfo.new(Socket.pack_sockaddr_un('socket'))
+      addrinfo.afamily.should == Socket::AF_UNIX
+    end
+  end
+end
+
 describe 'Socket' do
   before do
     @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)


### PR DESCRIPTION
Together with #700 this makes `examples/webserver.rb` work for me on macOS 😎