### PR TITLE
Use exact-width integers

### DIFF
--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -103,7 +103,7 @@ namespace ArrayPacker {
         void pack_c() {
             auto source = m_source->to_nat_int_t();
             if (m_source->is_bignum())
-                source = (m_source->integer().to_bigint() % 256).to_long_long();
+                source = (m_source->integer().to_bigint() % 256).to_int64_t();
 
             m_packed.append_char(static_cast<signed char>(source));
         }
@@ -111,7 +111,7 @@ namespace ArrayPacker {
         void pack_I() {
             auto source = (unsigned int)m_source->to_nat_int_t();
             if (m_source->is_bignum())
-                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(unsigned int))).to_long_long();
+                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(unsigned int))).to_int64_t();
 
             append_bytes((const char *)(&source), sizeof(source));
         }
@@ -119,7 +119,7 @@ namespace ArrayPacker {
         void pack_i() {
             auto source = (signed int)m_source->to_nat_int_t();
             if (m_source->is_bignum())
-                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_int64_t();
 
             append_bytes((const char *)(&source), sizeof(source));
         }
@@ -147,7 +147,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (unsigned long long)m_source->to_nat_int_t();
+                auto source = (uint64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }
@@ -157,7 +157,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (long long)m_source->to_nat_int_t();
+                auto source = (int64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }
@@ -168,7 +168,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (unsigned long long)m_source->to_nat_int_t();
+                auto source = (uint64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }
@@ -179,7 +179,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (long long)m_source->to_nat_int_t();
+                auto source = (int64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }
@@ -187,7 +187,7 @@ namespace ArrayPacker {
         void pack_S() {
             auto source = (unsigned short)m_source->to_nat_int_t();
             if (m_source->is_bignum())
-                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_int64_t();
 
             auto size = m_token.native_size ? sizeof(unsigned short) : 2;
             append_bytes((const char *)&source, size);
@@ -196,7 +196,7 @@ namespace ArrayPacker {
         void pack_s() {
             auto source = (signed short)m_source->to_nat_int_t();
             if (m_source->is_bignum())
-                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+                source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_int64_t();
 
             auto size = m_token.native_size ? sizeof(signed short) : 2;
             append_bytes((const char *)&source, size);
@@ -208,7 +208,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (unsigned long long)m_source->to_nat_int_t();
+                auto source = (uint64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }
@@ -219,7 +219,7 @@ namespace ArrayPacker {
             if (m_source->is_bignum()) {
                 pack_bignum(size * 8);
             } else {
-                auto source = (long long)m_source->to_nat_int_t();
+                auto source = (int64_t)m_source->to_nat_int_t();
                 append_bytes((const char *)(&source), size);
             }
         }

--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -57,9 +57,9 @@ public:
     // Constructors:
     BigInt();
     BigInt(const BigInt &);
-    BigInt(const long long &);
+    BigInt(const int64_t &);
     BigInt(const unsigned long int &);
-    BigInt(const unsigned long long &);
+    BigInt(const uint64_t &);
     BigInt(const long &);
     BigInt(const unsigned int &);
     BigInt(const int &);
@@ -68,7 +68,7 @@ public:
 
     // Assignment operators:
     BigInt &operator=(const BigInt &);
-    BigInt &operator=(const long long &);
+    BigInt &operator=(const int64_t &);
     BigInt &operator=(const TM::String &);
 
     // Unary arithmetic operators:
@@ -83,11 +83,11 @@ public:
     BigInt c_div(const BigInt &) const;
     BigInt operator%(const BigInt &) const;
     BigInt c_mod(const BigInt &) const;
-    BigInt operator+(const long long &) const;
-    BigInt operator-(const long long &) const;
-    BigInt operator*(const long long &) const;
-    BigInt operator/(const long long &) const;
-    BigInt operator%(const long long &) const;
+    BigInt operator+(const int64_t &) const;
+    BigInt operator-(const int64_t &) const;
+    BigInt operator*(const int64_t &) const;
+    BigInt operator/(const int64_t &) const;
+    BigInt operator%(const int64_t &) const;
     BigInt operator+(const TM::String &) const;
     BigInt operator-(const TM::String &) const;
     BigInt operator*(const TM::String &) const;
@@ -100,11 +100,11 @@ public:
     BigInt &operator*=(const BigInt &);
     BigInt &operator/=(const BigInt &);
     BigInt &operator%=(const BigInt &);
-    BigInt &operator+=(const long long &);
-    BigInt &operator-=(const long long &);
-    BigInt &operator*=(const long long &);
-    BigInt &operator/=(const long long &);
-    BigInt &operator%=(const long long &);
+    BigInt &operator+=(const int64_t &);
+    BigInt &operator-=(const int64_t &);
+    BigInt &operator*=(const int64_t &);
+    BigInt &operator/=(const int64_t &);
+    BigInt &operator%=(const int64_t &);
     BigInt &operator+=(const TM::String &);
     BigInt &operator-=(const TM::String &);
     BigInt &operator*=(const TM::String &);
@@ -124,12 +124,12 @@ public:
     bool operator>=(const BigInt &) const;
     bool operator==(const BigInt &) const;
     bool operator!=(const BigInt &) const;
-    bool operator<(const long long &) const;
-    bool operator>(const long long &) const;
-    bool operator<=(const long long &) const;
-    bool operator>=(const long long &) const;
-    bool operator==(const long long &) const;
-    bool operator!=(const long long &) const;
+    bool operator<(const int64_t &) const;
+    bool operator>(const int64_t &) const;
+    bool operator<=(const int64_t &) const;
+    bool operator>=(const int64_t &) const;
+    bool operator==(const int64_t &) const;
+    bool operator!=(const int64_t &) const;
     bool operator<(const int &) const;
     bool operator>(const int &) const;
     bool operator<=(const int &) const;
@@ -163,8 +163,7 @@ public:
     // Conversion functions:
     TM::String to_string() const;
     TM::String to_binary() const;
-    long to_long() const;
-    long long to_long_long() const;
+    int64_t to_int64_t() const;
     double to_double() const;
 
     // Random number generating functions:
@@ -175,16 +174,16 @@ private:
     char m_sign;
 };
 
-BigInt pow(const BigInt &base, long long exp);
+BigInt pow(const BigInt &base, int64_t exp);
 BigInt gcd(const BigInt &num1, const BigInt &num2);
 BigInt sqrt(const BigInt &num);
-BigInt operator+(const long long &lhs, const BigInt &rhs);
-BigInt operator-(const long long &lhs, const BigInt &rhs);
-BigInt operator*(const long long &lhs, const BigInt &rhs);
-BigInt operator/(const long long &lhs, const BigInt &rhs);
-BigInt operator%(const long long &lhs, const BigInt &rhs);
-bool operator<(const long long &lhs, const BigInt &rhs);
-bool operator==(const long long &lhs, const BigInt &rhs);
+BigInt operator+(const int64_t &lhs, const BigInt &rhs);
+BigInt operator-(const int64_t &lhs, const BigInt &rhs);
+BigInt operator*(const int64_t &lhs, const BigInt &rhs);
+BigInt operator/(const int64_t &lhs, const BigInt &rhs);
+BigInt operator%(const int64_t &lhs, const BigInt &rhs);
+bool operator<(const int64_t &lhs, const BigInt &rhs);
+bool operator==(const int64_t &lhs, const BigInt &rhs);
 
 BigInt abs(const BigInt &num);
 BigInt big_pow10(size_t exp);

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -118,8 +118,8 @@ public:
     nat_int_t to_nat_int_t() const {
         if (is_fixnum())
             return m_fixnum;
-        else // FIXME: this should probably panic since the number likely won't fit in a long long
-            return m_bignum->to_long_long();
+        else // FIXME: this should probably panic since the number likely won't fit in a int64_t
+            return m_bignum->to_int64_t();
     }
     double to_double() const;
     TM::String to_string() const;
@@ -141,16 +141,16 @@ private:
     bool m_is_fixnum { true };
 };
 
-Integer operator+(const long long &, const Integer &);
-Integer operator-(const long long &, const Integer &);
-Integer operator*(const long long &, const Integer &);
-Integer operator/(const long long &, const Integer &);
-Integer operator<(const long long &, const Integer &);
-Integer operator>(const long long &, const Integer &);
-Integer operator<=(const long long &, const Integer &);
-Integer operator>=(const long long &, const Integer &);
-Integer operator==(const long long &, const Integer &);
-Integer operator!=(const long long &, const Integer &);
+Integer operator+(const int64_t &, const Integer &);
+Integer operator-(const int64_t &, const Integer &);
+Integer operator*(const int64_t &, const Integer &);
+Integer operator/(const int64_t &, const Integer &);
+Integer operator<(const int64_t &, const Integer &);
+Integer operator>(const int64_t &, const Integer &);
+Integer operator<=(const int64_t &, const Integer &);
+Integer operator>=(const int64_t &, const Integer &);
+Integer operator==(const int64_t &, const Integer &);
+Integer operator!=(const int64_t &, const Integer &);
 Integer pow(Integer, Integer);
 Integer abs(const Integer &);
 Integer gcd(const Integer &, const Integer &);

--- a/include/natalie/natalie_parser/natalie_creator.hpp
+++ b/include/natalie/natalie_parser/natalie_creator.hpp
@@ -51,7 +51,7 @@ public:
         m_sexp->push(new IntegerObject(Integer(number)));
     }
 
-    virtual void append_fixnum(long long number) override {
+    virtual void append_fixnum(int64_t number) override {
         m_sexp->push(Value::integer(number));
     }
 
@@ -63,7 +63,7 @@ public:
         m_sexp->push(NilObject::the());
     }
 
-    virtual void append_range(long long first, long long last, bool exclude_end) override {
+    virtual void append_range(int64_t first, int64_t last, bool exclude_end) override {
         m_sexp->push(RangeObject::create(m_env, Value::integer(first), Value::integer(last), exclude_end));
     }
 

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -127,7 +127,7 @@ public:
     void append(const char *, size_t);
     void append(int);
     void append(long unsigned int);
-    void append(long long int);
+    void append(int64_t);
     void append(long int);
     void append(unsigned int);
     void append(double);

--- a/include/natalie/types.hpp
+++ b/include/natalie/types.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <limits.h>
+#include <stdint.h>
 
 #define NAT_INT_MIN LLONG_MIN
 #define NAT_INT_MAX LLONG_MAX
 
 namespace Natalie {
 
-using nat_int_t = long long;
+using nat_int_t = int64_t;
 
 }

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -125,11 +125,11 @@ public:
      * Constructs a new String by converting the given number.
      *
      * ```
-     * auto str = String { (long long)10 };
+     * auto str = String { (int64_t)10 };
      * assert_str_eq("10", str);
      * ```
      */
-    String(long long number) {
+    String(int64_t number) {
         int length = snprintf(NULL, 0, "%lli", number);
         char buf[length + 1];
         snprintf(buf, length + 1, "%lli", number);
@@ -140,12 +140,12 @@ public:
      * Constructs a new String by converting the given number.
      *
      * ```
-     * auto str = String { (unsigned long long)10 };
+     * auto str = String { (uint64_t)10 };
      * assert_str_eq("10", str);
      * ```
      */
 
-    String(unsigned long long number) {
+    String(uint64_t number) {
         int length = snprintf(NULL, 0, "%llu", number);
         char buf[length + 1];
         snprintf(buf, length + 1, "%llu", number);
@@ -264,7 +264,7 @@ public:
      * assert_str_eq("fe", str);
      * ```
      */
-    static String hex(long long number, HexFormat format = HexFormat::UppercaseAndPrefixed) {
+    static String hex(int64_t number, HexFormat format = HexFormat::UppercaseAndPrefixed) {
         bool uppercase = format == HexFormat::UppercaseAndPrefixed || format == HexFormat::Uppercase;
         bool prefixed = format == HexFormat::UppercaseAndPrefixed || format == HexFormat::LowercaseAndPrefixed;
         const char *format_str = uppercase ? "%llX" : "%llx";
@@ -610,7 +610,7 @@ public:
      * assert_str_eq("123abc", str);
      * ```
      */
-    void prepend(long long i) {
+    void prepend(int64_t i) {
         int length = snprintf(NULL, 0, "%lli", i);
         char buf[length + 1];
         snprintf(buf, length + 1, "%lli", i);
@@ -795,11 +795,11 @@ public:
      *
      * ```
      * auto str = String { "a" };
-     * str.append((long long)123);
+     * str.append((int64_t)123);
      * assert_str_eq("a123", str);
      * ```
      */
-    void append(long long i) {
+    void append(int64_t i) {
         int length = snprintf(NULL, 0, "%lli", i);
         char buf[length + 1];
         snprintf(buf, length + 1, "%lli", i);

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -199,7 +199,7 @@ BigInt::BigInt(const BigInt &num) {
     -----------------
 */
 
-BigInt::BigInt(const long long &num) {
+BigInt::BigInt(const int64_t &num) {
     m_value = TM::String(std::abs(num));
     m_sign = (num < 0) ? '-' : '+';
 }
@@ -219,7 +219,7 @@ BigInt::BigInt(const long &num) {
     -----------------
 */
 
-BigInt::BigInt(const unsigned long long &num) {
+BigInt::BigInt(const uint64_t &num) {
     m_value = TM::String(num);
     m_sign = '+';
 }
@@ -315,24 +315,14 @@ TM::String BigInt::to_string() const {
 }
 
 /*
-    to_long
-    -------
-    Converts a BigInt to a long int.
-    NOTE: If the BigInt is out of range of a long int, errno is set to ERANGE.
-*/
-
-long BigInt::to_long() const {
-    return strtol(this->to_string().c_str(), NULL, 10);
-}
-
-/*
-    to_long_long
+    to_int64_t
     ------------
-    Converts a BigInt to a long long int.
-    NOTE: If the BigInt is out of range of a long long int, errno is set to ERANGE.
+    Converts a BigInt to a int64_t.
+    NOTE: If the BigInt is out of range of a int64_t, errno is set to ERANGE.
 */
 
-long long BigInt::to_long_long() const {
+int64_t BigInt::to_int64_t() const {
+    static_assert(sizeof(long long) == 8);
     return strtoll(this->to_string().c_str(), NULL, 10);
 }
 
@@ -379,7 +369,7 @@ BigInt &BigInt::operator=(const BigInt &num) {
     ----------------
 */
 
-BigInt &BigInt::operator=(const long long &num) {
+BigInt &BigInt::operator=(const int64_t &num) {
     BigInt temp(num);
     m_value = temp.m_value;
     m_sign = temp.m_sign;
@@ -513,7 +503,7 @@ bool BigInt::operator>=(const BigInt &num) const {
     -----------------
 */
 
-bool BigInt::operator==(const long long &num) const {
+bool BigInt::operator==(const int64_t &num) const {
     return *this == BigInt(num);
 }
 
@@ -522,7 +512,7 @@ bool BigInt::operator==(const long long &num) const {
     -----------------
 */
 
-bool operator==(const long long &lhs, const BigInt &rhs) {
+bool operator==(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) == rhs;
 }
 
@@ -531,7 +521,7 @@ bool operator==(const long long &lhs, const BigInt &rhs) {
     -----------------
 */
 
-bool BigInt::operator!=(const long long &num) const {
+bool BigInt::operator!=(const int64_t &num) const {
     return !(*this == BigInt(num));
 }
 
@@ -540,7 +530,7 @@ bool BigInt::operator!=(const long long &num) const {
     -----------------
 */
 
-bool operator!=(const long long &lhs, const BigInt &rhs) {
+bool operator!=(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) != rhs;
 }
 
@@ -549,7 +539,7 @@ bool operator!=(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-bool BigInt::operator<(const long long &num) const {
+bool BigInt::operator<(const int64_t &num) const {
     return *this < BigInt(num);
 }
 
@@ -558,7 +548,7 @@ bool BigInt::operator<(const long long &num) const {
     ----------------
 */
 
-bool operator<(const long long &lhs, const BigInt &rhs) {
+bool operator<(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) < rhs;
 }
 
@@ -567,7 +557,7 @@ bool operator<(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-bool BigInt::operator>(const long long &num) const {
+bool BigInt::operator>(const int64_t &num) const {
     return *this > BigInt(num);
 }
 
@@ -576,7 +566,7 @@ bool BigInt::operator>(const long long &num) const {
     ----------------
 */
 
-bool operator>(const long long &lhs, const BigInt &rhs) {
+bool operator>(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) > rhs;
 }
 
@@ -585,7 +575,7 @@ bool operator>(const long long &lhs, const BigInt &rhs) {
     -----------------
 */
 
-bool BigInt::operator<=(const long long &num) const {
+bool BigInt::operator<=(const int64_t &num) const {
     return !(*this > BigInt(num));
 }
 
@@ -594,7 +584,7 @@ bool BigInt::operator<=(const long long &num) const {
     -----------------
 */
 
-bool operator<=(const long long &lhs, const BigInt &rhs) {
+bool operator<=(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) <= rhs;
 }
 
@@ -603,7 +593,7 @@ bool operator<=(const long long &lhs, const BigInt &rhs) {
     -----------------
 */
 
-bool BigInt::operator>=(const long long &num) const {
+bool BigInt::operator>=(const int64_t &num) const {
     return !(*this < BigInt(num));
 }
 
@@ -612,7 +602,7 @@ bool BigInt::operator>=(const long long &num) const {
     -----------------
 */
 
-bool operator>=(const long long &lhs, const BigInt &rhs) {
+bool operator>=(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) >= rhs;
 }
 
@@ -873,7 +863,7 @@ BigInt big_pow10(size_t exp) {
     Returns a BigInt equal to base^exp.
 */
 
-BigInt pow(const BigInt &base, long long exp) {
+BigInt pow(const BigInt &base, int64_t exp) {
     if (exp < 0) {
         // Cannot divide by zero
         assert(base != 0);
@@ -904,7 +894,7 @@ BigInt pow(const BigInt &base, long long exp) {
     Returns a BigInt equal to base^exp.
 */
 
-BigInt pow(const long long &base, int exp) {
+BigInt pow(const int64_t &base, int exp) {
     return pow(BigInt(base), exp);
 }
 
@@ -987,7 +977,7 @@ BigInt gcd(const BigInt &num1, const BigInt &num2) {
     --------------------
 */
 
-BigInt gcd(const BigInt &num1, const long long &num2) {
+BigInt gcd(const BigInt &num1, const int64_t &num2) {
     return gcd(num1, BigInt(num2));
 }
 
@@ -1005,7 +995,7 @@ BigInt gcd(const BigInt &num1, const TM::String &num2) {
     --------------------
 */
 
-BigInt gcd(const long long &num1, const BigInt &num2) {
+BigInt gcd(const int64_t &num1, const BigInt &num2) {
     return gcd(BigInt(num1), num2);
 }
 
@@ -1036,7 +1026,7 @@ BigInt lcm(const BigInt &num1, const BigInt &num2) {
     --------------------
 */
 
-BigInt lcm(const BigInt &num1, const long long &num2) {
+BigInt lcm(const BigInt &num1, const int64_t &num2) {
     return lcm(num1, BigInt(num2));
 }
 
@@ -1054,7 +1044,7 @@ BigInt lcm(const BigInt &num1, const TM::String &num2) {
     --------------------
 */
 
-BigInt lcm(const long long &num1, const BigInt &num2) {
+BigInt lcm(const int64_t &num1, const BigInt &num2) {
     return lcm(BigInt(num1), num2);
 }
 
@@ -1077,7 +1067,7 @@ BigInt lcm(const TM::String &num1, const BigInt &num2) {
 #include <cmath>
 #include <string>
 
-const long long FLOOR_SQRT_LLONG_MAX = 3037000499;
+const int64_t FLOOR_SQRT_LLONG_MAX = 3037000499;
 
 /*
     BigInt + BigInt
@@ -1272,7 +1262,7 @@ std::tuple<BigInt, BigInt> divide(const BigInt &dividend, const BigInt &divisor)
 
     temp = divisor;
     quotient = 1;
-    unsigned long long iterations = 0;
+    uint64_t iterations = 0;
     while (temp < dividend) {
         temp += divisor;
         iterations++;
@@ -1430,7 +1420,7 @@ BigInt BigInt::operator%(const BigInt &num) const {
     ----------------
 */
 
-BigInt BigInt::operator+(const long long &num) const {
+BigInt BigInt::operator+(const int64_t &num) const {
     return *this + BigInt(num);
 }
 
@@ -1439,7 +1429,7 @@ BigInt BigInt::operator+(const long long &num) const {
     ----------------
 */
 
-BigInt operator+(const long long &lhs, const BigInt &rhs) {
+BigInt operator+(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) + rhs;
 }
 
@@ -1448,7 +1438,7 @@ BigInt operator+(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-BigInt BigInt::operator-(const long long &num) const {
+BigInt BigInt::operator-(const int64_t &num) const {
     return *this - BigInt(num);
 }
 
@@ -1457,7 +1447,7 @@ BigInt BigInt::operator-(const long long &num) const {
     ----------------
 */
 
-BigInt operator-(const long long &lhs, const BigInt &rhs) {
+BigInt operator-(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) - rhs;
 }
 
@@ -1466,7 +1456,7 @@ BigInt operator-(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-BigInt BigInt::operator*(const long long &num) const {
+BigInt BigInt::operator*(const int64_t &num) const {
     return *this * BigInt(num);
 }
 
@@ -1475,7 +1465,7 @@ BigInt BigInt::operator*(const long long &num) const {
     ----------------
 */
 
-BigInt operator*(const long long &lhs, const BigInt &rhs) {
+BigInt operator*(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) * rhs;
 }
 
@@ -1484,7 +1474,7 @@ BigInt operator*(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-BigInt BigInt::operator/(const long long &num) const {
+BigInt BigInt::operator/(const int64_t &num) const {
     return *this / BigInt(num);
 }
 
@@ -1493,7 +1483,7 @@ BigInt BigInt::operator/(const long long &num) const {
     ----------------
 */
 
-BigInt operator/(const long long &lhs, const BigInt &rhs) {
+BigInt operator/(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) / rhs;
 }
 
@@ -1502,7 +1492,7 @@ BigInt operator/(const long long &lhs, const BigInt &rhs) {
     ----------------
 */
 
-BigInt BigInt::operator%(const long long &num) const {
+BigInt BigInt::operator%(const int64_t &num) const {
     return *this % BigInt(num);
 }
 
@@ -1511,7 +1501,7 @@ BigInt BigInt::operator%(const long long &num) const {
     ----------------
 */
 
-BigInt operator%(const long long &lhs, const BigInt &rhs) {
+BigInt operator%(const int64_t &lhs, const BigInt &rhs) {
     return BigInt(lhs) % rhs;
 }
 
@@ -1671,7 +1661,7 @@ BigInt &BigInt::operator%=(const BigInt &num) {
     -----------------
 */
 
-BigInt &BigInt::operator+=(const long long &num) {
+BigInt &BigInt::operator+=(const int64_t &num) {
     *this = *this + BigInt(num);
 
     return *this;
@@ -1682,7 +1672,7 @@ BigInt &BigInt::operator+=(const long long &num) {
     -----------------
 */
 
-BigInt &BigInt::operator-=(const long long &num) {
+BigInt &BigInt::operator-=(const int64_t &num) {
     *this = *this - BigInt(num);
 
     return *this;
@@ -1693,7 +1683,7 @@ BigInt &BigInt::operator-=(const long long &num) {
     -----------------
 */
 
-BigInt &BigInt::operator*=(const long long &num) {
+BigInt &BigInt::operator*=(const int64_t &num) {
     *this = *this * BigInt(num);
 
     return *this;
@@ -1704,7 +1694,7 @@ BigInt &BigInt::operator*=(const long long &num) {
     -----------------
 */
 
-BigInt &BigInt::operator/=(const long long &num) {
+BigInt &BigInt::operator/=(const int64_t &num) {
     *this = *this / BigInt(num);
 
     return *this;
@@ -1715,7 +1705,7 @@ BigInt &BigInt::operator/=(const long long &num) {
     -----------------
 */
 
-BigInt &BigInt::operator%=(const long long &num) {
+BigInt &BigInt::operator%=(const int64_t &num) {
     *this = *this % BigInt(num);
 
     return *this;

--- a/src/encoding/ascii_8bit_encoding_object.cpp
+++ b/src/encoding/ascii_8bit_encoding_object.cpp
@@ -19,7 +19,7 @@ std::pair<bool, StringView> Ascii8BitEncodingObject::next_char(const String &str
 
 String Ascii8BitEncodingObject::escaped_char(unsigned char c) const {
     char buf[5];
-    snprintf(buf, 5, "\\x%02llX", (long long)c);
+    snprintf(buf, 5, "\\x%02llX", (int64_t)c);
     return String(buf);
 }
 

--- a/src/encoding/us_ascii_encoding_object.cpp
+++ b/src/encoding/us_ascii_encoding_object.cpp
@@ -25,7 +25,7 @@ std::pair<bool, StringView> UsAsciiEncodingObject::next_char(const String &strin
 
 String UsAsciiEncodingObject::escaped_char(unsigned char c) const {
     char buf[5];
-    snprintf(buf, 5, "\\x%02llX", (long long)c);
+    snprintf(buf, 5, "\\x%02llX", (int64_t)c);
     return String(buf);
 }
 

--- a/src/encoding/utf32le_encoding_object.cpp
+++ b/src/encoding/utf32le_encoding_object.cpp
@@ -50,7 +50,7 @@ std::pair<bool, StringView> Utf32LeEncodingObject::next_char(const String &strin
 
 String Utf32LeEncodingObject::escaped_char(unsigned char c) const {
     char buf[7];
-    snprintf(buf, 7, "\\u%04llX", (long long)c);
+    snprintf(buf, 7, "\\u%04llX", (int64_t)c);
     return String(buf);
 }
 

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -147,7 +147,7 @@ std::pair<bool, StringView> Utf8EncodingObject::next_char(const String &string, 
 
 String Utf8EncodingObject::escaped_char(unsigned char c) const {
     char buf[7];
-    snprintf(buf, 7, "\\u%04llX", (long long)c);
+    snprintf(buf, 7, "\\u%04llX", (int64_t)c);
     return String(buf);
 }
 

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -108,7 +108,7 @@ Value FloatObject::to_s() const {
 
     if (decpt > 0) {
         string = String(out);
-        long long s_length = string.length();
+        int64_t s_length = string.length();
         if (decpt < s_length) {
             string.insert(decpt, '.');
         } else if (decpt <= DBL_DIG) {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -135,7 +135,7 @@ Value HashObject::set_default_proc(Env *env, Value value) {
     auto proc = to_proc_value->as_proc();
     auto arity = proc->arity();
     if (proc->is_lambda() && arity != 2)
-        env->raise("TypeError", "default_proc takes two arguments (2 for {})", (long long)arity);
+        env->raise("TypeError", "default_proc takes two arguments (2 for {})", (int64_t)arity);
     m_default_proc = proc;
     return value;
 }

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -31,7 +31,7 @@ Integer::Integer(const TM::String &other)
 
 Integer::Integer(const BigInt &other) {
     if (other <= NAT_MAX_FIXNUM && other >= NAT_MIN_FIXNUM) {
-        m_fixnum = other.to_long_long();
+        m_fixnum = other.to_int64_t();
         m_is_fixnum = true;
     } else {
         m_bignum = new BigInt(other);
@@ -368,43 +368,43 @@ Integer Integer::bit_length() const {
     return ceil(log2(nat_int < 0 ? -nat_int : nat_int + 1));
 }
 
-Integer operator+(const long long &lhs, const Integer &rhs) {
+Integer operator+(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) + rhs;
 }
 
-Integer operator-(const long long &lhs, const Integer &rhs) {
+Integer operator-(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) - rhs;
 }
 
-Integer operator*(const long long &lhs, const Integer &rhs) {
+Integer operator*(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) * rhs;
 }
 
-Integer operator/(const long long &lhs, const Integer &rhs) {
+Integer operator/(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) / rhs;
 }
 
-Integer operator<(const long long &lhs, const Integer &rhs) {
+Integer operator<(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) < rhs;
 }
 
-Integer operator>(const long long &lhs, const Integer &rhs) {
+Integer operator>(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) > rhs;
 }
 
-Integer operator<=(const long long &lhs, const Integer &rhs) {
+Integer operator<=(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) <= rhs;
 }
 
-Integer operator>=(const long long &lhs, const Integer &rhs) {
+Integer operator>=(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) >= rhs;
 }
 
-Integer operator==(const long long &lhs, const Integer &rhs) {
+Integer operator==(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) == rhs;
 }
 
-Integer operator!=(const long long &lhs, const Integer &rhs) {
+Integer operator!=(const int64_t &lhs, const Integer &rhs) {
     return Integer(lhs) != rhs;
 }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2257,16 +2257,16 @@ void StringObject::append(long unsigned int i) {
     m_string.append(i);
 }
 
-void StringObject::append(long long int i) {
+void StringObject::append(int64_t i) {
     m_string.append(i);
 }
 
 void StringObject::append(long int i) {
-    m_string.append((long long)i);
+    m_string.append((int64_t)i);
 }
 
 void StringObject::append(unsigned int i) {
-    m_string.append((long long)i);
+    m_string.append((int64_t)i);
 }
 
 void StringObject::append(double d) {

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -25,6 +25,8 @@ KNOWN_UNCOLLECTABLE_TYPES = [
   'int',
   'long',
   'long long',
+  'int64_t',
+  'uint64_t',
   'Natalie::Allocator',
   'Natalie::ArrayPacker::Token',
   'Natalie::Backtrace::Item',


### PR DESCRIPTION
I'd rather Natalie fail to build than to have weird behavior; seems like exact-width ints are a way to achieve that. This does fundamentally mean we only support 64-bit systems, but I'm sure that was already the case anyway. Now it's just explicit.

https://stackoverflow.com/a/9837399