### PR TITLE
Add String#unpack i/j/q

### DIFF
--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -60,6 +60,8 @@ public:
     BigInt(const long long &);
     BigInt(const unsigned long int &);
     BigInt(const unsigned long long &);
+    BigInt(const long &);
+    BigInt(const unsigned int &);
     BigInt(const int &);
     BigInt(const double &);
     BigInt(const TM::String &);

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -258,7 +258,10 @@ private:
                     out.append_char(pointer()[realidx]);
                 }
                 m_index += sizeof(T);
-                m_unpacked->push(Value::integer(*(T *)out.c_str()));
+                // Previosly had pushed Value::integer() values, but for large unsigned values
+                // it produced incorrect results.
+                auto bigint = BigInt(*(T *)out.c_str());
+                m_unpacked->push(IntegerObject::create(Integer(bigint)));
             }
             consumed++;
         }

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -49,11 +49,23 @@ public:
             case 'h':
                 unpack_h(token);
                 break;
+            case 'I':
+                unpack_int<unsigned int>(token);
+                break;
             case 'i':
-                unpack_i();
+                unpack_int<signed int>(token);
                 break;
             case 'J':
-                unpack_J();
+                unpack_int<uintptr_t>(token);
+                break;
+            case 'j':
+                unpack_int<intptr_t>(token);
+                break;
+            case 'L':
+                unpack_int<uint32_t>(token);
+                break;
+            case 'l':
+                unpack_int<int32_t>(token);
                 break;
             case 'M':
                 unpack_M(env, token);
@@ -67,11 +79,17 @@ public:
             case 'p':
                 unpack_p();
                 break;
+            case 'Q':
+                unpack_int<uint64_t>(token);
+                break;
+            case 'q':
+                unpack_int<int64_t>(token);
+                break;
             case 'S':
-                unpack_s<uint16_t>(token);
+                unpack_int<uint16_t>(token);
                 break;
             case 's':
-                unpack_s<int16_t>(token);
+                unpack_int<int16_t>(token);
                 break;
             case 'U':
                 unpack_U(env, token);
@@ -182,30 +200,6 @@ private:
         }
     }
 
-    template <typename T>
-    void unpack_s(Token &token) {
-        bool little_endian = (token.endianness == ArrayPacker::Endianness::Little) || (token.endianness == Endianness::Native && system_is_little_endian());
-        nat_int_t consumed = 0;
-        if (token.count == -1) token.count = 1;
-        while (token.star ? !at_end() : consumed < token.count) {
-            if ((m_index + 2) > m_source->length()) {
-                if (!token.star)
-                    m_unpacked->push(NilObject::the());
-                m_index++;
-            } else {
-                unsigned char c0 = next_char();
-                unsigned char c1 = next_char();
-                T result;
-                if (little_endian)
-                    result = (c1 << 8) + c0;
-                else
-                    result = (c0 << 8) + c1;
-                m_unpacked->push(Value::integer(result));
-            }
-            consumed++;
-        }
-    }
-
     void unpack_b(Token &token) {
         auto out = String();
 
@@ -244,24 +238,30 @@ private:
         m_unpacked->push(new StringObject { out, Encoding::US_ASCII });
     }
 
-    void unpack_i() {
-        if (m_index + sizeof(int) > m_source->length()) {
-            m_unpacked->push(NilObject::the());
-            return;
+    template <typename T>
+    void unpack_int(Token &token) {
+        bool little_endian = (token.endianness == ArrayPacker::Endianness::Little) || (token.endianness == Endianness::Native && system_is_little_endian());
+
+        nat_int_t consumed = 0;
+        if (token.count == -1) token.count = 1;
+        while (token.star ? !at_end() : consumed < token.count) {
+            if ((m_index + sizeof(T)) > m_source->length()) {
+                if (!token.star)
+                    m_unpacked->push(NilObject::the());
+                m_index++;
+            } else {
+                // NATFIXME: this method of fixing endianness may not be efficient
+                // reverse a character buffer based on endianness
+                auto out = String();
+                for (size_t idx = 0; idx < sizeof(T); idx++) {
+                    auto realidx = (little_endian) ? idx : (sizeof(T) - 1 - idx);
+                    out.append_char(pointer()[realidx]);
+                }
+                m_index += sizeof(T);
+                m_unpacked->push(Value::integer(*(T *)out.c_str()));
+            }
+            consumed++;
         }
-
-        m_unpacked->push(Value::integer(*(int *)pointer()));
-        m_index += sizeof(int);
-    }
-
-    void unpack_J() {
-        if (m_index + sizeof(uintptr_t) > m_source->length()) {
-            m_unpacked->push(NilObject::the());
-            return;
-        }
-
-        m_unpacked->push(Value::integer(*(uintptr_t *)pointer()));
-        m_index += sizeof(uintptr_t);
     }
 
     void unpack_M(Env *env, Token &token) {

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -157,13 +157,14 @@ public:
      *
      * ```
      * auto str = String { (unsigned long int)10 };
+     * auto str = String { (long int)10 };
      * assert_str_eq("10", str);
      * ```
      */
-    String(unsigned long int number) {
-        int length = snprintf(NULL, 0, "%lu", number);
+    String(long int number) {
+        int length = snprintf(NULL, 0, "%li", number);
         char buf[length + 1];
-        snprintf(buf, length + 1, "%lu", number);
+        snprintf(buf, length + 1, "%li", number);
         set_str(buf);
     }
 
@@ -179,6 +180,36 @@ public:
         int length = snprintf(NULL, 0, "%d", number);
         char buf[length + 1];
         snprintf(buf, length + 1, "%d", number);
+        set_str(buf);
+    }
+
+    /**
+     * Constructs a new String by converting the given number.
+     *
+     * ```
+     * auto str = String { (unsigned long)10 };
+     * assert_str_eq("10", str);
+     * ```
+     */
+    String(unsigned long number) {
+        int length = snprintf(NULL, 0, "%lu", number);
+        char buf[length + 1];
+        snprintf(buf, length + 1, "%lu", number);
+        set_str(buf);
+    }
+
+    /**
+     * Constructs a new String by converting the given number.
+     *
+     * ```
+     * auto str = String { (unsigned int)10 };
+     * assert_str_eq("10", str);
+     * ```
+     */
+    String(unsigned int number) {
+        int length = snprintf(NULL, 0, "%u", number);
+        char buf[length + 1];
+        snprintf(buf, length + 1, "%u", number);
         set_str(buf);
     }
 

--- a/spec/core/string/unpack/i_spec.rb
+++ b/spec/core/string/unpack/i_spec.rb
@@ -1,0 +1,152 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/integer'
+
+describe "String#unpack with format 'I'" do
+  describe "with modifier '<'" do
+    it_behaves_like :string_unpack_32bit_le, 'I<'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I<'
+  end
+
+  describe "with modifier '<' and '_'" do
+    it_behaves_like :string_unpack_32bit_le, 'I<_'
+    it_behaves_like :string_unpack_32bit_le, 'I_<'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I<_'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I_<'
+  end
+
+  describe "with modifier '<' and '!'" do
+    it_behaves_like :string_unpack_32bit_le, 'I<!'
+    it_behaves_like :string_unpack_32bit_le, 'I!<'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I<!'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I!<'
+  end
+
+  describe "with modifier '>'" do
+    it_behaves_like :string_unpack_32bit_be, 'I>'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I>'
+  end
+
+  describe "with modifier '>' and '_'" do
+    it_behaves_like :string_unpack_32bit_be, 'I>_'
+    it_behaves_like :string_unpack_32bit_be, 'I_>'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I>_'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I_>'
+  end
+
+  describe "with modifier '>' and '!'" do
+    it_behaves_like :string_unpack_32bit_be, 'I>!'
+    it_behaves_like :string_unpack_32bit_be, 'I!>'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I>!'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I!>'
+  end
+end
+
+describe "String#unpack with format 'i'" do
+  describe "with modifier '<'" do
+    it_behaves_like :string_unpack_32bit_le, 'i<'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i<'
+  end
+
+  describe "with modifier '<' and '_'" do
+    it_behaves_like :string_unpack_32bit_le, 'i<_'
+    it_behaves_like :string_unpack_32bit_le, 'i_<'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i<_'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i_<'
+  end
+
+  describe "with modifier '<' and '!'" do
+    it_behaves_like :string_unpack_32bit_le, 'i<!'
+    it_behaves_like :string_unpack_32bit_le, 'i!<'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i<!'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i!<'
+  end
+
+  describe "with modifier '>'" do
+    it_behaves_like :string_unpack_32bit_be, 'i>'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i>'
+  end
+
+  describe "with modifier '>' and '_'" do
+    it_behaves_like :string_unpack_32bit_be, 'i>_'
+    it_behaves_like :string_unpack_32bit_be, 'i_>'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i>_'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i_>'
+  end
+
+  describe "with modifier '>' and '!'" do
+    it_behaves_like :string_unpack_32bit_be, 'i>!'
+    it_behaves_like :string_unpack_32bit_be, 'i!>'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i>!'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i!>'
+  end
+end
+
+little_endian do
+  describe "String#unpack with format 'I'" do
+    it_behaves_like :string_unpack_basic, 'I'
+    it_behaves_like :string_unpack_32bit_le, 'I'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I'
+  end
+
+  describe "String#unpack with format 'I' with modifier '_'" do
+    it_behaves_like :string_unpack_32bit_le, 'I_'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I_'
+  end
+
+  describe "String#unpack with format 'I' with modifier '!'" do
+    it_behaves_like :string_unpack_32bit_le, 'I!'
+    it_behaves_like :string_unpack_32bit_le_unsigned, 'I!'
+  end
+
+  describe "String#unpack with format 'i'" do
+    it_behaves_like :string_unpack_basic, 'i'
+    it_behaves_like :string_unpack_32bit_le, 'i'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i'
+  end
+
+  describe "String#unpack with format 'i' with modifier '_'" do
+    it_behaves_like :string_unpack_32bit_le, 'i_'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i_'
+  end
+
+  describe "String#unpack with format 'i' with modifier '!'" do
+    it_behaves_like :string_unpack_32bit_le, 'i!'
+    it_behaves_like :string_unpack_32bit_le_signed, 'i!'
+  end
+end
+
+big_endian do
+  describe "String#unpack with format 'I'" do
+    it_behaves_like :string_unpack_basic, 'I'
+    it_behaves_like :string_unpack_32bit_be, 'I'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I'
+  end
+
+  describe "String#unpack with format 'I' with modifier '_'" do
+    it_behaves_like :string_unpack_32bit_be, 'I_'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I_'
+  end
+
+  describe "String#unpack with format 'I' with modifier '!'" do
+    it_behaves_like :string_unpack_32bit_be, 'I!'
+    it_behaves_like :string_unpack_32bit_be_unsigned, 'I!'
+  end
+
+  describe "String#unpack with format 'i'" do
+    it_behaves_like :string_unpack_basic, 'i'
+    it_behaves_like :string_unpack_32bit_be, 'i'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i'
+  end
+
+  describe "String#unpack with format 'i' with modifier '_'" do
+    it_behaves_like :string_unpack_32bit_be, 'i_'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i_'
+  end
+
+  describe "String#unpack with format 'i' with modifier '!'" do
+    it_behaves_like :string_unpack_32bit_be, 'i!'
+    it_behaves_like :string_unpack_32bit_be_signed, 'i!'
+  end
+end

--- a/spec/core/string/unpack/j_spec.rb
+++ b/spec/core/string/unpack/j_spec.rb
@@ -1,0 +1,272 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/integer'
+
+platform_is pointer_size: 64 do
+  little_endian do
+    describe "String#unpack with format 'J'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_64bit_le, 'J_'
+        it_behaves_like :string_unpack_64bit_le_unsigned, 'J_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_64bit_le, 'J!'
+        it_behaves_like :string_unpack_64bit_le_unsigned, 'J!'
+      end
+    end
+
+    describe "String#unpack with format 'j'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_64bit_le, 'j_'
+        it_behaves_like :string_unpack_64bit_le_signed, 'j_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_64bit_le, 'j!'
+        it_behaves_like :string_unpack_64bit_le_signed, 'j!'
+      end
+    end
+  end
+
+  big_endian do
+    describe "String#unpack with format 'J'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_64bit_be, 'J_'
+        it_behaves_like :string_unpack_64bit_be_unsigned, 'J_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_64bit_be, 'J!'
+        it_behaves_like :string_unpack_64bit_be_unsigned, 'J!'
+      end
+    end
+
+    describe "String#unpack with format 'j'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_64bit_be, 'j_'
+        it_behaves_like :string_unpack_64bit_be_signed, 'j_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_64bit_be, 'j!'
+        it_behaves_like :string_unpack_64bit_be_signed, 'j!'
+      end
+    end
+  end
+
+  describe "String#unpack with format 'J'" do
+    describe "with modifier '<'" do
+      it_behaves_like :string_unpack_64bit_le, 'J<'
+      it_behaves_like :string_unpack_64bit_le_unsigned, 'J<'
+    end
+
+    describe "with modifier '>'" do
+      it_behaves_like :string_unpack_64bit_be, 'J>'
+      it_behaves_like :string_unpack_64bit_be_unsigned, 'J>'
+    end
+
+    describe "with modifier '<' and '_'" do
+      it_behaves_like :string_unpack_64bit_le, 'J<_'
+      it_behaves_like :string_unpack_64bit_le, 'J_<'
+      it_behaves_like :string_unpack_64bit_le_unsigned, 'J<_'
+      it_behaves_like :string_unpack_64bit_le_unsigned, 'J_<'
+    end
+
+    describe "with modifier '<' and '!'" do
+      it_behaves_like :string_unpack_64bit_le, 'J<!'
+      it_behaves_like :string_unpack_64bit_le, 'J!<'
+      it_behaves_like :string_unpack_64bit_le_unsigned, 'J<!'
+      it_behaves_like :string_unpack_64bit_le_unsigned, 'J!<'
+    end
+
+    describe "with modifier '>' and '_'" do
+      it_behaves_like :string_unpack_64bit_be, 'J>_'
+      it_behaves_like :string_unpack_64bit_be, 'J_>'
+      it_behaves_like :string_unpack_64bit_be_unsigned, 'J>_'
+      it_behaves_like :string_unpack_64bit_be_unsigned, 'J_>'
+    end
+
+    describe "with modifier '>' and '!'" do
+      it_behaves_like :string_unpack_64bit_be, 'J>!'
+      it_behaves_like :string_unpack_64bit_be, 'J!>'
+      it_behaves_like :string_unpack_64bit_be_unsigned, 'J>!'
+      it_behaves_like :string_unpack_64bit_be_unsigned, 'J!>'
+    end
+  end
+
+  describe "String#unpack with format 'j'" do
+    describe "with modifier '<'" do
+      it_behaves_like :string_unpack_64bit_le, 'j<'
+      it_behaves_like :string_unpack_64bit_le_signed, 'j<'
+    end
+
+    describe "with modifier '>'" do
+      it_behaves_like :string_unpack_64bit_be, 'j>'
+      it_behaves_like :string_unpack_64bit_be_signed, 'j>'
+    end
+
+    describe "with modifier '<' and '_'" do
+      it_behaves_like :string_unpack_64bit_le, 'j<_'
+      it_behaves_like :string_unpack_64bit_le, 'j_<'
+      it_behaves_like :string_unpack_64bit_le_signed, 'j<_'
+      it_behaves_like :string_unpack_64bit_le_signed, 'j_<'
+    end
+
+    describe "with modifier '<' and '!'" do
+      it_behaves_like :string_unpack_64bit_le, 'j<!'
+      it_behaves_like :string_unpack_64bit_le, 'j!<'
+      it_behaves_like :string_unpack_64bit_le_signed, 'j<!'
+      it_behaves_like :string_unpack_64bit_le_signed, 'j!<'
+    end
+
+    describe "with modifier '>' and '_'" do
+      it_behaves_like :string_unpack_64bit_be, 'j>_'
+      it_behaves_like :string_unpack_64bit_be, 'j_>'
+      it_behaves_like :string_unpack_64bit_be_signed, 'j>_'
+      it_behaves_like :string_unpack_64bit_be_signed, 'j_>'
+    end
+
+    describe "with modifier '>' and '!'" do
+      it_behaves_like :string_unpack_64bit_be, 'j>!'
+      it_behaves_like :string_unpack_64bit_be, 'j!>'
+      it_behaves_like :string_unpack_64bit_be_signed, 'j>!'
+      it_behaves_like :string_unpack_64bit_be_signed, 'j!>'
+    end
+  end
+end
+
+platform_is pointer_size: 32 do
+  little_endian do
+    describe "String#unpack with format 'J'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_32bit_le, 'J_'
+        it_behaves_like :string_unpack_32bit_le_unsigned, 'J_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_32bit_le, 'J!'
+        it_behaves_like :string_unpack_32bit_le_unsigned, 'J!'
+      end
+    end
+
+    describe "String#unpack with format 'j'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_32bit_le, 'j_'
+        it_behaves_like :string_unpack_32bit_le_signed, 'j_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_32bit_le, 'j!'
+        it_behaves_like :string_unpack_32bit_le_signed, 'j!'
+      end
+    end
+  end
+
+  big_endian do
+    describe "String#unpack with format 'J'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_32bit_be, 'J_'
+        it_behaves_like :string_unpack_32bit_be_unsigned, 'J_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_32bit_be, 'J!'
+        it_behaves_like :string_unpack_32bit_be_unsigned, 'J!'
+      end
+    end
+
+    describe "String#unpack with format 'j'" do
+      describe "with modifier '_'" do
+        it_behaves_like :string_unpack_32bit_be, 'j_'
+        it_behaves_like :string_unpack_32bit_be_signed, 'j_'
+      end
+
+      describe "with modifier '!'" do
+        it_behaves_like :string_unpack_32bit_be, 'j!'
+        it_behaves_like :string_unpack_32bit_be_signed, 'j!'
+      end
+    end
+  end
+
+  describe "String#unpack with format 'J'" do
+    describe "with modifier '<'" do
+      it_behaves_like :string_unpack_32bit_le, 'J<'
+      it_behaves_like :string_unpack_32bit_le_unsigned, 'J<'
+    end
+
+    describe "with modifier '>'" do
+      it_behaves_like :string_unpack_32bit_be, 'J>'
+      it_behaves_like :string_unpack_32bit_be_unsigned, 'J>'
+    end
+
+    describe "with modifier '<' and '_'" do
+      it_behaves_like :string_unpack_32bit_le, 'J<_'
+      it_behaves_like :string_unpack_32bit_le, 'J_<'
+      it_behaves_like :string_unpack_32bit_le_unsigned, 'J<_'
+      it_behaves_like :string_unpack_32bit_le_unsigned, 'J_<'
+    end
+
+    describe "with modifier '<' and '!'" do
+      it_behaves_like :string_unpack_32bit_le, 'J<!'
+      it_behaves_like :string_unpack_32bit_le, 'J!<'
+      it_behaves_like :string_unpack_32bit_le_unsigned, 'J<!'
+      it_behaves_like :string_unpack_32bit_le_unsigned, 'J!<'
+    end
+
+    describe "with modifier '>' and '_'" do
+      it_behaves_like :string_unpack_32bit_be, 'J>_'
+      it_behaves_like :string_unpack_32bit_be, 'J_>'
+      it_behaves_like :string_unpack_32bit_be_unsigned, 'J>_'
+      it_behaves_like :string_unpack_32bit_be_unsigned, 'J_>'
+    end
+
+    describe "with modifier '>' and '!'" do
+      it_behaves_like :string_unpack_32bit_be, 'J>!'
+      it_behaves_like :string_unpack_32bit_be, 'J!>'
+      it_behaves_like :string_unpack_32bit_be_unsigned, 'J>!'
+      it_behaves_like :string_unpack_32bit_be_unsigned, 'J!>'
+    end
+  end
+
+  describe "String#unpack with format 'j'" do
+    describe "with modifier '<'" do
+      it_behaves_like :string_unpack_32bit_le, 'j<'
+      it_behaves_like :string_unpack_32bit_le_signed, 'j<'
+    end
+
+    describe "with modifier '>'" do
+      it_behaves_like :string_unpack_32bit_be, 'j>'
+      it_behaves_like :string_unpack_32bit_be_signed, 'j>'
+    end
+
+    describe "with modifier '<' and '_'" do
+      it_behaves_like :string_unpack_32bit_le, 'j<_'
+      it_behaves_like :string_unpack_32bit_le, 'j_<'
+      it_behaves_like :string_unpack_32bit_le_signed, 'j<_'
+      it_behaves_like :string_unpack_32bit_le_signed, 'j_<'
+    end
+
+    describe "with modifier '<' and '!'" do
+      it_behaves_like :string_unpack_32bit_le, 'j<!'
+      it_behaves_like :string_unpack_32bit_le, 'j!<'
+      it_behaves_like :string_unpack_32bit_le_signed, 'j<!'
+      it_behaves_like :string_unpack_32bit_le_signed, 'j!<'
+    end
+
+    describe "with modifier '>' and '_'" do
+      it_behaves_like :string_unpack_32bit_be, 'j>_'
+      it_behaves_like :string_unpack_32bit_be, 'j_>'
+      it_behaves_like :string_unpack_32bit_be_signed, 'j>_'
+      it_behaves_like :string_unpack_32bit_be_signed, 'j_>'
+    end
+
+    describe "with modifier '>' and '!'" do
+      it_behaves_like :string_unpack_32bit_be, 'j>!'
+      it_behaves_like :string_unpack_32bit_be, 'j!>'
+      it_behaves_like :string_unpack_32bit_be_signed, 'j>!'
+      it_behaves_like :string_unpack_32bit_be_signed, 'j!>'
+    end
+  end
+end

--- a/spec/core/string/unpack/q_spec.rb
+++ b/spec/core/string/unpack/q_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/integer'
+
+describe "String#unpack with format 'Q'" do
+  describe "with modifier '<'" do
+    it_behaves_like :string_unpack_64bit_le, 'Q<'
+    it_behaves_like :string_unpack_64bit_le_unsigned, 'Q<'
+  end
+
+  describe "with modifier '>'" do
+    it_behaves_like :string_unpack_64bit_be, 'Q>'
+    it_behaves_like :string_unpack_64bit_be_unsigned, 'Q>'
+  end
+end
+
+describe "String#unpack with format 'q'" do
+  describe "with modifier '<'" do
+    it_behaves_like :string_unpack_64bit_le, 'q<'
+    it_behaves_like :string_unpack_64bit_le_signed, 'q<'
+  end
+
+  describe "with modifier '>'" do
+    it_behaves_like :string_unpack_64bit_be, 'q>'
+    it_behaves_like :string_unpack_64bit_be_signed, 'q>'
+  end
+end
+
+describe "String#unpack with format 'Q'" do
+  it_behaves_like :string_unpack_basic, 'Q'
+end
+
+describe "String#unpack with format 'q'" do
+  it_behaves_like :string_unpack_basic, 'q'
+end
+
+little_endian do
+  describe "String#unpack with format 'Q'" do
+    it_behaves_like :string_unpack_64bit_le, 'Q'
+    it_behaves_like :string_unpack_64bit_le_extra, 'Q'
+    it_behaves_like :string_unpack_64bit_le_unsigned, 'Q'
+  end
+
+  describe "String#unpack with format 'q'" do
+    it_behaves_like :string_unpack_64bit_le, 'q'
+    it_behaves_like :string_unpack_64bit_le_extra, 'q'
+    it_behaves_like :string_unpack_64bit_le_signed, 'q'
+  end
+end
+
+big_endian do
+  describe "String#unpack with format 'Q'" do
+    it_behaves_like :string_unpack_64bit_be, 'Q'
+    it_behaves_like :string_unpack_64bit_be_extra, 'Q'
+    it_behaves_like :string_unpack_64bit_be_unsigned, 'Q'
+  end
+
+  describe "String#unpack with format 'q'" do
+    it_behaves_like :string_unpack_64bit_be, 'q'
+    it_behaves_like :string_unpack_64bit_be_extra, 'q'
+    it_behaves_like :string_unpack_64bit_be_signed, 'q'
+  end
+end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -201,20 +201,17 @@ BigInt::BigInt(const BigInt &num) {
 
 BigInt::BigInt(const long long &num) {
     m_value = TM::String(std::abs(num));
-    if (num < 0)
-        m_sign = '-';
-    else
-        m_sign = '+';
+    m_sign = (num < 0) ? '-' : '+';
 }
 
 /*
-    Unsigned Long to BigInt
-    -----------------
+    Long Integer to BigInt
+    ----------------------
 */
 
-BigInt::BigInt(const unsigned long int &num) {
-    m_value = TM::String(num);
-    m_sign = '+';
+BigInt::BigInt(const long &num) {
+    m_value = TM::String(std::abs(num));
+    m_sign = (num < 0) ? '-' : '+';
 }
 
 /*
@@ -234,10 +231,27 @@ BigInt::BigInt(const unsigned long long &num) {
 
 BigInt::BigInt(const int &num) {
     m_value = TM::String(std::abs(num));
-    if (num < 0)
-        m_sign = '-';
-    else
-        m_sign = '+';
+    m_sign = (num < 0) ? '-' : '+';
+}
+
+/*
+    Unsigned Long Integer to BigInt
+    -------------------------------
+*/
+
+BigInt::BigInt(const unsigned long &num) {
+    m_value = TM::String(num);
+    m_sign = '+';
+}
+
+/*
+    Unsigned Integer to BigInt
+    --------------------------
+*/
+
+BigInt::BigInt(const unsigned int &num) {
+    m_value = TM::String(num);
+    m_sign = '+';
 }
 
 /*


### PR DESCRIPTION
This PR seeks to address parts of #667, namely to add support for `String#unpack` of integer/pointer-types:
+ Modify the `unpack_s` function to handle more generic types, which replaces the existing `unpack_i` and `unpack_j` functions and was renamed `unpack_int`.
+ Add support for `i` `I`, `j`, `J`, `q`, `Q` directives.  These directives pass their respective specs.
+ Add tentative support for `l`, `L` directives using the same function as above - these do not pass all of the `l_spec` tests yet, I think the underlying code is valid, there is some weirdness in how platform-specific longs are treated in the tests, or an interaction with the `platform_is` function.  Ruby documentation says these directives correspond to `int32_t` and `uint32_t`, yet the spec would indicate otherwise 😞 

To support "Q" types, I found the need to use `BigInt` when building the integer value.  This in turn required adding support for different unsigned long/int types to `BigInt` and `TM::String`.  I'm interested in feedback to improve upon it, there was probably a better way that wasnt obvious to me.