### PR TITLE
Don't export the SymbolObject array in generated C++ code

### DIFF
--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -54,7 +54,7 @@ module Natalie
       end
 
       def declare_symbols
-        "SymbolObject *#{symbols_var_name}[#{@symbols.size}] = {};"
+        "static SymbolObject *#{symbols_var_name}[#{@symbols.size}] = {};"
       end
 
       def init_symbols


### PR DESCRIPTION
The old code did export the symbols array as a public symbol in the .o file, as can be seen with `objdump -t array.rb.o`:
```
0000000000000000 g     O .bss	0000000000000240 array_symbols
```
(Please mind the two different uses of the term symbols: the first occurence talks about Ruby symbols, the second occurence talks about symbols in object files)

This change marks them as non exported.

It is now possible to remove the method `symbols_var_name` and just use the constant `symbols` instead, this does not result in any more name clashes.