### PR TITLE
Fix whitespace after sign mark check in Kernel.Integer

### DIFF
--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2492,7 +2492,7 @@ Value StringObject::convert_integer(Env *env, nat_int_t base) {
         if ((base > 0) && (base != prefix_base)) {
             return nullptr;
         }
-    } else if (str[0] == '+' || str[0] == '-' || str[0] == '_' || str[0] == ' ') {
+    } else if (str[0] == '+' || str[0] == '-' || str[0] == '_' || is_strippable_whitespace(str[0])) {
         return nullptr;
     } else if (str.length() > 0 && str.last_char() == '_') {
         return nullptr;

--- a/test/natalie/Integer_test.rb
+++ b/test/natalie/Integer_test.rb
@@ -1,0 +1,13 @@
+require_relative '../spec_helper'
+
+describe 'Kernel.Integer' do
+  it 'Does not accept a any whitespace after a sign mark' do
+    -> { Integer("+\x001".b) }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\x001"')
+    -> { Integer("+\t1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\t1"')
+    -> { Integer("+\n1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\n1"')
+    -> { Integer("+\v1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\v1"')
+    -> { Integer("+\f1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\f1"')
+    -> { Integer("+\r1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\r1"')
+    -> { Integer("+ 1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+ 1"')
+  end
+end


### PR DESCRIPTION
Found this one by accident while I was looking at tests for #827