### PR TITLE
Fix StringScanner#scan_until for zero length matches

### DIFF
--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -92,7 +92,8 @@ class StringScanner
       return nil if @pos > @string.size
       @pos += 1
     end
-    @string[start...@pos + matched.size - 1]
+    index = matched.empty? ? @pos : @pos + matched.size - 1
+    @string[start...index]
   end
 
   def skip(pattern)

--- a/test/lib/strscan_test.rb
+++ b/test/lib/strscan_test.rb
@@ -21,4 +21,11 @@ describe 'StringScanner' do
     s.scan(/\s+/).should == nil
     s.scan(/\w+/).should == nil
   end
+
+  describe '#scan_until' do
+    it 'works with zero length matches' do
+      s = StringScanner.new('foo bar')
+      s.scan_until(/(?=\s)/).should == 'foo'
+    end
+  end
 end


### PR DESCRIPTION
Currently omitting the last character from the result string. For example:

    $ bin/natalie -r strscan
    nat> StringScanner.new('foo bar').scan_until(/(?=\s)/)
    "fo"
