### PR TITLE
Implement MatchData#dup

### DIFF
--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -29,7 +29,7 @@ public:
         onig_region_free(m_region, true);
     }
 
-    const StringObject *string() { return m_string; }
+    StringObject *string() const { return m_string; }
 
     size_t size() { return m_region->num_regs; }
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -890,6 +890,7 @@ gen.binding('MatchData', 'length', 'MatchDataObject', 'size', argc: 0, pass_env:
 gen.binding('MatchData', 'match', 'MatchDataObject', 'match', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('MatchData', 'match_length', 'MatchDataObject', 'match_length', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('MatchData', 'offset', 'MatchDataObject', 'offset', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('MatchData', 'string', 'MatchDataObject', 'string', argc: 0, pass_env: false, pass_block: false, return_type: :StringObject)
 gen.binding('MatchData', 'to_a', 'MatchDataObject', 'to_a', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('MatchData', 'to_s', 'MatchDataObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('MatchData', '[]', 'MatchDataObject', 'ref', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/matchdata/dup_spec.rb
+++ b/spec/core/matchdata/dup_spec.rb
@@ -9,8 +9,7 @@ describe "MatchData#dup" do
     duplicate.instance_variable_get(:@custom_ivar).should == 42
     # NATFIXME: Implement MatchData#regexp
     # original.regexp.should == duplicate.regexp
-    # NATFIXME: Implement MatchData#string
-    # original.string.should == duplicate.string
+    original.string.should == duplicate.string
     original.offset(0).should == duplicate.offset(0)
   end
 end

--- a/spec/core/matchdata/dup_spec.rb
+++ b/spec/core/matchdata/dup_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+
+describe "MatchData#dup" do
+  it "duplicates the match data" do
+    original = /ll/.match("hello")
+    original.instance_variable_set(:@custom_ivar, 42)
+    duplicate = original.dup
+
+    duplicate.instance_variable_get(:@custom_ivar).should == 42
+    # NATFIXME: Implement MatchData#regexp
+    # original.regexp.should == duplicate.regexp
+    # NATFIXME: Implement MatchData#string
+    # original.string.should == duplicate.string
+    original.offset(0).should == duplicate.offset(0)
+  end
+end

--- a/spec/core/matchdata/string_spec.rb
+++ b/spec/core/matchdata/string_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+
+describe "MatchData#string" do
+  it "returns a copy of the match string" do
+    str = /(.)(.)(\d+)(\d)/.match("THX1138.").string
+    str.should == "THX1138."
+  end
+
+  it "returns a frozen copy of the match string" do
+    str = /(.)(.)(\d+)(\d)/.match("THX1138.").string
+    str.should == "THX1138."
+    str.should.frozen?
+  end
+
+  it "returns the same frozen string for every call" do
+    md = /(.)(.)(\d+)(\d)/.match("THX1138.")
+    md.string.should equal(md.string)
+  end
+
+  # NATFIXME: Implement String#gsub
+  xit "returns a frozen copy of the matched string for gsub(String)" do
+    'he[[o'.gsub!('[', ']')
+    $~.string.should == 'he[[o'
+    $~.string.should.frozen?
+  end
+end

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -913,6 +913,8 @@ Value Object::dup(Env *env) const {
         return TrueObject::the();
     case Object::Type::UnboundMethod:
         return new UnboundMethodObject { *as_unbound_method() };
+    case Object::Type::MatchData:
+        return new MatchDataObject { *as_match_data() };
     default:
         fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_str().c_str(), static_cast<int>(m_type));
         abort();


### PR DESCRIPTION
That resolves another crashing state in the nightly spec result. I added the readers `MatchData#string` and `MatchData#regexp` as well, to fully make this spec pass