### PR TITLE
Time 20230126

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -20,6 +20,10 @@ public:
     TimeObject(ClassObject *klass)
         : Object { Object::Type::Time, klass } { }
 
+    ~TimeObject() {
+        free(m_zone);
+    }
+
     static TimeObject *at(Env *, Value, Value, Value);
     static TimeObject *at(Env *, Value, Value, Value, Value in);
     static TimeObject *create(Env *);
@@ -87,6 +91,7 @@ private:
     Mode m_mode;
     Value m_subsec;
     struct tm m_time;
+    char *m_zone { nullptr };
 };
 
 }

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -22,7 +22,7 @@ public:
 
     static TimeObject *at(Env *, Value, Value, Value);
     static TimeObject *create(Env *);
-    static TimeObject *initialize(Env *, Value, Value, Value, Value, Value, Value, Value);
+    static TimeObject *initialize(Env *, Value, Value, Value, Value, Value, Value, Value, Value _in);
     static TimeObject *local(Env *, Value, Value, Value, Value, Value, Value, Value);
     static TimeObject *now(Env *, Value in);
     static TimeObject *utc(Env *, Value, Value, Value, Value, Value, Value, Value);
@@ -73,6 +73,7 @@ private:
     static nat_int_t normalize_month(Env *, Value val);
     static nat_int_t normalize_field(Env *, Value val);
     static nat_int_t normalize_field(Env *, Value val, nat_int_t minval, nat_int_t maxval);
+    static nat_int_t normalize_timezone(Env *, Value val);
 
     Value build_string(Env *, const char *);
     void build_time(Env *, Value, Value, Value, Value, Value, Value);

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -21,8 +21,9 @@ public:
         : Object { Object::Type::Time, klass } { }
 
     static TimeObject *at(Env *, Value, Value, Value);
+    static TimeObject *at(Env *, Value, Value, Value, Value in);
     static TimeObject *create(Env *);
-    static TimeObject *initialize(Env *, Value, Value, Value, Value, Value, Value, Value, Value _in);
+    static TimeObject *initialize(Env *, Value, Value, Value, Value, Value, Value, Value, Value in);
     static TimeObject *local(Env *, Value, Value, Value, Value, Value, Value, Value);
     static TimeObject *now(Env *, Value in);
     static TimeObject *utc(Env *, Value, Value, Value, Value, Value, Value, Value);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1179,7 +1179,7 @@ gen.binding('Symbol', 'to_s', 'SymbolObject', 'to_s', argc: 0, pass_env: true, p
 gen.binding('Symbol', 'to_sym', 'SymbolObject', 'to_sym', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Symbol', 'upcase', 'SymbolObject', 'upcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
-gen.static_binding('Time', 'at', 'TimeObject', 'at', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Time', 'at', 'TimeObject', 'at', argc: 1..3, kwargs: [:in], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'local', 'TimeObject', 'local', argc: 1..7, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'new', 'TimeObject', 'initialize', argc: 0..7, kwargs: [:in], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'now', 'TimeObject', 'now', argc: 0, kwargs: [:in], pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1181,7 +1181,7 @@ gen.binding('Symbol', 'upcase', 'SymbolObject', 'upcase', argc: 0, pass_env: tru
 
 gen.static_binding('Time', 'at', 'TimeObject', 'at', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'local', 'TimeObject', 'local', argc: 1..7, pass_env: true, pass_block: false, return_type: :Object)
-gen.static_binding('Time', 'new', 'TimeObject', 'initialize', argc: 0..7, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Time', 'new', 'TimeObject', 'initialize', argc: 0..7, kwargs: [:in], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'now', 'TimeObject', 'now', argc: 0, kwargs: [:in], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Time', 'utc', 'TimeObject', 'utc', argc: 1..7, pass_env: true, pass_block: false, return_type: :Object)
 

--- a/spec/core/time/minus_spec.rb
+++ b/spec/core/time/minus_spec.rb
@@ -86,8 +86,7 @@ describe "Time#-" do
     (Time.local(2012) - 10).should_not.utc?
   end
 
-  # NATFIXME: Implement time offsets
-  xit "returns a time with the same fixed offset as self" do
+  it "returns a time with the same fixed offset as self" do
     (Time.new(2012, 1, 1, 0, 0, 0, 3600) - 10).utc_offset.should == 3600
   end
 

--- a/spec/core/time/plus_spec.rb
+++ b/spec/core/time/plus_spec.rb
@@ -1,0 +1,120 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Time#+" do
+  it "increments the time by the specified amount" do
+    (Time.at(0) + 100).should == Time.at(100)
+  end
+
+  it "is a commutative operator" do
+    (Time.at(1.1) + 0.9).should == Time.at(0.9) + 1.1
+  end
+
+  it "adds a negative Float" do
+    t = Time.at(100) + -1.3
+    t.usec.should == 699999
+    t.to_i.should == 98
+  end
+
+  it "raises a TypeError if given argument is a coercible String" do
+    -> { Time.now + "1" }.should raise_error(TypeError)
+    -> { Time.now + "0.1" }.should raise_error(TypeError)
+    -> { Time.now + "1/3" }.should raise_error(TypeError)
+  end
+
+  it "increments the time by the specified amount as rational numbers" do
+    (Time.at(Rational(11, 10)) + Rational(9, 10)).should == Time.at(2)
+  end
+
+  it "accepts arguments that can be coerced into Rational" do
+    (obj = mock_numeric('10')).should_receive(:to_r).and_return(Rational(10))
+    (Time.at(100) + obj).should == Time.at(110)
+  end
+
+  it "raises TypeError on argument that can't be coerced into Rational" do
+    -> { Time.now + Object.new }.should raise_error(TypeError)
+    -> { Time.now + "stuff" }.should raise_error(TypeError)
+  end
+
+  it "returns a UTC time if self is UTC" do
+    (Time.utc(2012) + 10).should.utc?
+  end
+
+  it "returns a non-UTC time if self is non-UTC" do
+    (Time.local(2012) + 10).should_not.utc?
+  end
+
+  it "returns a time with the same fixed offset as self" do
+    (Time.new(2012, 1, 1, 0, 0, 0, 3600) + 10).utc_offset.should == 3600
+  end
+
+  # NATFIXME: Implement time zones
+  xit "preserves time zone" do
+    time_with_zone = Time.now.utc
+    time_with_zone.zone.should == (time_with_zone + 1).zone
+
+    time_with_zone = Time.now
+    time_with_zone.zone.should == (time_with_zone + 1).zone
+  end
+
+  # NATFIXME: Implement time zones
+  xcontext "zone is a timezone object" do
+    it "preserves time zone" do
+      zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+      time = Time.new(2012, 1, 1, 12, 0, 0, zone) + 1
+
+      time.zone.should == zone
+    end
+  end
+
+  it "does not return a subclass instance" do
+    c = Class.new(Time)
+    x = c.now + 1
+    x.should be_an_instance_of(Time)
+  end
+
+  it "raises TypeError on Time argument" do
+    -> { Time.now + Time.now }.should raise_error(TypeError)
+  end
+
+  it "raises TypeError on nil argument" do
+    -> { Time.now + nil }.should raise_error(TypeError)
+  end
+
+  #see [ruby-dev:38446]
+  it "tracks microseconds" do
+    time = Time.at(0)
+    time += Rational(123_456, 1_000_000)
+    time.usec.should == 123_456
+    time += Rational(654_321, 1_000_000)
+    time.usec.should == 777_777
+  end
+
+  it "tracks nanoseconds" do
+    time = Time.at(0)
+    time += Rational(123_456_789, 1_000_000_000)
+    time.nsec.should == 123_456_789
+    time += Rational(876_543_210, 1_000_000_000)
+    time.nsec.should == 999_999_999
+  end
+
+  it "maintains precision" do
+    t = Time.at(0) + Rational(8_999_999_999_999_999, 1_000_000_000_000_000)
+    t.should_not == Time.at(9)
+  end
+
+  it "maintains microseconds precision" do
+    time = Time.at(0) + Rational(8_999_999_999_999_999, 1_000_000_000_000_000)
+    time.usec.should == 999_999
+  end
+
+  it "maintains nanoseconds precision" do
+    time = Time.at(0) + Rational(8_999_999_999_999_999, 1_000_000_000_000_000)
+    time.nsec.should == 999_999_999
+  end
+
+  it "maintains subseconds precision" do
+    time = Time.at(0) + Rational(8_999_999_999_999_999, 1_000_000_000_000_000)
+    time.subsec.should == Rational(999_999_999_999_999, 1_000_000_000_000_000)
+  end
+end

--- a/spec/core/time/shared/gmt_offset.rb
+++ b/spec/core/time/shared/gmt_offset.rb
@@ -48,15 +48,13 @@ describe :time_gmt_offset, shared: true do
   end
 
   context 'given positive offset' do
-    # NATFIXME: Implement more of Time#new
-    xit 'returns a positive offset' do
+    it 'returns a positive offset' do
       Time.new(2013,3,17,nil,nil,nil,"+03:00").send(@method).should == 10800
     end
   end
 
   context 'given negative offset' do
-    # NATFIXME: Implement more of Time#new
-    xit 'returns a negative offset' do
+    it 'returns a negative offset' do
       Time.new(2013,3,17,nil,nil,nil,"-03:00").send(@method).should == -10800
     end
   end

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -15,7 +15,7 @@ TimeObject *TimeObject::at(Env *env, Value time, Value subsec, Value unit, Value
     auto result = at(env, time, subsec, unit);
     if (in) {
         result->m_time.tm_gmtoff = normalize_timezone(env, in);
-        result->m_time.tm_zone = (char *)"UTC";
+        result->m_time.tm_zone = "UTC";
     }
     return result;
 }

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -1,4 +1,5 @@
 #include "natalie.hpp"
+#include <string.h>
 
 namespace Natalie {
 
@@ -15,7 +16,8 @@ TimeObject *TimeObject::at(Env *env, Value time, Value subsec, Value unit, Value
     auto result = at(env, time, subsec, unit);
     if (in) {
         result->m_time.tm_gmtoff = normalize_timezone(env, in);
-        result->m_time.tm_zone = "UTC";
+        result->m_zone = strdup("UTC");
+        result->m_time.tm_zone = result->m_zone;
     }
     return result;
 }
@@ -572,7 +574,7 @@ Value TimeObject::zone(Env *env) const {
     if (is_utc(env)) {
         return new StringObject { "UTC", Encoding::US_ASCII };
     }
-    return new StringObject { m_time.tm_zone, Encoding::US_ASCII };
+    return new StringObject { m_zone, Encoding::US_ASCII };
 }
 
 }

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -27,19 +27,25 @@ TimeObject *TimeObject::create(Env *env) {
     return now(env, nullptr);
 }
 
-TimeObject *TimeObject::initialize(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec, Value zone) {
+TimeObject *TimeObject::initialize(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec, Value tmzone, Value in) {
     if (!year) {
         return now(env, nullptr);
     } else if (year->is_nil()) {
         env->raise("TypeError", "Year cannot be nil");
     } else {
-
         auto result = now(env, nullptr);
         result->build_time(env, year, month, mday, hour, min, sec);
         int seconds = mktime(&result->m_time);
         result->m_mode = Mode::Localtime;
         result->m_integer = Value::integer(seconds);
         result->m_subsec = nullptr;
+        if (tmzone && in) {
+            env->raise("ArgumentError", "cannot specify zone and in:");
+        } else if (tmzone) {
+            result->m_time.tm_gmtoff = normalize_timezone(env, tmzone);
+        } else if (in) {
+            result->m_time.tm_gmtoff = normalize_timezone(env, in);
+        }
         return result;
     }
 }
@@ -264,6 +270,62 @@ Value TimeObject::yday(Env *) const {
 
 Value TimeObject::year(Env *) const {
     return Value::integer(m_time.tm_year + 1900);
+}
+
+// utc-offset and military timezone decoding
+nat_int_t TimeObject::normalize_timezone(Env *env, Value val) {
+    nat_int_t minsec = 60; // seconds in an minute
+    nat_int_t hoursec = 3600; // seconds in an hour
+    if (val->is_string()) {
+        auto str = val->as_string()->string();
+        auto ssize = str.size();
+        if (str == "UTC") {
+            return 0;
+        } else if (ssize == 1) {
+            char mil_tz = str.at(0);
+            // https://en.wikipedia.org/wiki/List_of_military_time_zones
+            if (mil_tz >= 'A' && mil_tz <= 'I') {
+                return (mil_tz - 'A' + 1) * hoursec;
+            } else if (mil_tz >= 'K' && mil_tz <= 'M') {
+                return (mil_tz - 'K' + 10) * hoursec;
+            } else if (mil_tz >= 'N' && mil_tz <= 'Y') {
+                return (mil_tz - 'N' + 1) * -1 * hoursec;
+            } else if (mil_tz == 'Z') {
+                return 0;
+            }
+            // other single characters are illegal
+        } else if (ssize == 6 || ssize == 9) {
+            char sign = str.at(0);
+            if ((sign == '+' || sign == '-') && isdigit(str[1]) && isdigit(str[2]) && str[3] == ':' && isdigit(str[4]) && isdigit(str[5]) && (ssize == 6 || (str[6] == ':' && isdigit(str[7]) && isdigit(str[8])))) {
+
+                nat_int_t isign = (sign == '+') ? 1 : -1;
+                auto hour = atoi(str.substring(1, 2).c_str());
+                auto min = atoi(str.substring(4, 2).c_str());
+                nat_int_t sec = 0;
+                if (ssize == 9) {
+                    sec = atoi(str.substring(7, 2).c_str());
+                }
+                if (hour < 24 && min < 60 && sec < 60) {
+                    return isign * ((hour * hoursec) + (min * minsec) + sec);
+                } else {
+                    env->raise("ArgumentError", "utc_offset out of range");
+                }
+            }
+        }
+        // any fall-through of the above ugly logic
+        env->raise("ArgumentError", "\"+HH:MM\", \"-HH:MM\", \"UTC\" or \"A\"..\"I\",\"K\"..\"Z\" expected for utc_offset: {}", str);
+    }
+    if (!val->is_integer() && val->respond_to(env, "to_int"_s)) {
+        val = val->send(env, "to_int"_s);
+    }
+    if (val->is_integer()) {
+        auto seconds = val->as_integer()->to_nat_int_t();
+        if (seconds > hoursec * -24 && seconds < hoursec * 24) {
+            return seconds;
+        }
+        env->raise("ArgumentError", "utc_offset out of range");
+    }
+    env->raise("NotImplementedError", "Not implemented for non String/Integer arg");
 }
 
 nat_int_t TimeObject::normalize_field(Env *env, Value val) {


### PR DESCRIPTION

+   Add `in:` kwarg for `Time.new`, 
+    Fix `Time.new` to set UTC mode when in/zone provided.
+   Add timezone/utc-offset support for `Time.new`, including numeric, `+/-HH:MM(:SS)` and Military TZ support,
+    Fix second handling in `Time.new` .
+    Preserve utc_offset in result for `Time#+` and `Time#-`
+    Remove resolved NATFIXMEs gmt_offset specs because more of Time.new is functional.
