### PR TITLE
Make float and integer comparison methods spec compliant

### DIFF
--- a/spec/core/float/comparison_spec.rb
+++ b/spec/core/float/comparison_spec.rb
@@ -7,9 +7,25 @@ describe "Float#<=>" do
     ((bignum_value*1.1) <=> bignum_value).should == 1
   end
 
-  it "returns nil when either argument is NaN" do
-    (nan_value <=> 71.2).should be_nil
-    (1771.176 <=> nan_value).should be_nil
+  it "returns nil if one side is NaN" do
+    [1.0, 42, bignum_value].each { |n|
+      (nan_value <=> n).should == nil
+      (n <=> nan_value).should == nil
+    }
+  end
+
+  it "handles positive infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (infinity_value <=> n).should == 1
+      (n <=> infinity_value).should == -1
+    }
+  end
+
+  it "handles negative infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (-infinity_value <=> n).should == -1
+      (n <=> -infinity_value).should == 1
+    }
   end
 
   it "returns nil when the given argument is not a Float" do
@@ -49,21 +65,10 @@ describe "Float#<=>" do
     }.should raise_error(TypeError, "coerce must return [x, y]")
   end
 
-  # The 4 tests below are taken from matz's revision 23730 for Ruby trunk
-  #
-  it "returns 1 when self is Infinity and other is an Integer" do
+  it "returns the correct result when one side is infinite" do
     (infinity_value <=> Float::MAX.to_i*2).should == 1
-  end
-
-  it "returns -1 when self is negative and other is Infinity" do
     (-Float::MAX.to_i*2 <=> infinity_value).should == -1
-  end
-
-  it "returns -1 when self is -Infinity and other is negative" do
     (-infinity_value <=> -Float::MAX.to_i*2).should == -1
-  end
-
-  it "returns 1 when self is negative and other is -Infinity" do
     (-Float::MAX.to_i*2 <=> -infinity_value).should == 1
   end
 

--- a/spec/core/float/gt_spec.rb
+++ b/spec/core/float/gt_spec.rb
@@ -14,4 +14,25 @@ describe "Float#>" do
     -> { 5.0 > "4"       }.should raise_error(ArgumentError)
     -> { 5.0 > mock('x') }.should raise_error(ArgumentError)
   end
+
+  it "returns false if one side is NaN" do
+    [1.0, 42, bignum_value].each { |n|
+      (nan_value > n).should == false
+      (n > nan_value).should == false
+    }
+  end
+
+  it "handles positive infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (infinity_value > n).should == true
+      (n > infinity_value).should == false
+    }
+  end
+
+  it "handles negative infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (-infinity_value > n).should == false
+      (n > -infinity_value).should == true
+    }
+  end
 end

--- a/spec/core/float/gte_spec.rb
+++ b/spec/core/float/gte_spec.rb
@@ -14,4 +14,25 @@ describe "Float#>=" do
     -> { 5.0 >= "4"       }.should raise_error(ArgumentError)
     -> { 5.0 >= mock('x') }.should raise_error(ArgumentError)
   end
+
+  it "returns false if one side is NaN" do
+    [1.0, 42, bignum_value].each { |n|
+      (nan_value >= n).should == false
+      (n >= nan_value).should == false
+    }
+  end
+
+  it "handles positive infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (infinity_value >= n).should == true
+      (n >= infinity_value).should == false
+    }
+  end
+
+  it "handles negative infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (-infinity_value >= n).should == false
+      (n >= -infinity_value).should == true
+    }
+  end
 end

--- a/spec/core/float/lt_spec.rb
+++ b/spec/core/float/lt_spec.rb
@@ -14,4 +14,25 @@ describe "Float#<" do
     -> { 5.0 < "4"       }.should raise_error(ArgumentError)
     -> { 5.0 < mock('x') }.should raise_error(ArgumentError)
   end
+
+  it "returns false if one side is NaN" do
+    [1.0, 42, bignum_value].each { |n|
+      (nan_value < n).should == false
+      (n < nan_value).should == false
+    }
+  end
+
+  it "handles positive infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (infinity_value < n).should == false
+      (n < infinity_value).should == true
+    }
+  end
+
+  it "handles negative infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (-infinity_value < n).should == true
+      (n < -infinity_value).should == false
+    }
+  end
 end

--- a/spec/core/float/lte_spec.rb
+++ b/spec/core/float/lte_spec.rb
@@ -15,4 +15,25 @@ describe "Float#<=" do
     -> { 5.0 <= "4"       }.should raise_error(ArgumentError)
     -> { 5.0 <= mock('x') }.should raise_error(ArgumentError)
   end
+
+  it "returns false if one side is NaN" do
+    [1.0, 42, bignum_value].each { |n|
+      (nan_value <= n).should == false
+      (n <= nan_value).should == false
+    }
+  end
+
+  it "handles positive infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (infinity_value <= n).should == false
+      (n <= infinity_value).should == true
+    }
+  end
+
+  it "handles negative infinity" do
+    [1.0, 42, bignum_value].each { |n|
+      (-infinity_value <= n).should == true
+      (n <= -infinity_value).should == false
+    }
+  end
 end

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -402,7 +402,7 @@ Value FloatObject::arg(Env *env) {
         }                                                                                                   \
                                                                                                             \
         if (lhs->as_float()->is_nan() || rhs->as_float()->is_nan()) {                                       \
-            return NilObject::the();                                                                        \
+            return false;                                                                                   \
         }                                                                                                   \
                                                                                                             \
         double lhs_d = lhs->as_float()->to_double();                                                        \

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -244,7 +244,7 @@ Value IntegerObject::powmod(Env *env, Value exponent, Value mod) {
 
 Value IntegerObject::cmp(Env *env, Value arg) {
     auto is_comparable_with = [](Value arg) -> bool {
-        return arg->is_integer() || arg->is_float();
+        return arg->is_integer() || (arg->is_float() && !arg->as_float()->is_nan());
     };
 
     // Check if we might want to coerce the value
@@ -288,8 +288,11 @@ bool IntegerObject::eq(Env *env, Value other) {
 }
 
 bool IntegerObject::lt(Env *env, Value other) {
-    if (other->is_float())
+    if (other->is_float()) {
+        if (other->as_float()->is_nan())
+            return false;
         return m_integer < other->as_float()->to_double();
+    }
 
     if (!other->is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, this);
@@ -310,8 +313,11 @@ bool IntegerObject::lt(Env *env, Value other) {
 }
 
 bool IntegerObject::lte(Env *env, Value other) {
-    if (other->is_float())
+    if (other->is_float()) {
+        if (other->as_float()->is_nan())
+            return false;
         return m_integer <= other->as_float()->to_double();
+    }
 
     if (!other->is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, this);
@@ -332,8 +338,11 @@ bool IntegerObject::lte(Env *env, Value other) {
 }
 
 bool IntegerObject::gt(Env *env, Value other) {
-    if (other->is_float())
+    if (other->is_float()) {
+        if (other->as_float()->is_nan())
+            return false;
         return m_integer > other->as_float()->to_double();
+    }
 
     if (!other->is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);
@@ -354,8 +363,11 @@ bool IntegerObject::gt(Env *env, Value other) {
 }
 
 bool IntegerObject::gte(Env *env, Value other) {
-    if (other->is_float())
+    if (other->is_float()) {
+        if (other->as_float()->is_nan())
+            return false;
         return m_integer >= other->as_float()->to_double();
+    }
 
     if (!other->is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, this, Natalie::CoerceInvalidReturnValueMode::Raise);


### PR DESCRIPTION
These should return `nil` and `false` if either side is `NaN`