### PR TITLE
Add stub file for lib/bigdecimal.rb

### DIFF
--- a/spec/core/integer/coerce_spec.rb
+++ b/spec/core/integer/coerce_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-# require 'bigdecimal'
+require 'bigdecimal'
 
 describe "Integer#coerce" do
   context "fixnum" do

--- a/spec/shared/rational/coerce.rb
+++ b/spec/shared/rational/coerce.rb
@@ -1,7 +1,6 @@
 require_relative '../../spec_helper'
 
-# NATFIXME: Implement BigDecimal
-# require 'bigdecimal'
+require 'bigdecimal'
 
 describe :rational_coerce, shared: true do
   it "returns the passed argument, self as Float, when given a Float" do


### PR DESCRIPTION
This fixes two crashes in the nightly overview of the specs, which means we can now run the other tests in the file, and get more specific error messages in the failed tests.