### PR TITLE
Raise argumenterror when raising negative to fractional

### DIFF
--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -362,6 +362,9 @@ Value FloatObject::pow(Env *env, Value rhs) {
     double base = to_double();
     double exponent = rhs->as_float()->to_double();
 
+    if (base < 0 && ::floor(exponent) != exponent)
+        env->raise("ArgumentError", "Not yet implemented: negative raised to a fractional power");
+
     return Value::floatingpoint(::pow(base, exponent));
 }
 


### PR DESCRIPTION
This code path first returned Float::NaN, which made the specs fail, so these specs were disabled. Pull Request #969 updated some behaviour of Float::NaN, which means the test would now erroneously pass. At the same time, Pull Request #959 did enable the tests with a NATFIXME block. These two changes combined resulted in passing tests within a NATFIXME block.

For now, just raise an exception so it's clear this still has to be implemented, and make the specs pass again.