### PR TITLE
Fix out of bounds read in String#chomp!

### DIFF
--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -187,7 +187,7 @@ Value StringObject::chomp_in_place(Env *env, Value record_separator) {
         if (m_string.at(end_idx - 1) == '\r') {
             --end_idx;
         } else if (m_string.at(end_idx - 1) == '\n') {
-            if (m_string.at(end_idx - 2) == '\r') {
+            if (end_idx > 1 && m_string.at(end_idx - 2) == '\r') {
                 --end_idx;
             }
             --end_idx;

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -500,6 +500,18 @@ describe 'string' do
     end
   end
 
+  describe '#chmop' do
+    it 'does not read out of bounds' do
+      "\n".chomp.should == ''
+    end
+  end
+
+  describe '#chomp!' do
+    it 'does not read out of bounds' do
+      "\n".chomp!.should == ''
+    end
+  end
+
   describe '#chop' do
     it 'returns a new copy of the string with the last character removed' do
       'foo!'.encode('us-ascii').chop.should == 'foo'


### PR DESCRIPTION
The statement `"\n".chomp!`` tried to check if there was a `\r` before the `\n`, which caused an out of buffer read