### PR TITLE
Implement Rational(NumericSubclass)

### DIFF
--- a/spec/shared/rational/Rational.rb
+++ b/spec/shared/rational/Rational.rb
@@ -68,8 +68,7 @@ describe :kernel_Rational, shared: true do
     end
   end
 
-  # NATFIXME: Implement Numeric#to_r
-  xdescribe "when passed a Numeric" do
+  describe "when passed a Numeric" do
     it "calls #to_r to convert the first argument to a Rational" do
       num = RationalSpecs::SubNumeric.new(2)
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -497,6 +497,10 @@ Value KernelModule::Rational(Env *env, Value x, Value y, bool exception) {
             return new RationalObject { x->as_integer(), new IntegerObject { 1 } };
         }
 
+        if (x->is_a(env, find_top_level_const(env, "Numeric"_s)->as_class()) && x->respond_to(env, "to_r"_s)) {
+            return x->public_send(env, "to_r"_s);
+        }
+
         x = Float(env, x, exception);
         if (!x) {
             return nullptr;


### PR DESCRIPTION
I'm not sure if this is the idiomatic way to do an `is_a` call from C++ code. The code feels a bit clunky compared to the `respond_to` in the same line, but something like `x->is_a?("Numeric"_s)` does not appear to be working.