### PR TITLE
Implement ruby_cmd for specs

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -235,6 +235,11 @@ def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0)
   output
 end
 
+def ruby_cmd(code, options: nil, args: nil)
+  binary = ENV['NAT_BINARY'] || 'bin/natalie'
+  "#{binary} #{options} -e #{code.inspect} #{args}"
+end
+
 def fixture(source, filename)
   dirname = File.dirname(File.realpath(source))
   dirname.delete_suffix!('/shared')


### PR DESCRIPTION
I tried using this with `kernel/backtick_spec`, but that simply yielded the next error, so I removed that spec again.

This method is required in a bunch of rubyspecs, so implementing it should get some more specific error messages in the nightly runs.

I tried it with this code in a temporary spec just to see if it works:
```ruby
`#{ruby_cmd('p 1 + 2')}`.should == "3\n
```