### PR TITLE
Refactor of EncodingObject into subclasses

### DIFF
--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 255;
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         return codepoint >= 0 && codepoint < 256;
     }
 
@@ -32,7 +32,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
-    virtual bool is_ascii_compatible() const { return true; };
+    virtual bool is_ascii_compatible() const override { return true; };
 };
 
 }

--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -18,6 +18,9 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 255;
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        return codepoint >= 0 && codepoint < 256;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
@@ -29,6 +32,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+    virtual bool is_ascii_compatible() const { return true; };
 };
 
 }

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 127;
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         return codepoint >= 0 && codepoint < 128;
     }
 
@@ -32,7 +32,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
-    virtual bool is_ascii_compatible() const { return true; };
+    virtual bool is_ascii_compatible() const override { return true; };
 };
 
 }

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -18,6 +18,9 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 127;
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        return codepoint >= 0 && codepoint < 128;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
@@ -29,6 +32,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+    virtual bool is_ascii_compatible() const { return true; };
 };
 
 }

--- a/include/natalie/encoding/utf16be_encoding_object.hpp
+++ b/include/natalie/encoding/utf16be_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf16be_encoding_object.hpp
+++ b/include/natalie/encoding/utf16be_encoding_object.hpp
@@ -19,6 +19,10 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        // it's positive and takes 1-4 bytes
+        return codepoint >= 0 && codepoint < 0x10000000000;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;

--- a/include/natalie/encoding/utf16le_encoding_object.hpp
+++ b/include/natalie/encoding/utf16le_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf16le_encoding_object.hpp
+++ b/include/natalie/encoding/utf16le_encoding_object.hpp
@@ -19,6 +19,10 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        // it's positive and takes 1-4 bytes
+        return codepoint >= 0 && codepoint < 0x10000000000;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
@@ -31,5 +35,4 @@ public:
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
 };
-
 }

--- a/include/natalie/encoding/utf32be_encoding_object.hpp
+++ b/include/natalie/encoding/utf32be_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf32be_encoding_object.hpp
+++ b/include/natalie/encoding/utf32be_encoding_object.hpp
@@ -19,6 +19,10 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        // it's positive and takes 1-4 bytes
+        return codepoint >= 0 && codepoint < 0x10000000000;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;

--- a/include/natalie/encoding/utf32le_encoding_object.hpp
+++ b/include/natalie/encoding/utf32le_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf32le_encoding_object.hpp
+++ b/include/natalie/encoding/utf32le_encoding_object.hpp
@@ -19,6 +19,10 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        // it's positive and takes 1-4 bytes
+        return codepoint >= 0 && codepoint < 0x10000000000;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // from RFC3629: 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
         return codepoint >= 0 && codepoint < 0x110000;
     }
 
@@ -33,7 +33,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
-    virtual bool is_ascii_compatible() const { return true; };
+    virtual bool is_ascii_compatible() const override { return true; };
 };
 
 }

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -19,6 +19,9 @@ public:
         // from RFC3629: 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) {
+        return codepoint >= 0 && codepoint < 0x110000;
+    }
 
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
@@ -30,6 +33,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+    virtual bool is_ascii_compatible() const { return true; };
 };
 
 }

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -25,6 +25,7 @@ public:
 
     EncodingObject(Encoding, std::initializer_list<const String>);
 
+    // Try to get rid of this
     Encoding num() const { return m_num; }
 
     const StringObject *name() const;
@@ -34,42 +35,9 @@ public:
 
     Value inspect(Env *) const;
 
-    bool in_encoding_codepoint_range(nat_int_t codepoint) {
-        switch (m_num) {
-        case Encoding::ASCII_8BIT:
-            return codepoint >= 0 && codepoint < 256;
-        case Encoding::US_ASCII:
-            return codepoint >= 0 && codepoint < 128;
-        case Encoding::UTF_8:
-            return codepoint >= 0 && codepoint < 1114112;
-        case Encoding::UTF_32LE:
-            // it's positive and takes 1-4 bytes
-            return codepoint >= 0 && codepoint < 0x10000000000;
-        case Encoding::UTF_32BE:
-            // it's positive and takes 1-4 bytes
-            return codepoint >= 0 && codepoint < 0x10000000000;
-        case Encoding::UTF_16LE:
-            // it's positive and takes 1-4 bytes
-            return codepoint >= 0 && codepoint < 0x10000000000;
-        case Encoding::UTF_16BE:
-            // it's positive and takes 1-4 bytes
-            return codepoint >= 0 && codepoint < 0x10000000000;
-        }
-        NAT_UNREACHABLE();
-    }
-
-    bool is_ascii_compatible() const {
-        switch (m_num) {
-        case Encoding::ASCII_8BIT:
-        case Encoding::US_ASCII:
-        case Encoding::UTF_8:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    bool is_dummy() { return m_dummy; }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) { NAT_UNREACHABLE(); }
+    virtual bool is_ascii_compatible() const { return false; } // default
+    virtual bool is_dummy() { return false; }
 
     virtual bool valid_codepoint(nat_int_t codepoint) const = 0;
     virtual std::pair<bool, StringView> prev_char(const String &, size_t *) const = 0;
@@ -105,7 +73,6 @@ public:
 private:
     Vector<String> m_names {};
     Encoding m_num;
-    bool m_dummy { false };
 
     static inline TM::Hashmap<Encoding, EncodingObject *> s_encoding_list {};
     static inline EncodingObject *s_default_internal = nullptr;

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -24,7 +24,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
         if (unicode_codepoint < 0) {
             StringObject *message;
 
-            if (num() != Encoding::UTF_8) {
+            if (name()->string() != "UTF-8") {
                 // Example: "\x8F" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII
                 message = StringObject::format(
                     "\"\\x{}\" to UTF-8 in conversion from {} to UTF-8 to {}",
@@ -47,7 +47,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
         if (destination_codepoint < 0) {
             StringObject *message;
 
-            if (orig_encoding->num() != Encoding::UTF_8)
+            if (orig_encoding->name()->string() != "UTF-8") {
                 message = StringObject::format(
                     // Example: "U+043F to WINDOWS-1252 in conversion from Windows-1251 to UTF-8 to WINDOWS-1252",
                     "U+{} to {} in conversion from {} to UTF-8 to {}",
@@ -55,7 +55,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
                     name(),
                     orig_encoding->name(),
                     name());
-            else {
+            } else {
                 // Example: U+0439 from UTF-8 to ASCII-8BIT
                 auto hex = String();
                 hex.append_sprintf("%04X", source_codepoint);
@@ -70,6 +70,9 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
     }
 
     str->set_str(temp_string.string().c_str(), temp_string.string().length());
+
+    // Would prefer to do the following but cannot because 'this' is a const EncodingObject*
+    // str->set_encoding(this);
     str->set_encoding(EncodingObject::get(num()));
     return str;
 }


### PR DESCRIPTION
 + Move functionality for `is_dummy`, `is_ascii_compatible`, and `in_encoding_codepoint_range` into the subclasses of
 `EncodingObject`.  There are a lot more encodings to implement and am trying to setup something more modular before adding those.
Remove calls to `EncodingObject::num()` where possible.  AFAICT there is one remaining external call to this function.  

Maybe removing this is a bad idea, but it feels like maintaining an enum list of `Encodings` would become fragile or harder to maintain when adding more encodings.  That said, it is convenient (and fast) and pretty pervasive, so I expect it would be non-trivial to get rid of it.
