### PR TITLE
Add Random.random_number and Random#random_number

### DIFF
--- a/spec/core/random/random_number_spec.rb
+++ b/spec/core/random/random_number_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'shared/rand'
+
+describe "Random.random_number" do
+  it_behaves_like :random_number, :random_number, Random.new
+
+  it_behaves_like :random_number, :random_number, Random
+end

--- a/src/random.rb
+++ b/src/random.rb
@@ -3,9 +3,12 @@ class Random
     def rand(*args)
       DEFAULT.rand(*args)
     end
+    alias random_number rand
 
     def bytes(*args)
       Random.new.bytes(*args)
     end
   end
+
+  alias random_number rand
 end


### PR DESCRIPTION
These methods are not mentioned in the documentation of the Random class of Ruby, but the specs imply they're just an alias of Random.rand / Random#rand.