### PR TITLE
Implement OpenSSL::Random.random_bytes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - name: install openssl
         run: brew install openssl
       - name: test with clang on macOS
-        env:
-          PKG_CONFIG_PATH: /opt/homebrew/opt/openssl@3/lib/pkgconfig
-        run: rake test
+        run: |
+          pkg_env=$(brew info openssl | grep PKG_CONFIG_PATH | sed 's/"//g')
+          $pkg_env
+          rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,5 +43,7 @@ jobs:
         run: git submodule update --init --recursive
       - name: install ruby
         run: brew install ruby autoconf automake libtool
+      - name: install openssl
+        run: brew install openssl && brew link --force openssl
       - name: test with clang on macOS
         run: rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
       - name: install ruby
         run: brew install ruby autoconf automake libtool
       - name: install openssl
-        run: brew install openssl && brew link --force openssl
+        run: brew install openssl
       - name: test with clang on macOS
+        env:
+          PKG_CONFIG_PATH: /opt/homebrew/opt/openssl@3/lib/pkgconfig
         run: rake test

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -28,6 +28,20 @@ module Natalie
       File.join(BUILD_DIR, 'onigmo/lib'),
       File.join(BUILD_DIR, 'zlib'),
     ]
+    if RUBY_PLATFORM =~ /darwin/
+      # OpenSSL needs to be installed via brew
+      openssl_info = `brew info openssl`
+      # export CPPFLAGS="-I/usr/local/opt/openssl@3/include"
+      openssl_cppflags = openssl_info.lines.find { |line| line.include?('export CPPFLAGS') }
+      if openssl_cppflags
+        INC_PATHS << openssl_cppflags.split('"')[1][2..]
+      end
+      # export LDFLAGS="-L/usr/local/opt/openssl@3/lib"
+      openssl_ldflags = openssl_info.lines.find { |line| line.include?('export LDFLAGS') }
+      if openssl_ldflags
+        LIB_PATHS << openssl_ldflags.split('"')[1][2..]
+      end
+    end
     SO_EXT = RUBY_PLATFORM =~ /darwin/ ? 'bundle' : 'so'
 
     # When running `bin/natalie script.rb`, we use dynamic linking to speed things up.

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -28,18 +28,12 @@ module Natalie
       File.join(BUILD_DIR, 'onigmo/lib'),
       File.join(BUILD_DIR, 'zlib'),
     ]
-    if RUBY_PLATFORM =~ /darwin/
-      # OpenSSL needs to be installed via brew
-      openssl_info = `brew info openssl`
-      # export CPPFLAGS="-I/usr/local/opt/openssl@3/include"
-      openssl_cppflags = openssl_info.lines.find { |line| line.include?('export CPPFLAGS') }
-      if openssl_cppflags
-        INC_PATHS << openssl_cppflags.split('"')[1][2..]
+    if system('pkg-config --exists openssl')
+      unless (openssl_inc_path = `pkg-config --cflags openssl`.strip).empty?
+        INC_PATHS << openssl_inc_path.sub(/^\-I/, '')
       end
-      # export LDFLAGS="-L/usr/local/opt/openssl@3/lib"
-      openssl_ldflags = openssl_info.lines.find { |line| line.include?('export LDFLAGS') }
-      if openssl_ldflags
-        LIB_PATHS << openssl_ldflags.split('"')[1][2..]
+      unless (openssl_lib_path = `pkg-config --libs-only-L openssl`.strip).empty?
+        LIB_PATHS << openssl_lib_path.sub(/^\-L/, '')
       end
     end
     SO_EXT = RUBY_PLATFORM =~ /darwin/ ? 'bundle' : 'so'

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -36,6 +36,16 @@ module Natalie
         )
       end
 
+      def generate_bind_static_method(transform, ruby_name, cpp_name = ruby_name)
+        ruby_name = comptime_symbol(ruby_name)
+        cpp_name = comptime_symbol(cpp_name)
+        arity = -1 # FIXME: not sure how to calculate this without more info
+        transform.exec_and_push(
+          :method,
+          "self->klass()->define_method(env, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
+        )
+      end
+
       def generate_cxx_flags(transform, flags)
         flags = comptime_string(flags)
         transform.add_cxx_flags(flags)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -28,6 +28,7 @@ module Natalie
 
       INLINE_CPP_MACROS = %i[
         __bind_method__
+        __bind_static_method__
         __call__
         __constant__
         __cxx_flags__

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -1,0 +1,32 @@
+#include <openssl/err.h>
+#include <openssl/rand.h>
+
+#include "natalie.hpp"
+
+using namespace Natalie;
+
+Value init(Env *env, Value self) {
+    return NilObject::the();
+}
+
+Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    Value length = args[0];
+    const auto to_int = "to_int"_s;
+    if (!length->is_integer() && length->respond_to(env, to_int))
+        length = length->send(env, to_int);
+    length->assert_type(env, ObjectType::Integer, "Integer");
+    const auto num = static_cast<int>(length->as_integer()->to_nat_int_t());
+    if (num < 0)
+        env->raise("ArgumentError", "negative string size (or size too big)");
+
+    unsigned char buf[num];
+    if (RAND_bytes(buf, num) != 1) {
+        const auto err = ERR_get_error();
+        char err_buf[256];
+        ERR_error_string_n(err, err_buf, 256);
+        env->raise("RuntimeError", err_buf);
+    }
+
+    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), EncodingObject::get(Encoding::ASCII_8BIT) };
+}

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -5,13 +5,6 @@ __ld_flags__ '-lcrypto'
 
 module OpenSSL
   module Random
-    __bind_method__ :random_bytes :OpenSSL_Random_random_bytes
-
-    # NATFIXME: __bind_method__ should support this directly
-    def self.random_bytes(length)
-      proxy = Object.new
-      proxy.extend(self)
-      proxy.random_bytes(length)
-    end
+    __bind_static_method__ :random_bytes :OpenSSL_Random_random_bytes
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -1,0 +1,17 @@
+require 'natalie/inline'
+require 'openssl.cpp'
+
+__ld_flags__ '-lcrypto'
+
+module OpenSSL
+  module Random
+    __bind_method__ :random_bytes :OpenSSL_Random_random_bytes
+
+    # NATFIXME: __bind_method__ should support this directly
+    def self.random_bytes(length)
+      proxy = Object.new
+      proxy.extend(self)
+      proxy.random_bytes(length)
+    end
+  end
+end

--- a/spec/library/openssl/random/pseudo_bytes_spec.rb
+++ b/spec/library/openssl/random/pseudo_bytes_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/random_bytes'
+
+if defined?(OpenSSL::Random.pseudo_bytes)
+  describe "OpenSSL::Random.pseudo_bytes" do
+    it_behaves_like :openssl_random_bytes, :pseudo_bytes
+  end
+end

--- a/spec/library/openssl/random/random_bytes_spec.rb
+++ b/spec/library/openssl/random/random_bytes_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/random_bytes'
+
+describe "OpenSSL::Random.random_bytes" do
+  it_behaves_like :openssl_random_bytes, :random_bytes
+end

--- a/spec/library/openssl/random/shared/random_bytes.rb
+++ b/spec/library/openssl/random/shared/random_bytes.rb
@@ -1,0 +1,29 @@
+require_relative '../../../../spec_helper'
+require 'openssl'
+
+describe :openssl_random_bytes, shared: true do |cmd|
+  it "generates a random binary string of specified length" do
+    (1..64).each do |idx|
+      bytes = OpenSSL::Random.send(@method, idx)
+      bytes.should be_kind_of(String)
+      bytes.length.should == idx
+    end
+  end
+
+  it "generates different binary strings with subsequent invocations" do
+    # quick and dirty check, but good enough
+    values = []
+    256.times do
+      val = OpenSSL::Random.send(@method, 16)
+      # make sure the random bytes are not repeating
+      values.include?(val).should == false
+      values << val
+    end
+  end
+
+  it "raises ArgumentError on negative arguments" do
+    -> {
+      OpenSSL::Random.send(@method, -1)
+    }.should raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Which also means this adds a hard dependency on the openssl headers to be able to compile. It would probably be nice to just skip the extension if those can't be found.

I might want to look into implementing more of OpenSSL later on, since cryptography is pretty much a requirement to do anything these days.