### PR TITLE
Import array/pack/x_spec from ruby-spec

### DIFF
--- a/spec/core/array/pack/x_spec.rb
+++ b/spec/core/array/pack/x_spec.rb
@@ -30,6 +30,7 @@ describe "Array#pack with format 'x'" do
 
   it "does not add a NULL byte when passed the '*' modifier" do
     [].pack("x*").should == ""
+    [1, 2].pack("Cx*C").should == "\x01\x02"
   end
 end
 


### PR DESCRIPTION
This is the latest upstream version. The spec passes, so this one can be checked off in #195 too