### PR TITLE
Some fixes for splat and double splat operations

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -267,7 +267,7 @@ module Natalie
             instructions: instructions,
             with_block_pass: !!block,
             args_array_on_stack: true,
-            has_keyword_hash: args.last.sexp_type == :bare_hash && args.last[1].sexp_type == :kwsplat
+            has_keyword_hash: args.last&.sexp_type == :bare_hash
           }
         end
 

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -267,7 +267,7 @@ module Natalie
             instructions: instructions,
             with_block_pass: !!block,
             args_array_on_stack: true,
-            has_keyword_hash: false, # TODO
+            has_keyword_hash: args.last.sexp_type == :bare_hash && args.last[1].sexp_type == :kwsplat
           }
         end
 

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -37,8 +37,7 @@ describe 'splat operators' do
     argument_proxy(*[1, 2], foo: 'a').should == [[1, 2], { foo: 'a' }]
   end
 
-  # NATFIXME: splat operator and double splat operator
-  xit 'should work with splat operator and double splat operator' do
+  it 'should work with splat operator and double splat operator' do
     args = [1, 2]
     kwargs = { foo: 'a' }
     argument_proxy(*args, **kwargs).should == [[1, 2], { foo: 'a' }]

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -30,8 +30,7 @@ describe 'splat operators' do
     argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
   end
 
-  # NATFIXME: splat operator and literal keywords
-  xit 'should work with splat operator and literal keywords' do
+  it 'should work with splat operator and literal keywords' do
     args = [1, 2]
     argument_proxy(*args, foo: 'a').should == [[1, 2], { foo: 'a' }]
     argument_proxy(*[1, 2], foo: 'a').should == [[1, 2], { foo: 'a' }]

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -1,0 +1,55 @@
+require_relative '../spec_helper'
+
+def argument_proxy(*args, **kwargs)
+  [args, kwargs]
+end
+
+describe 'splat operators' do
+  it 'should work with literal arguments' do
+    argument_proxy(1).should == [[1], {}]
+    argument_proxy(1, 2).should == [[1, 2], {}]
+    argument_proxy(1, 2, {}).should == [[1, 2, {}], {}]
+  end
+
+  it 'should work with literal keyword arguments' do
+    argument_proxy(foo: 'a').should == [[], { foo: 'a' }]
+    argument_proxy(foo: 'a', bar: 'b').should == [[], { foo: 'a', bar: 'b' }]
+  end
+
+  it 'should work with literal positional and keyword arguments' do
+    argument_proxy(1, foo: 'a').should == [[1], { foo: 'a' }]
+    argument_proxy(1, 2, foo: 'a', bar: 'b').should == [[1, 2], { foo: 'a', bar: 'b' }]
+  end
+
+  it 'should work with splat operators' do
+    args = [1, 2]
+    argument_proxy(*args).should == [[1, 2], {}]
+    argument_proxy(*[1, 2]).should == [[1, 2], {}]
+    args << {}
+    argument_proxy(*args).should == [[1, 2, {}], {}]
+    argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
+  end
+
+  # NATFIXME: splat operator and literal keywords
+  xit 'should work with splat operator and literal keywords' do
+    args = [1, 2]
+    argument_proxy(*args, foo: 'a').should == [[1, 2], { foo: 'a' }]
+    argument_proxy(*[1, 2], foo: 'a').should == [[1, 2], { foo: 'a' }]
+  end
+
+  # NATFIXME: splat operator and double splat operator
+  xit 'should work with splat operator and double splat operator' do
+    args = [1, 2]
+    kwargs = { foo: 'a' }
+    argument_proxy(*args, **kwargs).should == [[1, 2], { foo: 'a' }]
+    argument_proxy(*[1, 2], **kwargs).should == [[1, 2], { foo: 'a' }]
+    argument_proxy(*args, **{ foo: 'a' }).should == [[1, 2], { foo: 'a' }]
+    argument_proxy(*[1, 2], **{ foo: 'a' }).should == [[1, 2], { foo: 'a' }]
+  end
+
+  it 'should work with literal positional arguments and double splat operator' do
+    kwargs = { foo: 'a' }
+    argument_proxy(1, 2, **kwargs).should == [[1, 2], { foo: 'a' }]
+    argument_proxy(1, 2, **{ foo: 'a' }).should == [[1, 2], { foo: 'a' }]
+  end
+end

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -5,10 +5,20 @@ def argument_proxy(*args, **kwargs)
 end
 
 describe 'splat operators' do
-  it 'should work with literal arguments' do
-    argument_proxy(1).should == [[1], {}]
-    argument_proxy(1, 2).should == [[1, 2], {}]
-    argument_proxy(1, 2, {}).should == [[1, 2, {}], {}]
+  ruby_version_is ''...'3.0' do
+    it 'should work with literal arguments' do
+      argument_proxy(1).should == [[1], {}]
+      argument_proxy(1, 2).should == [[1, 2], {}]
+      argument_proxy(1, 2, {}).should == [[1, 2], {}]
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'should work with literal arguments' do
+      argument_proxy(1).should == [[1], {}]
+      argument_proxy(1, 2).should == [[1, 2], {}]
+      argument_proxy(1, 2, {}).should == [[1, 2, {}], {}]
+    end
   end
 
   it 'should work with literal keyword arguments' do
@@ -21,13 +31,26 @@ describe 'splat operators' do
     argument_proxy(1, 2, foo: 'a', bar: 'b').should == [[1, 2], { foo: 'a', bar: 'b' }]
   end
 
-  it 'should work with splat operators' do
-    args = [1, 2]
-    argument_proxy(*args).should == [[1, 2], {}]
-    argument_proxy(*[1, 2]).should == [[1, 2], {}]
-    args << {}
-    argument_proxy(*args).should == [[1, 2, {}], {}]
-    argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
+  ruby_version_is ''...'3.0' do
+    it 'should work with splat operators' do
+      args = [1, 2]
+      argument_proxy(*args).should == [[1, 2], {}]
+      argument_proxy(*[1, 2]).should == [[1, 2], {}]
+      args << {}
+      argument_proxy(*args).should == [[1, 2], {}]
+      argument_proxy(*[1, 2, {}]).should == [[1, 2], {}]
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'should work with splat operators' do
+      args = [1, 2]
+      argument_proxy(*args).should == [[1, 2], {}]
+      argument_proxy(*[1, 2]).should == [[1, 2], {}]
+      args << {}
+      argument_proxy(*args).should == [[1, 2, {}], {}]
+      argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
+    end
   end
 
   it 'should work with splat operator and literal keywords' do


### PR DESCRIPTION
Calling a method like this:
```ruby
foo(*args, **kwargs)
```
caused the keyword arguments to be added to the positional arguments. This appears to fix it (I added a bunch of tests, and they all pass), but the fix almost looks too simple to be true.

This started out as an attempt to implement `String#each_line`, and quite a few yaks have lined up to be shaved.