### PR TITLE
Stub method SpecEvaluate#desc=

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -84,6 +84,12 @@ class ScratchPad
   end
 end
 
+class SpecEvaluate
+  # NATFIXME: Implement this method
+  def self.desc=(description)
+  end
+end
+
 def ci?
   !!ENV['CI']
 end


### PR DESCRIPTION
For now just ignore the value. The description does not appear to be used, and this sub implementation resolves a few crashes in the spec results.