### PR TITLE
Update constructors of Method to take TM::String instead of char*

### DIFF
--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -11,16 +11,16 @@ namespace Natalie {
 
 class Method : public Cell {
 public:
-    Method(const TM::String &name, ModuleObject *owner, MethodFnPtr fn, int arity)
-        : m_name { name }
+    Method(TM::String &&name, ModuleObject *owner, MethodFnPtr fn, int arity)
+        : m_name { std::move(name) }
         , m_owner { owner }
         , m_fn { fn }
         , m_arity { arity } {
         assert(fn);
     }
 
-    Method(const TM::String &name, ModuleObject *owner, Block *block)
-        : m_name { name }
+    Method(TM::String &&name, ModuleObject *owner, Block *block)
+        : m_name { std::move(name) }
         , m_owner { owner }
         , m_arity { block->arity() }
         , m_env { new Env(*block->env()) } {
@@ -30,6 +30,11 @@ public:
         if (block->is_from_method())
             m_self = block->self();
     }
+
+    Method(const TM::String &name, ModuleObject *owner, MethodFnPtr fn, int arity)
+        : Method(TM::String(name), owner, fn, arity) { }
+    Method(const TM::String &name, ModuleObject *owner, Block *block)
+        : Method(TM::String(name), owner, block) { }
 
     MethodFnPtr fn() { return m_fn; }
     void set_fn(MethodFnPtr fn) { m_fn = fn; }

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -11,7 +11,7 @@ namespace Natalie {
 
 class Method : public Cell {
 public:
-    Method(const char *name, ModuleObject *owner, MethodFnPtr fn, int arity)
+    Method(const TM::String &name, ModuleObject *owner, MethodFnPtr fn, int arity)
         : m_name { name }
         , m_owner { owner }
         , m_fn { fn }
@@ -19,7 +19,7 @@ public:
         assert(fn);
     }
 
-    Method(const char *name, ModuleObject *owner, Block *block)
+    Method(const TM::String &name, ModuleObject *owner, Block *block)
         : m_name { name }
         , m_owner { owner }
         , m_arity { block->arity() }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -283,7 +283,7 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 }
 
 SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
-    Method *method = new Method { name->c_str(), this, fn, arity };
+    Method *method = new Method { name->string(), this, fn, arity };
     if (optimized)
         method->set_optimized(true);
     define_method(env, name, method, m_method_visibility);
@@ -293,7 +293,7 @@ SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFn
 }
 
 SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, Block *block) {
-    Method *method = new Method { name->c_str(), this, block };
+    Method *method = new Method { name->string(), this, block };
     define_method(env, name, method, m_method_visibility);
     if (m_module_function)
         define_singleton_method(env, name, block);


### PR DESCRIPTION
And fix the callers as well.
This one is a prelude to removing `SymbolObject::c_str()`, which has been deprecated in favour of `SymbolObject::string()`.