### PR TITLE
Raise NameError in Module#const_get if name is not defined

### DIFF
--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -69,7 +69,11 @@ Value ModuleObject::const_get(SymbolObject *name) const {
 }
 
 Value ModuleObject::const_get(Env *env, Value name) const {
-    return const_get(name->to_symbol(env, Object::Conversion::Strict));
+    auto symbol = name->to_symbol(env, Object::Conversion::Strict);
+    auto constant = const_get(symbol);
+    if (!constant)
+        env->raise("NameError", "uninitialized constant {}", symbol->c_str());
+    return constant;
 }
 
 Value ModuleObject::const_fetch(SymbolObject *name) {

--- a/test/natalie/module_test.rb
+++ b/test/natalie/module_test.rb
@@ -53,6 +53,10 @@ describe 'Module' do
       Object.const_get(:M3).should == M3
       M3.const_get('A').should == M3::A
     end
+
+    it 'raises a NameError if no constant is defined' do
+      -> { M1.const_get(:NameNotDefined) }.should raise_error(NameError)
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION
Currently this is returning nil:

    $ bin/natalie
    nat> Object.const_get(:FOO)
    nil