### PR TITLE
Fix String#inspect

### DIFF
--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -436,7 +436,7 @@ StringObject *StringObject::inspect(Env *env) {
             out->append("\\t");
         } else if (c == '\v') {
             out->append("\\v");
-        } else if ((int)c < 32) {
+        } else if ((int)c < 32 || (int)c == 127 || (int)c == 128) {
             auto escaped_char = m_encoding->escaped_char(c);
             out->append(escaped_char);
         } else {

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -53,6 +53,8 @@ describe 'string' do
       29.chr(enc).inspect.should == '"\x1D"'
       30.chr(enc).inspect.should == '"\x1E"'
       31.chr(enc).inspect.should == '"\x1F"'
+      127.chr(enc).inspect.should == '"\x7F"'
+      128.chr(enc).inspect.should == '"\x80"'
     end
   end
 


### PR DESCRIPTION
127 should be escaped as `\x7F` and 128 as `\x80`, for example with irb:

    irb(main):001:0> [127, 128].pack('C*')
    "\x7F\x80"
