### PR TITLE
Query encoding in String#ascii_only?

### DIFF
--- a/spec/core/string/ascii_only_spec.rb
+++ b/spec/core/string/ascii_only_spec.rb
@@ -49,13 +49,13 @@ describe "String#ascii_only?" do
     "".encode('UTF-8').ascii_only?.should be_true
   end
 
-  # FIXME: Implemet UTF-16BE encoding
-  xit "returns false for the empty String with a non-ASCII-compatible encoding" do
+  it "returns false for the empty String with a non-ASCII-compatible encoding" do
     "".force_encoding('UTF-16LE').ascii_only?.should be_false
-    "".encode('UTF-16BE').ascii_only?.should be_false
+    # NATFIXME: Implement UTF-16BE encoding
+    # "".encode('UTF-16BE').ascii_only?.should be_false
   end
 
-  xit "returns false for a non-empty String with non-ASCII-compatible encoding" do
+  it "returns false for a non-empty String with non-ASCII-compatible encoding" do
     "\x78\x00".force_encoding("UTF-16LE").ascii_only?.should be_false
   end
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2691,6 +2691,9 @@ Value StringObject::delete_suffix_in_place(Env *env, Value val) {
 }
 
 bool StringObject::ascii_only(Env *env) const {
+    if (m_encoding != nullptr && !m_encoding->is_ascii_compatible())
+        return false;
+
     for (size_t i = 0; i < length(); i++) {
         unsigned char c = c_str()[i];
         if (c > 127) {


### PR DESCRIPTION
If the encoding is not ASCII compatible, the string is not, even if it is empty.
Update the tests accordingly, and fix a type (Implemet => Implement) as well.