### PR TITLE
Fix #define_method with blocks converted from a Method

### DIFF
--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -11,11 +11,18 @@ class Block : public Cell {
     friend ProcObject;
 
 public:
-    Block(Env *env, Value self, MethodFnPtr fn, int arity)
+    enum class BlockType {
+        Proc,
+        Lambda,
+        Method
+    };
+
+    Block(Env *env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
         : m_fn { fn }
         , m_arity { arity }
         , m_env { new Env(*env) }
-        , m_self { self } { }
+        , m_self { self }
+        , m_type { type } { }
 
     // NOTE: This should only be called from one of the RUN_BLOCK_* macros!
     Value _run(Env *env, Args args = {}, Block *block = nullptr) {
@@ -32,11 +39,16 @@ public:
     bool has_env() { return !!m_env; }
     Env *env() { return m_env; }
 
+    void set_type(BlockType type) { m_type = type; }
+    bool is_lambda() const { return m_type == BlockType::Lambda; }
+    bool is_from_method() const { return m_type == BlockType::Method; }
+
     Env *calling_env() { return m_calling_env; }
     void set_calling_env(Env *env) { m_calling_env = env; }
     void clear_calling_env() { m_calling_env = nullptr; }
 
     void set_self(Value self) { m_self = self; }
+    Value self() const { return m_self; }
 
     void copy_fn_pointer_to_method(Method *);
 
@@ -56,6 +68,7 @@ private:
     Env *m_env { nullptr };
     Env *m_calling_env { nullptr };
     Value m_self { nullptr };
+    BlockType m_type { BlockType::Proc };
 };
 
 }

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -24,8 +24,11 @@ public:
         , m_owner { owner }
         , m_arity { block->arity() }
         , m_env { new Env(*block->env()) } {
-        block->copy_fn_pointer_to_method(this);
         assert(m_env);
+        block->copy_fn_pointer_to_method(this);
+
+        if (block->is_from_method())
+            m_self = block->self();
     }
 
     MethodFnPtr fn() { return m_fn; }
@@ -47,6 +50,7 @@ public:
     virtual void visit_children(Visitor &visitor) override final {
         visitor.visit(m_owner);
         visitor.visit(m_env);
+        visitor.visit(m_self);
     }
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -57,6 +61,7 @@ private:
     String m_name {};
     ModuleObject *m_owner;
     MethodFnPtr m_fn;
+    Value m_self { nullptr };
     int m_arity { 0 };
     Env *m_env { nullptr };
     bool m_optimized { false };

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -22,7 +22,7 @@ public:
     }
 
     virtual ProcObject *to_proc(Env *env) override {
-        auto block = new Block { env, m_object, m_method->fn(), m_method->arity() };
+        auto block = new Block { env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method };
         return new ProcObject { block };
     }
 

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -14,21 +14,15 @@ namespace Natalie {
 
 class ProcObject : public Object {
 public:
-    enum class ProcType {
-        Proc,
-        Lambda
-    };
-
     ProcObject()
         : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s)->as_class() } { }
 
     ProcObject(ClassObject *klass)
         : Object { Object::Type::Proc, klass } { }
 
-    ProcObject(Block *block, ProcType type = ProcType::Proc, nat_int_t break_point = 0)
+    ProcObject(Block *block, nat_int_t break_point = 0)
         : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s)->as_class() }
         , m_block { block }
-        , m_type { type }
         , m_break_point { break_point } {
         assert(m_block);
     }
@@ -36,7 +30,6 @@ public:
     ProcObject(const ProcObject &other)
         : Object { other }
         , m_block { other.m_block }
-        , m_type { other.m_type }
         , m_break_point { other.m_break_point } { }
 
     static Value from_block_maybe(Block *block) {
@@ -49,7 +42,7 @@ public:
     Value initialize(Env *, Block *);
 
     Block *block() { return m_block; }
-    bool is_lambda() { return m_type == ProcType::Lambda; }
+    bool is_lambda() { return m_block->is_lambda(); }
 
     virtual ProcObject *to_proc(Env *) override {
         return this;
@@ -72,7 +65,6 @@ public:
 
 private:
     Block *m_block { nullptr };
-    ProcType m_type { ProcType::Proc };
     nat_int_t m_break_point { 0 };
 };
 

--- a/lib/natalie/compiler/instructions/create_lambda_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_lambda_instruction.rb
@@ -13,7 +13,12 @@ module Natalie
 
       def generate(transform)
         block = transform.pop
-        transform.exec_and_push(:lambda, "Value(new ProcObject(#{block}, ProcObject::ProcType::Lambda, #{@break_point || 0}))")
+        block_temp = transform.temp('block')
+        transform.exec_and_push(:lambda, [
+          "auto #{block_temp} = #{block}",
+          "#{block_temp}->set_type(Block::BlockType::Lambda)",
+          "Value(new ProcObject(#{block_temp}, #{@break_point || 0}))"
+        ])
       end
 
       def execute(vm)

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -367,7 +367,8 @@ bool KernelModule::is_a(Env *env, Value module) {
 
 Value KernelModule::lambda(Env *env, Block *block) {
     if (block) {
-        return new ProcObject { block, ProcObject::ProcType::Lambda };
+        block->set_type(Block::BlockType::Lambda);
+        return new ProcObject { block };
     } else {
         env->raise("ArgumentError", "tried to create Proc object without a block");
     }

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -18,6 +18,10 @@ Value Method::call(Env *env, Value self, Args args, Block *block) const {
     e.set_line(env->line());
     e.set_block(block);
 
+    if (m_self) {
+        self = m_self;
+    }
+
     auto call_fn = [&](Args args) {
         if (block && !block->calling_env()) {
             Defer clear_calling_env([&]() {

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -1,4 +1,4 @@
-SKIP_CLASS_MEMBERS = { 
+SKIP_CLASS_MEMBERS = {
   # NOTE: our smart pointer type gets visited by everything else
   'Natalie::Value' => '*',
 
@@ -28,6 +28,7 @@ KNOWN_UNCOLLECTABLE_TYPES = [
   'Natalie::Allocator',
   'Natalie::ArrayPacker::Token',
   'Natalie::Backtrace::Item',
+  'Natalie::Block::BlockType',
   'Natalie::Encoding',
   'Natalie::Enumerator::ArithmeticSequenceObject::Origin',
   'Natalie::FiberObject::Status',
@@ -41,7 +42,6 @@ KNOWN_UNCOLLECTABLE_TYPES = [
   'Natalie::NativeProfilerEvent',
   'Natalie::NativeProfilerEvent::Type',
   'Natalie::ObjectType',
-  'Natalie::ProcObject::ProcType',
   'Natalie::TimeObject::Mode',
   'TM::Hashmap',
   'TM::Optional',
@@ -95,7 +95,7 @@ def get_class_details_for_path(path)
 
   cursor.visit_children do |cursor, parent|
     if cursor.location&.file == path
-      #p([cursor.kind, cursor.location&.line, cursor&.display_name])  
+      #p([cursor.kind, cursor.location&.line, cursor&.display_name])
       if %i[cursor_class_decl cursor_class_template cursor_struct cursor_union].include?(cursor.kind) && cursor.definition?
         line = code_lines[cursor.location.line - 1]
         if line =~ /:/

--- a/test/natalie/define_method_test.rb
+++ b/test/natalie/define_method_test.rb
@@ -7,3 +7,14 @@ describe 'define_singleton_method' do
     obj.foo.should == 'foo method'
   end
 end
+
+describe 'define_method' do
+  it 'calls method on method owner if block comes from another object' do
+    class Bar
+      class << self
+        define_method(:new, &String.method(:new))
+      end
+    end
+    Bar.new.class.should == String
+  end
+end


### PR DESCRIPTION
Blocks created from a method object (using #to_proc or the ampersand) do behave different than normal blocks passed to #define_method. When calling the newly defined method the "self" object should be the "self" object of the block rather than the current "self" object.

For example:

```ruby
class MethodHolder
  class << self
    define_method(:new, &String.method(:new))
  end
end

p MethodHolder.new.class
```

This should not invoke the "new"-Method on the MethodHolder class but on the String class.

Closes #718