### PR TITLE
Implement respond_to matcher

### DIFF
--- a/spec/language/array_spec.rb
+++ b/spec/language/array_spec.rb
@@ -140,7 +140,7 @@ describe "The unpacking splat operator (*)" do
 
   it "when applied to a non-Array value uses it unchanged if it does not respond_to?(:to_a)" do
     obj = Object.new
-    #obj.should_not respond_to(:to_a) # FIXME: What does this do?
+    obj.should_not respond_to(:to_a)
     [1, *obj].should == [1, obj]
   end
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1111,6 +1111,24 @@ class HavePublicInstanceMethodExpectation
   end
 end
 
+class RespondToExpectation
+  def initialize(method)
+    @method = method
+  end
+
+  def match(subject)
+    unless subject.respond_to?(@method)
+      raise SpecFailedException, "Expected #{subject} to respond to '#{@method.to_s}' but it does not"
+    end
+  end
+
+  def inverted_match(subject)
+    if subject.respond_to?(@method)
+      raise SpecFailedException, "Expected #{subject} to not respond to '#{@method.to_s}' but it does"
+    end
+  end
+end
+
 class Object
   def should(*args)
     Matcher.new(self, false, args)
@@ -1243,6 +1261,10 @@ class Object
 
   def have_public_instance_method(method, include_super = true)
     HavePublicInstanceMethodExpectation.new(method, include_super)
+  end
+
+  def respond_to(method)
+    RespondToExpectation.new(method)
   end
 
   def stub!(message)


### PR DESCRIPTION
And enable the one line in the spec that needs it.