### PR TITLE
Small fixes to test support

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -354,6 +354,7 @@ public:
     virtual String dbg_inspect() const override;
 
     virtual void visit_children(Visitor &visitor) override final {
+        Object::visit_children(visitor);
         visitor.visit(m_encoding);
     }
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -528,6 +528,20 @@ class EqualExpectation
   end
 end
 
+class TrueFalseExpectation
+  def match(subject)
+    unless subject == true || subject == false
+      raise SpecFailedException, subject.inspect + ' should be true or false'
+    end
+  end
+
+  def inverted_match(subject)
+    if subject == true || subject == false
+      raise SpecFailedException, subject.inspect + ' should not be true or false'
+    end
+  end
+end
+
 class BeCloseExpectation
   def initialize(target, tolerance = TOLERANCE)
     @target = target
@@ -1131,6 +1145,10 @@ class Object
 
   def be_false
     EqualExpectation.new(false)
+  end
+
+  def be_true_or_false
+    TrueFalseExpectation.new()
   end
 
   def be_close(target, tolerance)

--- a/test/support/spec_helpers/fs.rb
+++ b/test/support/spec_helpers/fs.rb
@@ -83,8 +83,8 @@ end
 # if it does not exist.
 def touch(name, mode = "w")
   mkdir_p File.dirname(name)
-
+  has_block = block_given? # NATFIXME: workaround for issue #742
   File.open(name, mode) do |f|
-    yield f if block_given?
+    yield f if has_block
   end
 end


### PR DESCRIPTION
Add `be_true_or_false` test method.
Provide workaround of issue #742 for `test/support/spec_helper/fs.rb`