### PR TITLE
Implement String#unpack1

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -306,6 +306,7 @@ public:
     static Value try_convert(Env *, Value);
     Value uminus(Env *);
     Value unpack(Env *, Value, Value = nullptr) const;
+    Value unpack1(Env *, Value, Value = nullptr) const;
     Value upcase(Env *);
     Value uplus(Env *);
     Value upto(Env *, Value, Value = nullptr, Block * = nullptr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1078,6 +1078,7 @@ gen.binding('String', 'tr', 'StringObject', 'tr', argc: 2, pass_env: true, pass_
 gen.binding('String', 'tr!', 'StringObject', 'tr_in_place', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('String', 'try_convert', 'StringObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'unpack', 'StringObject', 'unpack', argc: 1, kwargs: [:offset], pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('String', 'unpack1', 'StringObject', 'unpack1', argc: 1, kwargs: [:offset], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'upcase', 'StringObject', 'upcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'upto', 'StringObject', 'upto', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('String', 'valid_encoding?', 'StringObject', 'valid_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/array/pack/shared/unicode.rb
+++ b/spec/core/array/pack/shared/unicode.rb
@@ -29,7 +29,7 @@ describe :array_pack_unicode, shared: true do
     str.valid_encoding?.should be_true
   end
 
-  # FIXME: add this back once we get support for the C directive
+  # NATFIXME: add this back once we get support for the C directive
   xit "encodes values larger than UTF-8 max codepoints" do
     [
       [[0x00110000], [244, 144, 128, 128].pack('C*').force_encoding('utf-8')],

--- a/spec/core/enumerable/grep_spec.rb
+++ b/spec/core/enumerable/grep_spec.rb
@@ -25,13 +25,13 @@ describe "Enumerable#grep" do
     @a.grep(3..7) {|a| a+1}.should == [5,7]
   end
 
-  # FIXME: nth ref inside block
+  # NATFIXME: nth ref inside block
   xit "can use $~ in the block when used with a Regexp" do
     ary = ["aba", "aba"]
     ary.grep(/a(b)a/) { $1 }.should == ["b", "b"]
   end
 
-  # FIXME: back ref inside block
+  # NATFIXME: back ref inside block
   xit "sets $~ in the block" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].grep(/b/) { |e|
@@ -43,7 +43,7 @@ describe "Enumerable#grep" do
     $~.should == nil
   end
 
-  # FIXME: back ref outside block
+  # NATFIXME: back ref outside block
   xit "sets $~ to the last match when given no block" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].grep(/b/).should == ["abc"]

--- a/spec/core/enumerable/sum_spec.rb
+++ b/spec/core/enumerable/sum_spec.rb
@@ -9,7 +9,7 @@ describe 'Enumerable#sum' do
         yield 0
         yield(-1)
         yield 2
-        # FIXME: Re-add rationals if implemented
+        # NATFIXME: Support the last statement
         # yield 2/3r
       end
     end

--- a/spec/core/enumerator/lazy/grep_spec.rb
+++ b/spec/core/enumerator/lazy/grep_spec.rb
@@ -34,7 +34,7 @@ describe "Enumerator::Lazy#grep" do
     Enumerator::Lazy.new(Object.new, 100) {}.grep(Object).size.should == nil
   end
 
-  # FIXME: back ref inside block
+  # NATFIXME: back ref inside block
   xit "sets $~ in the block" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].lazy.grep(/b/) { |e|
@@ -46,7 +46,7 @@ describe "Enumerator::Lazy#grep" do
     $~.should == nil
   end
 
-  # FIXME: back ref inside block
+  # NATFIXME: back ref inside block
   xit "sets $~ in the next block with each" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].lazy.grep(/b/).each { |e|
@@ -58,7 +58,7 @@ describe "Enumerator::Lazy#grep" do
     $~.should == nil
   end
 
-  # FIXME: back ref inside block
+  # NATFIXME: back ref inside block
   xit "sets $~ in the next block with map" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].lazy.grep(/b/).map { |e|

--- a/spec/core/enumerator/rewind_spec.rb
+++ b/spec/core/enumerator/rewind_spec.rb
@@ -38,7 +38,7 @@ describe "Enumerator#rewind" do
     @enum.peek.should == 2
   end
 
-  # FIXME: Natalie does not keep a reference to the object yet
+  # NATFIXME: Natalie does not keep a reference to the object yet
   xit "calls the enclosed object's rewind method if one exists" do
     obj = mock('rewinder')
     enum = obj.to_enum

--- a/spec/core/float/constants_spec.rb
+++ b/spec/core/float/constants_spec.rb
@@ -32,7 +32,7 @@ describe "Float constant" do
 
   it "MAX is 1.7976931348623157e+308" do
     # See https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Double-precision_examples
-    # FIXME: rhs returns Infinity, not sure why
+    # NATFIXME: rhs returns Infinity, not sure why
     #Float::MAX.should == (1 + (1 - (2 ** -52))) * (2.0 ** 1023)
     Float::MAX.should == 1.7976931348623157e+308
   end

--- a/spec/core/process/constants_spec.rb
+++ b/spec/core/process/constants_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper' # NATFIXME: ruby spec forgot to include this line
+require_relative '../../spec_helper'
 
 describe "Process::Constants" do
   platform_is :darwin, :netbsd, :freebsd do

--- a/spec/core/process/constants_spec.rb
+++ b/spec/core/process/constants_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper' # ruby spec forgot to include this line
+require_relative '../../spec_helper' # NATFIXME: ruby spec forgot to include this line
 
 describe "Process::Constants" do
   platform_is :darwin, :netbsd, :freebsd do

--- a/spec/core/string/shared/eql.rb
+++ b/spec/core/string/shared/eql.rb
@@ -12,17 +12,17 @@ describe :string_eql_value, shared: true do
     "less".send(@method, "greater").should be_false
   end
 
-  #FIXME: add back once we support iso-8859-1 encoding
+  # NATFIXME: add back once we support iso-8859-1 encoding
   xit "ignores encoding difference of compatible string" do
     "hello".force_encoding("utf-8").send(@method, "hello".force_encoding("iso-8859-1")).should be_true
   end
 
-  #FIXME: add back once we support iso-8859-1 encoding
+  # NATFIXME: add back once we support iso-8859-1 encoding
   xit "considers encoding difference of incompatible string" do
     "\xff".force_encoding("utf-8").send(@method, "\xff".force_encoding("iso-8859-1")).should be_false
   end
 
-  #FIXME: add back once we support utf-32le encoding
+  # NATFIXME: add back once we support utf-32le encoding
   xit "considers encoding compatibility" do
     "hello".force_encoding("utf-8").send(@method, "hello".force_encoding("utf-32le")).should be_false
   end

--- a/spec/core/string/unpack1_spec.rb
+++ b/spec/core/string/unpack1_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../spec_helper'
+
+describe "String#unpack1" do
+  it "returns the first value of #unpack" do
+    "ABCD".unpack1('x3C').should == "ABCD".unpack('x3C')[0]
+    "\u{3042 3044 3046}".unpack1("U*").should == 0x3042
+    "aG9nZWZ1Z2E=".unpack1("m").should == "hogefuga"
+    "A".unpack1("B*").should == "01000001"
+  end
+
+  ruby_version_is "3.1" do
+    it "starts unpacking from the given offset" do
+      "ZZABCD".unpack1('x3C', offset: 2).should == "ABCD".unpack('x3C')[0]
+      "ZZZZaG9nZWZ1Z2E=".unpack1("m", offset: 4).should == "hogefuga"
+      "ZA".unpack1("B*", offset: 1).should == "01000001"
+    end
+
+    it "raises an ArgumentError when the offset is negative" do
+      -> { "a".unpack1("C", offset: -1) }.should raise_error(ArgumentError)
+    end
+
+    it "returns nil if the offset is at the end of the string" do
+      "a".unpack1("C", offset: 1).should == nil
+    end
+
+    it "raises an ArgumentError when the offset is larget than the string" do
+      -> { "a".unpack1("C", offset: 2) }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1877,6 +1877,12 @@ Value StringObject::unpack(Env *env, Value format, Value offset_value) const {
     return unpacker->unpack(env);
 }
 
+// NATFIXME: This shouldn't make the temporary array
+Value StringObject::unpack1(Env *env, Value format, Value offset_value) const {
+    auto array = unpack(env, format, offset_value);
+    return array->as_array()->first();
+}
+
 Value StringObject::split(Env *env, Value splitter, Value max_count_value) {
     ArrayObject *ary = new ArrayObject {};
     if (!splitter) {


### PR DESCRIPTION
It's the simple and slow implementation: call `String#unpack` with the original arguments, and call `first` on the result of that call. I left a FIXME as a reminder that this can be optimized.

This resolves an issue from #667