### PR TITLE
Fix Numeric#quo

### DIFF
--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -108,7 +108,6 @@ public:
     Value complement(Env *) const;
     Value ord() { return IntegerObject::create(m_integer); }
     Value denominator() { return Value::integer(1); }
-    Value quo(Env *, Value);
     Value round(Env *, Value, Value);
     Value truncate(Env *, Value);
     Value ref(Env *, Value, Value);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -786,7 +786,6 @@ gen.binding('Integer', 'next', 'IntegerObject', 'succ', argc: 0, pass_env: true,
 gen.binding('Integer', 'numerator', 'IntegerObject', 'numerator', argc: 0, pass_env: false, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Integer', 'odd?', 'IntegerObject', 'is_odd', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)
 gen.binding('Integer', 'ord', 'IntegerObject', 'ord', argc: 0, pass_env: false, pass_block: false, return_type: :Object, optimized: true)
-gen.binding('Integer', 'quo', 'IntegerObject', 'quo', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'round', 'IntegerObject', 'round', argc: 0..1, kwargs: [:half], pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Integer', 'size', 'IntegerObject', 'size', argc: 0, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Integer', 'succ', 'IntegerObject', 'succ', argc: 0, pass_env: true, pass_block: false, return_type: :Object, optimized: true)

--- a/spec/core/numeric/quo_spec.rb
+++ b/spec/core/numeric/quo_spec.rb
@@ -1,0 +1,67 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/quo'
+
+describe "Numeric#quo" do
+  it "returns the result of self divided by the given Integer as a Rational" do
+    5.quo(2).should eql(Rational(5,2))
+  end
+
+  it "returns the result of self divided by the given Float as a Float" do
+    2.quo(2.5).should eql(0.8)
+  end
+
+  it "returns the result of self divided by the given Bignum as a Float" do
+    45.quo(bignum_value).should be_close(1.04773789668636e-08, TOLERANCE)
+  end
+
+  it "raises a ZeroDivisionError when the given Integer is 0" do
+    -> { 0.quo(0) }.should raise_error(ZeroDivisionError)
+    -> { 10.quo(0) }.should raise_error(ZeroDivisionError)
+    -> { -10.quo(0) }.should raise_error(ZeroDivisionError)
+    -> { bignum_value.quo(0) }.should raise_error(ZeroDivisionError)
+    -> { (-bignum_value).quo(0) }.should raise_error(ZeroDivisionError)
+  end
+
+  # NATFIXME: calls #to_r to convert the object to a Rational
+  xit "calls #to_r to convert the object to a Rational" do
+    obj = NumericSpecs::Subclass.new
+    obj.should_receive(:to_r).and_return(Rational(1))
+
+    obj.quo(19).should == Rational(1, 19)
+  end
+
+  # NATFIXME: raises a TypeError of #to_r does not return a Rational
+  xit "raises a TypeError of #to_r does not return a Rational" do
+    obj = NumericSpecs::Subclass.new
+    obj.should_receive(:to_r).and_return(1)
+
+    -> { obj.quo(19) }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError when given a non-Integer" do
+    -> {
+      (obj = mock('x')).should_not_receive(:to_int)
+      13.quo(obj)
+    }.should raise_error(TypeError)
+    -> { 13.quo("10")    }.should raise_error(TypeError)
+    -> { 13.quo(:symbol) }.should raise_error(TypeError)
+  end
+
+  # NATFIXME: returns the result of calling self#/ with other
+  xit "returns the result of calling self#/ with other" do
+    obj = NumericSpecs::Subclass.new
+    obj.should_receive(:to_r).and_return(19.quo(20))
+
+    obj.quo(19).should == 1.quo(20)
+  end
+
+  it "raises a ZeroDivisionError if the given argument is zero and not a Float" do
+    -> { 1.quo(0) }.should raise_error(ZeroDivisionError)
+  end
+
+  it "returns infinity if the given argument is zero and is a Float" do
+    (1.quo(0.0)).to_s.should == 'Infinity'
+    (-1.quo(0.0)).to_s.should == '-Infinity'
+  end
+end

--- a/spec/core/numeric/quo_spec.rb
+++ b/spec/core/numeric/quo_spec.rb
@@ -23,16 +23,14 @@ describe "Numeric#quo" do
     -> { (-bignum_value).quo(0) }.should raise_error(ZeroDivisionError)
   end
 
-  # NATFIXME: calls #to_r to convert the object to a Rational
-  xit "calls #to_r to convert the object to a Rational" do
+  it "calls #to_r to convert the object to a Rational" do
     obj = NumericSpecs::Subclass.new
     obj.should_receive(:to_r).and_return(Rational(1))
 
     obj.quo(19).should == Rational(1, 19)
   end
 
-  # NATFIXME: raises a TypeError of #to_r does not return a Rational
-  xit "raises a TypeError of #to_r does not return a Rational" do
+  it "raises a TypeError of #to_r does not return a Rational" do
     obj = NumericSpecs::Subclass.new
     obj.should_receive(:to_r).and_return(1)
 
@@ -48,8 +46,7 @@ describe "Numeric#quo" do
     -> { 13.quo(:symbol) }.should raise_error(TypeError)
   end
 
-  # NATFIXME: returns the result of calling self#/ with other
-  xit "returns the result of calling self#/ with other" do
+  it "returns the result of calling self#/ with other" do
     obj = NumericSpecs::Subclass.new
     obj.should_receive(:to_r).and_return(19.quo(20))
 

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -572,11 +572,6 @@ Value IntegerObject::sqrt(Env *env, Value arg) {
     return create(Natalie::sqrt(argument));
 }
 
-Value IntegerObject::quo(Env *env, Value quotient) {
-    auto rat = new RationalObject { this->as_integer(), new IntegerObject { 1 } };
-    return rat->div(env, quotient);
-}
-
 Value IntegerObject::round(Env *env, Value ndigits, Value half) {
     if (!ndigits)
         return IntegerObject::create(m_integer);

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -139,6 +139,10 @@ class Numeric
     Float(self) / Float(other)
   end
 
+  def quo(quotient)
+    Rational(self) / quotient
+  end
+
   def finite?
     true
   end


### PR DESCRIPTION
Both the specs and the MRI implementation showed this method should be defined on `Numeric` instead of `Integer`. Some subclasses like `Rational` and `Float` still have their own implementation (just like MRI).
Moving the code just happened to fix all the failing specs.