### PR TITLE
Convert base argument to integer in Kernel.Integer using to_int

### DIFF
--- a/spec/core/kernel/Integer_spec.rb
+++ b/spec/core/kernel/Integer_spec.rb
@@ -577,6 +577,13 @@ describe "Integer() given a String and base", shared: true do
     it "raises an ArgumentError if a base is given for a non-String value" do
       -> { Integer(98, 15) }.should raise_error(ArgumentError)
     end
+
+    it "tries to convert the base to an integer using to_int" do
+      obj = mock('8')
+      obj.should_receive(:to_int).and_return(8)
+
+      Integer("777", obj).should == 0777
+    end
   end
 
   describe "when passed exception: false" do

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -135,8 +135,12 @@ Value KernelModule::exit_bang(Env *env, Value status) {
 
 Value KernelModule::Integer(Env *env, Value value, Value base, Value exception) {
     nat_int_t base_int = 0; // default to zero if unset
-    if (base && base->is_integer())
+    if (base) {
+        if (!base->is_integer() && base->respond_to(env, "to_int"_s))
+            base = base->send(env, "to_int"_s);
+
         base_int = base->as_integer()->to_nat_int_t();
+    }
     return Integer(env, value, base_int, exception ? exception->is_true() : true);
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -139,7 +139,10 @@ Value KernelModule::Integer(Env *env, Value value, Value base, Value exception) 
         if (!base->is_integer() && base->respond_to(env, "to_int"_s))
             base = base->send(env, "to_int"_s);
 
-        base_int = base->as_integer()->to_nat_int_t();
+        // NATFIXME: Discard base argument if it still isn't an int
+        // Likely a bug in Ruby: https://bugs.ruby-lang.org/issues/19349
+        if (base->is_integer())
+            base_int = base->as_integer()->to_nat_int_t();
     }
     return Integer(env, value, base_int, exception ? exception->is_true() : true);
 }

--- a/test/natalie/Integer_test.rb
+++ b/test/natalie/Integer_test.rb
@@ -28,4 +28,9 @@ describe 'Kernel.Integer' do
     Integer('0010', 8).should == 8
     Integer('0010', 10).should == 10
   end
+
+  # NATFIXME: Probably a bug in Ruby: https://bugs.ruby-lang.org/issues/19349
+  it 'ignores a base argument that does not respond to #to_int' do
+    Integer('10', '8').should == 10
+  end
 end


### PR DESCRIPTION
There was an explicit check for this in the spec for `String#to_i`, but not in the spec of `Kernel.Integer`. It turned out MRI does this conversion.

I added https://github.com/ruby/spec/pull/997 as an upstream request to add this to the spec.