### PR TITLE
Convert ParserObject::node_to_ruby to use a const reference

### DIFF
--- a/include/natalie/parser_object.hpp
+++ b/include/natalie/parser_object.hpp
@@ -18,7 +18,7 @@ public:
     Value tokens(Env *, Value, Value);
 
 private:
-    Value node_to_ruby(Env *env, SharedPtr<NatalieParser::Node> node);
+    Value node_to_ruby(Env *env, const NatalieParser::Node &node);
     Value token_to_ruby(Env *env, NatalieParser::Token &token, bool with_line_and_column_numbers = false);
     void validate_token(Env *env, NatalieParser::Token &token);
 };

--- a/src/parser_object.cpp
+++ b/src/parser_object.cpp
@@ -24,7 +24,7 @@ Value ParserObject::parse(Env *env, Value code, Value source_path) {
     } catch (NatalieParser::Parser::SyntaxError &e) {
         env->raise("SyntaxError", e.message());
     }
-    auto ast = node_to_ruby(env, tree);
+    auto ast = node_to_ruby(env, *tree);
     return ast;
 }
 
@@ -98,9 +98,9 @@ void ParserObject::validate_token(Env *env, NatalieParser::Token &token) {
     }
 }
 
-Value ParserObject::node_to_ruby(Env *env, SharedPtr<NatalieParser::Node> node) {
+Value ParserObject::node_to_ruby(Env *env, const NatalieParser::Node &node) {
     NatalieCreator creator { env };
-    node->transform(&creator);
+    node.transform(&creator);
     return creator.sexp();
 }
 


### PR DESCRIPTION
The body of the method did not use the shared pointer semantics, it just needed a value. This change is according to [rule F.7 of the C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f7-for-general-use-take-t-or-t-arguments-rather-than-smart-pointers).