### PR TITLE
Import passing specs for Set

### DIFF
--- a/spec/library/set/include_spec.rb
+++ b/spec/library/set/include_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'shared/include'
+require 'set'
+
+describe "Set#include?" do
+  it_behaves_like :set_include, :include?
+end

--- a/spec/library/set/pretty_print_spec.rb
+++ b/spec/library/set/pretty_print_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require 'set'
+
+ruby_version_is ""..."3.1" do
+  describe "Set#pretty_print" do
+    it "passes the 'pretty print' representation of self to the pretty print writer" do
+      pp = mock("PrettyPrint")
+      set = Set[1, 2, 3]
+
+      pp.should_receive(:text).with("#<Set: {")
+      pp.should_receive(:text).with("}>")
+
+      pp.should_receive(:nest).with(1).and_yield
+      pp.should_receive(:seplist).with(set)
+
+      set.pretty_print(pp)
+    end
+  end
+end


### PR DESCRIPTION
The specs `include_spec` and `pretty_print_spec` pass with the current implementation. These issues can be closed in #840.