### PR TITLE
Implement Complex#quo

### DIFF
--- a/spec/core/complex/quo_spec.rb
+++ b/spec/core/complex/quo_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/divide'
+
+describe "Complex#quo" do
+  it_behaves_like :complex_divide, :quo
+end

--- a/src/complex.rb
+++ b/src/complex.rb
@@ -120,6 +120,7 @@ class Complex
       return first / second
     end
   end
+  alias quo /
 
   def *(other)    
     # (a + bi) * (c + di) = (ac - bd) + (ad + bc)i


### PR DESCRIPTION
This checks off one of the items of #608
It turned out to be an alias of `Complex#/`, which was implemented, but not yet checked off in #608