### PR TITLE
Remove explicit copyright notices from ruby spec files

### DIFF
--- a/spec/language/alias_spec.rb
+++ b/spec/language/alias_spec.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 require_relative '../spec_helper'
 
 class AliasObject

--- a/spec/language/and_spec.rb
+++ b/spec/language/and_spec.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 require_relative '../spec_helper'
 
 describe "The '&&' statement" do

--- a/spec/language/array_spec.rb
+++ b/spec/language/array_spec.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 require_relative '../spec_helper'
 require_relative 'fixtures/array'
 

--- a/spec/language/block_spec.rb
+++ b/spec/language/block_spec.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 require_relative '../spec_helper'
 require_relative 'fixtures/block'
 

--- a/spec/language/fixtures/array.rb
+++ b/spec/language/fixtures/array.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 module ArraySpec
   class Splat
     def unpack_3args(a, b, c)

--- a/spec/language/fixtures/block.rb
+++ b/spec/language/fixtures/block.rb
@@ -1,7 +1,3 @@
-# This file is taken from https://github.com/ruby/spec
-# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
-# Licensed MIT.
-
 module BlockSpecs
   class Yielder
     def z


### PR DESCRIPTION
There is a generic spec/LICENSE file. Removing this duplication reduces the number of changes between this checkout and upstream.