### PR TITLE
Implement some time stuff

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -46,6 +46,7 @@ public:
     Value to_r(Env *);
     Value to_s(Env *);
     Value usec(Env *);
+    Value utc_offset(Env *) const;
     Value wday(Env *) const;
     Value yday(Env *) const;
     Value year(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1019,10 +1019,11 @@ gen.binding('Time', 'to_i', 'TimeObject', 'to_i', argc: 0, pass_env: true, pass_
 gen.binding('Time', 'to_r', 'TimeObject', 'to_r', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'to_s', 'TimeObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'usec', 'TimeObject', 'usec', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Time', 'utc?', 'TimeObject', 'is_utc', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('Time', 'utc_offset', 'TimeObject', 'utc_offset', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'wday', 'TimeObject', 'wday', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'yday', 'TimeObject', 'yday', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Time', 'year', 'TimeObject', 'year', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Time', 'utc?', 'TimeObject', 'is_utc', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 
 gen.undefine_singleton_method('TrueClass', 'new')
 gen.binding('TrueClass', '&', 'TrueObject', 'and_method', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/spec/core/struct/element_reference_spec.rb
+++ b/spec/core/struct/element_reference_spec.rb
@@ -1,0 +1,53 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Struct[]" do
+  it "is a synonym for new" do
+    StructClasses::Ruby['2.0', 'i686'].should be_kind_of(StructClasses::Ruby)
+  end
+end
+
+describe "Struct#[]" do
+  it "returns the attribute referenced" do
+    car = StructClasses::Car.new('Ford', 'Ranger', 1983)
+    car['make'].should == 'Ford'
+    car['model'].should == 'Ranger'
+    car['year'].should == 1983
+    car[:make].should == 'Ford'
+    car[:model].should == 'Ranger'
+    car[:year].should == 1983
+    car[0].should == 'Ford'
+    car[1].should == 'Ranger'
+    car[2].should == 1983
+    car[-3].should == 'Ford'
+    car[-2].should == 'Ranger'
+    car[-1].should == 1983
+  end
+
+  it "fails when it does not know about the requested attribute" do
+    car = StructClasses::Car.new('Ford', 'Ranger')
+    -> { car[3]        }.should raise_error(IndexError)
+    -> { car[-4]       }.should raise_error(IndexError)
+    -> { car[:body]    }.should raise_error(NameError)
+    -> { car['wheels'] }.should raise_error(NameError)
+  end
+
+  # NATFIXME: define_method does not check argument count
+  xit "fails if passed too many arguments" do
+    car = StructClasses::Car.new('Ford', 'Ranger')
+    -> { car[:make, :model] }.should raise_error(ArgumentError)
+  end
+
+  it "fails if not passed a string, symbol, or integer" do
+    car = StructClasses::Car.new('Ford', 'Ranger')
+    -> { car[Object.new] }.should raise_error(TypeError)
+  end
+
+  it "returns attribute names that contain hyphens" do
+    klass = Struct.new(:'current-state')
+    tuple = klass.new(0)
+    tuple['current-state'].should == 0
+    tuple[:'current-state'].should == 0
+    tuple[0].should == 0
+  end
+end

--- a/spec/core/struct/fixtures/classes.rb
+++ b/spec/core/struct/fixtures/classes.rb
@@ -1,0 +1,26 @@
+module StructClasses
+
+  class Apple < Struct; end
+
+  Ruby = Struct.new(:version, :platform)
+
+  Car = Struct.new(:make, :model, :year)
+
+  class Honda < Car
+    def initialize(*args)
+      self.make = "Honda"
+      super(*args)
+    end
+  end
+
+  class SubclassX < Struct
+  end
+
+  class SubclassX
+    attr_reader :key
+    def initialize(*)
+      @key = :value
+      super
+    end
+  end
+end

--- a/spec/core/time/shared/gmt_offset.rb
+++ b/spec/core/time/shared/gmt_offset.rb
@@ -1,0 +1,63 @@
+describe :time_gmt_offset, shared: true do
+  it "returns the offset in seconds between the timezone of time and UTC" do
+    with_timezone("AST", 3) do
+      Time.new.send(@method).should == 10800
+    end
+  end
+
+  # NATFIXME: Implement Time#utc
+  xit "returns 0 when the date is UTC" do
+    with_timezone("AST", 3) do
+      Time.new.utc.send(@method).should == 0
+    end
+  end
+
+  platform_is_not :windows do
+    it "returns the correct offset for US Eastern time zone around daylight savings time change" do
+      # "2010-03-14 01:59:59 -0500" + 1 ==> "2010-03-14 03:00:00 -0400"
+      with_timezone("EST5EDT") do
+        t = Time.local(2010,3,14,1,59,59)
+        t.send(@method).should == -5*60*60
+        (t + 1).send(@method).should == -4*60*60
+      end
+    end
+
+    it "returns the correct offset for Hawaii around daylight savings time change" do
+      # "2010-03-14 01:59:59 -1000" + 1 ==> "2010-03-14 02:00:00 -1000"
+      with_timezone("Pacific/Honolulu") do
+        t = Time.local(2010,3,14,1,59,59)
+        t.send(@method).should == -10*60*60
+        (t + 1).send(@method).should == -10*60*60
+      end
+    end
+
+    it "returns the correct offset for New Zealand around daylight savings time change" do
+      # "2010-04-04 02:59:59 +1300" + 1 ==> "2010-04-04 02:00:00 +1200"
+      with_timezone("Pacific/Auckland") do
+        t = Time.local(2010,4,4,1,59,59) + (60 * 60)
+        t.send(@method).should == 13*60*60
+        (t + 1).send(@method).should == 12*60*60
+      end
+    end
+  end
+
+  # NATFIXME: Implement more of Time#new
+  xit "returns offset as Rational" do
+    Time.new(2010,4,4,1,59,59,7245).send(@method).should == 7245
+    Time.new(2010,4,4,1,59,59,7245.5).send(@method).should == Rational(14491,2)
+  end
+
+  context 'given positive offset' do
+    # NATFIXME: Implement more of Time#new
+    xit 'returns a positive offset' do
+      Time.new(2013,3,17,nil,nil,nil,"+03:00").send(@method).should == 10800
+    end
+  end
+
+  context 'given negative offset' do
+    # NATFIXME: Implement more of Time#new
+    xit 'returns a negative offset' do
+      Time.new(2013,3,17,nil,nil,nil,"-03:00").send(@method).should == -10800
+    end
+  end
+end

--- a/spec/core/time/utc_offset_spec.rb
+++ b/spec/core/time/utc_offset_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/gmt_offset'
+
+describe "Time#utc_offset" do
+  it_behaves_like :time_gmt_offset, :utc_offset
+end

--- a/spec/core/time/wday_spec.rb
+++ b/spec/core/time/wday_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+
+describe "Time#wday" do
+  it "returns an integer representing the day of the week, 0..6, with Sunday being 0" do
+    with_timezone("GMT", 0) do
+      Time.at(0).wday.should == 4
+    end
+  end
+end

--- a/src/struct.rb
+++ b/src/struct.rb
@@ -1,6 +1,7 @@
 class Struct
   class << self
     alias_method :_original_new, :new
+    alias_method :[], :new
   end
 
   def self.new(*attrs)
@@ -36,6 +37,16 @@ class Struct
             str << ', ' unless index == attrs.size - 1
           end
           str << '>'
+        end
+
+        define_method :[] do |arg|
+          case arg
+          when Integer
+            attribute = attrs.fetch(arg)
+            send(attribute)
+          else
+            send(arg)
+          end
         end
       end
     else

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -228,6 +228,10 @@ Value TimeObject::usec(Env *env) {
     }
 }
 
+Value TimeObject::utc_offset(Env *env) const {
+    return IntegerObject::create((nat_int_t)m_time.tm_gmtoff);
+}
+
 Value TimeObject::wday(Env *) const {
     return Value::integer(m_time.tm_wday);
 }

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -139,9 +139,15 @@ def with_feature(name)
   yield if MSpec.features[name]
 end
 
-def with_timezone(zone, offset)
+def with_timezone(zone, offset = nil)
   old_tz = ENV['TZ']
-  ENV['TZ'] = "#{zone}#{(-offset).to_s}:00:00"
+
+  if offset
+    zone += "#{(-offset).to_s}:00:00"
+  end
+
+  ENV['TZ'] = zone
+
   begin
     yield
   ensure

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -139,6 +139,19 @@ def with_feature(name)
   yield if MSpec.features[name]
 end
 
+def with_timezone(zone, offset)
+  old_tz = ENV['TZ']
+  ENV['TZ'] = "#{zone}#{(-offset).to_s}:00:00"
+  begin
+    yield
+  ensure
+    # Natalie does not allow setting ENV values that are not strings?
+    if old_tz.is_a?(String)
+      ENV['TZ'] = old_tz
+    end
+  end
+end
+
 def nan_value
   0 / 0.0
 end


### PR DESCRIPTION
This implements some random time stuff. 

The `Struct#[]` method is actually needed to implement `Time#new` (the specs depend on the Struct method). However, I could not finish the work on `Time#new`, because there seems to be a bug in how we dispatch the `new`-method if redefined.

The following code should print `String` but with Natalie it prints `MethodHolder`. Maybe somebody has an idea 😅 

```ruby
class MethodHolder
  class << self
    define_method(:new, &String.method(:new))
  end
end

p MethodHolder.new.class
```

