### PR TITLE
Make enum_for compatible with keyword arguments

### DIFF
--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -14,11 +14,11 @@ module Kernel
   end
   alias yield_self then
 
-  def enum_for(method = :each, *args, &block)
+  def enum_for(method = :each, *args, **kwargs, &block)
     enum =
       Enumerator.new do |yielder|
         the_proc = yielder.to_proc || ->(*i) { yielder.yield(*i) }
-        send(method, *args, &the_proc)
+        send(method, *args, **kwargs, &the_proc)
       end
     if block_given?
       enum.instance_variable_set(:@size_block, block)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -824,6 +824,13 @@ Value Object::send(Env *env, Args args, Block *block) {
 
 Value Object::send(Env *env, SymbolObject *name, Args args, Block *block, MethodVisibility visibility_at_least) {
     Method *method = find_method(env, name, visibility_at_least);
+    // Remove empty keyword arguments
+    // This can be created with `send(m, *args, **kwargs)` where kwargs is empty
+    if (args.has_keyword_hash()) {
+        auto hash = args.keyword_hash();
+        if (hash && hash->is_empty())
+            args.pop_keyword_hash();
+    }
     if (method) {
         return method->call(env, this, args, block);
     } else if (respond_to(env, "method_missing"_s)) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1122,7 +1122,7 @@ Value Object::enum_for(Env *env, const char *method, Args args) {
     for (size_t i = 0; i < args.size(); i++) {
         args2[i + 1] = args[i];
     }
-    return this->public_send(env, "enum_for"_s, Args(args.size() + 1, args2));
+    return this->public_send(env, "enum_for"_s, Args(args.size() + 1, args2, args.has_keyword_hash()));
 }
 
 void Object::visit_children(Visitor &visitor) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2029,11 +2029,13 @@ static Value lines_inner(Value self, EncodingObject *encoding, bool is_each_line
         });
         return self;
     } else if (is_each_line) {
-        // NATFIXME: Include chomp_value as keyword argument (blocked by https://github.com/natalie-lang/natalie/pull/816)
+        Vector<Value> args { separator };
         if (chomp) {
-            NAT_NOT_YET_IMPLEMENTED();
+            auto hash = new HashObject {};
+            hash->put(env, "chomp"_s, chomp_value);
+            args.push(hash);
         }
-        return self->enum_for(env, "each_line", { separator });
+        return self->enum_for(env, "each_line", Args(args, chomp));
     } else {
         ArrayObject *ary = new ArrayObject {};
         run_split([&](Value out) {

--- a/test/natalie/enum_for_with_keyword_arguments_test.rb
+++ b/test/natalie/enum_for_with_keyword_arguments_test.rb
@@ -1,0 +1,63 @@
+require_relative '../spec_helper'
+
+class EnumForWrapper < String
+  def each_char_ord(ord = false)
+    if block_given?
+      each_char { |c| yield(ord ? c.ord : c) }
+    else
+      enum_for(:each_char_ord, ord)
+    end
+  end
+
+  def each_char_ord_kw(ord: false)
+    if block_given?
+      each_char { |c| yield(ord ? c.ord : c) }
+    else
+      enum_for(:each_char_ord_kw, ord: ord)
+    end
+  end
+end
+
+describe 'enum_for with argument forwarding' do
+  it 'block without arguments' do
+    array = []
+    EnumForWrapper.new('abc').each_char_ord { |c| array << c }
+    array.should == %w[a b c]
+  end
+
+  it 'block with arguments' do
+    array = []
+    EnumForWrapper.new('abc').each_char_ord(true) { |c| array << c }
+    array.should == %w[a b c].map(&:ord)
+  end
+
+  it 'without block and without arguments' do
+    EnumForWrapper.new('abc').each_char_ord.to_a.should == %w[a b c]
+  end
+
+  it 'without block and with arguments' do
+    EnumForWrapper.new('abc').each_char_ord(true).to_a.should == %w[a b c].map(&:ord)
+  end
+end
+
+describe 'enum_for with keyword argument forwarding' do
+  it 'block without arguments' do
+    array = []
+    EnumForWrapper.new('abc').each_char_ord_kw { |c| array << c }
+    array.should == %w[a b c]
+  end
+
+  it 'block with arguments' do
+    array = []
+    EnumForWrapper.new('abc').each_char_ord_kw(ord: true) { |c| array << c }
+    array.should == %w[a b c].map(&:ord)
+  end
+
+  it 'without block and without arguments' do
+    EnumForWrapper.new('abc').each_char_ord_kw.to_a.should == %w[a b c]
+  end
+
+  it 'without block and with arguments' do
+    EnumForWrapper.new('abc').each_char_ord_kw(ord: true).to_a.should == %w[a b c].map(&:ord)
+  end
+end

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -668,4 +668,12 @@ describe 'string' do
       'tim'.tr('a-z', '').should == ''
     end
   end
+
+  describe '#each_line' do
+    it 'can save keyword arguments' do
+      'aXbXc'.each_line('X').to_a.should == %w[aX bX c]
+      'aXbXc'.each_line('X', chomp: true).to_a.should == %w[a b c]
+      "a\nb\nc".each_line(chomp: true).to_a.should == %w[a b c]
+    end
+  end
 end


### PR DESCRIPTION
I ran into this issue when working on `String#each_line`, which is one of the few occasions where you can pass on keyword arguments into an enumerator. Something breaks, but I haven't gotten to the exact cause yet. #807 was just the beginning of this quest :wink: 

This case adds a dumb example to show the issue. The spec passes in Ruby (I've used 3.1), and errors in Natalie.

The spec adds an ugly monkey patch for String, which probably should be removed at some points, but it's good enough to test and work with.