### PR TITLE
Remove FIXME marker in spec of Rational about nesting inside String

### DIFF
--- a/spec/shared/rational/Rational.rb
+++ b/spec/shared/rational/Rational.rb
@@ -68,7 +68,6 @@ describe :kernel_Rational, shared: true do
     end
   end
 
-  # NATFIXME: bug in spec; 'when passed a Numeric' and co. should not be nested inside 'when passed a String'
   # NATFIXME: Implement Numeric#to_r
   xdescribe "when passed a Numeric" do
     it "calls #to_r to convert the first argument to a Rational" do


### PR DESCRIPTION
This has been fixed upstream (https://github.com/ruby/spec/pull/982).