### PR TITLE
Fix escaping of \ in string output of Regex

### DIFF
--- a/spec/language/case_spec.rb
+++ b/spec/language/case_spec.rb
@@ -116,8 +116,7 @@ describe "The 'case'-construct" do
     $1.should == "44"
   end
 
-  # NATFIXME: regexp interpolated within another regexp
-  xit "tests with a regexp interpolated within another regexp" do
+  it "tests with a regexp interpolated within another regexp" do
     digits_regexp = /\d+/
     case "foo43"
     when /oo(#{digits_regexp})/

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -56,7 +56,11 @@ Value RegexpObject::inspect(Env *env) {
             if (i < (len - 1) && str[i + 1] == '/') {
                 break;
             }
-            out->append("\\\\");
+            out->append("\\");
+            if (i < (len - 1) && str[i + 1] == '\\') {
+                out->append("\\");
+                i++;
+            }
             break;
         default:
             out->append_char(c);
@@ -274,7 +278,11 @@ Value RegexpObject::to_s(Env *env) const {
             if (i < (len - 1) && str[i + 1] == '/') {
                 break;
             }
-            out->append("\\\\");
+            out->append("\\");
+            if (i < (len - 1) && str[i + 1] == '\\') {
+                out->append("\\");
+                i++;
+            }
             break;
         default:
             out->append_char(c);


### PR DESCRIPTION
The \ character might need some extra escaping, but not when it's used for a character class. The old code had the following output:

    /\d+/.to_s == "(?-mix:\\\\d+)"

This changed the behaviour: instead of matching one of more decimals, this regex would match a literal \ followed by one or more d's. This made it impossible to embed these kind of regexes into another regexp.

This scenario was not defined in the regex specs, but it did accidentally get caught in the spec for the case statement.