### PR TITLE
Fix Rational(obj) where obj has a to_r method

### DIFF
--- a/spec/core/rational/to_r_spec.rb
+++ b/spec/core/rational/to_r_spec.rb
@@ -8,10 +8,11 @@ describe "Rational#to_r" do
     -> { Rational(obj) }.should raise_error(TypeError)
   end
 
-  # NATFIXME: Call #to_r in Kernel::Rational
-  xit "works when a BasicObject has to_r" do
+  it "works when a BasicObject has to_r" do
     obj = BasicObject.new; def obj.to_r; 1 / 2.to_r end
-    Rational(obj).should == Rational('1/2')
+    # NATFIXME: Implement Rational(String)
+    # Rational(obj).should == Rational('1/2')
+    Rational(obj).should == Rational(1, 2)
   end
 
   it "fails when a BasicObject's to_r does not return a Rational" do

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -497,8 +497,15 @@ Value KernelModule::Rational(Env *env, Value x, Value y, bool exception) {
             return new RationalObject { x->as_integer(), new IntegerObject { 1 } };
         }
 
-        if (x->is_a(env, find_top_level_const(env, "Numeric"_s)->as_class()) && x->respond_to(env, "to_r"_s)) {
-            return x->public_send(env, "to_r"_s);
+        if (x->is_nil()) {
+            if (!exception) return nullptr;
+            env->raise("TypeError", "can't convert {} into Rational", x->klass()->inspect_str());
+        }
+
+        if (x->respond_to(env, "to_r"_s)) {
+            auto result = x->public_send(env, "to_r"_s);
+            result->assert_type(env, Object::Type::Rational, "Rational");
+            return result;
         }
 
         x = Float(env, x, exception);


### PR DESCRIPTION
This does not have a dependency on the argument being a numeric type. It should raise a TypeError if the result of the to_r call is not a Rational.
As a side effect, this required an additional check for the argument being nil, since `nil.to_r` does return a Rational(0, 1).

There was a slight change needed in the spec, since Rational(String) is not implemented.