### PR TITLE
Fixes for singleton classes and frozen properties

### DIFF
--- a/include/natalie/complex_object.hpp
+++ b/include/natalie/complex_object.hpp
@@ -13,20 +13,28 @@ class ComplexObject : public Object {
 
 public:
     ComplexObject()
-        : Object { Object::Type::Complex, GlobalEnv::the()->Object()->const_fetch("Complex"_s)->as_class() } { }
+        : Object { Object::Type::Complex, GlobalEnv::the()->Object()->const_fetch("Complex"_s)->as_class() } {
+        freeze();
+    }
 
     ComplexObject(ClassObject *klass)
-        : Object { Object::Type::Complex, klass } { }
+        : Object { Object::Type::Complex, klass } {
+        freeze();
+    }
 
     ComplexObject(Value real)
         : Object { Object::Type::Complex, GlobalEnv::the()->Object()->const_fetch("Complex"_s)->as_class() }
         , m_real { real }
-        , m_imaginary { Value::integer(0) } { }
+        , m_imaginary { Value::integer(0) } {
+        freeze();
+    }
 
     ComplexObject(Value real, Value imaginary)
         : Object { Object::Type::Complex, GlobalEnv::the()->Object()->const_fetch("Complex"_s)->as_class() }
         , m_real { real }
-        , m_imaginary { imaginary } { }
+        , m_imaginary { imaginary } {
+        freeze();
+    }
 
     Value imaginary(Env *);
     Value inspect(Env *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -302,7 +302,7 @@ public:
 
     bool is_main_object() const { return this == GlobalEnv::the()->main_obj(); }
 
-    void freeze() { m_flags = m_flags | Flag::Frozen; }
+    void freeze();
     bool is_frozen() const { return is_integer() || is_float() || (m_flags & Flag::Frozen) == Flag::Frozen; }
 
     void add_synthesized_flag() { m_flags = m_flags | Flag::Synthesized; }

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -11,12 +11,16 @@ public:
     RationalObject(IntegerObject *numerator, IntegerObject *denominator)
         : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s)->as_class() }
         , m_numerator { numerator }
-        , m_denominator { denominator } { }
+        , m_denominator { denominator } {
+        freeze();
+    }
 
     RationalObject(const RationalObject &other)
         : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s)->as_class() }
         , m_numerator { other.m_numerator }
-        , m_denominator { other.m_denominator } { }
+        , m_denominator { other.m_denominator } {
+        freeze();
+    }
 
     static RationalObject *create(Env *env, IntegerObject *numerator, IntegerObject *denominator);
 

--- a/spec/language/singleton_class_spec.rb
+++ b/spec/language/singleton_class_spec.rb
@@ -37,13 +37,13 @@ describe "A singleton class" do
     Class.should be_ancestor_of(Object.singleton_class)
   end
 
-  # NATFIXME: A singleton class should be a subclass of Class's singleton class
+  # NATFIXME: is a subclass of Class's singleton class
   xit "is a subclass of Class's singleton class" do
     ec = ClassSpecs::A.singleton_class
     ec.should be_kind_of(Class.singleton_class)
   end
 
-  # NATFIXME: A singleton class should be a subclass of the same level of Class's singleton class
+  # NATFIXME: is a subclass of the same level of Class's singleton class
   xit "is a subclass of the same level of Class's singleton class" do
     ecec = ClassSpecs::A.singleton_class.singleton_class
     class_ec = Class.singleton_class
@@ -80,7 +80,7 @@ describe "A singleton class" do
   end
 end
 
-# NATFIXME: constants on singleton classes
+# NATFIXME: A constant on a singleton class results in a time out
 xdescribe "A constant on a singleton class" do
   before :each do
     @object = Object.new
@@ -270,13 +270,13 @@ describe "Class methods of a singleton class" do
     end
   end
 
-  # NATFIXME: A singleton class should be a subclass of Class's singleton class
-  xdescribe "for a singleton class" do
+  describe "for a singleton class" do
     it "include instance methods of the singleton class of Class" do
       @a_c_sc.singleton_class.should have_method(:example_instance_method_of_singleton_class)
     end
 
-    it "include class methods of the singleton class of Class" do
+    # NATFIXME: include class methods of the singleton class of Class
+    xit "include class methods of the singleton class of Class" do
       @a_c_sc.singleton_class.should have_method(:example_class_method_of_singleton_class)
     end
   end

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -711,12 +711,16 @@ void Object::alias(Env *env, SymbolObject *new_name, SymbolObject *old_name) {
 
 SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
     ClassObject *klass = singleton_class(env);
+    if (klass->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", to_s(env)->string());
     klass->define_method(env, name, fn, arity, optimized);
     return name;
 }
 
 SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, Block *block) {
     ClassObject *klass = singleton_class(env);
+    if (klass->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", to_s(env)->string());
     klass->define_method(env, name, block);
     return name;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -553,6 +553,7 @@ ClassObject *Object::singleton_class(Env *env) {
     auto new_singleton_class = new ClassObject { singleton_superclass };
     singleton_superclass->initialize_subclass_without_checks(new_singleton_class, env, name);
     set_singleton_class(new_singleton_class);
+    if (is_frozen()) m_singleton_class->freeze();
     return m_singleton_class;
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1001,6 +1001,11 @@ ProcObject *Object::to_proc(Env *env) {
     }
 }
 
+void Object::freeze() {
+    m_flags = m_flags | Flag::Frozen;
+    if (m_singleton_class) m_singleton_class->freeze();
+}
+
 Value Object::instance_eval(Env *env, Value string, Block *block) {
     if (string || !block) {
         env->raise("ArgumentError", "Natalie only supports instance_eval with a block");

--- a/test/natalie/complex_test.rb
+++ b/test/natalie/complex_test.rb
@@ -25,4 +25,9 @@ describe 'complex' do
   it 'does not have have Comparable mixin more than once' do
     Complex.ancestors.count(Comparable).should == 1
   end
+
+  it 'is frozen' do
+    r = Complex(1)
+    r.frozen?.should == true
+  end
 end

--- a/test/natalie/complex_test.rb
+++ b/test/natalie/complex_test.rb
@@ -26,6 +26,7 @@ describe 'complex' do
     Complex.ancestors.count(Comparable).should == 1
   end
 
+  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1007 is merged
   it 'is frozen' do
     r = Complex(1)
     r.frozen?.should == true

--- a/test/natalie/rational_test.rb
+++ b/test/natalie/rational_test.rb
@@ -12,4 +12,9 @@ describe 'rational' do
     reduced.numerator.should == 10
     reduced.denominator.should == 3
   end
+
+  it 'is frozen' do
+    r = Rational(1)
+    r.frozen?.should == true
+  end
 end

--- a/test/natalie/rational_test.rb
+++ b/test/natalie/rational_test.rb
@@ -13,6 +13,7 @@ describe 'rational' do
     reduced.denominator.should == 3
   end
 
+  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1007 is merged
   it 'is frozen' do
     r = Rational(1)
     r.frozen?.should == true

--- a/test/natalie/singleton_class_test.rb
+++ b/test/natalie/singleton_class_test.rb
@@ -71,4 +71,11 @@ describe 'singleton_class' do
     o.freeze
     klass.frozen?.should == true
   end
+
+  it 'cannot define a method on a frozen singleton class' do
+    o = Object.new
+    o.freeze
+    klass = o.singleton_class
+    -> { o.define_singleton_method(:foo) { 1 } }.should raise_error(FrozenError)
+  end
 end

--- a/test/natalie/singleton_class_test.rb
+++ b/test/natalie/singleton_class_test.rb
@@ -56,4 +56,19 @@ describe 'singleton_class' do
     true.singleton_class.singleton_class?.should == false
     false.singleton_class.singleton_class?.should == false
   end
+
+  it 'is frozen if the object it is created from is frozen' do
+    o = Object.new
+    o.freeze
+    klass = o.singleton_class
+    klass.frozen?.should == true
+  end
+
+  it 'will be frozen if the object it is created from becomes frozen' do
+    o = Object.new
+    klass = o.singleton_class
+    klass.frozen?.should == false
+    o.freeze
+    klass.frozen?.should == true
+  end
 end

--- a/test/natalie/singleton_class_test.rb
+++ b/test/natalie/singleton_class_test.rb
@@ -57,6 +57,7 @@ describe 'singleton_class' do
     false.singleton_class.singleton_class?.should == false
   end
 
+  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1008 is merged
   it 'is frozen if the object it is created from is frozen' do
     o = Object.new
     o.freeze
@@ -64,6 +65,7 @@ describe 'singleton_class' do
     klass.frozen?.should == true
   end
 
+  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1008 is merged
   it 'will be frozen if the object it is created from becomes frozen' do
     o = Object.new
     klass = o.singleton_class
@@ -72,6 +74,7 @@ describe 'singleton_class' do
     klass.frozen?.should == true
   end
 
+  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1008 is merged
   it 'cannot define a method on a frozen singleton class' do
     o = Object.new
     o.freeze


### PR DESCRIPTION
A fine example of yak shaving when I was looking into fixing the spec of [Singleton method on Numeric](https://github.com/ruby/spec/blob/master/core/numeric/singleton_method_added_spec.rb). I found some inconsistencies between objects being frozen with MRI. A few new Natalie tests have been added, I'm going to try to push those to the upstream specs.