### PR TITLE
Fix unit tests of include/tm

### DIFF
--- a/include/tm/optional.hpp
+++ b/include/tm/optional.hpp
@@ -136,7 +136,7 @@ public:
      * auto obj2 = Thing(2);
      * auto opt = Optional<Thing>(obj1);
      * opt = std::move(obj2);
-     * assert_eq(obj2, opt.value());
+     * assert_eq(Thing(2), opt.value());
      * ```
      */
     Optional<T> &operator=(T &&value) {

--- a/include/tm/string.hpp
+++ b/include/tm/string.hpp
@@ -178,8 +178,9 @@ public:
      *
      * ```
      * auto str = String { (unsigned long int)10 };
-     * auto str = String { (long int)10 };
+     * auto str2 = String { (long int)10 };
      * assert_str_eq("10", str);
+     * assert_str_eq("10", str2);
      * ```
      */
     String(long int number) {


### PR DESCRIPTION
* string.hpp:
This was a compile error, there were two variables named `str`.

* optional.hpp:
The value from ob2 was moved. Thing has been updated to reset the value after a move operation, so we need a new Thing object to validate the Thing inside the optional.

I've found these by copying the files to a checkout of the `tm` repo and running the unit tests over there. I'm fixing them here, since this repository contains the latest version of the tm headers.