### PR TITLE
Add missing ">" to Stringification of Set

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -56,7 +56,7 @@ class Set
   end
 
   def inspect
-    "#<Set: {#{to_a}}"
+    "#<Set: {#{to_a}}>"
   end
   alias to_s inspect
 


### PR DESCRIPTION
Just noticed this while I was writing  #875: The stringification methods of Set were missing the final `>`. Since the specs are pretty incomplete in this case (we're skipping the spec for the recursive case, so the only test left was just to see if the output was a String), this went unnoticed in the specs