### PR TITLE
Import constants from fnmatch.h into File namespace

### DIFF
--- a/spec/core/file/constants/constants_spec.rb
+++ b/spec/core/file/constants/constants_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../../spec_helper'
+
+# NATFIXME: Implement FNM_* constants
+# ["APPEND", "CREAT", "EXCL", "FNM_CASEFOLD",
+#   "FNM_DOTMATCH", "FNM_EXTGLOB", "FNM_NOESCAPE", "FNM_PATHNAME",
+#   "FNM_SYSCASE", "LOCK_EX", "LOCK_NB", "LOCK_SH",
+["APPEND", "CREAT", "EXCL",
+  "LOCK_EX", "LOCK_NB", "LOCK_SH",
+  "LOCK_UN", "NONBLOCK", "RDONLY",
+  "RDWR", "TRUNC", "WRONLY"].each do |const|
+  describe "File::Constants::#{const}" do
+    it "is defined" do
+      File::Constants.const_defined?(const).should be_true
+    end
+  end
+end
+
+platform_is :windows do
+  describe "File::Constants::BINARY" do
+    it "is defined" do
+      File::Constants.const_defined?(:BINARY).should be_true
+    end
+  end
+end
+
+platform_is_not :windows do
+  ["NOCTTY", "SYNC"].each do |const|
+    describe "File::Constants::#{const}" do
+      it "is defined" do
+        File::Constants.const_defined?(const).should be_true
+      end
+    end
+  end
+end

--- a/spec/core/file/constants/constants_spec.rb
+++ b/spec/core/file/constants/constants_spec.rb
@@ -1,10 +1,11 @@
 require_relative '../../../spec_helper'
 
-# NATFIXME: Implement FNM_* constants
+# NATFIXME: Implement missing FNM_* constants
 # ["APPEND", "CREAT", "EXCL", "FNM_CASEFOLD",
 #   "FNM_DOTMATCH", "FNM_EXTGLOB", "FNM_NOESCAPE", "FNM_PATHNAME",
 #   "FNM_SYSCASE", "LOCK_EX", "LOCK_NB", "LOCK_SH",
-["APPEND", "CREAT", "EXCL",
+["APPEND", "CREAT", "EXCL", "FNM_CASEFOLD",
+  "FNM_NOESCAPE", "FNM_PATHNAME",
   "LOCK_EX", "LOCK_NB", "LOCK_SH",
   "LOCK_UN", "NONBLOCK", "RDONLY",
   "RDWR", "TRUNC", "WRONLY"].each do |const|

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <filesystem>
+#include <fnmatch.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 
@@ -171,6 +172,13 @@ void FileObject::build_constants(Env *env, ClassObject *klass) {
     Constants->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
     klass->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
     Constants->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
+
+    klass->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
+    Constants->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
+    klass->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
+    Constants->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
+    klass->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
+    Constants->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
 }
 
 bool FileObject::exist(Env *env, Value path) {


### PR DESCRIPTION
Besides these entries from fnmatch.h, Ruby also adds three other FNM_ constants. These appear to be unique to Ruby, and have not been added in this patch. These values probably have to be hardcoded.
