### PR TITLE
Update == method for Numeric subclasses

### DIFF
--- a/spec/shared/rational/equal_value.rb
+++ b/spec/shared/rational/equal_value.rb
@@ -21,8 +21,7 @@ describe :rational_equal_value_int, shared: true do
 end
 
 describe :rational_equal_value_float, shared: true do
-  # NATFIXME: converts self to a Float and compares it with the passed argument
-  xit "converts self to a Float and compares it with the passed argument" do
+  it "converts self to a Float and compares it with the passed argument" do
     (Rational(3, 4) == 0.75).should be_true
     (Rational(4, 2) == 2.0).should be_true
     (Rational(-4, 2) == -2.0).should be_true
@@ -31,8 +30,7 @@ describe :rational_equal_value_float, shared: true do
 end
 
 describe :rational_equal_value, shared: true do
-  # NATFIXME: returns the result of calling #== with self on the passed argument
-  xit "returns the result of calling #== with self on the passed argument" do
+  it "returns the result of calling #== with self on the passed argument" do
     obj = mock("Object")
     obj.should_receive(:==).and_return(:result)
 

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -29,11 +29,7 @@ bool FloatObject::eq(Env *env, Value other) {
         auto *f = other->as_float();
         return f->m_double == m_double;
     }
-    auto equal_symbol = "=="_s;
-    if (other->respond_to(env, equal_symbol)) {
-        return other.send(env, equal_symbol, { this })->is_truthy();
-    }
-    return false;
+    return other.send(env, "=="_s, { this })->is_truthy();
 }
 
 bool FloatObject::eql(Value other) const {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -264,11 +264,6 @@ bool IntegerObject::eq(Env *env, Value other) {
     if (other->is_integer())
         return m_integer == other->as_integer()->integer();
 
-    if (other->respond_to(env, "coerce"_s)) {
-        auto result = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
-        return result.first->send(env, "=="_s, { result.second })->is_truthy();
-    }
-
     return other->send(env, "=="_s, { this })->is_truthy();
 }
 

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -112,16 +112,21 @@ Value RationalObject::div(Env *env, Value other) {
 }
 
 bool RationalObject::eq(Env *env, Value other) {
-    if (m_klass != other->klass()) {
-        // NATFIXME: Use Coercion
+    if (other->is_integer())
         return m_denominator->to_nat_int_t() == 1 && m_numerator->eq(env, other);
-    }
-    if (!m_numerator->eq(env, other->as_rational()->m_numerator)) {
+
+    if (other->is_float())
+        return to_f(env)->as_float()->eq(env, other);
+
+    if (!other->is_rational())
+        return other.send(env, "=="_s, { this })->is_truthy();
+
+    if (!m_numerator->eq(env, other->as_rational()->m_numerator))
         return false;
-    }
-    if (!m_denominator->eq(env, other->as_rational()->m_denominator)) {
+
+    if (!m_denominator->eq(env, other->as_rational()->m_denominator))
         return false;
-    }
+
     return true;
 }
 

--- a/test/natalie/numeric_test.rb
+++ b/test/natalie/numeric_test.rb
@@ -1,0 +1,72 @@
+require_relative '../spec_helper'
+
+describe 'Equals methods on numeric classes' do
+  before do
+    @no_equals_method = Object.new.tap { |obj| obj.singleton_class.undef_method(:==) }
+  end
+
+  it 'should work on Integer' do
+    (3 == 3).should be_true
+    (3 == 3.0).should be_true
+    (3 == Rational(3)).should be_true
+    (3 == Complex(3)).should be_true
+    (3 == Complex(3.0)).should be_true
+    -> { 3 == @no_equals_method }.should raise_error(NoMethodError)
+  end
+
+  it 'should work on Float' do
+    (3.0 == 3).should be_true
+    (3.0 == 3.0).should be_true
+    (3.0 == Rational(3)).should be_true
+    (3.0 == Complex(3)).should be_true
+    (3.0 == Complex(3.0)).should be_true
+    # NATFIXME: Should raise NoMethodError
+    (3.0 == @no_equals_method).should be_false
+
+    # NATFIXME: These should all be_true
+    (0.75 == Rational(3, 4)).should be_false
+    (2.0 == Rational(4, 2)).should be_true
+    (-2.0 == Rational(-4, 2)).should be_true
+    (-2.0 == Rational(4, -2)).should be_true
+  end
+
+  it 'should work on Rational' do
+    (Rational(3) == 3).should be_true
+    (Rational(3) == 3.0).should be_true
+    (Rational(3) == Rational(3)).should be_true
+    (Rational(3) == Complex(3)).should be_true
+    (Rational(3) == Complex(3.0)).should be_true
+    -> { Rational(3) == @no_equals_method }.should raise_error(NoMethodError)
+
+    # NATFIXME: These should all be_true
+    (Rational(3, 4) == 0.75).should be_false
+    (Rational(4, 2) == 2.0).should be_true
+    (Rational(-4, 2) == -2.0).should be_true
+    (Rational(4, -2) == -2.0).should be_true
+    # NATFIXME: Should raise NoMethodError
+    (Rational(3, 4) == @no_equals_method).should be_false
+
+    # NATFIXME: This should be be_false
+    obj = mock("Object")
+    obj.should_receive(:==).and_return(:result)
+    (Rational(3, 4) == obj).should_not be_true
+    obj == 1 # NATFXIME: Handle expectation to make the test pass
+  end
+
+  it 'should work on Complex' do
+    (Complex(3) == 3).should be_true
+    (Complex(3) == 3.0).should be_true
+    (Complex(3) == Rational(3)).should be_true
+    (Complex(3) == Complex(3)).should be_true
+    (Complex(3) == Complex(3.0)).should be_true
+    -> { Complex(3) == @no_equals_method }.should raise_error(NoMethodError)
+
+    (Complex(3.0) == 3).should be_true
+    (Complex(3.0) == 3.0).should be_true
+    (Complex(3.0) == Rational(3)).should be_true
+    (Complex(3.0) == Complex(3)).should be_true
+    (Complex(3.0) == Complex(3.0)).should be_true
+    # NATFIXME: Should raise NoMethodError
+    (Complex(3.0) == @no_equals_method).should be_false
+  end
+end

--- a/test/natalie/numeric_test.rb
+++ b/test/natalie/numeric_test.rb
@@ -22,8 +22,7 @@ describe 'Equals methods on numeric classes' do
     (3.0 == Complex(3.0)).should be_true
     -> { 3.0 == @no_equals_method }.should raise_error(NoMethodError)
 
-    # NATFIXME: These should all be_true
-    (0.75 == Rational(3, 4)).should be_false
+    (0.75 == Rational(3, 4)).should be_true
     (2.0 == Rational(4, 2)).should be_true
     (-2.0 == Rational(-4, 2)).should be_true
     (-2.0 == Rational(4, -2)).should be_true
@@ -37,19 +36,15 @@ describe 'Equals methods on numeric classes' do
     (Rational(3) == Complex(3.0)).should be_true
     -> { Rational(3) == @no_equals_method }.should raise_error(NoMethodError)
 
-    # NATFIXME: These should all be_true
-    (Rational(3, 4) == 0.75).should be_false
+    (Rational(3, 4) == 0.75).should be_true
     (Rational(4, 2) == 2.0).should be_true
     (Rational(-4, 2) == -2.0).should be_true
     (Rational(4, -2) == -2.0).should be_true
-    # NATFIXME: Should raise NoMethodError
-    (Rational(3, 4) == @no_equals_method).should be_false
+    -> { Rational(3, 4) == @no_equals_method }.should raise_error(NoMethodError)
 
-    # NATFIXME: This should be be_false
     obj = mock("Object")
     obj.should_receive(:==).and_return(:result)
-    (Rational(3, 4) == obj).should_not be_true
-    obj == 1 # NATFXIME: Handle expectation to make the test pass
+    (Rational(3, 4) == obj).should_not be_false
   end
 
   it 'should work on Complex' do

--- a/test/natalie/numeric_test.rb
+++ b/test/natalie/numeric_test.rb
@@ -20,8 +20,7 @@ describe 'Equals methods on numeric classes' do
     (3.0 == Rational(3)).should be_true
     (3.0 == Complex(3)).should be_true
     (3.0 == Complex(3.0)).should be_true
-    # NATFIXME: Should raise NoMethodError
-    (3.0 == @no_equals_method).should be_false
+    -> { 3.0 == @no_equals_method }.should raise_error(NoMethodError)
 
     # NATFIXME: These should all be_true
     (0.75 == Rational(3, 4)).should be_false
@@ -66,7 +65,6 @@ describe 'Equals methods on numeric classes' do
     (Complex(3.0) == Rational(3)).should be_true
     (Complex(3.0) == Complex(3)).should be_true
     (Complex(3.0) == Complex(3.0)).should be_true
-    # NATFIXME: Should raise NoMethodError
-    (Complex(3.0) == @no_equals_method).should be_false
+    -> { Complex(3.0) == @no_equals_method }.should raise_error(NoMethodError)
   end
 end


### PR DESCRIPTION
This one has a dependency on the changes of  #897, and will crash without it. I'll leave the case as a draft for now.

The behaviour has been analyzed by reopening the classes Integer, Float, Complex and Rational, and printing debug messages whenever `coerce` or `==` is called. It turns out: these numeric classes do not use coerce, but instead flip the call sequence if the receiving object is not compatible with this class. This is even explicitly mentioned in the specs of Rational.

This has been split of from  #825 since that MR is about coercing integers, and this does not use coercion.