### PR TITLE
Optimize Bigint::big_pow10

### DIFF
--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -919,8 +919,8 @@ BigInt abs(const BigInt &num) {
 */
 
 BigInt big_pow10(size_t exp) {
-    auto string = TM::String(exp, '0');
-    string.prepend_char('1');
+    auto string = TM::String(exp + 1, '0');
+    string[0] = '1';
     return BigInt(string);
 }
 


### PR DESCRIPTION
TM::String::prepend_char does result in a memory allocation + move. Just create the string with an extra zero, then replace the first character with a 1.