### PR TITLE
Some minor optimizations for TM::String

### DIFF
--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -75,6 +75,27 @@ public:
     }
 
     /**
+     * Constructs a new String by moving the contents
+     * from an existing String.
+     *
+     * ```
+     * auto str1 = String { "foo" };
+     * auto str2 = String { std::move(str1) };
+     * assert_str_eq("foo", str2);
+     * assert_eq(0, str1.size());
+     * ```
+     */
+    String(String &&other) {
+        m_str = other.m_str;
+        m_length = other.m_length;
+        m_capacity = other.m_capacity;
+
+        other.m_str = nullptr;
+        other.m_length = 0;
+        other.m_capacity = 0;
+    }
+
+    /**
      * Constructs a new String by copying the contents
      * from an existing String pointer.
      *
@@ -295,6 +316,33 @@ public:
             m_length = other.m_length;
         else
             set_str(other.c_str(), other.size());
+        return *this;
+    }
+
+    /**
+     * Replaces the String data by moving from an another String.
+     *
+     * ```
+     * auto str1 = String { "foo" };
+     * auto str2 = String { std::move(str1) };
+     * assert_str_eq("foo", str2);
+     * assert_eq(0, str1.size());
+     * ```
+     */
+    String &operator=(String &&other) {
+        if (m_str == other.m_str)
+            m_length = other.m_length;
+        else {
+            delete[] m_str;
+
+            m_str = other.m_str;
+            m_length = other.m_length;
+            m_capacity = other.m_capacity;
+
+            other.m_str = nullptr;
+            other.m_length = 0;
+            other.m_capacity = 0;
+        }
         return *this;
     }
 

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -1479,9 +1479,8 @@ public:
     static void format(String &out, const char *fmt, T first, Args... rest) {
         for (const char *c = fmt; *c != 0; c++) {
             if (*c == '{' && *(c + 1) == '}') {
-                c++;
                 out.append(first);
-                format(out, c + 1, rest...);
+                format(out, c + 2, rest...);
                 return;
             } else {
                 out.append_char(*c);

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -280,7 +280,7 @@ BigInt::BigInt(const TM::String &num) {
         TM::String magnitude = num.substring(1);
         // Expected an integer, got num
         assert(is_valid_number(magnitude));
-        m_value = magnitude;
+        m_value = std::move(magnitude);
         m_sign = num[0];
     } else { // if no sign is specified
         // Expected an integer, got num
@@ -1948,9 +1948,8 @@ std::tuple<TM::String, TM::String> sign_extend_binary(const TM::String &num1, co
 */
 
 BigInt BigInt::operator&(const BigInt &num) const {
-    TM::String lhs_binary, rhs_binary;
-    lhs_binary = to_binary();
-    rhs_binary = num.to_binary();
+    const TM::String lhs_binary = to_binary();
+    const TM::String rhs_binary = num.to_binary();
 
     TM::String larger, smaller;
     std::tie(larger, smaller) = sign_extend_binary(lhs_binary, rhs_binary);
@@ -1974,9 +1973,8 @@ BigInt BigInt::operator&(const BigInt &num) const {
 */
 
 BigInt BigInt::operator|(const BigInt &num) const {
-    TM::String lhs_binary, rhs_binary;
-    lhs_binary = to_binary();
-    rhs_binary = num.to_binary();
+    const TM::String lhs_binary = to_binary();
+    const TM::String rhs_binary = num.to_binary();
 
     TM::String larger, smaller;
     std::tie(larger, smaller) = sign_extend_binary(lhs_binary, rhs_binary);
@@ -2000,9 +1998,8 @@ BigInt BigInt::operator|(const BigInt &num) const {
 */
 
 BigInt BigInt::operator^(const BigInt &num) const {
-    TM::String lhs_binary, rhs_binary;
-    lhs_binary = to_binary();
-    rhs_binary = num.to_binary();
+    const TM::String lhs_binary = to_binary();
+    const TM::String rhs_binary = num.to_binary();
 
     TM::String larger, smaller;
     std::tie(larger, smaller) = sign_extend_binary(lhs_binary, rhs_binary);
@@ -2026,8 +2023,7 @@ BigInt BigInt::operator^(const BigInt &num) const {
 */
 
 BigInt BigInt::operator~() const {
-    TM::String lhs_binary;
-    lhs_binary = to_binary();
+    const TM::String lhs_binary = to_binary();
 
     TM::String complete_string;
     for (size_t i = 0; i < lhs_binary.size(); i++) {
@@ -2052,7 +2048,7 @@ BigInt BigInt::operator<<(const size_t &num) const {
 }
 
 BigInt BigInt::operator>>(const size_t &num) const {
-    TM::String binary = to_binary();
+    const TM::String binary = to_binary();
     TM::String complete_string;
 
     if (num > binary.size()) {


### PR DESCRIPTION
Mostly implementing (and using) move semantics. This can prevent some memory moves.