### PR TITLE
Remove as_string call in MatchDataObject::inspect

### DIFF
--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -70,7 +70,7 @@ Value MatchDataObject::inspect(Env *env) {
             out->append(i);
             out->append_char(':');
         }
-        out->append(this->group(i)->as_string()->inspect(env));
+        out->append(this->group(i)->inspect_str(env));
     }
     out->append_char('>');
     return out;


### PR DESCRIPTION
These values can be nil, for example this line from the specs:

    /something is( not)? (right)/.match("something is right")
    #<MatchData "something is right" 1:nil 2:"right">

The output is still the same as Ruby's output.

This will probably fix a few crashes in the regexp spec