### PR TITLE
Implement Process.groups

### DIFF
--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -66,6 +66,8 @@ public:
         return idval;
     }
 
+    static Value groups(Env *env);
+
 private:
     static uid_t value_to_uid(Env *env, Value idval) {
         uid_t uid;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -985,6 +985,7 @@ gen.module_function_binding('Process', 'exit', 'KernelModule', 'exit', argc: 0..
 gen.module_function_binding('Process', 'exit!', 'KernelModule', 'exit_bang', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'gid', 'ProcessModule', 'gid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'gid=', 'ProcessModule', 'setgid', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.module_function_binding('Process', 'groups', 'ProcessModule', 'groups', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'pid', 'ProcessModule', 'pid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'ppid', 'ProcessModule', 'ppid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'uid', 'ProcessModule', 'uid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/process/groups_spec.rb
+++ b/spec/core/process/groups_spec.rb
@@ -1,0 +1,72 @@
+require_relative '../../spec_helper'
+
+describe "Process.groups" do
+  platform_is_not :windows do
+    it "gets an Array of the gids of groups in the supplemental group access list" do
+      # NATFIXME: Implement String#scan
+      # groups = `id -G`.scan(/\d+/).map { |i| i.to_i }
+      groups = `id -G`.chomp.split(/\s+/).map { |i| i.to_i }
+      # Include the standard `id` command output.  On macOS, GNU
+      # coreutils `id` is limited to NGROUPS_MAX groups, because of
+      # the backward compatibility of getgroups(2).
+      # NATFIXME: Implement String#scan
+      # (groups |= `/usr/bin/id -G`.scan(/\d+/).map { |i| i.to_i }) rescue nil
+      (groups |= `/usr/bin/id -G`.chomp.split(/\s+/).map { |i| i.to_i }) rescue nil
+      gid = Process.gid
+
+      expected = (groups.sort - [gid]).uniq.sort
+      actual = (Process.groups - [gid]).uniq.sort
+      actual.should == expected
+    end
+  end
+end
+
+# NATFIXME: Implement Process.groups=
+xdescribe "Process.groups=" do
+  platform_is_not :windows, :android do
+    as_superuser do
+      it "sets the list of gids of groups in the supplemental group access list" do
+        groups = Process.groups
+        Process.groups = []
+        Process.groups.should == []
+        Process.groups = groups
+        Process.groups.sort.should == groups.sort
+      end
+    end
+
+    as_user do
+      platform_is :aix do
+        it "sets the list of gids of groups in the supplemental group access list" do
+          # setgroups() is not part of the POSIX standard,
+          # so its behavior varies from OS to OS.  AIX allows a non-root
+          # process to set the supplementary group IDs, as long as
+          # they are presently in its supplementary group IDs.
+          # The order of the following tests matters.
+          # After this process executes "Process.groups = []"
+          # it should no longer be able to set any supplementary
+          # group IDs, even if it originally belonged to them.
+          # It should only be able to set its primary group ID.
+          groups = Process.groups
+          Process.groups = groups
+          Process.groups.sort.should == groups.sort
+          Process.groups = []
+          Process.groups.should == []
+          Process.groups = [ Process.gid ]
+          Process.groups.should == [ Process.gid ]
+          supplementary = groups - [ Process.gid ]
+          if supplementary.length > 0
+            -> { Process.groups = supplementary }.should raise_error(Errno::EPERM)
+          end
+        end
+      end
+
+      platform_is_not :aix do
+        it "raises Errno::EPERM" do
+          -> {
+            Process.groups = [0]
+          }.should raise_error(Errno::EPERM)
+        end
+      end
+    end
+  end
+end

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -1,0 +1,23 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+Value ProcessModule::groups(Env *env) {
+    const auto size = getgroups(0, nullptr);
+    gid_t list[size];
+    if (getgroups(size, list) < 0)
+        env->raise_errno();
+    auto result = new ArrayObject { static_cast<size_t>(size) };
+    // MacOS does not include the effective GID in the output of getgroups
+    const auto egid = getegid();
+    bool has_egid = false;
+    for (int i = 0; i < size; i++) {
+        result->push(Value::integer(list[i]));
+        has_egid = has_egid || list[i] == egid;
+    }
+    if (!has_egid)
+        result->push(Value::integer(egid));
+    return result;
+}
+
+}


### PR DESCRIPTION
This is a dependency in [`FileTest.grpowned?`](https://github.com/ruby/spec/blob/738c8f6e64031d3a2083b585dd8ea6b813766f49/shared/file/grpowned.rb).

Ironically, this spec depends on `String#scan`