### PR TITLE
Handle self-references in Set#inspect

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -99,7 +99,8 @@ class Set
   alias === include?
 
   def inspect
-    "#<Set: {#{to_a}}>"
+    items = to_a.map { |e| equal?(e) ? '#<Set: {...}>' : e.to_s }
+    "#<Set: {#{items.join(', ')}}>"
   end
   alias to_s inspect
 

--- a/spec/library/set/shared/inspect.rb
+++ b/spec/library/set/shared/inspect.rb
@@ -7,7 +7,7 @@ describe :set_inspect, shared: true do
     Set[:a, "b", Set[?c]].send(@method).should be_kind_of(String)
   end
 
-  xit "correctly handles self-references" do
+  it "correctly handles self-references" do
     # NATFIXME: Support this syntax
     # (set = Set[]) << set
     set = Set[]


### PR DESCRIPTION
This fixes the remaining issues of `Set#inspect` and `Set#to_s` in #840. The official specs still won't compile with Natalie, but that's due to #873 and not related to `Set`.