### PR TITLE
Implement Regexp#encoding for default encoding of US-ASCII

### DIFF
--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -175,6 +175,7 @@ public:
     bool has_match(Env *env, Value, Value);
     Value initialize(Env *, Value, Value);
     Value inspect(Env *env);
+    Value encoding(Env *env);
     Value eqtilde(Env *env, Value);
     Value match(Env *env, Value, Value = nullptr, Block * = nullptr);
     Value source(Env *env) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -870,6 +870,7 @@ gen.binding('Regexp', '===', 'RegexpObject', 'eqeqeq', argc: 1, pass_env: true, 
 gen.binding('Regexp', '=~', 'RegexpObject', 'eqtilde', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', '~', 'RegexpObject', 'tilde', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'casefold?', 'RegexpObject', 'casefold', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('Regexp', 'encoding', 'RegexpObject', 'encoding', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'hash', 'RegexpObject', 'hash', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'initialize', 'RegexpObject', 'initialize', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)
 gen.binding('Regexp', 'inspect', 'RegexpObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/regexp/encoding_spec.rb
+++ b/spec/core/regexp/encoding_spec.rb
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+
+describe "Regexp#encoding" do
+  it "returns an Encoding object" do
+    /glar/.encoding.should be_an_instance_of(Encoding)
+  end
+
+  it "defaults to US-ASCII if the Regexp contains only US-ASCII character" do
+    /ASCII/.encoding.should == Encoding::US_ASCII
+  end
+
+  it "returns US_ASCII if the 'n' modifier is supplied and only US-ASCII characters are present" do
+    /ASCII/n.encoding.should == Encoding::US_ASCII
+  end
+
+  xit "returns BINARY if the 'n' modifier is supplied and non-US-ASCII characters are present" do
+    /\xc2\xa1/n.encoding.should == Encoding::BINARY
+  end
+
+  xit "defaults to UTF-8 if \\u escapes appear" do
+    /\u{9879}/.encoding.should == Encoding::UTF_8
+  end
+
+  xit "defaults to UTF-8 if a literal UTF-8 character appears" do
+    /¥/.encoding.should == Encoding::UTF_8
+  end
+
+  xit "returns UTF-8 if the 'u' modifier is supplied" do
+    /ASCII/u.encoding.should == Encoding::UTF_8
+  end
+
+  xit "returns Windows-31J if the 's' modifier is supplied" do
+    /ASCII/s.encoding.should == Encoding::Windows_31J
+  end
+
+  xit "returns EUC_JP if the 'e' modifier is supplied" do
+    /ASCII/e.encoding.should == Encoding::EUC_JP
+  end
+
+  xit "upgrades the encoding to that of an embedded String" do
+    str = "文字化け".encode('euc-jp')
+    /#{str}/.encoding.should == Encoding::EUC_JP
+  end
+
+  xit "ignores the encoding and uses US-ASCII if the string has only ASCII characters" do
+    str = "abc".encode('euc-jp')
+    str.encoding.should == Encoding::EUC_JP
+    /#{str}/.encoding.should == Encoding::US_ASCII
+  end
+
+  xit "ignores the default_internal encoding" do
+    old_internal = Encoding.default_internal
+    Encoding.default_internal = Encoding::EUC_JP
+    /foo/.encoding.should_not == Encoding::EUC_JP
+    Encoding.default_internal = old_internal
+  end
+
+  xit "allows otherwise invalid characters if NOENCODING is specified" do
+    Regexp.new('([\x00-\xFF])', Regexp::IGNORECASE | Regexp::NOENCODING).encoding.should == Encoding::BINARY
+  end
+end

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -70,6 +70,11 @@ Value RegexpObject::inspect(Env *env) {
     return out;
 }
 
+Value RegexpObject::encoding(Env *env) {
+    // NATFIXME: Implement support for other encodings.
+    return EncodingObject::get(Encoding::US_ASCII);
+}
+
 Value RegexpObject::eqtilde(Env *env, Value other) {
     Value result = match(env, other);
     if (result->is_nil()) {


### PR DESCRIPTION
Not fully implemented / spec compliant... from what I can tell we only support US-ASCII regexps currently?