### PR TITLE
File/FileTest Improvements

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -46,7 +46,7 @@ public:
     static void unlink(Env *env, Value path);
     static Value unlink(Env *env, Args args);
 
-    static void build_constants(Env *env, ClassObject *klass);
+    static void build_constants(Env *env, ModuleObject *);
 
     static bool exist(Env *env, Value path);
 

--- a/spec/core/file/chmod_spec.rb
+++ b/spec/core/file/chmod_spec.rb
@@ -1,0 +1,185 @@
+require_relative '../../spec_helper'
+
+describe "File#chmod" do
+  before :each do
+    @filename = tmp('i_exist.exe')
+    @file = File.open(@filename, 'w')
+  end
+
+  after :each do
+    @file.close
+    rm_r @filename
+  end
+
+  it "returns 0 if successful" do
+    @file.chmod(0755).should == 0
+  end
+
+  it "raises RangeError with too large values" do
+    -> { @file.chmod(2**64) }.should raise_error(RangeError)
+    -> { @file.chmod(-2**63 - 1) }.should raise_error(RangeError)
+  end
+
+  it "invokes to_int on non-integer argument" do
+    mode = File.stat(@filename).mode
+    (obj = mock('mode')).should_receive(:to_int).and_return(mode)
+    @file.chmod(obj)
+    File.stat(@filename).mode.should == mode
+  end
+
+  platform_is :windows do
+    it "with '0444' makes file readable and executable but not writable" do
+      @file.chmod(0444)
+      File.readable?(@filename).should == true
+      File.writable?(@filename).should == false
+      File.executable?(@filename).should == true
+    end
+
+    it "with '0644' makes file readable and writable and also executable" do
+      @file.chmod(0644)
+      File.readable?(@filename).should == true
+      File.writable?(@filename).should == true
+      File.executable?(@filename).should == true
+    end
+  end
+
+  platform_is_not :windows do
+    as_user do
+      it "with '0222' makes file writable but not readable or executable" do
+        @file.chmod(0222)
+        File.readable?(@filename).should == false
+        File.writable?(@filename).should == true
+        File.executable?(@filename).should == false
+      end
+
+      it "with '0444' makes file readable but not writable or executable" do
+        @file.chmod(0444)
+        File.readable?(@filename).should == true
+        File.writable?(@filename).should == false
+        File.executable?(@filename).should == false
+      end
+
+      it "with '0666' makes file readable and writable but not executable" do
+        @file.chmod(0666)
+        File.readable?(@filename).should == true
+        File.writable?(@filename).should == true
+        File.executable?(@filename).should == false
+      end
+
+      it "with '0111' makes file executable but not readable or writable" do
+        @file.chmod(0111)
+        File.readable?(@filename).should == false
+        File.writable?(@filename).should == false
+        File.executable?(@filename).should == true
+      end
+
+      it "modifies the permission bits of the files specified" do
+        @file.chmod(0755)
+        File.stat(@filename).mode.should == 33261
+      end
+    end
+  end
+end
+
+describe "File.chmod" do
+  before :each do
+    @file = tmp('i_exist.exe')
+    touch @file
+    @count = File.chmod(0755, @file)
+  end
+
+  after :each do
+    rm_r @file
+  end
+
+  it "returns the number of files modified" do
+    @count.should == 1
+  end
+
+  it "raises RangeError with too large values" do
+    -> { File.chmod(2**64, @file) }.should raise_error(RangeError)
+    -> { File.chmod(-2**63 - 1, @file) }.should raise_error(RangeError)
+  end
+
+  it "accepts an object that has a #to_path method" do
+    File.chmod(0, mock_to_path(@file))
+  end
+
+  it "throws a TypeError if the given path is not coercible into a string" do
+    -> { File.chmod(0, []) }.should raise_error(TypeError)
+  end
+
+  it "raises an error for a non existent path" do
+    -> {
+      File.chmod(0644, "#{@file}.not.existing")
+    }.should raise_error(Errno::ENOENT)
+  end
+
+  it "invokes to_int on non-integer argument" do
+    mode = File.stat(@file).mode
+    (obj = mock('mode')).should_receive(:to_int).and_return(mode)
+    File.chmod(obj, @file)
+    File.stat(@file).mode.should == mode
+  end
+
+  it "invokes to_str on non-string file names" do
+    mode = File.stat(@file).mode
+    (obj = mock('path')).should_receive(:to_str).and_return(@file)
+    File.chmod(mode, obj)
+    File.stat(@file).mode.should == mode
+  end
+
+  platform_is :windows do
+    it "with '0444' makes file readable and executable but not writable" do
+      File.chmod(0444, @file)
+      File.readable?(@file).should == true
+      File.writable?(@file).should == false
+      File.executable?(@file).should == true
+    end
+
+    it "with '0644' makes file readable and writable and also executable" do
+      File.chmod(0644, @file)
+      File.readable?(@file).should == true
+      File.writable?(@file).should == true
+      File.executable?(@file).should == true
+    end
+  end
+
+  platform_is_not :windows do
+    as_user do
+      it "with '0222' makes file writable but not readable or executable" do
+        File.chmod(0222, @file)
+        File.readable?(@file).should == false
+        File.writable?(@file).should == true
+        File.executable?(@file).should == false
+      end
+
+      it "with '0444' makes file readable but not writable or executable" do
+        File.chmod(0444, @file)
+        File.readable?(@file).should == true
+        File.writable?(@file).should == false
+        File.executable?(@file).should == false
+      end
+    end
+
+    it "with '0666' makes file readable and writable but not executable" do
+      File.chmod(0666, @file)
+      File.readable?(@file).should == true
+      File.writable?(@file).should == true
+      File.executable?(@file).should == false
+    end
+
+    as_user do
+      it "with '0111' makes file executable but not readable or writable" do
+        File.chmod(0111, @file)
+        File.readable?(@file).should == false
+        File.writable?(@file).should == false
+        File.executable?(@file).should == true
+      end
+    end
+
+    it "modifies the permission bits of the files specified" do
+      File.stat(@file).mode.should == 33261
+    end
+  end
+end

--- a/spec/core/file/constants/constants_spec.rb
+++ b/spec/core/file/constants/constants_spec.rb
@@ -1,12 +1,8 @@
 require_relative '../../../spec_helper'
 
-# NATFIXME: Implement missing FNM_* constants
-# ["APPEND", "CREAT", "EXCL", "FNM_CASEFOLD",
-#   "FNM_DOTMATCH", "FNM_EXTGLOB", "FNM_NOESCAPE", "FNM_PATHNAME",
-#   "FNM_SYSCASE", "LOCK_EX", "LOCK_NB", "LOCK_SH",
 ["APPEND", "CREAT", "EXCL", "FNM_CASEFOLD",
-  "FNM_NOESCAPE", "FNM_PATHNAME",
-  "LOCK_EX", "LOCK_NB", "LOCK_SH",
+  "FNM_DOTMATCH", "FNM_EXTGLOB", "FNM_NOESCAPE", "FNM_PATHNAME",
+  "FNM_SYSCASE", "LOCK_EX", "LOCK_NB", "LOCK_SH",
   "LOCK_UN", "NONBLOCK", "RDONLY",
   "RDWR", "TRUNC", "WRONLY"].each do |const|
   describe "File::Constants::#{const}" do

--- a/spec/core/file/file_spec.rb
+++ b/spec/core/file/file_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/file/file'
+
+describe "File" do
+  it "includes Enumerable" do
+    File.include?(Enumerable).should == true
+  end
+
+  it "includes File::Constants" do
+    File.include?(File::Constants).should == true
+  end
+end
+
+describe "File.file?" do
+  it_behaves_like :file_file, :file?, File
+end

--- a/spec/core/file/null_spec.rb
+++ b/spec/core/file/null_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "File::NULL" do
+  platform_is :windows do
+    it "returns NUL as a string" do
+      File::NULL.should == 'NUL'
+    end
+  end
+
+  platform_is_not :windows do
+    it "returns /dev/null as a string" do
+      File::NULL.should == '/dev/null'
+    end
+  end
+end

--- a/spec/core/filetest/directory_spec.rb
+++ b/spec/core/filetest/directory_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/file/directory'
+
+describe "FileTest.directory?" do
+  it_behaves_like :file_directory, :directory?, FileTest
+end
+
+describe "FileTest.directory?" do
+  it_behaves_like :file_directory_io, :directory?, FileTest
+end

--- a/spec/core/filetest/size_spec.rb
+++ b/spec/core/filetest/size_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/file/size'
+
+describe "FileTest.size?" do
+  it_behaves_like :file_size,                     :size?, FileTest
+end
+
+describe "FileTest.size?" do
+  it_behaves_like :file_size_nil_when_missing,    :size?, FileTest
+end
+
+describe "FileTest.size?" do
+  it_behaves_like :file_size_nil_when_empty,      :size?, FileTest
+end
+
+describe "FileTest.size?" do
+  it_behaves_like :file_size_with_file_argument,  :size?, FileTest
+end
+
+describe "FileTest.size" do
+  it_behaves_like :file_size,                     :size,  FileTest
+end
+
+describe "FileTest.size" do
+  it_behaves_like :file_size_raise_when_missing,  :size,  FileTest
+end
+
+describe "FileTest.size" do
+  it_behaves_like :file_size_0_when_empty,        :size,  FileTest
+end
+
+describe "FileTest.size" do
+  it_behaves_like :file_size_with_file_argument,  :size,  FileTest
+end

--- a/spec/core/filetest/zero_spec.rb
+++ b/spec/core/filetest/zero_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/file/zero'
+
+describe "FileTest.zero?" do
+  it_behaves_like :file_zero, :zero?, FileTest
+  it_behaves_like :file_zero_missing, :zero?, FileTest
+
+  platform_is :solaris do
+    it "returns false for /dev/null" do
+      File.zero?('/dev/null').should == true
+    end
+  end
+end

--- a/spec/core/io/constants_spec.rb
+++ b/spec/core/io/constants_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+describe "IO::SEEK_SET" do
+  it "is defined" do
+    IO.const_defined?(:SEEK_SET).should == true
+  end
+end
+
+describe "IO::SEEK_CUR" do
+  it "is defined" do
+    IO.const_defined?(:SEEK_CUR).should == true
+  end
+end
+
+describe "IO::SEEK_END" do
+  it "is defined" do
+    IO.const_defined?(:SEEK_END).should == true
+  end
+end

--- a/spec/core/io/io_spec.rb
+++ b/spec/core/io/io_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "IO" do
+  it "includes File::Constants" do
+    IO.include?(File::Constants).should == true
+  end
+
+  it "includes Enumerable" do
+    IO.include?(Enumerable).should == true
+  end
+end

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -166,45 +166,7 @@ Value FileObject::unlink(Env *env, Args args) {
     return Value::integer(args.size());
 }
 
-void FileObject::build_constants(Env *env, ClassObject *klass) {
-    Value Constants = new ModuleObject { "Constants" };
-    klass->const_set("Constants"_s, Constants);
-    klass->const_set("APPEND"_s, Value::integer(O_APPEND));
-    Constants->const_set("APPEND"_s, Value::integer(O_APPEND));
-    klass->const_set("RDONLY"_s, Value::integer(O_RDONLY));
-    Constants->const_set("RDONLY"_s, Value::integer(O_RDONLY));
-    klass->const_set("WRONLY"_s, Value::integer(O_WRONLY));
-    Constants->const_set("WRONLY"_s, Value::integer(O_WRONLY));
-    klass->const_set("TRUNC"_s, Value::integer(O_TRUNC));
-    Constants->const_set("TRUNC"_s, Value::integer(O_TRUNC));
-    klass->const_set("CREAT"_s, Value::integer(O_CREAT));
-    Constants->const_set("CREAT"_s, Value::integer(O_CREAT));
-    klass->const_set("DSYNC"_s, Value::integer(O_DSYNC));
-    Constants->const_set("DSYNC"_s, Value::integer(O_DSYNC));
-    klass->const_set("EXCL"_s, Value::integer(O_EXCL));
-    Constants->const_set("EXCL"_s, Value::integer(O_EXCL));
-    klass->const_set("NOCTTY"_s, Value::integer(O_NOCTTY));
-    Constants->const_set("NOCTTY"_s, Value::integer(O_NOCTTY));
-    klass->const_set("NOFOLLOW"_s, Value::integer(O_NOFOLLOW));
-    Constants->const_set("NOFOLLOW"_s, Value::integer(O_NOFOLLOW));
-    klass->const_set("NONBLOCK"_s, Value::integer(O_NONBLOCK));
-    Constants->const_set("NONBLOCK"_s, Value::integer(O_NONBLOCK));
-    klass->const_set("RDWR"_s, Value::integer(O_RDWR));
-    Constants->const_set("RDWR"_s, Value::integer(O_RDWR));
-    klass->const_set("SYNC"_s, Value::integer(O_SYNC));
-    Constants->const_set("SYNC"_s, Value::integer(O_SYNC));
-
-    klass->const_set("LOCK_EX"_s, Value::integer(LOCK_EX));
-    Constants->const_set("LOCK_EX"_s, Value::integer(LOCK_EX));
-    klass->const_set("LOCK_NB"_s, Value::integer(LOCK_NB));
-    Constants->const_set("LOCK_NB"_s, Value::integer(LOCK_NB));
-    klass->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
-    Constants->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
-    klass->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
-    Constants->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
-
-    // MRI defines these constants differently than the OS does in fnmatch.h
-
+// MRI defines these constants differently than the OS does in fnmatch.h
 #define FNM_NOESCAPE 0x01
 #define FNM_PATHNAME 0x02
 #define FNM_DOTMATCH 0x04
@@ -213,20 +175,37 @@ void FileObject::build_constants(Env *env, ClassObject *klass) {
 #define FNM_SYSCASE 0
 #define FNM_SHORTNAME 0
 
-    klass->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
+void FileObject::build_constants(Env *env, ClassObject *klass) {
+    ModuleObject *Constants = new ModuleObject { "Constants" };
+    klass->const_set("Constants"_s, Constants);
+    Constants->const_set("APPEND"_s, Value::integer(O_APPEND));
+    Constants->const_set("RDONLY"_s, Value::integer(O_RDONLY));
+    Constants->const_set("WRONLY"_s, Value::integer(O_WRONLY));
+    Constants->const_set("TRUNC"_s, Value::integer(O_TRUNC));
+    Constants->const_set("CREAT"_s, Value::integer(O_CREAT));
+    Constants->const_set("DSYNC"_s, Value::integer(O_DSYNC));
+    Constants->const_set("EXCL"_s, Value::integer(O_EXCL));
+    Constants->const_set("NOCTTY"_s, Value::integer(O_NOCTTY));
+    Constants->const_set("NOFOLLOW"_s, Value::integer(O_NOFOLLOW));
+    Constants->const_set("NONBLOCK"_s, Value::integer(O_NONBLOCK));
+    Constants->const_set("RDWR"_s, Value::integer(O_RDWR));
+    Constants->const_set("SYNC"_s, Value::integer(O_SYNC));
+    Constants->const_set("LOCK_EX"_s, Value::integer(LOCK_EX));
+    Constants->const_set("LOCK_NB"_s, Value::integer(LOCK_NB));
+    Constants->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
+    Constants->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
     Constants->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
-    klass->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
     Constants->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
-    klass->const_set("FNM_DOTMATCH"_s, Value::integer(FNM_DOTMATCH));
     Constants->const_set("FNM_DOTMATCH"_s, Value::integer(FNM_DOTMATCH));
-    klass->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
     Constants->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
-    klass->const_set("FNM_EXTGLOB"_s, Value::integer(FNM_EXTGLOB));
     Constants->const_set("FNM_EXTGLOB"_s, Value::integer(FNM_EXTGLOB));
-    klass->const_set("FNM_SYSCASE"_s, Value::integer(FNM_SYSCASE));
     Constants->const_set("FNM_SYSCASE"_s, Value::integer(FNM_SYSCASE));
-    klass->const_set("FNM_SHORTNAME"_s, Value::integer(FNM_SHORTNAME));
     Constants->const_set("FNM_SHORTNAME"_s, Value::integer(FNM_SHORTNAME));
+    Value null_file = new StringObject { "/dev/null", Encoding::US_ASCII };
+    null_file->freeze();
+    Constants->const_set("NULL"_s, null_file);
+    // include Constants module in File
+    klass->include_once(env, Constants);
 }
 
 bool FileObject::exist(Env *env, Value path) {

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -175,37 +175,33 @@ Value FileObject::unlink(Env *env, Args args) {
 #define FNM_SYSCASE 0
 #define FNM_SHORTNAME 0
 
-void FileObject::build_constants(Env *env, ClassObject *klass) {
-    ModuleObject *Constants = new ModuleObject { "Constants" };
-    klass->const_set("Constants"_s, Constants);
-    Constants->const_set("APPEND"_s, Value::integer(O_APPEND));
-    Constants->const_set("RDONLY"_s, Value::integer(O_RDONLY));
-    Constants->const_set("WRONLY"_s, Value::integer(O_WRONLY));
-    Constants->const_set("TRUNC"_s, Value::integer(O_TRUNC));
-    Constants->const_set("CREAT"_s, Value::integer(O_CREAT));
-    Constants->const_set("DSYNC"_s, Value::integer(O_DSYNC));
-    Constants->const_set("EXCL"_s, Value::integer(O_EXCL));
-    Constants->const_set("NOCTTY"_s, Value::integer(O_NOCTTY));
-    Constants->const_set("NOFOLLOW"_s, Value::integer(O_NOFOLLOW));
-    Constants->const_set("NONBLOCK"_s, Value::integer(O_NONBLOCK));
-    Constants->const_set("RDWR"_s, Value::integer(O_RDWR));
-    Constants->const_set("SYNC"_s, Value::integer(O_SYNC));
-    Constants->const_set("LOCK_EX"_s, Value::integer(LOCK_EX));
-    Constants->const_set("LOCK_NB"_s, Value::integer(LOCK_NB));
-    Constants->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
-    Constants->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
-    Constants->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
-    Constants->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
-    Constants->const_set("FNM_DOTMATCH"_s, Value::integer(FNM_DOTMATCH));
-    Constants->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
-    Constants->const_set("FNM_EXTGLOB"_s, Value::integer(FNM_EXTGLOB));
-    Constants->const_set("FNM_SYSCASE"_s, Value::integer(FNM_SYSCASE));
-    Constants->const_set("FNM_SHORTNAME"_s, Value::integer(FNM_SHORTNAME));
+void FileObject::build_constants(Env *env, ModuleObject *fcmodule) {
+    fcmodule->const_set("APPEND"_s, Value::integer(O_APPEND));
+    fcmodule->const_set("RDONLY"_s, Value::integer(O_RDONLY));
+    fcmodule->const_set("WRONLY"_s, Value::integer(O_WRONLY));
+    fcmodule->const_set("TRUNC"_s, Value::integer(O_TRUNC));
+    fcmodule->const_set("CREAT"_s, Value::integer(O_CREAT));
+    fcmodule->const_set("DSYNC"_s, Value::integer(O_DSYNC));
+    fcmodule->const_set("EXCL"_s, Value::integer(O_EXCL));
+    fcmodule->const_set("NOCTTY"_s, Value::integer(O_NOCTTY));
+    fcmodule->const_set("NOFOLLOW"_s, Value::integer(O_NOFOLLOW));
+    fcmodule->const_set("NONBLOCK"_s, Value::integer(O_NONBLOCK));
+    fcmodule->const_set("RDWR"_s, Value::integer(O_RDWR));
+    fcmodule->const_set("SYNC"_s, Value::integer(O_SYNC));
+    fcmodule->const_set("LOCK_EX"_s, Value::integer(LOCK_EX));
+    fcmodule->const_set("LOCK_NB"_s, Value::integer(LOCK_NB));
+    fcmodule->const_set("LOCK_SH"_s, Value::integer(LOCK_SH));
+    fcmodule->const_set("LOCK_UN"_s, Value::integer(LOCK_UN));
+    fcmodule->const_set("FNM_NOESCAPE"_s, Value::integer(FNM_NOESCAPE));
+    fcmodule->const_set("FNM_PATHNAME"_s, Value::integer(FNM_PATHNAME));
+    fcmodule->const_set("FNM_DOTMATCH"_s, Value::integer(FNM_DOTMATCH));
+    fcmodule->const_set("FNM_CASEFOLD"_s, Value::integer(FNM_CASEFOLD));
+    fcmodule->const_set("FNM_EXTGLOB"_s, Value::integer(FNM_EXTGLOB));
+    fcmodule->const_set("FNM_SYSCASE"_s, Value::integer(FNM_SYSCASE));
+    fcmodule->const_set("FNM_SHORTNAME"_s, Value::integer(FNM_SHORTNAME));
     Value null_file = new StringObject { "/dev/null", Encoding::US_ASCII };
     null_file->freeze();
-    Constants->const_set("NULL"_s, null_file);
-    // include Constants module in File
-    klass->include_once(env, Constants);
+    fcmodule->const_set("NULL"_s, null_file);
 }
 
 bool FileObject::exist(Env *env, Value path) {

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -460,7 +460,6 @@ Value FileObject::mkfifo(Env *env, Value path, Value mode) {
 // TODO: chmod can take multiple paths, implement that later.
 Value FileObject::chmod(Env *env, Value mode, Value path) {
     path = fileutil::convert_using_to_path(env, path);
-    mode->assert_type(env, Object::Type::Integer, "Integer");
     mode_t modenum = IntegerObject::convert_to_int(env, mode);
     int result = ::chmod(path->as_string()->c_str(), modenum);
     if (result < 0) env->raise_errno();

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -156,6 +156,7 @@ Env *build_top_env() {
 
     ClassObject *IO = Object->subclass(env, "IO", Object::Type::Io);
     Object->const_set("IO"_s, IO);
+    IO->include_once(env, Enumerable);
 
     ClassObject *File = IO->subclass(env, "File");
     Object->const_set("File"_s, File);
@@ -224,9 +225,16 @@ Env *build_top_env() {
     ClassObject *UnboundMethod = Object->subclass(env, "UnboundMethod", Object::Type::UnboundMethod);
     Object->const_set("UnboundMethod"_s, UnboundMethod);
 
+    ModuleObject *FileConstants = new ModuleObject { "Constants" };
+    File->const_set("Constants"_s, FileConstants);
+
     // Build File Constants after Encodings are defined since some
     // strings depend on the encoding.
-    FileObject::build_constants(env, File);
+    FileObject::build_constants(env, FileConstants);
+
+    // include File::Constants module in File and IO
+    File->include_once(env, FileConstants);
+    IO->include_once(env, FileConstants);
 
     env->global_set("$NAT_at_exit_handlers"_s, new ArrayObject {});
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -159,7 +159,7 @@ Env *build_top_env() {
 
     ClassObject *File = IO->subclass(env, "File");
     Object->const_set("File"_s, File);
-    FileObject::build_constants(env, File);
+    File->include_once(env, Enumerable);
 
     ModuleObject *FileTest = new ModuleObject { "FileTest" };
     Object->const_set("FileTest"_s, FileTest);
@@ -223,6 +223,10 @@ Env *build_top_env() {
 
     ClassObject *UnboundMethod = Object->subclass(env, "UnboundMethod", Object::Type::UnboundMethod);
     Object->const_set("UnboundMethod"_s, UnboundMethod);
+
+    // Build File Constants after Encodings are defined since some
+    // strings depend on the encoding.
+    FileObject::build_constants(env, File);
 
     env->global_set("$NAT_at_exit_handlers"_s, new ArrayObject {});
 


### PR DESCRIPTION
-    Add `File::Constants::NULL`
-    Include `File::Constants` in `File`
-    Include `File::Constants` and `Enumerable` into `IO`
    - because both File and IO now include the `File::Constants`, moving the module definition code back into natalie.cpp was convenient and felt appropriate. 
-    Fix `File.chmod` to accept object that responds to `to_int`
-    Add IO support for `FileTest.size/directory` and add specs.