### PR TITLE
Fixes for EncodingObject

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -66,6 +66,8 @@ public:
         }
     }
 
+    bool is_dummy() { return m_dummy; }
+
     virtual bool valid_codepoint(nat_int_t codepoint) const = 0;
     virtual std::pair<bool, StringView> prev_char(const String &, size_t *) const = 0;
     virtual std::pair<bool, StringView> next_char(const String &, size_t *) const = 0;
@@ -80,12 +82,18 @@ public:
     [[noreturn]] void raise_encoding_invalid_byte_sequence_error(Env *env, const String &, size_t) const;
 
     static HashObject *aliases(Env *);
-    static EncodingObject *find(Env *, Value);
+    static Value find(Env *, Value);
     static ArrayObject *list(Env *env);
     static const TM::Hashmap<Encoding, EncodingObject *> &encodings() { return EncodingObject::s_encoding_list; }
+    static EncodingObject *default_external() { return s_default_external; }
     static EncodingObject *default_internal() { return s_default_internal; }
+    static EncodingObject *locale() { return s_locale; }
+    static EncodingObject *filesystem() { return s_filesystem; }
+    static EncodingObject *set_default_external(Env *, Value);
     static EncodingObject *set_default_internal(Env *, Value);
     static EncodingObject *get(Encoding encoding) { return s_encoding_list.get(encoding); }
+    static Value locale_charmap();
+    static void initialize_defaults(Env *);
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<EncodingObject %p>", this);
@@ -94,9 +102,14 @@ public:
 private:
     Vector<String> m_names {};
     Encoding m_num;
+    bool m_dummy { false };
 
     static inline TM::Hashmap<Encoding, EncodingObject *> s_encoding_list {};
     static inline EncodingObject *s_default_internal = nullptr;
+    // external, locale and filesystem are set by a static initializer function
+    static inline EncodingObject *s_default_external = nullptr;
+    static inline EncodingObject *s_locale = nullptr;
+    static inline EncodingObject *s_filesystem = nullptr;
 };
 
 }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -448,11 +448,16 @@ gen.binding('Complex', 'imaginary', 'ComplexObject', 'imaginary', argc: 0, pass_
 gen.binding('Complex', 'real', 'ComplexObject', 'real', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('Encoding', 'aliases', 'EncodingObject', 'aliases', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Encoding', 'default_external', 'EncodingObject', 'default_external', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.static_binding('Encoding', 'default_external=', 'EncodingObject', 'set_default_external', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Encoding', 'default_internal', 'EncodingObject', 'default_internal', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Encoding', 'default_internal=', 'EncodingObject', 'set_default_internal', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Encoding', 'locale_charmap', 'EncodingObject', 'locale_charmap', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+
 gen.static_binding('Encoding', 'find', 'EncodingObject', 'find', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Encoding', 'list', 'EncodingObject', 'list', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Encoding', 'ascii_compatible?', 'EncodingObject', 'is_ascii_compatible', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Encoding', 'dummy?', 'EncodingObject', 'is_dummy', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Encoding', 'inspect', 'EncodingObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Encoding', 'name', 'EncodingObject', 'name', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Encoding', 'names', 'EncodingObject', 'names', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/encoding/find_spec.rb
+++ b/spec/core/encoding/find_spec.rb
@@ -1,0 +1,82 @@
+require_relative '../../spec_helper'
+
+describe "Encoding.find" do
+  before :all do
+    @encodings = Encoding.aliases.to_a.flatten.uniq
+  end
+
+  it "returns the corresponding Encoding object if given a valid encoding name" do
+    @encodings.each do |enc|
+      Encoding.find(enc).should be_an_instance_of(Encoding)
+    end
+  end
+
+  it "returns the corresponding Encoding object if given a valid alias name" do
+    Encoding.aliases.keys.each do |enc_alias|
+      Encoding.find(enc_alias).should be_an_instance_of(Encoding)
+    end
+  end
+
+  it "raises a TypeError if passed a Symbol" do
+    -> { Encoding.find(:"utf-8") }.should raise_error(TypeError)
+  end
+
+  it "returns the passed Encoding object" do
+    Encoding.find(Encoding::UTF_8).should == Encoding::UTF_8
+  end
+
+  it "accepts encoding names as Strings" do
+    Encoding.list.each do |enc|
+      Encoding.find(enc.name).should == enc
+    end
+  end
+
+  it "accepts any object as encoding name, if it responds to #to_str" do
+    obj = Class.new do
+      attr_writer :encoding_name
+      def to_str; @encoding_name; end
+    end.new
+
+    Encoding.list.each do |enc|
+      obj.encoding_name = enc.name
+      Encoding.find(obj).should == enc
+    end
+  end
+
+  it "is case insensitive" do
+    @encodings.each do |enc|
+      Encoding.find(enc.upcase).should == Encoding.find(enc)
+    end
+  end
+
+  it "raises an ArgumentError if the given encoding does not exist" do
+    -> { Encoding.find('dh2dh278d') }.should raise_error(ArgumentError)
+  end
+
+  # Not sure how to do a better test, since locale depends on weird platform-specific stuff
+  it "supports the 'locale' encoding alias" do
+    enc = Encoding.find('locale')
+    enc.should_not == nil
+  end
+
+  it "returns default external encoding for the 'external' encoding alias" do
+    enc = Encoding.find('external')
+    enc.should == Encoding.default_external
+  end
+
+  it "returns default internal encoding for the 'internal' encoding alias" do
+    enc = Encoding.find('internal')
+    enc.should == Encoding.default_internal
+  end
+
+  platform_is_not :windows do
+    it "uses default external encoding for the 'filesystem' encoding alias" do
+      enc = Encoding.find('filesystem')
+      enc.should == Encoding.default_external
+    end
+  end
+
+  platform_is :windows do
+    it "needs to be reviewed for spec completeness"
+  end
+end

--- a/spec/core/encoding/inspect_spec.rb
+++ b/spec/core/encoding/inspect_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+describe "Encoding#inspect" do
+  it "returns a String" do
+    Encoding::UTF_8.inspect.should be_an_instance_of(String)
+  end
+
+  it "returns #<Encoding:name> for a non-dummy encoding named 'name'" do
+    Encoding.list.to_a.reject {|e| e.dummy? }.each do |enc|
+      enc.inspect.should =~ /#<Encoding:#{enc.name}>/
+    end
+  end
+
+  it "returns #<Encoding:name (dummy)> for a dummy encoding named 'name'" do
+    Encoding.list.to_a.select {|e| e.dummy? }.each do |enc|
+      enc.inspect.should =~ /#<Encoding:#{enc.name} \(dummy\)>/
+    end
+  end
+end

--- a/spec/core/encoding/locale_charmap_spec.rb
+++ b/spec/core/encoding/locale_charmap_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../../spec_helper'
+
+describe "Encoding.locale_charmap" do
+  it "returns a String" do
+    Encoding.locale_charmap.should be_an_instance_of(String)
+  end
+
+  # FIXME: Get this working on Windows
+  platform_is :linux do
+    platform_is_not :android do
+      it "returns a value based on the LC_ALL environment variable" do
+        old_lc_all = ENV['LC_ALL']
+        ENV['LC_ALL'] = 'C'
+        ruby_exe("print Encoding.locale_charmap").should == 'ANSI_X3.4-1968'
+        ENV['LC_ALL'] = old_lc_all
+      end
+    end
+  end
+
+  platform_is :freebsd, :openbsd, :darwin do
+    it "returns a value based on the LC_ALL environment variable" do
+      old_lc_all = ENV['LC_ALL']
+      ENV['LC_ALL'] = 'C'
+      ruby_exe("print Encoding.locale_charmap").should == 'US-ASCII'
+      ENV['LC_ALL'] = old_lc_all
+    end
+  end
+
+  platform_is :netbsd do
+    it "returns a value based on the LC_ALL environment variable" do
+      old_lc_all = ENV['LC_ALL']
+      ENV['LC_ALL'] = 'C'
+      ruby_exe("print Encoding.locale_charmap").should == '646'
+      ENV['LC_ALL'] = old_lc_all
+    end
+  end
+
+  platform_is :android do
+    it "always returns UTF-8" do
+      old_lc_all = ENV['LC_ALL']
+      ENV['LC_ALL'] = 'C'
+      ruby_exe("print Encoding.locale_charmap").should == 'UTF-8'
+      ENV['LC_ALL'] = old_lc_all
+    end
+  end
+
+  platform_is :bsd, :darwin, :linux do
+    it "is unaffected by assigning to ENV['LC_ALL'] in the same process" do
+      old_charmap = Encoding.locale_charmap
+      old_lc_all = ENV['LC_ALL']
+      ENV['LC_ALL'] = 'C'
+      Encoding.locale_charmap.should == old_charmap
+      ENV['LC_ALL'] = old_lc_all
+    end
+  end
+end

--- a/src/array_packer/string_handler.cpp
+++ b/src/array_packer/string_handler.cpp
@@ -192,7 +192,7 @@ namespace ArrayPacker {
         for (size_t index = 0; index < m_source.size(); index++) {
             unsigned char c = m_source[index];
 
-            if (c != '=' && (c == '\t' || c == '\n' || isprint(c))) {
+            if (c == '\t' || c == '\n' || (isprint(c) && c != '=' && (unsigned int)c <= 0176)) {
                 m_packed.append_char(c);
                 line_size++;
                 if (c == '\n')

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -208,6 +208,9 @@ Env *build_top_env() {
     Encoding->const_set("UTF_32BE"_s, EncodingUTF32BE);
     Encoding->const_set("UCS_4BE"_s, EncodingUTF32BE);
 
+    // Must set defaults after the encodings are defined above.
+    EncodingObject::initialize_defaults(env);
+
     ModuleObject *Process = new ModuleObject { "Process" };
     Object->const_set("Process"_s, Process);
     Value ProcessSys = new ModuleObject { "Sys" };


### PR DESCRIPTION
+ Add `Encoding.locale_charmap`
+ Add `Encoding.dummy?`.  None of our active encodings are dummies, so this is not yet fully testable.
+ Fix `Encoding.find` to support special lookups for "internal", "external", "filesystem" and "locale"
+ Add support for getting/setting default_external, locale and filesystem encodings, with a static initializer.  Unclear at this point how OS dependent this is for the platforms Natalie supports.
