### PR TITLE
Sync enumerable/sum_spec with upstream

### DIFF
--- a/spec/core/enumerable/sum_spec.rb
+++ b/spec/core/enumerable/sum_spec.rb
@@ -25,8 +25,31 @@ describe 'Enumerable#sum' do
     @enum.sum.should == 1
   end
 
-  it 'takes a block to transform the elements' do
-    # @enum.sum { |element| element * 2 }.should == 10/3r
-    @enum.sum { |element| element * 2 }.should == 2
+  context 'with a block' do
+    it 'transforms the elements' do
+      # @enum.sum { |element| element * 2 }.should == 10/3r
+      @enum.sum { |element| element * 2 }.should == 2
+    end
+
+    it 'does not destructure array elements' do
+      class << @enum
+        def each
+          yield [1,2]
+          yield [3]
+        end
+      end
+
+      @enum.sum(&:last).should == 5
+    end
+  end
+
+  # https://bugs.ruby-lang.org/issues/12217
+  # https://github.com/ruby/ruby/blob/master/doc/ChangeLog-2.4.0#L6208-L6214
+  # NATFIXME: uses Kahan's compensated summation algorithm for precise sum of float numbers
+  xit "uses Kahan's compensated summation algorithm for precise sum of float numbers" do
+    floats = [2.7800000000000002, 5.0, 2.5, 4.44, 3.89, 3.89, 4.44, 7.78, 5.0, 2.7800000000000002, 5.0, 2.5].to_enum
+    naive_sum = floats.reduce { |sum, e| sum + e }
+    naive_sum.should == 50.00000000000001
+    floats.sum.should == 50.0
   end
 end


### PR DESCRIPTION
And disable the new spec for Kahan's compensated summation algorithm.

I had this change in the branch of #825, but I think it's better to merge it separately. It keeps the other branch a bit more focused on the actual problem it's trying to solve.