### PR TITLE
Add options keyword to ruby_exe spec helper

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -199,17 +199,17 @@ def min_long
   -(2**(0.size * 8 - 1))
 end
 
-def ruby_exe(code, args: nil, exit_status: 0)
+def ruby_exe(code, options: nil, args: nil, exit_status: 0)
   binary = ENV['NAT_BINARY'] || 'bin/natalie'
 
   output = if File.readable?(code)
-             `#{binary} #{code} #{args}`
+             `#{binary} #{options} #{code} #{args}`
            else
              Tempfile.create('ruby_exe.rb') do |file|
                file.write(code)
                file.rewind
 
-               `#{binary} #{file.path} #{args}`
+               `#{binary} #{options} #{file.path} #{args}`
              end
            end
 


### PR DESCRIPTION
This is used by a number of specs to add extra arguments to the executable (not the script itself). Natalie probably doesn't support these options, but this way the error message will become a bit clearer.

Example of it being used: https://github.com/ruby/spec/blob/master/command_line/backtrace_limit_spec.rb#L7 (which is the first error on the specs result page of Natalie)