### PR TITLE
Pack rational as float

### DIFF
--- a/spec/core/array/pack/shared/float.rb
+++ b/spec/core/array/pack/shared/float.rb
@@ -68,8 +68,7 @@ describe :array_pack_float_le, shared: true do
     [2 ** 65].pack(pack_format).should == [(2 ** 65).to_f].pack(pack_format)
   end
 
-  # NATFIXME: encodes a rational as a float
-  xit "encodes a rational as a float" do
+  it "encodes a rational as a float" do
     [Rational(3, 4)].pack(pack_format).should == [Rational(3, 4).to_f].pack(pack_format)
   end
 end

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -110,8 +110,11 @@ namespace ArrayPacker {
             case 'g': {
                 pack_with_loop(env, token, [&]() {
                     auto value = m_source->at(m_index);
-                    if (value->is_integer())
+                    if (value->is_integer()) {
                         value = value->as_integer()->to_f();
+                    } else if (value->is_rational()) {
+                        value = value->as_rational()->to_f(env);
+                    }
                     auto packer = FloatHandler { value->as_float_or_raise(env), token };
                     m_packed.append(packer.pack(env));
                 });


### PR DESCRIPTION
This looks like it is an explicit conversion in Ruby, not using Float or Object#coerce. A String '0.75' does not work.