### PR TITLE
Fix Kernel#is_a? for comparing Module to itself

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -891,9 +891,7 @@ Value Object::clone(Env *env) const {
 bool Object::is_a(Env *env, Value val) const {
     if (!val->is_module()) return false;
     ModuleObject *module = val->as_module();
-    if (this == module) {
-        return false;
-    } else if (m_klass == module || singleton_class() == module) {
+    if (m_klass == module || singleton_class() == module) {
         return true;
     } else {
         ClassObject *klass = singleton_class();

--- a/test/natalie/kernel_test.rb
+++ b/test/natalie/kernel_test.rb
@@ -10,6 +10,28 @@ describe 'Kernel' do
     end
   end
 
+  describe '#is_a?' do
+    it 'returns false with a module and itself' do
+      Enumerable.is_a?(Enumerable).should == false
+    end
+
+    it 'returns true with the Module object and itself' do
+      Module.is_a?(Module).should == true
+    end
+
+    it 'returns true with a module and the Module object' do
+      Enumerable.is_a?(Module).should == true
+    end
+
+    it 'returns true with the Class object and the Module object' do
+      Class.is_a?(Module).should == true
+    end
+
+    it 'returns true with the Module object and the Class object' do
+      Module.is_a?(Class).should == true
+    end
+  end
+
   describe '#sleep' do
     it 'sleeps the number of seconds' do
       # TODO: add a way to measure time


### PR DESCRIPTION
In the general case where the receiver and the argument are the same value this should return false, but there's an edge case for the `Module` object where it should return true:

    $ irb
    irb(main):001:0> Module.is_a?(Module)
    => true

This also fixes Kernel#instance_of? which currently raises an error with `Module` as an argument, for example:

    $ bin/natalie
    nat> Enumerable.instance_of?(Module)
    Traceback (most recent call last):
            2: from (repl):1:in `<main>'
            1: from src/kernel.rb:40:in `instance_of?'
    src/kernel.rb:40:in `raise': class or module required (TypeError)
