### PR TITLE
Import basicobject_spec

### DIFF
--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -53,7 +53,7 @@ public:
 
     Value const_get(Env *, Value) const;
     Value const_set(Env *, Value, Value);
-    Value constants(Env *) const;
+    Value constants(Env *, Value) const;
 
     void make_alias(Env *, SymbolObject *, SymbolObject *);
     virtual void alias(Env *, SymbolObject *, SymbolObject *) override;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -907,7 +907,7 @@ gen.binding('Module', 'class_exec', 'ModuleObject', 'module_exec', argc: :any, p
 gen.binding('Module', 'const_defined?', 'ModuleObject', 'const_defined', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Module', 'const_get', 'ModuleObject', 'const_get', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'const_set', 'ModuleObject', 'const_set', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Module', 'constants', 'ModuleObject', 'constants', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Module', 'constants', 'ModuleObject', 'constants', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'define_method', 'ModuleObject', 'define_method', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Module', 'deprecate_constant', 'ModuleObject', 'deprecate_constant', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'extend', 'Object', 'extend', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/basicobject/basicobject_spec.rb
+++ b/spec/core/basicobject/basicobject_spec.rb
@@ -1,0 +1,96 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+
+describe "BasicObject" do
+  it "raises NoMethodError for nonexistent methods after #method_missing is removed" do
+    script = fixture __FILE__, "remove_method_missing.rb"
+    ruby_exe(script).chomp.should == "NoMethodError"
+  end
+
+  # NATFIXME: raises NameError when referencing built-in constants
+  xit "raises NameError when referencing built-in constants" do
+    -> { class BasicObjectSpecs::BOSubclass; Kernel; end }.should raise_error(NameError)
+  end
+
+  # NATFIXME: does not define built-in constants (according to const_defined?)
+  xit "does not define built-in constants (according to const_defined?)" do
+    BasicObject.const_defined?(:Kernel).should be_false
+  end
+
+  # NATFIXME: does not define built-in constants (according to defined?)
+  xit "does not define built-in constants (according to defined?)" do
+    BasicObjectSpecs::BOSubclass.kernel_defined?.should be_nil
+  end
+
+  it "is included in Object's list of constants" do
+    Object.constants(false).should include(:BasicObject)
+  end
+
+  # NATFIXME: includes itself in its list of constants
+  xit "includes itself in its list of constants" do
+    BasicObject.constants(false).should include(:BasicObject)
+  end
+end
+
+describe "BasicObject metaclass" do
+  before :each do
+    @meta = class << BasicObject; self; end
+  end
+
+  it "is an instance of Class" do
+    @meta.should be_an_instance_of(Class)
+  end
+
+  it "has Class as superclass" do
+    @meta.superclass.should equal(Class)
+  end
+
+  it "contains methods for the BasicObject class" do
+    @meta.class_eval do
+      def rubyspec_test_method() :test end
+    end
+
+    BasicObject.rubyspec_test_method.should == :test
+  end
+end
+
+describe "BasicObject instance metaclass" do
+  before :each do
+    @object = BasicObject.new
+    @meta = class << @object; self; end
+  end
+
+  it "is an instance of Class" do
+    @meta.should be_an_instance_of(Class)
+  end
+
+  it "has BasicObject as superclass" do
+    @meta.superclass.should equal(BasicObject)
+  end
+
+  it "contains methods defined for the BasicObject instance" do
+    @meta.class_eval do
+      def test_method() :test end
+    end
+
+    @object.test_method.should == :test
+  end
+end
+
+describe "BasicObject subclass" do
+  it "contains Kernel methods when including Kernel" do
+    obj = BasicObjectSpecs::BOSubclass.new
+
+    obj.instance_variable_set(:@test, :value)
+    obj.instance_variable_get(:@test).should == :value
+
+    obj.respond_to?(:hash).should == true
+  end
+
+  describe "BasicObject references" do
+    # NATFIXME: uninitialized constant BasicObject::BasicObject (NameError)
+    xit "can refer to BasicObject from within itself" do
+      -> { BasicObject::BasicObject }.should_not raise_error
+    end
+  end
+end

--- a/spec/core/basicobject/fixtures/common.rb
+++ b/spec/core/basicobject/fixtures/common.rb
@@ -1,0 +1,11 @@
+module BasicObjectSpecs
+  class BOSubclass < BasicObject
+    def self.kernel_defined?
+      defined?(Kernel)
+    end
+
+    # NATFIXME: This results in "wrong number of arguments (given 0, expected 1+) (ArgumentError)"
+    # include ::Kernel
+    include(::Kernel)
+  end
+end

--- a/spec/core/basicobject/fixtures/remove_method_missing.rb
+++ b/spec/core/basicobject/fixtures/remove_method_missing.rb
@@ -1,0 +1,9 @@
+class BasicObject
+  remove_method :method_missing
+end
+
+begin
+  Object.new.test_method
+rescue NoMethodError => e
+  puts e.class.name
+end

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -208,10 +208,17 @@ Value ModuleObject::const_set(Env *env, Value name, Value val) {
     return const_set(name->to_symbol(env, Object::Conversion::Strict), val);
 }
 
-Value ModuleObject::constants(Env *env) const {
+Value ModuleObject::constants(Env *env, Value inherit) const {
     auto ary = new ArrayObject;
     for (auto pair : m_constants)
         ary->push(pair.first);
+    if (inherit == nullptr || inherit->is_truthy()) {
+        for (ModuleObject *module : m_included_modules) {
+            if (module != this) {
+                ary->concat(*module->constants(env, inherit)->as_array());
+            }
+        }
+    }
     return ary;
 }
 


### PR DESCRIPTION
This unearthed an error with include without parentheses. Support for the argument `inherit` in `Module#constants` has been added.