### PR TITLE
Pass -r arguments to Natalie to legacy REPL

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -136,7 +136,7 @@ class Runner
     load_code
     if @repl
       repl = options[:experimental_repl_v2] ? Natalie::ExperimentalReplV2.new : Natalie::Repl.new
-      repl.go
+      repl.go(options)
     elsif options[:ast]
       if RUBY_ENGINE == 'natalie'
         # FIXME: implement PrettyPrinter

--- a/lib/natalie/repl/legacy.rb
+++ b/lib/natalie/repl/legacy.rb
@@ -23,12 +23,12 @@ end
 
 module Natalie
   class Repl
-    def go
+    def go(options)
       GC.disable
       env = nil
       vars = {}
       repl_num = 0
-      multi_line_expr = []
+      multi_line_expr = options[:require].map { |file| "require '#{file}'" }
       loop do
         break unless (line = get_line)
         begin

--- a/lib/natalie/repl/main.rb
+++ b/lib/natalie/repl/main.rb
@@ -5,7 +5,7 @@ require_relative 'repl'
 
 module Natalie
   class ExperimentalReplV2
-    def go
+    def go(_options)
       GC.disable
       env = nil
       vars = {}


### PR DESCRIPTION
This is the first step in fixing #875. The default/legacy REPL now works. The experimental REPL does receive the argument, but ignores it for now.

I might have a look at the v2-repl one day, but for now this resolves a few issues I had to work around.