### PR TITLE
Allow "b" and "t" modes for File open

### DIFF
--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -3,7 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <filesystem>
-//#include <fnmatch.h> // use ruby defined values instead of os-defined
+// #include <fnmatch.h> // use ruby defined values instead of os-defined
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -58,22 +58,36 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Block *b
             flags = flags_obj->as_integer()->to_nat_int_t();
             break;
         case Object::Type::String: {
-            const char *flags_str = flags_obj->as_string()->c_str();
-            if (strcmp(flags_str, "r") == 0) {
-                flags = O_RDONLY;
-            } else if (strcmp(flags_str, "r+") == 0) {
-                flags = O_RDWR;
-            } else if (strcmp(flags_str, "w") == 0) {
-                flags = O_WRONLY | O_CREAT | O_TRUNC;
-            } else if (strcmp(flags_str, "w+") == 0) {
-                flags = O_RDWR | O_CREAT | O_TRUNC;
-            } else if (strcmp(flags_str, "a") == 0) {
-                flags = O_WRONLY | O_CREAT | O_APPEND;
-            } else if (strcmp(flags_str, "a+") == 0) {
-                flags = O_RDWR | O_CREAT | O_APPEND;
-            } else {
+            auto flags_str = flags_obj->as_string()->string();
+            if (flags_str.length() < 1 || flags_str.length() > 3)
                 env->raise("ArgumentError", "invalid access mode {}", flags_str);
-            }
+
+            // rb+ => 'r', 'b', '+'
+            auto main_mode = flags_str.at(0);
+            auto read_write_mode = flags_str.length() > 1 ? flags_str.at(1) : 0;
+            auto binary_text_mode = flags_str.length() > 2 ? flags_str.at(2) : 0;
+
+            // rb+ => r+b
+            if (read_write_mode == 'b' || read_write_mode == 't')
+                std::swap(read_write_mode, binary_text_mode);
+
+            if (binary_text_mode && binary_text_mode != 'b' && binary_text_mode != 't')
+                env->raise("ArgumentError", "invalid access mode {}", flags_str);
+
+            if (main_mode == 'r' && !read_write_mode)
+                flags = O_RDONLY;
+            else if (main_mode == 'r' && read_write_mode == '+')
+                flags = O_RDWR;
+            else if (main_mode == 'w' && !read_write_mode)
+                flags = O_WRONLY | O_CREAT | O_TRUNC;
+            else if (main_mode == 'w' && read_write_mode == '+')
+                flags = O_RDWR | O_CREAT | O_TRUNC;
+            else if (main_mode == 'a' && !read_write_mode)
+                flags = O_WRONLY | O_CREAT | O_APPEND;
+            else if (main_mode == 'a' && read_write_mode == '+')
+                flags = O_RDWR | O_CREAT | O_APPEND;
+            else
+                env->raise("ArgumentError", "invalid access mode {}", flags_str);
             break;
         }
         default:
@@ -93,7 +107,7 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Block *b
 Value FileObject::expand_path(Env *env, Value path, Value root) {
     path->assert_type(env, Object::Type::String, "String");
     StringObject *merged;
-    if (path->as_string()->length() > 0 && path->as_string()->c_str()[0] == '/') {
+    if (path->as_string()->length() > 0 && path->as_string()->string()[0] == '/') {
         merged = path->as_string();
     } else if (root) {
         root->assert_type(env, Object::Type::String, "String");
@@ -118,7 +132,7 @@ Value FileObject::expand_path(Env *env, Value path, Value root) {
         merged = merged->sub(env, &dot, &slash)->as_string();
     } while (env->has_last_match());
     // remove trailing slash
-    if (merged->length() > 1 && merged->c_str()[merged->length() - 1] == '/') {
+    if (merged->length() > 1 && merged->string()[merged->length() - 1] == '/') {
         merged->truncate(merged->length() - 1);
     }
     return merged;

--- a/test/natalie/file_test.rb
+++ b/test/natalie/file_test.rb
@@ -71,6 +71,30 @@ describe 'File' do
       end
       file.closed?.should == true
     end
+
+    # NOTE: these modes do something on Windows only
+    it 'accepts "b" and "t" as a mode modifier' do
+      %w[rb r+b rb+ rt r+t rt+].each do |mode|
+        file = File.open('test/support/file.txt', mode)
+        file.read.should == "foo bar baz\n"
+        file.close
+      end
+      %w[wb w+b wb+ wt w+t wt+].each do |mode|
+        file = File.open('test/tmp/file.txt', mode)
+        file.write('stuff')
+        file.close
+      end
+      %w[ab a+b ab+ at a+t at+].each do |mode|
+        file = File.open('test/tmp/file.txt', mode)
+        file.write('stuff')
+        file.close
+      end
+    end
+
+    it 'does not accept "b" and "t" in the wrong position' do
+      -> { File.open('test/support/file.txt', 'br') }.should raise_error(ArgumentError, 'invalid access mode br')
+      -> { File.open('test/support/file.txt', 'tw') }.should raise_error(ArgumentError, 'invalid access mode tw')
+    end
   end
 
   describe '#read' do


### PR DESCRIPTION
These don't do anything on *nix as far as I can tell. And we don't support Windows anyway. So let's just ignore them for now.