### PR TITLE
Add implementation of NATFIXME for review

### DIFF
--- a/test/natalie/natfixme_test.rb
+++ b/test/natalie/natfixme_test.rb
@@ -15,15 +15,15 @@ describe "NATFIXME" do
     end
   end
 
-  it "hides a failing block with klass" do
-    NATFIXME "cant load a missing thing", klass: LoadError do
+  it "hides a failing block with exception" do
+    NATFIXME "cant load a missing thing", exception: LoadError do
       load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
     end
   end
 
-  it "hides a failing block with klass and match" do
+  it "hides a failing block with exception and message" do
     s = "567879"
-    NATFIXME "Pending String#foo", klass: NoMethodError, match: /method.*foo/ do
+    NATFIXME "Pending String#foo", exception: NoMethodError, message: /method.*foo/ do
       s.foo.should == "foo567879"
     end
   end
@@ -37,9 +37,9 @@ describe "NATFIXME" do
     }.should raise_error(NatalieFixMeException)
   end
 
-  it "raises when the block raises but with the wrong klass" do
+  it "raises when the block raises but with the wrong exception" do
     -> {
-      NATFIXME "cant load a missing thing", klass: ZeroDivisionError do
+      NATFIXME "cant load a missing thing", exception: ZeroDivisionError do
         load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
       end
     }.should raise_error(NatalieFixMeException)
@@ -47,7 +47,7 @@ describe "NATFIXME" do
 
   it "raises when the block raises but with the wrong message" do
     -> {
-      NATFIXME "cant load a missing thing", klass: ZeroDivisionError, match: "divided by ZERO" do
+      NATFIXME "cant load a missing thing", exception: ZeroDivisionError, message: "divided by ZERO" do
         1 / 0
       end
     }.should raise_error(NatalieFixMeException)

--- a/test/natalie/natfixme_test.rb
+++ b/test/natalie/natfixme_test.rb
@@ -1,0 +1,57 @@
+require_relative '../spec_helper'
+
+
+describe "NATFIXME" do
+
+  # Reference expectation check, not testing NATFIXME
+  it "fails spec outside natfixme" do
+    a = 5
+    -> {
+      a.should == 6
+    }.should raise_error(SpecFailedException)
+  end
+
+  it "hides a failing block with klass only" do
+    NATFIXME "Descriptive message" do
+      raise "fake error which will be hidden"
+    end
+  end
+  it "hides a failing block with klass only" do
+    NATFIXME "cant load a missing thing", klass: LoadError do
+      load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
+    end
+  end
+
+  it "hides a failing block with klass and match" do
+    s = "567879"
+    NATFIXME "Pending String#foo", klass: NoMethodError, match: /method.*foo/ do
+      s.foo.should == "foo567879"
+    end
+  end
+  
+  it "fails when the block passes" do
+    -> {
+      NATFIXME "Pending String#sub" do
+        s = "567879".sub(/9/,"9")
+        s.should == "567879"
+      end
+    }.should raise_error(NatalieFixMeException)
+  end
+
+  it "fails when the block fails but with the wrong klass" do
+    -> {
+    NATFIXME "cant load a missing thing", klass: ZeroDivisionError do
+      load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
+    end
+    }.should raise_error(NatalieFixMeException)
+  end
+
+  it "fails when the block fails but with the wrong message" do
+    -> {
+    NATFIXME "cant load a missing thing", klass: ZeroDivisionError, match: "divided by ZERO" do
+      1/0
+    end
+    }.should raise_error(NatalieFixMeException)
+  end
+
+end

--- a/test/natalie/natfixme_test.rb
+++ b/test/natalie/natfixme_test.rb
@@ -1,8 +1,6 @@
-require_relative '../spec_helper'
-
+require_relative "../spec_helper"
 
 describe "NATFIXME" do
-
   # Reference expectation check, not testing NATFIXME
   it "fails spec outside natfixme" do
     a = 5
@@ -11,12 +9,13 @@ describe "NATFIXME" do
     }.should raise_error(SpecFailedException)
   end
 
-  it "hides a failing block with klass only" do
+  it "hides a failing block" do
     NATFIXME "Descriptive message" do
       raise "fake error which will be hidden"
     end
   end
-  it "hides a failing block with klass only" do
+
+  it "hides a failing block with klass" do
     NATFIXME "cant load a missing thing", klass: LoadError do
       load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
     end
@@ -28,30 +27,29 @@ describe "NATFIXME" do
       s.foo.should == "foo567879"
     end
   end
-  
-  it "fails when the block passes" do
+
+  it "raises when the block passes" do
     -> {
       NATFIXME "Pending String#sub" do
-        s = "567879".sub(/9/,"9")
+        s = "567879".sub(/9/, "9")
         s.should == "567879"
       end
     }.should raise_error(NatalieFixMeException)
   end
 
-  it "fails when the block fails but with the wrong klass" do
+  it "raises when the block raises but with the wrong klass" do
     -> {
-    NATFIXME "cant load a missing thing", klass: ZeroDivisionError do
-      load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
-    end
+      NATFIXME "cant load a missing thing", klass: ZeroDivisionError do
+        load "/tmp/xyzzy.eW91dmVfYmVlbl9lYXRlbl9ieV9hX2dydWUK"
+      end
     }.should raise_error(NatalieFixMeException)
   end
 
-  it "fails when the block fails but with the wrong message" do
+  it "raises when the block raises but with the wrong message" do
     -> {
-    NATFIXME "cant load a missing thing", klass: ZeroDivisionError, match: "divided by ZERO" do
-      1/0
-    end
+      NATFIXME "cant load a missing thing", klass: ZeroDivisionError, match: "divided by ZERO" do
+        1 / 0
+      end
     }.should raise_error(NatalieFixMeException)
   end
-
 end


### PR DESCRIPTION
Based on ideas from @herwinw 👏 

This PR implements #837 with some additions:
- Able to wrap expectations/matchers inside an 'it' block without modification
- Adds a new `NatalieFixMeException` class.
- Adds optional `klass:` and `match:` keyword arguments so that the expected failure signature is captured. If the specs no longer fail or the failure is different (no longer same as the given klass / match), then it will raise `NatalieFixMeException`

Some tests were added, hopefully I haven't missed some critical use cases.  Feedback would be appreciated.
