### PR TITLE
Enable passing `-e` multiple times

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -14,7 +14,7 @@ require 'tempfile'
 
 require_relative '../lib/natalie'
 
-options = { load_path: [], require: [], profile: false, transform_only: false }
+options = { load_path: [], require: [], execute: [], profile: false, transform_only: false }
 OptionParser.new do |opts|
   opts.banner = 'Usage: natalie [options] file.rb'
 
@@ -52,7 +52,7 @@ OptionParser.new do |opts|
   end
 
   opts.on('-e one-line-script', 'Execute one-line script') do |e|
-    options[:execute] = e
+    options[:execute] << e
   end
 
   opts.on(
@@ -258,9 +258,9 @@ class Runner
   end
 
   def load_code
-    if options[:execute]
+    if options[:execute].any?
       @source_path = '-e'
-      @code = options[:execute].gsub(/\\n/, "\n")
+      @code = options[:execute].join("\n").gsub(/\\n/, "\n")
       if options[:require].any?
         @code = options[:require].map { |l| "require #{l.inspect}" }.join("\n") + "\n" + @code
       end

--- a/spec/command_line/dash_e_spec.rb
+++ b/spec/command_line/dash_e_spec.rb
@@ -5,8 +5,7 @@ describe "The -e command line option" do
     ruby_exe("puts 'foo'").chomp.should == "foo"
   end
 
-  # NATFIXME: Support -e multiple times
-  xit "joins multiple strings with newlines" do
+  it "joins multiple strings with newlines" do
     ruby_exe(nil, args: %Q{-e "puts 'hello" -e "world'" 2>&1}).chomp.should == "hello\nworld"
   end
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -204,7 +204,11 @@ end
 
 def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0)
   binary = ENV['NAT_BINARY'] || 'bin/natalie'
-  return binary if code.nil?
+  if code.nil?
+    return binary if args.nil?
+
+    return `#{binary} #{options} #{args}`
+  end
 
   output = if !escape
              `#{binary} #{options} -e #{code.inspect} #{args}`


### PR DESCRIPTION
This did require a slight fix in the `ruby_exe` method as well, since this hit a case we didn't see before.