### PR TITLE
Reimplement String#encode

### DIFF
--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -59,6 +59,7 @@ public:
     BigInt(const BigInt &);
     BigInt(const long long &);
     BigInt(const unsigned long int &);
+    BigInt(const unsigned long long &);
     BigInt(const int &);
     BigInt(const double &);
     BigInt(const TM::String &);

--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -24,7 +24,8 @@ public:
 
     virtual String escaped_char(unsigned char c) const override;
 
-    virtual Value encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const override;
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override;
+    virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const override;
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -24,7 +24,8 @@ public:
 
     virtual String escaped_char(unsigned char c) const override;
 
-    virtual Value encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const override;
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override;
+    virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const override;
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -25,7 +25,8 @@ public:
 
     virtual String escaped_char(unsigned char c) const override;
 
-    virtual Value encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const override;
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override;
+    virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const override;
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -61,9 +61,12 @@ public:
     virtual std::pair<bool, StringView> prev_char(const String &, size_t *) const = 0;
     virtual std::pair<bool, StringView> next_char(const String &, size_t *) const = 0;
     virtual String escaped_char(unsigned char c) const = 0;
-    virtual Value encode(Env *, EncodingObject *, StringObject *) const = 0;
+    virtual Value encode(Env *, EncodingObject *, StringObject *) const;
     virtual String encode_codepoint(nat_int_t codepoint) const = 0;
     virtual nat_int_t decode_codepoint(StringView &str) const = 0;
+
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const = 0;
+    virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const = 0;
 
     [[noreturn]] void raise_encoding_invalid_byte_sequence_error(Env *env, const String &, size_t) const;
 

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -40,28 +40,28 @@ public:
 
     static Value setuid(Env *env, Value idval) {
         uid_t uid = value_to_uid(env, idval);
-        if (setresuid(uid, -1, -1) < 0)
+        if (setreuid(uid, -1) < 0)
             env->raise_errno();
         return idval;
     }
 
     static Value seteuid(Env *env, Value idval) {
         uid_t euid = value_to_uid(env, idval);
-        if (setresuid(-1, euid, -1) < 0)
+        if (setreuid(-1, euid) < 0)
             env->raise_errno();
         return idval;
     }
 
     static Value setgid(Env *env, Value idval) {
         gid_t gid = value_to_gid(env, idval);
-        if (setresgid(gid, -1, -1) < 0)
+        if (setregid(gid, -1) < 0)
             env->raise_errno();
         return idval;
     }
 
     static Value setegid(Env *env, Value idval) {
         gid_t egid = value_to_gid(env, idval);
-        if (setresgid(-1, egid, -1) < 0)
+        if (setregid(-1, egid) < 0)
             env->raise_errno();
         return idval;
     }

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -140,6 +140,22 @@ public:
      * Constructs a new String by converting the given number.
      *
      * ```
+     * auto str = String { (unsigned long long)10 };
+     * assert_str_eq("10", str);
+     * ```
+     */
+
+    String(unsigned long long number) {
+        int length = snprintf(NULL, 0, "%llu", number);
+        char buf[length + 1];
+        snprintf(buf, length + 1, "%llu", number);
+        set_str(buf);
+    }
+
+    /**
+     * Constructs a new String by converting the given number.
+     *
+     * ```
      * auto str = String { (unsigned long int)10 };
      * assert_str_eq("10", str);
      * ```

--- a/spec/core/string/encode/ascii_8bit_spec.rb
+++ b/spec/core/string/encode/ascii_8bit_spec.rb
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../../spec_helper'
+
+describe "String#encode - to ASCII-8BIT" do
+  context "from US-ASCII" do
+    it "returns correct String in ASCII-8BIT" do
+      a = "\x61".force_encoding("US-ASCII") # "a" - 0x61 (ASCII)
+
+      a.encode("ASCII-8BIT").bytes.should == [0x61]
+      a.encode("ASCII-8BIT").encoding.should == Encoding::ASCII_8BIT
+    end
+  end
+
+  context "from ASCII-8BIT" do
+    context "0-127" do
+      it "returns correct String in ASCII-8BIT" do
+        b = "\x61".force_encoding("ASCII-8BIT") # "a" - 0x61 (ASCII)
+
+        b.encode("ASCII-8BIT").bytes.should == [0x61]
+        b.encode("ASCII-8BIT").encoding.should == Encoding::ASCII_8BIT
+      end
+    end
+  end
+
+  context "from UTF-8" do
+    context "from 1-byte UTF-8" do
+      it "returns correct String in ASCII-8BIT" do
+        a = "\x61".force_encoding("UTF-8") # "a" - U+0061 (Unicode)
+
+        a.encode("ASCII-8BIT").bytes.should == [0x61]
+        a.encode("ASCII-8BIT").encoding.should == Encoding::ASCII_8BIT
+      end
+    end
+
+    context "multi-bytes UTF-8" do
+      it "returns correct String in US-ASCII" do
+        c = "\xC2\xA5".force_encoding("UTF-8") # "¥" - U+00A5 (Unicode, Latin-1 Supplement)
+        -> { c.encode("ASCII-8BIT") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+00A5 from UTF-8 to ASCII-8BIT")
+
+        c = "\xE2\x84\x9C".force_encoding("UTF-8") # "ℜ" - U+211C (Unicode, Letterlike Symbols)
+        -> { c.encode("ASCII-8BIT") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+211C from UTF-8 to ASCII-8BIT")
+
+        c = "\xF0\x90\x85\x87".force_encoding("UTF-8") # U+10147 (Unicode, Ancient Greek Numbers)
+        -> { c.encode("ASCII-8BIT") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+10147 from UTF-8 to ASCII-8BIT")
+      end
+    end
+  end
+end

--- a/spec/core/string/encode/us_ascii_spec.rb
+++ b/spec/core/string/encode/us_ascii_spec.rb
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../../spec_helper'
+
+describe "String#encode - to US-ASCII" do
+  context "from US-ASCII" do
+    it "returns correct String in US-ASCII" do
+      a = "\x61".force_encoding("US-ASCII") # "a" - 0x61 (ASCII)
+
+      a.encode("US-ASCII").bytes.should == [0x61]
+      a.encode("US-ASCII").encoding.should == Encoding::US_ASCII
+    end
+  end
+
+  context "from ASCII-8BIT" do
+    context "0-127" do
+      it "returns correct String in US-ASCII" do
+        a = "\x61".force_encoding("ASCII-8BIT") # "a" - 0x61 (ASCII)
+
+        a.encode("US-ASCII").bytes.should == [0x61]
+        a.encode("US-ASCII").encoding.should == Encoding::US_ASCII
+      end
+    end
+
+    context "128-255" do
+      it "raises Encoding::UndefinedConversionError" do
+        b = "\x8F".force_encoding("ASCII-8BIT") # = 128
+
+        -> { b.encode("US-ASCII") }.should raise_error(
+          Encoding::UndefinedConversionError,
+          '"\x8F" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII'
+        )
+      end
+    end
+  end
+
+  context "from UTF-8" do
+    context "from 1-byte UTF-8" do
+      it "returns correct String in US-ASCII" do
+        a = "\x61".force_encoding("UTF-8") # "a" - U+0061 (Unicode)
+
+        a.encode("US-ASCII").bytes.should == [0x61]
+        a.encode("US-ASCII").encoding.should == Encoding::US_ASCII
+      end
+    end
+
+    context "multi-bytes UTF-8" do
+      it "returns correct String in US-ASCII" do
+        c = "\xC2\xA5".force_encoding("UTF-8") # "¥" - U+00A5 (Unicode, Latin-1 Supplement)
+        -> { c.encode("US-ASCII") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+00A5 from UTF-8 to US-ASCII")
+
+        c = "\xE2\x84\x9C".force_encoding("UTF-8") # "ℜ" - U+211C (Unicode, Letterlike Symbols)
+        -> { c.encode("US-ASCII") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+211C from UTF-8 to US-ASCII")
+
+        c = "\xF0\x90\x85\x87".force_encoding("UTF-8") # U+10147 (Unicode, Ancient Greek Numbers)
+        -> { c.encode("US-ASCII") }.should raise_error(
+          Encoding::UndefinedConversionError, "U+10147 from UTF-8 to US-ASCII")
+      end
+    end
+  end
+end

--- a/spec/core/string/encode/utf_8_spec.rb
+++ b/spec/core/string/encode/utf_8_spec.rb
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../../spec_helper'
+
+describe "String#encode - to UTF-8" do
+  context "from US-ASCII" do
+    it "returns correct String in UTF-8" do
+      a = "\x61".force_encoding("US-ASCII") # "a" - 0x61 (ASCII)
+
+      a.encode("UTF-8").bytes.should == [0x61]
+      a.encode("UTF-8").encoding.should == Encoding::UTF_8
+    end
+  end
+
+  context "from ASCII-8BIT" do
+    context "0-127" do
+      it "returns correct String in UTF-8" do
+        b = "\x61".force_encoding("ASCII-8BIT") # "a" - 0x61 (ASCII)
+
+        b.encode("UTF-8").bytes.should == [0x61]
+        b.encode("UTF-8").encoding.should == Encoding::UTF_8
+      end
+    end
+
+    context "128-255" do
+      it "raises Encoding::UndefinedConversionError" do
+        b = "\x8F".force_encoding("ASCII-8BIT") # = 128
+
+        -> { b.encode("UTF-8") }.should raise_error(
+          Encoding::UndefinedConversionError, '"\x8F" from ASCII-8BIT to UTF-8')
+      end
+    end
+  end
+
+  context "from UTF-8" do
+    it "returns correct String in UTF-8" do
+      a = "\x61".force_encoding("UTF-8") # "a" - U+0061 (Unicode)
+      a.encode("UTF-8").bytes.should == [0x61]
+      a.encode("UTF-8").encoding.should == Encoding::UTF_8
+
+      a = "\xC2\xA5".force_encoding("UTF-8") # "¥" - U+00A5 (Unicode, Latin-1 Supplement)
+      a.encode("UTF-8").bytes.should == [0xC2, 0xA5]
+      a.encode("UTF-8").encoding.should == Encoding::UTF_8
+
+      a = "\xE2\x84\x9C".force_encoding("UTF-8") # "ℜ" - U+211C (Unicode, Letterlike Symbols)
+      a.encode("UTF-8").bytes.should == [0xE2, 0x84, 0x9C]
+      a.encode("UTF-8").encoding.should == Encoding::UTF_8
+
+      a = "\xF0\x90\x85\x87".force_encoding("UTF-8") # U+10147 (Unicode, Ancient Greek Numbers)
+      a.encode("UTF-8").bytes.should == [0xF0, 0x90, 0x85, 0x87]
+      a.encode("UTF-8").encoding.should == Encoding::UTF_8
+    end
+  end
+end

--- a/spec/core/string/valid_encoding/utf_8_spec.rb
+++ b/spec/core/string/valid_encoding/utf_8_spec.rb
@@ -1,0 +1,214 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../../spec_helper'
+
+describe "String#valid_encoding? and UTF-8" do
+  def utf8(bytes)
+    bytes.pack("C*").force_encoding("UTF-8")
+  end
+
+  describe "1-byte character" do
+    it "is valid if is in format 0xxxxxxx" do
+      utf8([0b00000000]).valid_encoding?.should == true
+      utf8([0b01111111]).valid_encoding?.should == true
+    end
+
+    it "is not valid if is not in format 0xxxxxxx" do
+      utf8([0b10000000]).valid_encoding?.should == false
+      utf8([0b11111111]).valid_encoding?.should == false
+    end
+  end
+
+  describe "2-bytes character" do
+    it "is valid if in format [110xxxxx 10xxxxx]" do
+      utf8([0b11000010, 0b10000000]).valid_encoding?.should == true
+      utf8([0b11000010, 0b10111111]).valid_encoding?.should == true
+
+      utf8([0b11011111, 0b10000000]).valid_encoding?.should == true
+      utf8([0b11011111, 0b10111111]).valid_encoding?.should == true
+    end
+
+    it "is not valid if the first byte is not in format 110xxxxx" do
+      utf8([0b00000010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b00100010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01000010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01100010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10000010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10100010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11000010, 0b10000000]).valid_encoding?.should == true # correct bytes
+      utf8([0b11100010, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is not in format 10xxxxxx" do
+      utf8([0b11000010, 0b00000000]).valid_encoding?.should == false
+      utf8([0b11000010, 0b01000000]).valid_encoding?.should == false
+      utf8([0b11000010, 0b11000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if is smaller than [xxxxxx10 xx000000] (codepoints < U+007F, that are encoded with the 1-byte format)" do
+      utf8([0b11000000, 0b10111111]).valid_encoding?.should == false
+      utf8([0b11000001, 0b10111111]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the first byte is missing" do
+      bytes = [0b11000010, 0b10000000]
+      utf8(bytes[1..1]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is missing" do
+      bytes = [0b11000010, 0b10000000]
+      utf8(bytes[0..0]).valid_encoding?.should == false
+    end
+  end
+
+  describe "3-bytes character" do
+    it "is valid if in format [1110xxxx 10xxxxxx 10xxxxxx]" do
+      utf8([0b11100000, 0b10100000, 0b10000000]).valid_encoding?.should == true
+      utf8([0b11100000, 0b10100000, 0b10111111]).valid_encoding?.should == true
+      utf8([0b11100000, 0b10111111, 0b10111111]).valid_encoding?.should == true
+      utf8([0b11101111, 0b10111111, 0b10111111]).valid_encoding?.should == true
+    end
+
+    it "is not valid if the first byte is not in format 1110xxxx" do
+      utf8([0b00000000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b00010000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b00100000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b00110000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01000000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01010000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01100000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01110000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10000000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10010000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10100000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10110000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11000000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11010000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10100000, 0b10000000]).valid_encoding?.should == true # correct bytes
+      utf8([0b11110000, 0b10100000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is not in format 10xxxxxx" do
+      utf8([0b11100000, 0b00100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b01100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b11100000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the third byte is not in format 10xxxxxx" do
+      utf8([0b11100000, 0b10100000, 0b00000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10100000, 0b01000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10100000, 0b01000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if is smaller than [xxxx0000 xx100000 xx000000] (codepoints < U+07FF that are encoded with the 2-byte format)" do
+      utf8([0b11100000, 0b10010000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10001000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10000100, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10000010, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10000001, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11100000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if in range [xxxx1101 xx100000 xx000000] - [xxxx1101 xx111111 xx111111] (codepoints U+D800 - U+DFFF)" do
+      utf8([0b11101101, 0b10100000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11101101, 0b10100000, 0b10000001]).valid_encoding?.should == false
+      utf8([0b11101101, 0b10111111, 0b10111111]).valid_encoding?.should == false
+
+      utf8([0b11101101, 0b10011111, 0b10111111]).valid_encoding?.should == true # lower boundary - 1
+      utf8([0b11101110, 0b10000000, 0b10000000]).valid_encoding?.should == true # upper boundary + 1
+    end
+
+    it "is not valid if the first byte is missing" do
+      bytes = [0b11100000, 0b10100000, 0b10000000]
+      utf8(bytes[2..3]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is missing" do
+      bytes = [0b11100000, 0b10100000, 0b10000000]
+      utf8([bytes[0], bytes[2]]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second and the third bytes are missing" do
+      bytes = [0b11100000, 0b10100000, 0b10000000]
+      utf8(bytes[0..0]).valid_encoding?.should == false
+    end
+  end
+
+  describe "4-bytes character" do
+    it "is valid if in format [11110xxx 10xxxxxx 10xxxxxx 10xxxxxx]" do
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == true
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b10111111]).valid_encoding?.should == true
+      utf8([0b11110000, 0b10010000, 0b10111111, 0b10111111]).valid_encoding?.should == true
+      utf8([0b11110000, 0b10111111, 0b10111111, 0b10111111]).valid_encoding?.should == true
+      utf8([0b11110100, 0b10001111, 0b10111111, 0b10111111]).valid_encoding?.should == true
+    end
+
+    it "is not valid if the first byte is not in format 11110xxx" do
+      utf8([0b11100000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11010000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b10110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b01110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is not in format 10xxxxxx" do
+      utf8([0b11110000, 0b00010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b01010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == true # correct bytes
+      utf8([0b11110000, 0b11010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the third byte is not in format 10xxxxxx" do
+      utf8([0b11110000, 0b10010000, 0b00000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10010000, 0b01000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == true # correct bytes
+      utf8([0b11110000, 0b10010000, 0b11000000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the forth byte is not in format 10xxxxxx" do
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b00000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b01000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == true # correct bytes
+      utf8([0b11110000, 0b10010000, 0b10000000, 0b11000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if is smaller than [xxxxx000 xx001000 xx000000 xx000000] (codepoint < U+10000)" do
+      utf8([0b11110000, 0b10000111, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000110, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000101, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000100, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000011, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000010, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000001, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110000, 0b10000000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+    end
+
+    it "is not valid if is greater than [xxxxx100 xx001111 xx111111 xx111111] (codepoint > U+10FFFF)" do
+      utf8([0b11110100, 0b10010000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110100, 0b10100000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+      utf8([0b11110100, 0b10110000, 0b10000000, 0b10000000]).valid_encoding?.should == false
+
+      utf8([0b11110101, 0b10001111, 0b10111111, 0b10111111]).valid_encoding?.should == false
+      utf8([0b11110110, 0b10001111, 0b10111111, 0b10111111]).valid_encoding?.should == false
+      utf8([0b11110111, 0b10001111, 0b10111111, 0b10111111]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the first byte is missing" do
+      bytes = [0b11110000, 0b10010000, 0b10000000, 0b10000000]
+      utf8(bytes[1..3]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second byte is missing" do
+      bytes = [0b11110000, 0b10010000, 0b10000000, 0b10000000]
+      utf8([bytes[0], bytes[2], bytes[3]]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second and the third bytes are missing" do
+      bytes = [0b11110000, 0b10010000, 0b10000000, 0b10000000]
+      utf8([bytes[0], bytes[3]]).valid_encoding?.should == false
+    end
+
+    it "is not valid if the second, the third and the fourth bytes are missing" do
+      bytes = [0b11110000, 0b10010000, 0b10000000, 0b10000000]
+      utf8(bytes[0..0]).valid_encoding?.should == false
+    end
+  end
+end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -218,6 +218,16 @@ BigInt::BigInt(const unsigned long int &num) {
 }
 
 /*
+    Unsigned Long Long to BigInt
+    -----------------
+*/
+
+BigInt::BigInt(const unsigned long long &num) {
+    m_value = TM::String(num);
+    m_sign = '+';
+}
+
+/*
     Integer to BigInt
     -----------------
 */

--- a/src/encoding/ascii_8bit_encoding_object.cpp
+++ b/src/encoding/ascii_8bit_encoding_object.cpp
@@ -23,31 +23,18 @@ String Ascii8BitEncodingObject::escaped_char(unsigned char c) const {
     return String(buf);
 }
 
-Value Ascii8BitEncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const {
-    ClassObject *EncodingClass = find_top_level_const(env, "Encoding"_s)->as_class();
-    switch (orig_encoding->num()) {
-    case Encoding::ASCII_8BIT:
-        // nothing to do
-        return str;
-    case Encoding::US_ASCII:
-        str->set_encoding(EncodingObject::get(num()));
-        return str;
-    case Encoding::UTF_8: {
-        ArrayObject *chars = str->chars(env)->as_array();
-        for (size_t i = 0; i < chars->size(); i++) {
-            StringObject *char_obj = (*chars)[i]->as_string();
-            if (char_obj->length() > 1) {
-                Value ord = char_obj->ord(env);
-                auto message = StringObject::format("U+{} from UTF-8 to ASCII-8BIT", String::hex(ord->as_integer()->to_nat_int_t(), String::HexFormat::Uppercase));
-                env->raise(EncodingClass->const_find(env, "UndefinedConversionError"_s)->as_class(), message);
-            }
-        }
-        str->set_encoding(EncodingObject::get(num()));
-        return str;
-    }
-    default:
-        env->raise(EncodingClass->const_find(env, "ConverterNotFoundError"_s)->as_class(), "code converter not found");
-    }
+nat_int_t Ascii8BitEncodingObject::to_unicode_codepoint(nat_int_t codepoint) const {
+    if (codepoint >= 128)
+        return -1;
+
+    return codepoint;
+}
+
+nat_int_t Ascii8BitEncodingObject::from_unicode_codepoint(nat_int_t codepoint) const {
+    if (codepoint >= 128)
+        return -1;
+
+    return codepoint;
 }
 
 String Ascii8BitEncodingObject::encode_codepoint(nat_int_t codepoint) const {

--- a/src/encoding/us_ascii_encoding_object.cpp
+++ b/src/encoding/us_ascii_encoding_object.cpp
@@ -29,41 +29,15 @@ String UsAsciiEncodingObject::escaped_char(unsigned char c) const {
     return String(buf);
 }
 
-Value UsAsciiEncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const {
-    ClassObject *EncodingClass = find_top_level_const(env, "Encoding"_s)->as_class();
-    switch (orig_encoding->num()) {
-    case Encoding::ASCII_8BIT: {
-        auto string = str->string();
-        for (size_t i = 0; i < string.size(); ++i) {
-            unsigned char c = string[i];
-            if (!valid_codepoint(c)) {
-                Value ord = Value::integer(c);
-                auto message = StringObject::format("U+{} from UTF-8 to US-ASCII", String::hex(ord->as_integer()->to_nat_int_t(), String::HexFormat::Uppercase));
-                env->raise(EncodingClass->const_find(env, "UndefinedConversionError"_s)->as_class(), message);
-            }
-        }
-        str->set_encoding(EncodingObject::get(num()));
-        return str;
-    }
-    case Encoding::US_ASCII:
-        // nothing to do
-        return str;
-    case Encoding::UTF_8: {
-        ArrayObject *chars = str->chars(env)->as_array();
-        for (size_t i = 0; i < chars->size(); i++) {
-            StringObject *char_obj = (*chars)[i]->as_string();
-            if (char_obj->length() > 1) {
-                Value ord = char_obj->ord(env);
-                auto message = StringObject::format("U+{} from UTF-8 to US-ASCII", String::hex(ord->as_integer()->to_nat_int_t(), String::HexFormat::Uppercase));
-                env->raise(EncodingClass->const_find(env, "UndefinedConversionError"_s)->as_class(), message);
-            }
-        }
-        str->set_encoding(EncodingObject::get(num()));
-        return str;
-    }
-    default:
-        env->raise(EncodingClass->const_find(env, "ConverterNotFoundError"_s)->as_class(), "code converter not found");
-    }
+nat_int_t UsAsciiEncodingObject::to_unicode_codepoint(nat_int_t codepoint) const {
+    return codepoint;
+}
+
+nat_int_t UsAsciiEncodingObject::from_unicode_codepoint(nat_int_t codepoint) const {
+    if (codepoint >= 128)
+        return -1;
+
+    return codepoint;
 }
 
 String UsAsciiEncodingObject::encode_codepoint(nat_int_t codepoint) const {

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -151,20 +151,12 @@ String Utf8EncodingObject::escaped_char(unsigned char c) const {
     return String(buf);
 }
 
-Value Utf8EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const {
-    switch (orig_encoding->num()) {
-    case Encoding::UTF_8:
-        // nothing to do
-        return str;
-    case Encoding::ASCII_8BIT:
-    case Encoding::US_ASCII:
-        // TODO: some sort of conversion?
-        str->set_encoding(EncodingObject::get(num()));
-        return str;
-    default:
-        ClassObject *EncodingClass = find_top_level_const(env, "Encoding"_s)->as_class();
-        env->raise(EncodingClass->const_find(env, "ConverterNotFoundError"_s)->as_class(), "code converter not found");
-    }
+nat_int_t Utf8EncodingObject::to_unicode_codepoint(nat_int_t codepoint) const {
+    return codepoint;
+}
+
+nat_int_t Utf8EncodingObject::from_unicode_codepoint(nat_int_t codepoint) const {
+    return codepoint;
 }
 
 // public domain


### PR DESCRIPTION
Implemented strings encoding in two-steps - convert a character to Unicode and then to the destination encoding.

Changes:
- reimplemented `String#encode`
- fixed compiling issues on MacOS
- added specs for `String#valid_encoding?` for UTF-8 (that were merged into RubySpec [here](https://github.com/ruby/spec/pull/975))