### PR TITLE
Dir: Add home empty? delete unlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ENV CXX=$CXX
 ARG NAT_CXX_FLAGS
 ENV NAT_CXX_FLAGS=$NAT_CXX_FLAGS
 
+ENV USER=root
+
 COPY ext ext
 COPY Rakefile Rakefile
 

--- a/include/natalie/dir_object.hpp
+++ b/include/natalie/dir_object.hpp
@@ -20,6 +20,8 @@ public:
     DirObject()
         : Object { GlobalEnv::the()->Object()->const_fetch("Dir"_s)->as_class() } { }
 
+    static bool is_empty(Env *, Value);
+    static Value home(Env *, Value);
     static Value mkdir(Env *env, Value path, Value mode);
     //static Value pwd(Env *env);
     //static Value chdir(Env *env, Value path) // also takes a block

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -14,6 +14,11 @@
 
 namespace Natalie {
 
+namespace fileutil {
+    // Utility Function Common to File and Dir
+    Value convert_using_to_path(Env *env, Value path);
+}
+
 class FileObject : public IoObject {
 public:
     FileObject()

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -568,11 +568,13 @@ gen.static_binding('FileTest', 'writable?', 'FileObject', 'is_writable', argc: 1
 gen.static_binding('FileTest', 'writable_real?', 'FileObject', 'is_writable_real', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('FileTest', 'zero?', 'FileObject', 'is_zero', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 
+gen.static_binding('Dir', 'delete', 'DirObject', 'rmdir', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'empty?', 'DirObject', 'is_empty', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.static_binding('Dir', 'exist?', 'FileObject', 'is_directory', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('Dir', 'home', 'DirObject', 'home', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'mkdir', 'DirObject', 'mkdir', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'rmdir', 'DirObject', 'rmdir', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
-gen.static_binding('Dir', 'exist?', 'FileObject', 'is_directory', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.static_binding('Dir', 'unlink', 'DirObject', 'rmdir', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.undefine_singleton_method('Float', 'new')
 gen.binding('Float', '%', 'FloatObject', 'mod', argc: 1, pass_env: true, pass_block: false, return_type: :Object, optimized: true)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -568,6 +568,8 @@ gen.static_binding('FileTest', 'writable?', 'FileObject', 'is_writable', argc: 1
 gen.static_binding('FileTest', 'writable_real?', 'FileObject', 'is_writable_real', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('FileTest', 'zero?', 'FileObject', 'is_zero', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 
+gen.static_binding('Dir', 'empty?', 'DirObject', 'is_empty', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.static_binding('Dir', 'home', 'DirObject', 'home', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'mkdir', 'DirObject', 'mkdir', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'rmdir', 'DirObject', 'rmdir', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'exist?', 'FileObject', 'is_directory', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/spec/core/dir/delete_spec.rb
+++ b/spec/core/dir/delete_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+require_relative 'shared/delete'
+
+describe "Dir.delete" do
+  before :all do
+    DirSpecs.create_mock_dirs
+  end
+
+  after :all do
+    DirSpecs.delete_mock_dirs
+  end
+
+  it_behaves_like :dir_delete, :delete
+end

--- a/spec/core/dir/empty_spec.rb
+++ b/spec/core/dir/empty_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../spec_helper'
+
+describe "Dir.empty?" do
+  before :all do
+    @empty_dir = tmp("empty_dir")
+    mkdir_p @empty_dir
+  end
+
+  after :all do
+    rm_r @empty_dir
+  end
+
+  it "returns true for empty directories" do
+    result = Dir.empty? @empty_dir
+    result.should be_true
+  end
+
+  it "returns false for non-empty directories" do
+    result = Dir.empty? __dir__
+    result.should be_false
+  end
+
+  it "returns false for a non-directory" do
+    result = Dir.empty? __FILE__
+    result.should be_false
+  end
+
+  it "raises ENOENT for nonexistent directories" do
+    -> { Dir.empty? tmp("nonexistent") }.should raise_error(Errno::ENOENT)
+  end
+end

--- a/spec/core/dir/fixtures/common.rb
+++ b/spec/core/dir/fixtures/common.rb
@@ -1,0 +1,204 @@
+# encoding: utf-8
+
+module DirSpecs
+  def self.mock_dir(dirs = ['dir_specs_mock'])
+    @mock_dir ||= tmp("")
+    File.join @mock_dir, dirs
+  end
+
+  def self.nonexistent
+    name = File.join mock_dir, "nonexistent00"
+    name = name.next while File.exist? name
+    name
+  end
+
+  # TODO: make these relative to the mock_dir
+  def self.clear_dirs
+    [ 'nonexisting',
+      'default_perms',
+      'reduced',
+      'always_returns_0',
+      '???',
+      [0xe9].pack('U')
+    ].each do |dir|
+      begin
+        Dir.rmdir mock_dir(dir)
+      rescue
+      end
+    end
+  end
+
+  # The names of the fixture directories and files used by
+  # various Dir specs.
+  def self.mock_dir_files
+    unless @mock_dir_files
+      @mock_dir_files = %w[
+        .dotfile
+        .dotsubdir/.dotfile
+        .dotsubdir/nondotfile
+        nested/.dotsubir/.dotfile
+        nested/.dotsubir/nondotfile
+
+        deeply/.dotfile
+        deeply/nested/.dotfile.ext
+        deeply/nested/directory/structure/.ext
+        deeply/nested/directory/structure/bar
+        deeply/nested/directory/structure/baz
+        deeply/nested/directory/structure/file_one
+        deeply/nested/directory/structure/file_one.ext
+        deeply/nested/directory/structure/foo
+        deeply/nondotfile
+
+        file_one.ext
+        file_two.ext
+
+        dir_filename_ordering
+        dir/filename_ordering
+
+        nondotfile
+
+        subdir_one/.dotfile
+        subdir_one/nondotfile
+        subdir_two/nondotfile
+        subdir_two/nondotfile.ext
+
+        brace/a
+        brace/a.js
+        brace/a.erb
+        brace/a.js.rjs
+        brace/a.html.erb
+
+        special/+
+
+        special/^
+        special/$
+
+        special/(
+        special/)
+        special/[
+        special/]
+        special/{
+        special/}
+
+        special/test{1}/file[1]
+        special/{}/special
+        special/test\ +()[]{}/hello_world.erb
+      ]
+
+      platform_is_not :windows do
+        @mock_dir_files += %w[
+          special/*
+          special/?
+
+          special/|
+
+          special/こんにちは.txt
+          special/\a
+        ]
+        @mock_dir_files << "special/_\u{1f60e}.erb"
+      end
+    end
+
+    @mock_dir_files
+  end
+
+  def self.mock_dir_links
+    unless @mock_dir_links
+      @mock_dir_links = []
+      platform_is_not :windows do
+        @mock_dir_links += [
+          ['special/ln', 'subdir_one']
+        ]
+      end
+    end
+    @mock_dir_links
+  end
+
+  def self.create_mock_dirs
+    mock_dir_files.each do |name|
+      file = File.join mock_dir, name
+      mkdir_p File.dirname(file)
+      touch file
+    end
+    mock_dir_links.each do |link, target|
+      full_link = File.join mock_dir, link
+      full_target = File.join mock_dir, target
+
+      File.symlink full_target, full_link
+    end
+  end
+
+  def self.delete_mock_dirs
+    begin
+      rm_r mock_dir
+    rescue Errno::ENOTEMPTY => e
+      puts Dir["#{mock_dir}/**/*"]
+      raise e
+    end
+  end
+
+  def self.mock_rmdir(*dirs)
+    mock_dir ['rmdir_dirs'].concat(dirs)
+  end
+
+  def self.rmdir_dirs(create = true)
+    dirs = %w[
+      empty
+      nonempty
+      nonempty/child
+      noperm
+      noperm/child
+    ]
+
+    base_dir = mock_dir ['rmdir_dirs']
+
+    dirs.reverse_each do |d|
+      dir = File.join base_dir, d
+      if File.exist? dir
+        File.chmod 0777, dir
+        rm_r dir
+      end
+    end
+    rm_r base_dir
+
+    if create
+      dirs.each do |d|
+        dir = File.join base_dir, d
+        unless File.exist? dir
+          mkdir_p dir
+          File.chmod 0777, dir
+        end
+      end
+    end
+  end
+
+  def self.expected_paths
+    %w[
+      .
+      ..
+      .dotfile
+      .dotsubdir
+      brace
+      deeply
+      dir
+      dir_filename_ordering
+      file_one.ext
+      file_two.ext
+      nested
+      nondotfile
+      special
+      subdir_one
+      subdir_two
+    ]
+  end
+
+  if RUBY_VERSION > '3.1'
+    def self.expected_glob_paths
+      expected_paths - ['..']
+    end
+  else
+    def self.expected_glob_paths
+      expected_paths
+    end
+  end
+end

--- a/spec/core/dir/home_spec.rb
+++ b/spec/core/dir/home_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+
+describe "Dir.home" do
+  before :each do
+    @home = ENV['HOME']
+    ENV['HOME'] = "/rubyspec_home"
+  end
+
+  after :each do
+    ENV['HOME'] = @home
+  end
+
+  describe "when called without arguments" do
+    it "returns the current user's home directory, reading $HOME first" do
+      Dir.home.should == "/rubyspec_home"
+    end
+
+    it "returns a non-frozen string" do
+      Dir.home.should_not.frozen?
+    end
+  end
+
+  describe "when called with the current user name" do
+    platform_is :solaris do
+      it "returns the named user's home directory from the user database" do
+        Dir.home(ENV['USER']).should == `getent passwd #{ENV['USER']}|cut -d: -f6`.chomp
+      end
+    end
+
+    platform_is_not :windows, :solaris, :android, :wasi do
+      it "returns the named user's home directory, from the user database" do
+        Dir.home(ENV['USER']).should == `echo ~#{ENV['USER']}`.chomp
+      end
+    end
+
+    it "returns a non-frozen string" do
+      Dir.home(ENV['USER']).should_not.frozen?
+    end
+  end
+
+  it "raises an ArgumentError if the named user doesn't exist" do
+    -> { Dir.home('geuw2n288dh2k') }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/core/dir/shared/delete.rb
+++ b/spec/core/dir/shared/delete.rb
@@ -1,0 +1,63 @@
+describe :dir_delete, shared: true do
+  before :each do
+    DirSpecs.rmdir_dirs true
+  end
+
+  after :each do
+    DirSpecs.rmdir_dirs false
+  end
+
+  it "removes empty directories" do
+    Dir.send(@method, DirSpecs.mock_rmdir("empty")).should == 0
+  end
+
+  it "calls #to_path on non-String arguments" do
+    p = mock('path')
+    p.should_receive(:to_path).and_return(DirSpecs.mock_rmdir("empty"))
+    Dir.send(@method, p)
+  end
+
+  platform_is_not :solaris do
+    it "raises an Errno::ENOTEMPTY when trying to remove a nonempty directory" do
+      -> do
+        Dir.send @method, DirSpecs.mock_rmdir("nonempty")
+      end.should raise_error(Errno::ENOTEMPTY)
+    end
+  end
+
+  platform_is :solaris do
+    it "raises an Errno::EEXIST when trying to remove a nonempty directory" do
+      -> do
+        Dir.send @method, DirSpecs.mock_rmdir("nonempty")
+      end.should raise_error(Errno::EEXIST)
+    end
+  end
+
+  it "raises an Errno::ENOENT when trying to remove a non-existing directory" do
+    -> do
+      Dir.send @method, DirSpecs.nonexistent
+    end.should raise_error(Errno::ENOENT)
+  end
+
+  it "raises an Errno::ENOTDIR when trying to remove a non-directory" do
+    file = DirSpecs.mock_rmdir("nonempty/regular")
+    touch(file)
+    -> do
+      Dir.send @method, file
+    end.should raise_error(Errno::ENOTDIR)
+  end
+
+  # this won't work on Windows, since chmod(0000) does not remove all permissions
+  platform_is_not :windows do
+    as_user do
+      it "raises an Errno::EACCES if lacking adequate permissions to remove the directory" do
+        parent = DirSpecs.mock_rmdir("noperm")
+        child = DirSpecs.mock_rmdir("noperm", "child")
+        File.chmod(0000, parent)
+        -> do
+          Dir.send @method, child
+        end.should raise_error(Errno::EACCES)
+      end
+    end
+  end
+end

--- a/spec/core/dir/unlink_spec.rb
+++ b/spec/core/dir/unlink_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+require_relative 'shared/delete'
+
+describe "Dir.unlink" do
+  before :all do
+    DirSpecs.create_mock_dirs
+  end
+
+  after :all do
+    DirSpecs.delete_mock_dirs
+  end
+
+  it_behaves_like :dir_delete, :unlink
+end

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -8,9 +8,11 @@ namespace Natalie {
 
 Value DirObject::mkdir(Env *env, Value path, Value mode) {
     mode_t octmode = 0777;
-    if (mode)
+    if (mode) {
+        mode->assert_type(env, Object::Type::Integer, "Integer");
         octmode = (mode_t)(mode->as_integer()->to_nat_int_t());
-    path->assert_type(env, Object::Type::String, "String");
+    }
+    path = fileutil::convert_using_to_path(env, path);
     auto result = ::mkdir(path->as_string()->c_str(), octmode);
     if (result < 0) env->raise_errno();
     // need to check dir exists and return nil if mkdir was unsuccessful.
@@ -18,7 +20,7 @@ Value DirObject::mkdir(Env *env, Value path, Value mode) {
 }
 
 Value DirObject::rmdir(Env *env, Value path) {
-    path->assert_type(env, Object::Type::String, "String");
+    path = fileutil::convert_using_to_path(env, path);
     auto result = ::rmdir(path->as_string()->c_str());
     if (result < 0) env->raise_errno();
     return Value::integer(0);


### PR DESCRIPTION
This PR adds class methods and tests for `Dir.home`, `Dir.empty?`, `Dir.delete` and `Dir.unlink`.

`Dir.rmdir` is the same as delete/unlink, but for some reason the tests are different, and it does not pass dependencies on code not yet written - so that test was not included.

Also, a common helper function on the C++ side (`convert_using_to_path`) was pushed into a namespace and shared between `FileObject` and `DirObject`.  Unsure if this is where it should go or how it should be done (maybe a static method on `FileObject` instead?