### PR TITLE
RbConfig updates

### DIFF
--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -92,7 +92,7 @@ module Natalie
       def macro_require(expr:, current_path:) # rubocop:disable Lint/UnusedMethodArgument
         args = expr[3..]
         node = args.first
-        raise ArgumentError, "Expected a String, but got #{node.inspect}" unless node.sexp_type == :str
+        raise ArgumentError, "Expected a String, but got #{node.inspect} at #{node.file}##{node.line}" unless node.sexp_type == :str
         name = node[1]
         return s(:block) if name == 'tempfile' && interpret? # FIXME: not sure how to handle this actually
         if name == 'natalie/inline'
@@ -110,7 +110,7 @@ module Natalie
       def macro_require_relative(expr:, current_path:)
         args = expr[3..]
         node = args.first
-        raise ArgumentError, "Expected a String, but got #{node.inspect}" unless node.sexp_type == :str
+        raise ArgumentError, "Expected a String, but got #{node.inspect} at #{node.file}##{node.line}" unless node.sexp_type == :str
         name = node[1]
         base = File.dirname(current_path)
         ['.rb', '.cpp', ''].each do |extension|
@@ -124,7 +124,7 @@ module Natalie
       def macro_load(expr:, current_path:) # rubocop:disable Lint/UnusedMethodArgument
         args = expr[3..]
         node = args.first
-        raise ArgumentError, "Expected a String, but got #{node.inspect}" unless node.sexp_type == :str
+        raise ArgumentError, "Expected a String, but got #{node.inspect} at #{node.file}##{node.line}" unless node.sexp_type == :str
         path = node.last
         full_path = find_full_path(path, base: Dir.pwd, search: true)
         return load_file(full_path, require_once: false) if full_path

--- a/lib/rbconfig.rb
+++ b/lib/rbconfig.rb
@@ -1,7 +1,13 @@
 module RbConfig
   CONFIG = {
-    bindir: File.expand_path('../bin', __dir__),
-    ruby_install_name: 'natalie',
-    EXTEXT: nil,
+    "bindir" => File.expand_path('../bin', __dir__),
+    "ruby_install_name" => 'natalie',
+    "RUBY_INSTALL_NAME" => 'natalie',
+    "EXEEXT" => (RUBY_PLATFORM =~ /msys/ ? '.exe' : ''),
+    "host_cpu" => RUBY_PLATFORM.split('-')[0],
+    "host_os" => RUBY_PLATFORM.split('-')[1],
+    "AR" => "ar",
+    "STRIP" => "strip",
   }.freeze
+  TOPDIR = nil
 end

--- a/spec/library/rbconfig/rbconfig_spec.rb
+++ b/spec/library/rbconfig/rbconfig_spec.rb
@@ -1,0 +1,102 @@
+require_relative '../../spec_helper'
+require 'rbconfig'
+
+describe 'RbConfig::CONFIG' do
+  it 'values are all strings' do
+    RbConfig::CONFIG.each do |k, v|
+      k.should be_kind_of String
+      v.should be_kind_of String
+    end
+  end
+
+  # These directories have no meanings before the installation.
+  guard -> { RbConfig::TOPDIR } do
+    it "['rubylibdir'] returns the directory containing Ruby standard libraries" do
+      rubylibdir = RbConfig::CONFIG['rubylibdir']
+      File.directory?(rubylibdir).should == true
+      File.should.exist?("#{rubylibdir}/fileutils.rb")
+    end
+
+    it "['archdir'] returns the directory containing standard libraries C extensions" do
+      archdir = RbConfig::CONFIG['archdir']
+      File.directory?(archdir).should == true
+      File.should.exist?("#{archdir}/etc.#{RbConfig::CONFIG['DLEXT']}")
+    end
+
+    it "['sitelibdir'] is set and is part of $LOAD_PATH" do
+      sitelibdir = RbConfig::CONFIG['sitelibdir']
+      sitelibdir.should be_kind_of String
+      $LOAD_PATH.map{|path| File.realpath(path) rescue path }.should.include? sitelibdir
+    end
+  end
+  # NATFIXME: Pending support for frozen-string-literal
+  xit "contains no frozen strings even with --enable-frozen-string-literal" do
+    ruby_exe(<<-RUBY, options: '--enable-frozen-string-literal').should == "Done\n"
+      require 'rbconfig'
+      RbConfig::CONFIG.each do |k, v|
+        if v.frozen?
+          puts "\#{k} Failure"
+        end
+      end
+      puts 'Done'
+    RUBY
+  end
+
+  platform_is_not :windows do
+    it "['LIBRUBY'] is the same as LIBRUBY_SO if and only if ENABLE_SHARED" do
+      case RbConfig::CONFIG['ENABLE_SHARED']
+      when 'yes'
+        RbConfig::CONFIG['LIBRUBY'].should == RbConfig::CONFIG['LIBRUBY_SO']
+      when 'no'
+        RbConfig::CONFIG['LIBRUBY'].should_not == RbConfig::CONFIG['LIBRUBY_SO']
+      end
+    end
+  end
+
+  guard -> { RbConfig::TOPDIR } do
+    it "libdir/LIBRUBY_SO is the path to libruby and it exists if and only if ENABLE_SHARED" do
+      libdirname = RbConfig::CONFIG['LIBPATHENV'] == 'PATH' ? 'bindir' :
+                     RbConfig::CONFIG['libdirname']
+      libdir = RbConfig::CONFIG[libdirname]
+      libruby_so = "#{libdir}/#{RbConfig::CONFIG['LIBRUBY_SO']}"
+      case RbConfig::CONFIG['ENABLE_SHARED']
+      when 'yes'
+        File.should.exist?(libruby_so)
+      when 'no'
+        File.should_not.exist?(libruby_so)
+      end
+    end
+  end
+
+  platform_is :linux do
+    it "['AR'] exists and can be executed" do
+      ar = RbConfig::CONFIG.fetch('AR')
+      out = `#{ar} --version`
+      $?.should.success?
+      out.should_not be_empty
+    end
+
+    # NATFIXME: cp helper not yet implemented
+    xit "['STRIP'] exists and can be executed" do
+      strip = RbConfig::CONFIG.fetch('STRIP')
+      copy = tmp("sh")
+      cp '/bin/sh', copy
+      begin
+        out = `#{strip} #{copy}`
+        $?.should.success?
+      ensure
+        rm_r copy
+      end
+    end
+  end
+end
+
+describe "RbConfig::TOPDIR" do
+  it "either returns nil (if not installed) or the prefix" do
+    if RbConfig::TOPDIR
+      RbConfig::TOPDIR.should == RbConfig::CONFIG["prefix"]
+    else
+      RbConfig::TOPDIR.should == nil
+    end
+  end
+end

--- a/test/ruby/rbconfig_test.rb
+++ b/test/ruby/rbconfig_test.rb
@@ -5,7 +5,7 @@ require_relative '../support/nat_binary'
 describe 'RbConfig' do
   describe 'CONFIG' do
     it 'has a bindir that points to natalie' do
-      out = `#{NAT_BINARY} -r rbconfig -e "puts RbConfig::CONFIG[:bindir]"`.strip
+      out = `#{NAT_BINARY} -r rbconfig -e "puts RbConfig::CONFIG['bindir']"`.strip
       expect(out).must_equal File.expand_path('../../bin', __dir__)
     end
   end


### PR DESCRIPTION
Fix `RbConfig` to use String keys (instead of Symbol keys) and enable applicable specs.
Improve error messages for load/require failures in macro_expander to note file/line for `macro_require_relative` and `macro_load`.

I added a few more entries into RbConfig in order to pass the specs, however the Natalie configure process is not the same as MRI's configure process so some of the entries in RbConfig may not make sense or could be incorrect.

I had made these edits a few weeks ago while trying to get Mspec working with Natalie, as Mspec has a dependency on several RbConfig variables.
