### PR TITLE
Prevent segfault in String#gsub

### DIFF
--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -516,7 +516,7 @@ describe "String#gsub with pattern and block" do
   end
 end
 
-# NATFIXME: Segfault
+# NATFIXME: String#gsub with pattern and without replacement and block
 xdescribe "String#gsub with pattern and without replacement and block" do
   it "returns an enumerator" do
     enum = "abca".gsub(/a/)

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1794,11 +1794,13 @@ StringObject *StringObject::regexp_sub(Env *env, RegexpObject *find, StringObjec
         out->append(*expanded_replacement);
         if (index + length < m_string.length())
             out->append(m_string.substring(index + length));
-    } else {
+    } else if (replacement) {
         *expanded_replacement = expand_backrefs(env, replacement->as_string(), *match);
         out->append(*expanded_replacement);
         if (index + length < m_string.length())
             out->append(m_string.substring(index + length));
+    } else {
+        NAT_NOT_YET_IMPLEMENTED("Enumerator reply in String#gsub");
     }
     return out;
 }


### PR DESCRIPTION
It is possible to call String#gsub with only one argument and no block, in that case the reply should be an enumerator. The code did not handle that case, and tried to dererence a nullptr into a string.

This change adds the extra case with a NAT_NOT_YET_IMPLEMENTED. It still halts the program, but at least now it shows what is missing, and it resolves the security issues of segfaults.