### PR TITLE
Update specs for new encodings

### DIFF
--- a/spec/core/float/shared/to_s.rb
+++ b/spec/core/float/shared/to_s.rb
@@ -86,9 +86,8 @@ describe :float_to_s, shared: true do
     value = 0.21611564636388508
     string = "0.21611564636388508"
 
-    # NATFIXME: Support String#to_f
-    # value.send(@method).should == string
-    # string.to_f.should == value
+    value.send(@method).should == string
+    string.to_f.should == value
   end
 
   it "outputs the minimal, unique form to represent the value" do

--- a/spec/core/float/shared/to_s.rb
+++ b/spec/core/float/shared/to_s.rb
@@ -287,7 +287,6 @@ describe :float_to_s, shared: true do
     end
   end
 
-  # NATFIXME: Support different encodings
   describe 'encoding' do
     before :each do
       @internal = Encoding.default_internal
@@ -303,9 +302,7 @@ describe :float_to_s, shared: true do
     end
 
     it "returns a String in US-ASCII encoding when Encoding.default_internal is not nil" do
-      # NATFIXME: implement Encoding::IBM437
-      #Encoding.default_internal = Encoding::IBM437
-      Encoding.default_internal = Encoding::ASCII_8BIT
+      Encoding.default_internal = Encoding::IBM437
       5.47.send(@method).encoding.should equal(Encoding::US_ASCII)
     end
   end

--- a/spec/core/integer/chr_spec.rb
+++ b/spec/core/integer/chr_spec.rb
@@ -245,10 +245,10 @@ describe "Integer#chr with an encoding argument" do
       [0xDBFF, "UTF-8"],
       [0xDC00, "UTF-8"],
       [0xDFFF, "UTF-8"],
-      # [0xD800, "UTF-16"],
-      # [0xDBFF, "UTF-16"],
-      # [0xDC00, "UTF-16"],
-      # [0xDFFF, "UTF-16"],
+      [0xD800, "UTF-16"],
+      [0xDBFF, "UTF-16"],
+      [0xDC00, "UTF-16"],
+      [0xDFFF, "UTF-16"],
     ].each do |integer, encoding_name|
       -> { integer.chr(encoding_name) }.should raise_error(RangeError)
     end

--- a/spec/core/integer/chr_spec.rb
+++ b/spec/core/integer/chr_spec.rb
@@ -68,9 +68,8 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.encoding.should == Encoding::US_ASCII
 
-          # NATFIXME: Implement Encoding::SHIFT_JIS
-          #Encoding.default_internal = Encoding::SHIFT_JIS
-          #c.chr.encoding.should == Encoding::US_ASCII
+          Encoding.default_internal = Encoding::SHIFT_JIS
+          c.chr.encoding.should == Encoding::US_ASCII
         end
       end
 
@@ -79,9 +78,8 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.bytes.to_a.should == [c]
 
-          # NATFIXME: Implement Encoding::SHIFT_JIS
-          #Encoding.default_internal = Encoding::SHIFT_JIS
-          #c.chr.bytes.to_a.should == [c]
+          Encoding.default_internal = Encoding::SHIFT_JIS
+          c.chr.bytes.to_a.should == [c]
         end
       end
     end
@@ -92,9 +90,8 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.encoding.should == Encoding::BINARY
 
-          # NATFIXME: Implement Encoding::SHIFT_JIS
-          # Encoding.default_internal = Encoding::SHIFT_JIS
-          # c.chr.encoding.should == Encoding::BINARY
+          Encoding.default_internal = Encoding::SHIFT_JIS
+          c.chr.encoding.should == Encoding::BINARY
         end
       end
 
@@ -103,9 +100,8 @@ describe "Integer#chr without argument" do
           Encoding.default_internal = Encoding::UTF_8
           c.chr.bytes.to_a.should == [c]
 
-          # NATFIXME: Implement Encoding::SHIFT_JIS
-          # Encoding.default_internal = Encoding::SHIFT_JIS
-          # c.chr.bytes.to_a.should == [c]
+          Encoding.default_internal = Encoding::SHIFT_JIS
+          c.chr.bytes.to_a.should == [c]
         end
       end
     end
@@ -116,7 +112,7 @@ describe "Integer#chr without argument" do
         0x0100.chr.encoding.should == Encoding::UTF_8
         0x3000.chr.encoding.should == Encoding::UTF_8
 
-        # NATFIXME: Implement Encoding::SHIFT_JIS
+        # NATFIXME: Implement multibyte characters and Encoding::SHIFT_JIS
         # Encoding.default_internal = Encoding::SHIFT_JIS
         # 0x8140.chr.encoding.should == Encoding::SHIFT_JIS
         # 0xFC4B.chr.encoding.should == Encoding::SHIFT_JIS
@@ -182,7 +178,7 @@ describe "Integer#chr with an encoding argument" do
     -> { 2206368128.chr(Encoding::UTF_8) }.should raise_error(RangeError)
   end
 
-  # NATFIXME: Add Encoding::SHIFT_JIS
+  # NATFIXME: Implement multibyte characters and Encoding::SHIFT_JIS
   it "returns a String with the specified encoding" do
     0x0000.chr(Encoding::US_ASCII).encoding.should == Encoding::US_ASCII
     0x007F.chr(Encoding::US_ASCII).encoding.should == Encoding::US_ASCII
@@ -207,7 +203,7 @@ describe "Integer#chr with an encoding argument" do
     # 0xFC4B.chr(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
   end
 
-  # NATFIXME: Add Encoding::SHIFT_JIS
+  # NATFIXME: Implement multibyte characters and Encoding::SHIFT_JIS
   it "returns a String encoding self interpreted as a codepoint in the specified encoding" do
     0x0000.chr(Encoding::US_ASCII).bytes.to_a.should == [0x00]
     0x007F.chr(Encoding::US_ASCII).bytes.to_a.should == [0x7F]
@@ -241,8 +237,8 @@ describe "Integer#chr with an encoding argument" do
       # [0x0100, "EUC-JP"],
       # [0xA1A0, "EUC-JP"],
       # [0xA1,   "EUC-JP"],
-      # [0x80,   "SHIFT_JIS"],
-      # [0xE0,   "SHIFT_JIS"],
+      [0x80,   "SHIFT_JIS"],
+      [0xE0,   "SHIFT_JIS"],
       # [0x0100, "ISO-8859-9"],
       # [620,    "TIS-620"],
       [0xD800, "UTF-8"],

--- a/spec/core/integer/chr_spec.rb
+++ b/spec/core/integer/chr_spec.rb
@@ -134,8 +134,8 @@ describe "Integer#chr without argument" do
       it "raises RangeError if self is invalid as a codepoint in the default internal encoding" do
         [ [0x0100, "US-ASCII"],
           [0x0100, "BINARY"],
-          #[0x0100, "EUC-JP"],
-          #[0xA1A0, "EUC-JP"],
+          [0x0100, "EUC-JP"],
+          [0xA1A0, "EUC-JP"],
           #[0x0100, "ISO-8859-9"],
           #[620,    "TIS-620"]
         ].each do |integer, encoding_name|
@@ -156,7 +156,7 @@ describe "Integer#chr with an encoding argument" do
     8287.chr(Encoding::UTF_8).should_not equal(8287.chr(Encoding::UTF_8))
   end
 
-  # NATFIXME: Implement Encoding::EUC_JP
+  # NATFIXME: Implement multibyte characters and Encoding::EUC_JP
   xit "accepts a String as an argument" do
     -> { 0xA4A2.chr('euc-jp') }.should_not raise_error
   end
@@ -170,8 +170,7 @@ describe "Integer#chr with an encoding argument" do
   # http://redmine.ruby-lang.org/issues/4869
   it "raises a RangeError is self is less than 0" do
     -> { -1.chr(Encoding::UTF_8) }.should raise_error(RangeError)
-    # NATFIXME: Implement Encoding::EUC_JP
-    # -> { (-bignum_value).chr(Encoding::EUC_JP) }.should raise_error(RangeError)
+    -> { (-bignum_value).chr(Encoding::EUC_JP) }.should raise_error(RangeError)
   end
 
   it "raises a RangeError if self is too large" do
@@ -234,9 +233,9 @@ describe "Integer#chr with an encoding argument" do
   xit "raises RangeError if self is invalid as a codepoint in the specified encoding" do
     [ [0x80,   "US-ASCII"],
       [0x0100, "BINARY"],
-      # [0x0100, "EUC-JP"],
-      # [0xA1A0, "EUC-JP"],
-      # [0xA1,   "EUC-JP"],
+      [0x0100, "EUC-JP"],
+      [0xA1A0, "EUC-JP"],
+      [0xA1,   "EUC-JP"],
       [0x80,   "SHIFT_JIS"],
       [0xE0,   "SHIFT_JIS"],
       # [0x0100, "ISO-8859-9"],

--- a/spec/core/regexp/shared/quote.rb
+++ b/spec/core/regexp/shared/quote.rb
@@ -23,9 +23,7 @@ describe :regexp_quote, shared: true do
   end
 
   it "sets the encoding of the result to US-ASCII if there are only US-ASCII characters present in the input String" do
-    # NATFIXME: Implement euc-jp encoding
-    # str = "abc".force_encoding("euc-jp")
-    str = "abc".force_encoding("utf-8")
+    str = "abc".force_encoding("euc-jp")
     Regexp.send(@method, str).encoding.should == Encoding::US_ASCII
   end
 

--- a/spec/core/string/include_spec.rb
+++ b/spec/core/string/include_spec.rb
@@ -15,18 +15,16 @@ describe "String#include? with String" do
 
   it "returns true if both strings are empty" do
     "".should.include?("")
-    # NATFIXME: Implement EUC-JP encoding
-    # "".force_encoding("EUC-JP").should.include?("")
-    # "".should.include?("".force_encoding("EUC-JP"))
-    # "".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+    "".force_encoding("EUC-JP").should.include?("")
+    "".should.include?("".force_encoding("EUC-JP"))
+    "".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
   end
 
   it "returns true if the RHS is empty" do
     "a".should.include?("")
-    # NATFIXME: Implement EUC-JP encoding
-    # "a".force_encoding("EUC-JP").should.include?("")
-    # "a".should.include?("".force_encoding("EUC-JP"))
-    # "a".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+    "a".force_encoding("EUC-JP").should.include?("")
+    "a".should.include?("".force_encoding("EUC-JP"))
+    "a".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
   end
 
   it "tries to convert other to string using to_str" do
@@ -42,7 +40,7 @@ describe "String#include? with String" do
     -> { "hello".include?(mock('x')) }.should raise_error(TypeError)
   end
 
-  # NATFIXME: Implement EUC-JP encoding
+  # NATFIXME: Implement multibyte characters and EUC-JP encoding
   xit "raises an Encoding::CompatibilityError if the encodings are incompatible" do
     pat = "ア".encode Encoding::EUC_JP
     -> do

--- a/spec/core/string/insert_spec.rb
+++ b/spec/core/string/insert_spec.rb
@@ -63,7 +63,7 @@ describe "String#insert with index, other" do
     str.encoding.should == Encoding::UTF_8
   end
 
-  # NATFIXME: Implement Encoding::EUC_JP
+  # NATFIXME: Implement multibyte characters and Encoding::EUC_JP
   xit "raises an Encoding::CompatibilityError if the encodings are incompatible" do
     pat = "ア".encode Encoding::EUC_JP
     -> do

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -149,8 +149,7 @@ describe :string_concat_encoding, shared: true do
       "abc".encode("UTF-8").send(@method, "123".encode("SHIFT_JIS")).encoding.should == Encoding::UTF_8
     end
 
-    # NATFIXME: Implement ISO-8859-1
-    xit "uses self's encoding if the argument is ASCII-only" do
+    it "uses self's encoding if the argument is ASCII-only" do
       "\u00E9".encode("UTF-8").send(@method, "123".encode("ISO-8859-1")).encoding.should == Encoding::UTF_8
     end
 

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -74,10 +74,9 @@ describe :string_concat, shared: true do
       a.should == 255.chr
     end
 
-    # NATFIXME: Implement EUC_JP encoding
     it "raises RangeError if the argument is an invalid codepoint for self's encoding" do
       -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
-      # -> { "".encode(Encoding::EUC_JP).send(@method, 0x81)  }.should raise_error(RangeError)
+      -> { "".encode(Encoding::EUC_JP).send(@method, 0x81)  }.should raise_error(RangeError)
     end
 
     it "raises RangeError if the argument is negative" do

--- a/spec/core/string/shared/eql.rb
+++ b/spec/core/string/shared/eql.rb
@@ -12,8 +12,7 @@ describe :string_eql_value, shared: true do
     "less".send(@method, "greater").should be_false
   end
 
-  # NATFIXME: add back once we support iso-8859-1 encoding
-  xit "ignores encoding difference of compatible string" do
+  it "ignores encoding difference of compatible string" do
     "hello".force_encoding("utf-8").send(@method, "hello".force_encoding("iso-8859-1")).should be_true
   end
 

--- a/spec/library/stringio/external_encoding_spec.rb
+++ b/spec/library/stringio/external_encoding_spec.rb
@@ -1,8 +1,7 @@
 require 'stringio'
 require_relative '../../spec_helper'
 
-# NATFIXME: Support Encoding::EUC_JP
-xdescribe "StringIO#external_encoding" do
+describe "StringIO#external_encoding" do
   it "gets the encoding of the underlying String" do
     io = StringIO.new
     io.set_encoding Encoding::EUC_JP

--- a/spec/library/stringio/initialize_spec.rb
+++ b/spec/library/stringio/initialize_spec.rb
@@ -206,8 +206,7 @@ xdescribe "StringIO#initialize sets" do
     io.string.encoding.should == Encoding::ISO_8859_2
   end
 
-  # NATFIXME: Implement Encoding::EUC_JP
-  xit "the encoding to the encoding of the String when passed a String" do
+  it "the encoding to the encoding of the String when passed a String" do
     s = ''.force_encoding(Encoding::EUC_JP)
     io = StringIO.new(s)
     io.string.encoding.should == Encoding::EUC_JP
@@ -217,8 +216,7 @@ xdescribe "StringIO#initialize sets" do
     stringio_version = StringIO.const_defined?(:VERSION) ? StringIO::VERSION : "0.0.2"
     version_is(stringio_version, "0.0.3"..."0.1.1")
   } do
-    # NATFIXME: Implement Encoding::EUC_JP
-    xit "the #external_encoding to the encoding of the String when passed a String" do
+    it "the #external_encoding to the encoding of the String when passed a String" do
       s = ''.force_encoding(Encoding::EUC_JP)
       io = StringIO.new(s)
       io.external_encoding.should == Encoding::EUC_JP

--- a/spec/shared/string/end_with.rb
+++ b/spec/shared/string/end_with.rb
@@ -46,7 +46,7 @@ describe :end_with, shared: true do
     "céréale".send(@method).should.end_with?("réale")
   end
 
-  # NATFIXME: no support yet for EUC_JP encoding
+  # NATFIXME: Implement multibyte characters and Encoding::EUC_JP
   xit "raises an Encoding::CompatibilityError if the encodings are incompatible" do
     pat = "ア".encode Encoding::EUC_JP
     -> do


### PR DESCRIPTION
A bunch of NATFIXMEs had been fixed, others needed an update as to why the NATFIXME marker was still needed