### PR TITLE
Improve Kernel.dup

### DIFF
--- a/spec/core/class/dup_spec.rb
+++ b/spec/core/class/dup_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+# NOTE: This is actually implemented by Module#initialize_copy
+describe "Class#dup" do
+  it "duplicates both the class and the singleton class" do
+    klass = Class.new do
+      def hello
+        "hello"
+      end
+
+      def self.message
+        "text"
+      end
+    end
+
+    klass_dup = klass.dup
+
+    klass_dup.new.hello.should == "hello"
+    klass_dup.message.should == "text"
+  end
+
+  it "retains an included module in the ancestor chain for the singleton class" do
+    klass = Class.new
+    mod = Module.new do
+      def hello
+        "hello"
+      end
+    end
+
+    klass.extend(mod)
+    klass_dup = klass.dup
+    klass_dup.hello.should == "hello"
+  end
+
+  it "retains the correct ancestor chain for the singleton class" do
+    super_klass = Class.new do
+      def hello
+        "hello"
+      end
+
+      def self.message
+        "text"
+      end
+    end
+
+    klass = Class.new(super_klass)
+    klass_dup = klass.dup
+
+    klass_dup.new.hello.should == "hello"
+    klass_dup.message.should == "text"
+  end
+
+  it "sets the name from the class to nil if not assigned to a constant" do
+    copy = CoreClassSpecs::Record.dup
+    copy.name.should be_nil
+  end
+
+  it "stores the new name if assigned to a constant" do
+    CoreClassSpecs::RecordCopy = CoreClassSpecs::Record.dup
+    CoreClassSpecs::RecordCopy.name.should == "CoreClassSpecs::RecordCopy"
+  end
+
+end

--- a/spec/core/class/fixtures/classes.rb
+++ b/spec/core/class/fixtures/classes.rb
@@ -1,0 +1,47 @@
+module CoreClassSpecs
+  class Record
+  end
+
+  module M
+    def inherited(klass)
+      ScratchPad.record klass
+      super
+    end
+  end
+
+  class F; end
+  class << F
+    include M
+  end
+
+  class A
+    def self.inherited(klass)
+      ScratchPad.record klass
+    end
+  end
+
+  class H < A
+    def self.inherited(klass)
+      super
+    end
+  end
+
+  module Inherited
+    class A
+      SUBCLASSES = []
+      def self.inherited(subclass)
+        SUBCLASSES << [self, subclass]
+      end
+    end
+
+    class B < A; end
+    class B < A; end # reopen
+    class C < B; end
+
+    class D
+      def self.inherited(subclass)
+        ScratchPad << self
+      end
+    end
+  end
+end

--- a/spec/core/struct/dup_spec.rb
+++ b/spec/core/struct/dup_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/dup'
+
+describe "Struct-based class#dup" do
+
+  it_behaves_like :struct_dup, :dup
+
+  # From https://github.com/jruby/jruby/issues/3686
+  it "retains an included module in the ancestor chain for the struct's singleton class" do
+    klass = Struct.new(:foo)
+    mod = Module.new do
+      def hello
+        "hello"
+      end
+    end
+
+    klass.extend(mod)
+    klass_dup = klass.dup
+    NATFIXME 'Responsibility of Kernel#dup, not Struct. Can be reproduced by using any class', exception: NoMethodError, message: "undefined method `hello'" do
+      klass_dup.hello.should == "hello"
+    end
+  end
+
+end

--- a/spec/core/struct/dup_spec.rb
+++ b/spec/core/struct/dup_spec.rb
@@ -17,9 +17,7 @@ describe "Struct-based class#dup" do
 
     klass.extend(mod)
     klass_dup = klass.dup
-    NATFIXME 'Responsibility of Kernel#dup, not Struct. Can be reproduced by using any class', exception: NoMethodError, message: "undefined method `hello'" do
-      klass_dup.hello.should == "hello"
-    end
+    klass_dup.hello.should == "hello"
   end
 
 end


### PR DESCRIPTION
In case a Class is duplicated, we need to duplicate the singleton class too. This was tested in the dup spec of Struct, but the same thing happened when you replaced `Struct.new(:foo)` with `Class.new {}` in that test.

Duplicating any other instance should not copy the singleton class, this is explicitly tested in `spec/core/hash/shared/store.rb`