### PR TITLE
Support ruby_exe without arguments

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -199,8 +199,9 @@ def min_long
   -(2**(0.size * 8 - 1))
 end
 
-def ruby_exe(code, options: nil, args: nil, exit_status: 0)
+def ruby_exe(code = nil, options: nil, args: nil, exit_status: 0)
   binary = ENV['NAT_BINARY'] || 'bin/natalie'
+  return binary if code.nil?
 
   output = if File.readable?(code)
              `#{binary} #{options} #{code} #{args}`


### PR DESCRIPTION
This is used in some specs, and should just return the executable.

As an example: https://github.com/ruby/spec/blob/master/command_line/dash_e_spec.rb#L21