### PR TITLE
Implement UTF16-BE encoding

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -23,6 +23,7 @@
 #include "natalie/dir_object.hpp"
 #include "natalie/encoding/ascii_8bit_encoding_object.hpp"
 #include "natalie/encoding/us_ascii_encoding_object.hpp"
+#include "natalie/encoding/utf16be_encoding_object.hpp"
 #include "natalie/encoding/utf16le_encoding_object.hpp"
 #include "natalie/encoding/utf32be_encoding_object.hpp"
 #include "natalie/encoding/utf32le_encoding_object.hpp"

--- a/include/natalie/encoding/utf16be_encoding_object.hpp
+++ b/include/natalie/encoding/utf16be_encoding_object.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <assert.h>
+#include <initializer_list>
+
+#include "natalie/encoding_object.hpp"
+#include "natalie/string_object.hpp"
+
+namespace Natalie {
+
+using namespace TM;
+
+class Utf16BeEncodingObject : public EncodingObject {
+public:
+    Utf16BeEncodingObject()
+        : EncodingObject { Encoding::UTF_16BE, { "UTF-16BE" } } { }
+
+    virtual bool valid_codepoint(nat_int_t codepoint) const override {
+        // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
+        return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
+    }
+
+    virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
+    virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
+
+    virtual String escaped_char(unsigned char c) const override;
+
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override;
+    virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const override;
+
+    virtual String encode_codepoint(nat_int_t codepoint) const override;
+    virtual nat_int_t decode_codepoint(StringView &str) const override;
+};
+
+}

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -51,6 +51,9 @@ public:
         case Encoding::UTF_16LE:
             // it's positive and takes 1-4 bytes
             return codepoint >= 0 && codepoint < 0x10000000000;
+        case Encoding::UTF_16BE:
+            // it's positive and takes 1-4 bytes
+            return codepoint >= 0 && codepoint < 0x10000000000;
         }
         NAT_UNREACHABLE();
     }

--- a/include/natalie/encodings.hpp
+++ b/include/natalie/encodings.hpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 
-const int EncodingCount = 6;
+const int EncodingCount = 7;
 
 enum class Encoding {
     ASCII_8BIT = 1,
@@ -11,6 +11,7 @@ enum class Encoding {
     UTF_32LE = 4,
     UTF_32BE = 5,
     UTF_16LE = 6,
+    UTF_16BE = 7,
 };
 
 }

--- a/spec/core/array/shared/inspect.rb
+++ b/spec/core/array/shared/inspect.rb
@@ -127,7 +127,7 @@ describe :array_inspect, shared: true do
       array.send(@method).encoding.name.should == "US-ASCII"
     end
 
-    # NATFIXME: implement Encoding.default_external
+    # NATFIXME: Implement String#encode!
     xit "does not raise if inspected result is not default external encoding" do
       utf_16be = mock("utf_16be")
       utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode!(Encoding::UTF_16BE))

--- a/spec/core/hash/shared/to_s.rb
+++ b/spec/core/hash/shared/to_s.rb
@@ -89,7 +89,7 @@ describe :hash_to_s, shared: true do
     end
   end
 
-  # NATFIXME: we don't have this character encoding
+  # NATFIXME: Implement String#encode!
   xit "does not raise if inspected result is not default external encoding" do
     utf_16be = mock("utf_16be")
     utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode!(Encoding::UTF_16BE))

--- a/spec/core/string/ascii_only_spec.rb
+++ b/spec/core/string/ascii_only_spec.rb
@@ -51,8 +51,7 @@ describe "String#ascii_only?" do
 
   it "returns false for the empty String with a non-ASCII-compatible encoding" do
     "".force_encoding('UTF-16LE').ascii_only?.should be_false
-    # NATFIXME: Implement UTF-16BE encoding
-    # "".encode('UTF-16BE').ascii_only?.should be_false
+    "".encode('UTF-16BE').ascii_only?.should be_false
   end
 
   it "returns false for a non-empty String with non-ASCII-compatible encoding" do

--- a/src/encoding/utf16be_encoding_object.cpp
+++ b/src/encoding/utf16be_encoding_object.cpp
@@ -1,0 +1,159 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+std::pair<bool, StringView> Utf16BeEncodingObject::prev_char(const String &string, size_t *index) const {
+    if (*index == 0)
+        return { true, StringView() };
+
+    size_t i = *index;
+
+    // there are not enough bytes left
+    if (*index < 2) {
+        *index--;
+        return { false, StringView(&string, i - 1, 1) };
+    }
+
+    size_t code_unit_high = (unsigned char)string[i - 2]
+        + ((unsigned char)string[i - 1] << 8);
+
+    //  2-bytes logic
+
+    // single code unit - 0000..D7FF or E000..FFFF
+    if (code_unit_high <= 0xD7FF || code_unit_high >= 0xE000) {
+        *index -= 2;
+        return { true, StringView(&string, i - 2, 2) };
+    }
+
+    // there are not enough bytes left
+    if (*index < 4) {
+        *index--;
+        return { false, StringView(&string, i - 1, 1) };
+    }
+
+    //  4-bytes logic
+
+    size_t code_unit_low = (unsigned char)string[i - 4]
+        + ((unsigned char)string[i - 3] << 8);
+
+    // 1st code unit - D800..DBFF and 2nd - DC00..DFFF
+    if (code_unit_low >= 0xD800 && code_unit_low <= 0xDBFF
+        && code_unit_high >= 0xDC00 && code_unit_high <= 0xDFFF) {
+        *index -= 4;
+        return { true, StringView(&string, i - 4, 4) };
+    }
+
+    *index -= 2;
+    return { false, StringView(&string, i - 2, 2) };
+}
+
+/*
+    See: https://en.wikipedia.org/wiki/UTF-16
+*/
+std::pair<bool, StringView> Utf16BeEncodingObject::next_char(const String &string, size_t *index) const {
+    size_t len = string.size();
+    size_t i = *index;
+
+    if (*index >= len)
+        return { true, StringView() };
+
+    // there are not enough bytes left
+    if (*index + 1 >= len) {
+        *index += 1;
+        return { false, StringView(&string, i, 1) };
+    }
+
+    size_t code_unit_low = (unsigned char)string[i]
+        + ((unsigned char)string[i + 1] << 8);
+
+    //  2-bytes logic
+
+    // single code unit - 0000..D7FF or E000..FFFF
+    if (code_unit_low <= 0xD7FF || code_unit_low >= 0xE000) {
+        *index += 2;
+        return { true, StringView(&string, i, 2) };
+    }
+
+    // there are not enough bytes left
+    if (*index + 3 >= len) {
+        *index += 2;
+        return { false, StringView(&string, i, 2) };
+    }
+
+    //  4-bytes logic
+
+    size_t code_unit_high = (unsigned char)string[i + 2]
+        + ((unsigned char)string[i + 3] << 8);
+
+    // 1st code unit - D800..DBFF and 2nd - DC00..DFFF
+    if (code_unit_low >= 0xD800 && code_unit_low <= 0xDBFF
+        && code_unit_high >= 0xDC00 && code_unit_high <= 0xDFFF) {
+        *index += 4;
+        return { true, StringView(&string, i, 4) };
+    }
+
+    *index += 2;
+    return { false, StringView(&string, i, 2) };
+}
+
+String Utf16BeEncodingObject::escaped_char(unsigned char c) const {
+    char buf[7];
+    snprintf(buf, 7, "\\u%04llX", (long long)c);
+    return String(buf);
+}
+
+nat_int_t Utf16BeEncodingObject::to_unicode_codepoint(nat_int_t codepoint) const {
+    return codepoint;
+}
+
+nat_int_t Utf16BeEncodingObject::from_unicode_codepoint(nat_int_t codepoint) const {
+    return codepoint;
+}
+
+String Utf16BeEncodingObject::encode_codepoint(nat_int_t codepoint) const {
+    String buf;
+
+    if (codepoint <= 0xFFFF) {
+        buf.append_char(codepoint >> 8);
+        buf.append_char(codepoint & 0xFF);
+    } else if (codepoint <= 0x10FFFF) {
+        size_t code_unit_low = ((codepoint - 0x10000) & 0x03FF) + 0xDC00;
+        size_t code_unit_high = ((codepoint - 0x10000) >> 10) + 0xD800;
+
+        buf.append_char(code_unit_low >> 8);
+        buf.append_char(code_unit_low & 0xFF);
+        buf.append_char(code_unit_high >> 8);
+        buf.append_char(code_unit_high & 0xFF);
+    } else {
+        TM_UNREACHABLE();
+    }
+
+    return buf;
+}
+
+nat_int_t Utf16BeEncodingObject::decode_codepoint(StringView &str) const {
+    switch (str.size()) {
+    case 2:
+        // assert(result < 0xD800 || result > 0xDFFF)
+
+        return ((unsigned char)str[1] << 8)
+            + ((unsigned char)str[0]);
+    case 4: {
+        int high_surrogate = ((unsigned char)str[2])
+            + ((unsigned char)str[3] << 8);
+        int low_surrogate = ((unsigned char)str[0])
+            + ((unsigned char)str[1] << 8);
+
+        // assert(high_surrogate >= 0xD800 && high_surrogate <= 0xDBFF)
+        // assert(low_surrogate >= 0xDC00 && low_surrogate <= 0xDFFF)
+
+        return ((high_surrogate - 0xD800) << 10)
+            + (low_surrogate - 0xDC00)
+            + 0x10000;
+    }
+    default:
+        return -1;
+    }
+}
+
+}

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -201,6 +201,9 @@ Env *build_top_env() {
     Value EncodingUTF16LE = new Utf16LeEncodingObject {};
     Encoding->const_set("UTF_16LE"_s, EncodingUTF16LE);
 
+    Value EncodingUTF16BE = new Utf16BeEncodingObject {};
+    Encoding->const_set("UTF_16BE"_s, EncodingUTF16BE);
+
     Value EncodingUTF32LE = new Utf32LeEncodingObject {};
     Encoding->const_set("UTF_32LE"_s, EncodingUTF32LE);
     Encoding->const_set("UCS_4LE"_s, EncodingUTF32LE);


### PR DESCRIPTION
In my mind, this would resolve a lot of issues in the spec, but once I tried I could only enable 1 line.