### PR TITLE
Implement move semantics for IntegerObject and underlying data types

### DIFF
--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -57,6 +57,7 @@ public:
     // Constructors:
     BigInt();
     BigInt(const BigInt &);
+    BigInt(BigInt &&);
     BigInt(const long long &);
     BigInt(const unsigned long int &);
     BigInt(const unsigned long long &);
@@ -68,6 +69,7 @@ public:
 
     // Assignment operators:
     BigInt &operator=(const BigInt &);
+    BigInt &operator=(BigInt &&);
     BigInt &operator=(const long long &);
     BigInt &operator=(const TM::String &);
 

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -15,13 +15,16 @@ public:
     Integer(int);
     Integer(double);
     Integer(const BigInt &);
+    Integer(BigInt &&);
     Integer(const TM::String &);
     Integer(const Integer &);
+    Integer(Integer &&);
 
     static bool will_multiplication_overflow(nat_int_t, nat_int_t);
 
     // Assignment operators
     Integer &operator=(const Integer &);
+    Integer &operator=(Integer &&);
     Integer &operator+=(const Integer &);
     Integer &operator-=(const Integer &);
     Integer &operator*=(const Integer &);

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -18,7 +18,7 @@ namespace Natalie {
 
 class IntegerObject : public Object {
 public:
-    IntegerObject(nat_int_t integer)
+    IntegerObject(const nat_int_t integer)
         : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
         , m_integer { integer } { }
 
@@ -26,8 +26,16 @@ public:
         : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
         , m_integer { integer } { }
 
+    IntegerObject(Integer &&integer)
+        : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
+        , m_integer { std::move(integer) } { }
+
+    static Value create(const nat_int_t);
     static Value create(const Integer &);
+    static Value create(Integer &&);
     static Value create(const char *);
+    static Value create(const TM::String &);
+    static Value create(TM::String &&);
 
     Integer integer() const {
         return m_integer;

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -99,7 +99,7 @@ private:
                 // Previosly had pushed Value::integer() values, but for large unsigned values
                 // it produced incorrect results.
                 auto bigint = BigInt(*(T *)out.c_str());
-                m_unpacked->push(IntegerObject::create(Integer(bigint)));
+                m_unpacked->push(IntegerObject::create(Integer(std::move(bigint))));
             }
             consumed++;
         }

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -244,6 +244,16 @@ BigInt::BigInt(const BigInt &num) {
 }
 
 /*
+    Move constructor
+    ----------------
+*/
+
+BigInt::BigInt(BigInt &&num) {
+    m_value = std::move(num.m_value);
+    m_sign = num.m_sign;
+}
+
+/*
     Long to BigInt
     -----------------
 */
@@ -426,6 +436,15 @@ BigInt &BigInt::operator=(const BigInt &num) {
     if (num == *this) return *this;
 
     m_value = num.m_value;
+    m_sign = num.m_sign;
+
+    return *this;
+}
+
+BigInt &BigInt::operator=(BigInt &&num) {
+    if (num == *this) return *this;
+
+    m_value = std::move(num.m_value);
     m_sign = num.m_sign;
 
     return *this;

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -39,6 +39,16 @@ Integer::Integer(const BigInt &other) {
     }
 }
 
+Integer::Integer(BigInt &&other) {
+    if (other <= NAT_MAX_FIXNUM && other >= NAT_MIN_FIXNUM) {
+        m_fixnum = other.to_long_long();
+        m_is_fixnum = true;
+    } else {
+        m_bignum = new BigInt(std::move(other));
+        m_is_fixnum = false;
+    }
+}
+
 Integer::Integer(const Integer &other) {
     if (other.is_fixnum()) {
         m_fixnum = other.m_fixnum;
@@ -49,6 +59,18 @@ Integer::Integer(const Integer &other) {
     }
 }
 
+Integer::Integer(Integer &&other) {
+    if (other.is_fixnum()) {
+        m_fixnum = other.m_fixnum;
+        m_is_fixnum = true;
+    } else {
+        m_bignum = other.m_bignum;
+        m_is_fixnum = false;
+        other.m_fixnum = 0;
+        other.m_is_fixnum = true;
+    }
+}
+
 Integer &Integer::operator=(const Integer &other) {
     if (other.is_fixnum()) {
         m_fixnum = other.m_fixnum;
@@ -56,6 +78,20 @@ Integer &Integer::operator=(const Integer &other) {
     } else {
         m_bignum = new BigInt { *other.m_bignum };
         m_is_fixnum = false;
+    }
+    return *this;
+}
+
+Integer &Integer::operator=(Integer &&other) {
+    if (&other == this) return *this;
+    if (other.is_fixnum()) {
+        m_fixnum = other.m_fixnum;
+        m_is_fixnum = true;
+    } else {
+        m_bignum = other.m_bignum;
+        m_is_fixnum = false;
+        other.m_fixnum = 0;
+        other.m_is_fixnum = true;
     }
     return *this;
 }

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -4,14 +4,32 @@
 
 namespace Natalie {
 
+Value IntegerObject::create(const nat_int_t integer) {
+    return Value::integer(integer);
+}
+
 Value IntegerObject::create(const Integer &integer) {
     if (integer.is_bignum())
         return new IntegerObject { integer };
     return Value::integer(integer.to_nat_int_t());
 }
 
+Value IntegerObject::create(Integer &&integer) {
+    if (integer.is_bignum())
+        return new IntegerObject { std::move(integer) };
+    return Value::integer(integer.to_nat_int_t());
+}
+
 Value IntegerObject::create(const char *string) {
     return new IntegerObject { BigInt(string) };
+};
+
+Value IntegerObject::create(const TM::String &string) {
+    return new IntegerObject { BigInt(string) };
+};
+
+Value IntegerObject::create(TM::String &&string) {
+    return new IntegerObject { BigInt(std::move(string)) };
 };
 
 Value IntegerObject::to_s(Env *env, Value base_value) const {

--- a/src/string_unpacker.cpp
+++ b/src/string_unpacker.cpp
@@ -535,7 +535,7 @@ void StringUnpacker::unpack_w(Env *env, Token &token) {
                 keep_going = false;
             }
         }
-        m_unpacked->push(new IntegerObject(result));
+        m_unpacked->push(new IntegerObject(std::move(result)));
 
         return !at_end();
     });


### PR DESCRIPTION
This reduces the number of objects created (and destroyed).