### PR TITLE
Group tests in test/runner.rb

### DIFF
--- a/test/runner.rb
+++ b/test/runner.rb
@@ -4,6 +4,10 @@
 #
 #     bin/natalie test/runner.rb spec/core/array/pack/{a,b}_spec.rb
 #
+# to run all the tests grouped:
+#
+#     bin/natalie test/runner.rb --run-grouped spec/core/array/pack/{a,b}_spec.rb
+#
 # usage with flags:
 #
 #     bin/natalie -c2 test/runner.rb -- -c2 spec/core/array/pack/{a,b}_spec.rb
@@ -13,13 +17,36 @@ require_relative 'support/nat_binary'
 flags = []
 flags << ARGV.shift while ARGV.first.to_s.start_with?('-')
 
-ARGV.each do |path|
-  if File.directory?(path)
-    $stderr.puts "WARNING: skipping directory #{path}"
-    next
+if flags.delete('--run-grouped')
+  flags.prepend('-I.', '-Itest/support')
+  require 'tempfile'
+  Tempfile.create('test_runner') do |f|
+    ARGV.each do |path|
+      if File.directory?(path)
+        $stderr.puts "WARNING: skipping directory #{path}"
+        next
+      elsif !File.exist?(path)
+        $stderr.puts "WARNING: skipping invalid file #{path}"
+        next
+      end
+
+      f.puts "require #{path.inspect}"
+    end
+    f.close
+
+    pid = spawn(NAT_BINARY, *(flags + [f.path]))
+    Process.wait(pid)
   end
-  puts path
-  pid = spawn(NAT_BINARY, *(flags + [path]))
-  Process.wait(pid)
   exit $?.exitstatus unless $?.success?
+else
+  ARGV.each do |path|
+    if File.directory?(path)
+      $stderr.puts "WARNING: skipping directory #{path}"
+      next
+    end
+    puts path
+    pid = spawn(NAT_BINARY, *(flags + [path]))
+    Process.wait(pid)
+    exit $?.exitstatus unless $?.success?
+  end
 end


### PR DESCRIPTION
This has two advantages.
First of all, this groups the compilation step, so we only have to run the compiler one. This results in a small performance boost (running the tests of `spec/library/set` on my machine drop from around 1m35 to 1m20, so that's around 15% performance increase).
Second, this does continue the run if a single test is failing, and shows a readable overview at the end of the run.

Because Natalie does not support variables in `load` or `require`, we had to jump through a few hoops to combine all the arguments into a single file.