### PR TITLE
Update Float#coerce

### DIFF
--- a/spec/core/float/coerce_spec.rb
+++ b/spec/core/float/coerce_spec.rb
@@ -5,7 +5,7 @@ describe "Float#coerce" do
     1.2.coerce(1).should == [1.0, 1.2]
     5.28.coerce(1.0).should == [1.0, 5.28]
     1.0.coerce(1).should == [1.0, 1.0]
-    #1.0.coerce("2.5").should == [2.5, 1.0]
+    1.0.coerce("2.5").should == [2.5, 1.0]
     1.0.coerce(3.14).should == [3.14, 1.0]
 
     #a, b = -0.0.coerce(bignum_value)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -188,19 +188,14 @@ Value FloatObject::coerce(Env *env, Value arg) {
     switch (arg->type()) {
     case Object::Type::Float:
         ary->push(arg);
-        ary->push(this);
         break;
     case Object::Type::Integer:
         ary->push(new FloatObject { arg->as_integer()->to_nat_int_t() });
-        ary->push(this);
-        break;
-    case Object::Type::String:
-        printf("TODO\n");
-        abort();
         break;
     default:
-        env->raise("ArgumentError", "invalid value for Float(): {}", arg->inspect_str(env));
+        ary->push(KernelModule::Float(env, arg, true));
     }
+    ary->push(this);
     return ary;
 }
 


### PR DESCRIPTION
Experimenting with IRB shows that this is implemented using Kernel.Float:

```
irb(main):001:0> 1.0.coerce('2')
=> [2.0, 1.0]
irb(main):002:0> 1.0.coerce('2x')
(irb):2:in `coerce': invalid value for Float(): "2x" (ArgumentError)
```

This change removes an ugly `abort()` from the code too.