### PR TITLE
Implement Numeric#i

### DIFF
--- a/spec/core/numeric/i_spec.rb
+++ b/spec/core/numeric/i_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "Numeric#i" do
+  it "returns a Complex object" do
+    34.i.should be_an_instance_of(Complex)
+  end
+
+  it "sets the real part to 0" do
+    7342.i.real.should == 0
+  end
+
+  it "sets the imaginary part to self" do
+    62.81.i.imag.should == 62.81
+  end
+end

--- a/src/complex.rb
+++ b/src/complex.rb
@@ -325,6 +325,7 @@ class Complex
     self.real.rationalize eps
   end
 
+  undef :i
   undef :positive?
   undef :negative?
 

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -64,6 +64,10 @@ class Numeric
 
   alias conjugate conj
 
+  def i
+    Complex(0, self)
+  end
+
   def imag
     0
   end


### PR DESCRIPTION
And remove it from Complex. Even if there is no spec for it, this looks like the behaviour of MRI.

MRI still enables to rebind the method to call it:

    irb(main):001:0> Numeric.instance_method(:i).bind(Complex(1)).call
    => (0+1i)
    irb(main):002:0> Numeric.instance_method(:i).bind(Complex(1, 2)).call
    => (-2+1i)

This does not work in Natalie, it tries to call `#negative?` on the Complex value. Given that there is no spec for it, and the MRI behaviour seems a bit weird given the method `Complex#i` is explicitly removed, I'm just going to assume this is undefined behaviour.