### PR TITLE
Add float/double support for String.unpack, directives d/e/f/g

### DIFF
--- a/spec/core/string/unpack/d_spec.rb
+++ b/spec/core/string/unpack/d_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/float'
+
+little_endian do
+  describe "String#unpack with format 'D'" do
+    it_behaves_like :string_unpack_basic, 'D'
+    it_behaves_like :string_unpack_double_le, 'D'
+  end
+
+  describe "String#unpack with format 'd'" do
+    it_behaves_like :string_unpack_basic, 'd'
+    it_behaves_like :string_unpack_double_le, 'd'
+  end
+end
+
+big_endian do
+  describe "String#unpack with format 'D'" do
+    it_behaves_like :string_unpack_basic, 'D'
+    it_behaves_like :string_unpack_double_be, 'D'
+  end
+
+  describe "String#unpack with format 'd'" do
+    it_behaves_like :string_unpack_basic, 'd'
+    it_behaves_like :string_unpack_double_be, 'd'
+  end
+end

--- a/spec/core/string/unpack/e_spec.rb
+++ b/spec/core/string/unpack/e_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/float'
+
+describe "String#unpack with format 'E'" do
+  it_behaves_like :string_unpack_basic, 'E'
+  it_behaves_like :string_unpack_double_le, 'E'
+end
+
+describe "String#unpack with format 'e'" do
+  it_behaves_like :string_unpack_basic, 'e'
+  it_behaves_like :string_unpack_float_le, 'e'
+end

--- a/spec/core/string/unpack/f_spec.rb
+++ b/spec/core/string/unpack/f_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/float'
+
+little_endian do
+  describe "String#unpack with format 'F'" do
+    it_behaves_like :string_unpack_basic, 'F'
+    it_behaves_like :string_unpack_float_le, 'F'
+  end
+
+  describe "String#unpack with format 'f'" do
+    it_behaves_like :string_unpack_basic, 'f'
+    it_behaves_like :string_unpack_float_le, 'f'
+  end
+end
+
+big_endian do
+  describe "String#unpack with format 'F'" do
+    it_behaves_like :string_unpack_basic, 'F'
+    it_behaves_like :string_unpack_float_be, 'F'
+  end
+
+  describe "String#unpack with format 'f'" do
+    it_behaves_like :string_unpack_basic, 'f'
+    it_behaves_like :string_unpack_float_be, 'f'
+  end
+end

--- a/spec/core/string/unpack/g_spec.rb
+++ b/spec/core/string/unpack/g_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative 'shared/basic'
+require_relative 'shared/float'
+
+describe "String#unpack with format 'G'" do
+  it_behaves_like :string_unpack_basic, 'G'
+  it_behaves_like :string_unpack_double_be, 'G'
+end
+
+describe "String#unpack with format 'g'" do
+  it_behaves_like :string_unpack_basic, 'g'
+  it_behaves_like :string_unpack_float_be, 'g'
+end


### PR DESCRIPTION
Per #667 Implements `String.unpack` directives d,D,e,E,f,F,g,G to support double/float types using a templated function.
