### PR TITLE
Fix Kernel.Integer for negative BigInt String values

### DIFF
--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2497,6 +2497,7 @@ Value StringObject::convert_integer(Env *env, nat_int_t base) {
     char *end;
     auto convint = strtoll(str.c_str(), &end, base);
     if (convint == NAT_INT_MIN || convint == NAT_INT_MAX) {
+        if (signchar == '-') str.prepend_char(signchar);
         return IntegerObject::create(BigInt(str, base));
     }
 


### PR DESCRIPTION
The sign char was stripped before the string gets passed to the BigInt constructor, so the result was always the absolute value of the input.

Without this patch:
```
nat> bigint = '-245789127594125924165923648312749312749327482'
"-245789127594125924165923648312749312749327482"
nat> bigint.to_i
-245789127594125924165923648312749312749327482
nat> Integer(bigint)
245789127594125924165923648312749312749327482
```