### PR TITLE
Update docs for move constructor of TM::Optional

### DIFF
--- a/include/tm/optional.hpp
+++ b/include/tm/optional.hpp
@@ -56,7 +56,7 @@ public:
      * ```
      * auto obj = Thing(1);
      * auto opt1 = Optional<Thing>(obj);
-     * auto opt2 = Optional<Thing>(opt1);
+     * auto opt2 = Optional<Thing>(std::move(opt1));
      * assert_not(opt1);
      * assert_eq(obj, opt2.value());
      * ```


### PR DESCRIPTION
The documentation showed the use of the copy constructor, not the move constructor.