### PR TITLE
Fix String#valid_encoding? for UTF-8

### DIFF
--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -13,7 +13,7 @@ using namespace TM;
 class UsAsciiEncodingObject : public EncodingObject {
 public:
     UsAsciiEncodingObject()
-        : EncodingObject { Encoding::US_ASCII, { "US-ASCII", "ASCII" } } { }
+        : EncodingObject { Encoding::US_ASCII, { "US-ASCII", "ASCII", "ANSI_X3.4-1968", "646" } } { }
 
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 127;

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -13,7 +13,7 @@ using namespace TM;
 class Utf8EncodingObject : public EncodingObject {
 public:
     Utf8EncodingObject()
-        : EncodingObject { Encoding::UTF_8, { "UTF-8" } } { }
+        : EncodingObject { Encoding::UTF_8, { "UTF-8", "CP65001", "locale", "external", "filesystem" } } { }
 
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         // from RFC3629: 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF

--- a/spec/core/string/setbyte_spec.rb
+++ b/spec/core/string/setbyte_spec.rb
@@ -31,7 +31,6 @@ describe "String#setbyte" do
     str.getbyte(1).should == 254
   end
 
-  # NATFIXME: Fix String#valid_encoding?
   it "can invalidate a String's encoding" do
     str = "glark"
     str.valid_encoding?.should be_true

--- a/spec/core/string/setbyte_spec.rb
+++ b/spec/core/string/setbyte_spec.rb
@@ -32,7 +32,7 @@ describe "String#setbyte" do
   end
 
   # NATFIXME: Fix String#valid_encoding?
-  xit "can invalidate a String's encoding" do
+  it "can invalidate a String's encoding" do
     str = "glark"
     str.valid_encoding?.should be_true
     str.setbyte(2,253)

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -24,14 +24,29 @@ std::pair<bool, StringView> Utf8EncodingObject::prev_char(const String &string, 
     return { true, StringView(&string, *index, length) };
 }
 
+/*
+    Code point ↔ UTF-8 conversion:
+
+    First code point Last code point Byte 1   Byte 2   Byte 3   Byte 4
+    U+0000           U+007F	         0xxxxxxx
+    U+0080           U+07FF	         110xxxxx	10xxxxxx
+    U+0800           U+FFFF	         1110xxxx	10xxxxxx 10xxxxxx
+    U+10000          U+10FFFF        11110xxx	10xxxxxx 10xxxxxx 10xxxxxx
+
+    See: https://en.wikipedia.org/wiki/UTF-8
+*/
 std::pair<bool, StringView> Utf8EncodingObject::next_char(const String &string, size_t *index) const {
     size_t len = string.size();
+
     if (*index >= len)
         return { true, StringView() };
+
     size_t i = *index;
     int length = 0;
     unsigned char c = string[i];
     bool valid = true;
+
+    // Check the first byte and determine length
     if ((c >> 3) == 0b11110) { // 11110xxx, 4 bytes
         if (i + 3 >= len) {
             *index = len;
@@ -53,9 +68,79 @@ std::pair<bool, StringView> Utf8EncodingObject::next_char(const String &string, 
     } else if ((c >> 7) == 0b0) { // 0xxxxxxx, 1 byte
         length = 1;
     } else {
-        length = 1;
-        valid = false;
+        *index += 1;
+        return { false, StringView(&string, i, 1) };
     }
+
+    // All, but the 1st, bytes should match the format 10xxxxxx
+    for (size_t j = i + 1; j <= i + length - 1; j++) {
+        unsigned char cj = string[j];
+        if (cj >> 6 != 0b10) {
+            *index += 1;
+            return { false, StringView(&string, i, 1) };
+        }
+    }
+
+    // Check whether a codepoint is in a valid range
+    switch (length) {
+    case 1:
+        // no check
+        // all values that can be represented with 7 bits (0-127) are correct
+        break;
+    case 2: {
+        // Codepoints range: U+0080..U+07FF
+        // Check the highest 4 significant bits of
+        // 110xxxx-	10------
+        unsigned char extra_bits = (unsigned char)string[i] & 0b11110;
+
+        if (extra_bits == 0) {
+            valid = false;
+            length = 1;
+        }
+
+        break;
+    }
+    case 3: {
+        // Codepoints range: U+0800..U+FFFF.
+        // Check the highest 5 significant bits of
+        // 1110xxxx	10x-----	10------
+        //
+        // U+D800..U+DFFF - invalid codepoints
+        // xxxx1101 xx1----- xx------
+        unsigned char extra_bits1 = (unsigned char)string[i] & 0b1111;
+        unsigned char extra_bits2 = (unsigned char)string[i + 1] & 0b100000;
+        unsigned char significant_bits1 = (unsigned char)string[i] & 0b1111;
+        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
+
+        if (extra_bits1 == 0 && extra_bits2 == 0) {
+            valid = false;
+            length = 1;
+        } else if (significant_bits1 == 0b1101 && (significant_bits2 >> 5) == 1) {
+            valid = false;
+            length = 1;
+        }
+
+        break;
+    }
+    case 4: {
+        // Codepoints range: U+10000..U+10FFFF.
+        // 11110xxx	10xxxxxx 10xxxxxx 10xxxxxx
+        unsigned char significant_bits1 = (unsigned char)string[i] & 0b111;
+        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
+        unsigned char significant_bits3 = (unsigned char)string[i + 2] & 0b111111;
+        unsigned char significant_bits4 = (unsigned char)string[i + 3] & 0b111111;
+
+        int codepoint = significant_bits4 | (significant_bits3 << 6) | (significant_bits2 << 12) | (significant_bits1 << 18);
+
+        if (codepoint < 0x10000 || codepoint > 0x10FFFF) {
+            valid = false;
+            length = 1;
+        }
+
+        break;
+    }
+    }
+
     *index += length;
     return { valid, StringView(&string, i, length) };
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -182,9 +182,11 @@ Env *build_top_env() {
     Value EncodingUsAscii = new UsAsciiEncodingObject {};
     Encoding->const_set("US_ASCII"_s, EncodingUsAscii);
     Encoding->const_set("ASCII"_s, EncodingUsAscii);
+    Encoding->const_set("ANSI_X3_4_1968"_s, EncodingUsAscii);
 
     Value EncodingUTF8 = new Utf8EncodingObject {};
     Encoding->const_set("UTF_8"_s, EncodingUTF8);
+    Encoding->const_set("CP65001"_s, EncodingUTF8);
 
     Value Process = new ModuleObject { "Process" };
     Object->const_set("Process"_s, Process);


### PR DESCRIPTION
There was one failing spec in `spec/core/string/setbyte_spec.rb`. I've investigated it and found out that current implementation of `Utf8EncodingObject::next_char` is not comprehensive and allows false positives.

Changes:
- fixed String#valid_encoding? for UTF-8
- added missing aliases for UTF-8 and US-ASCII

Specs are added to RubySpec here https://github.com/ruby/spec/pull/975.