### PR TITLE
Add missing comma to alias_method in Struct

### DIFF
--- a/src/struct.rb
+++ b/src/struct.rb
@@ -84,7 +84,7 @@ class Struct
           end
         end
 
-        alias_method :values :to_a
+        alias_method :values, :to_a
 
         define_method :inspect do
           inspected_attrs = attrs.map { |attr| "#{attr}=#{send(attr).inspect}" }


### PR DESCRIPTION
The old version results in a parser error in MRI.