### PR TITLE
Update some specs, resolve the "NATFIXME: bug in spec" entries

### DIFF
--- a/spec/core/array/keep_if_spec.rb
+++ b/spec/core/array/keep_if_spec.rb
@@ -1,4 +1,3 @@
-# NATFIXME: bug in spec; missing require_relative '../../spec_helper'
 require_relative '../../spec_helper'
 require_relative 'shared/keep_if'
 

--- a/spec/core/float/divmod_spec.rb
+++ b/spec/core/float/divmod_spec.rb
@@ -23,7 +23,6 @@ describe "Float#divmod" do
 
   # Behaviour established as correct in r23953
   it "raises a FloatDomainError if other is NaN" do
-    # NATFIXME: bug in spec; '1.divmod' should be '1.0.divmod'
     -> { 1.0.divmod(nan_value) }.should raise_error(FloatDomainError)
   end
 

--- a/spec/core/kernel/singleton_class_spec.rb
+++ b/spec/core/kernel/singleton_class_spec.rb
@@ -1,4 +1,3 @@
-# NATFIXME: bug in spec; require_relative is missing
 require_relative '../../spec_helper'
 
 describe "Kernel#singleton_class" do

--- a/spec/core/regexp/initialize_spec.rb
+++ b/spec/core/regexp/initialize_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../spec_helper'
 
 describe "Regexp#initialize" do
-  # NATFIXME: bug in spec; have_private_method should be have_private_instance_method
   it "is a private method" do
     Regexp.should have_private_instance_method(:initialize)
   end

--- a/spec/language/case_spec.rb
+++ b/spec/language/case_spec.rb
@@ -103,8 +103,7 @@ describe "The 'case'-construct" do
     $1.should == "42"
   end
 
-  # NATFIXME: bug in spec; test description should be swapped with the one below
-  it "tests with a regexp interpolated within another regexp" do
+  it "tests with a string interpolated in a regexp" do
     digits = '\d+'
     case "foo44"
     when /oo(#{digits})/
@@ -118,7 +117,7 @@ describe "The 'case'-construct" do
   end
 
   # NATFIXME: regexp interpolated within another regexp
-  xit "tests with a string interpolated in a regexp" do
+  xit "tests with a regexp interpolated within another regexp" do
     digits_regexp = /\d+/
     case "foo43"
     when /oo(#{digits_regexp})/


### PR DESCRIPTION
I went through the chore of upstreaming all these FIXME statements. I tried to give credit to the original author, but since I just used git blame this might sometimes be the wrong person (in case did a minor change to the line after the FIXME was added). All the FIXME statements now have the upstream pull requests listed in them, so it's easier to match them.

I marked this pull request as a draft, response time from ruby-spec is generally pretty quick, so I guess I can update the PR later today with the FIXMEs removed.