### PR TITLE
Array#pack q/Q and buffer: kwarg support

### DIFF
--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -183,7 +183,7 @@ public:
     Value multiply(Env *, Value);
     Value none(Env *, Args, Block *);
     Value one(Env *, Args, Block *);
-    Value pack(Env *, Value);
+    Value pack(Env *, Value, Value);
     Value pop(Env *, Value);
     Value product(Env *, Args, Block *);
     Value push(Env *, Args);

--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -31,6 +31,8 @@ namespace ArrayPacker {
         void pack_l();
         void pack_N();
         void pack_n();
+        void pack_Q();
+        void pack_q();
         void pack_S();
         void pack_s();
         void pack_V();

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -22,7 +22,7 @@ namespace ArrayPacker {
 
         ~Packer() { delete m_directives; }
 
-        StringObject *pack(Env *env);
+        StringObject *pack(Env *env, StringObject *buffer);
 
         virtual void visit_children(Visitor &visitor) override {
             visitor.visit(m_source);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -392,7 +392,7 @@ gen.binding('Array', 'min', 'ArrayObject', 'min', argc: 0..1, pass_env: true, pa
 gen.binding('Array', 'minmax', 'ArrayObject', 'minmax', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Array', 'none?', 'ArrayObject', 'none', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Array', 'one?', 'ArrayObject', 'one', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
-gen.binding('Array', 'pack', 'ArrayObject', 'pack', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Array', 'pack', 'ArrayObject', 'pack', argc: 1, kwargs: [:buffer], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', 'pop', 'ArrayObject', 'pop', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', 'product', 'ArrayObject', 'product', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Array', 'push', 'ArrayObject', 'push', argc: :any, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/array/pack/u_spec.rb
+++ b/spec/core/array/pack/u_spec.rb
@@ -134,8 +134,7 @@ describe "Array#pack with format 'u'" do
     -> { [bignum_value].pack("u") }.should raise_error(TypeError)
   end
 
-  # Add this back once we get support for US-ASCII 
-  xit "sets the output string to US-ASCII encoding" do
+  it "sets the output string to US-ASCII encoding" do
     ["abcd"].pack("u").encoding.should == Encoding::US_ASCII
   end
 end

--- a/src/array_packer/integer_handler.cpp
+++ b/src/array_packer/integer_handler.cpp
@@ -50,6 +50,12 @@ namespace ArrayPacker {
         case 'n':
             pack_n();
             break;
+        case 'Q':
+            pack_Q();
+            break;
+        case 'q':
+            pack_q();
+            break;
         case 'S':
             pack_S();
             break;
@@ -178,6 +184,26 @@ namespace ArrayPacker {
         } else {
             auto source = (long long)m_source->to_nat_int_t();
             append_bytes((const char *)(&source), size);
+        }
+    }
+
+    void IntegerHandler::pack_Q() {
+        auto size = sizeof(uint64_t);
+        if (m_source->is_bignum()) {
+            pack_bignum(size * 8);
+        } else {
+            auto source = (uint64_t)m_source->to_nat_int_t();
+            append_bytes((const char *)&source, size);
+        }
+    }
+
+    void IntegerHandler::pack_q() {
+        auto size = sizeof(int64_t);
+        if (m_source->is_bignum()) {
+            pack_bignum(size * 8);
+        } else {
+            auto source = (int64_t)m_source->to_nat_int_t();
+            append_bytes((const char *)&source, size);
         }
     }
 

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -4,7 +4,11 @@ namespace Natalie {
 
 namespace ArrayPacker {
 
-    StringObject *Packer::pack(Env *env) {
+    StringObject *Packer::pack(Env *env, StringObject *buffer) {
+
+        m_packed = buffer->string();
+        m_encoding = buffer->encoding();
+
         for (auto token : *m_directives) {
             if (token.error)
                 env->raise("ArgumentError", *token.error);
@@ -58,7 +62,7 @@ namespace ArrayPacker {
                 auto packer = StringHandler { string, string_object, token };
                 m_packed.append(packer.pack(env));
 
-                if (d == 'm' || d == 'M')
+                if (d == 'm' || d == 'M' || d == 'u')
                     m_encoding = EncodingObject::get(Encoding::US_ASCII);
 
                 m_index++;
@@ -156,7 +160,10 @@ namespace ArrayPacker {
             }
             }
         }
-        return new StringObject { m_packed, m_encoding };
+        // must force str length in case m_packed was stuffed with '\0's
+        buffer->set_str(m_packed.c_str(), m_packed.length());
+        buffer->set_encoding(m_encoding);
+        return buffer;
     }
 
 }

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -74,6 +74,8 @@ namespace ArrayPacker {
             case 'l':
             case 'N':
             case 'n':
+            case 'Q':
+            case 'q':
             case 'S':
             case 's':
             case 'U':


### PR DESCRIPTION
This implements the 'q' and 'Q' directives for `Array#pack` and also implements the `buffer:` keyword arg which allows an existing buffer to be manipulated rather than starting from an empty new buffer and returning the new object.

Also, one extra `xit`ed NATFIXME was removed.

This should close issue #195 , as the percent_spec was already passing.
 