### PR TITLE
Fix String#include? for empty strings

### DIFF
--- a/spec/core/string/include_spec.rb
+++ b/spec/core/string/include_spec.rb
@@ -13,6 +13,22 @@ describe "String#include? with String" do
     StringSpecs::MyString.new("hello").include?(StringSpecs::MyString.new("lo")).should == true
   end
 
+  it "returns true if both strings are empty" do
+    "".should.include?("")
+    # NATFIXME: Implement EUC-JP encoding
+    # "".force_encoding("EUC-JP").should.include?("")
+    # "".should.include?("".force_encoding("EUC-JP"))
+    # "".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+  end
+
+  it "returns true if the RHS is empty" do
+    "a".should.include?("")
+    # NATFIXME: Implement EUC-JP encoding
+    # "a".force_encoding("EUC-JP").should.include?("")
+    # "a".should.include?("".force_encoding("EUC-JP"))
+    # "a".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+  end
+
   it "tries to convert other to string using to_str" do
     other = mock('lo')
     other.should_receive(:to_str).and_return("lo")

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1956,6 +1956,8 @@ Value StringObject::split(Env *env, Value splitter, Value max_count_value) {
 bool StringObject::include(Env *env, Value arg) {
     if (!arg->is_string())
         arg = arg->to_str(env);
+    if (arg->as_string()->is_empty())
+        return true;
     return m_string.find(arg->as_string()->m_string) != -1;
 }
 


### PR DESCRIPTION
Won't be fully spec compliant until we implement EUC-JP encoding, for now just fixing the simple empty string cases.