### PR TITLE
Remove natfixme from symbol/name_spec

### DIFF
--- a/spec/core/symbol/name_spec.rb
+++ b/spec/core/symbol/name_spec.rb
@@ -4,8 +4,7 @@ ruby_version_is "3.0" do
   describe "Symbol#name" do
     it "returns string" do
       :ruby.name.should == "ruby"
-      # NATFIXME Support different encodings
-      # :ルビー.name.should == "ルビー"
+      :ルビー.name.should == "ルビー"
     end
 
     it "returns same string instance" do


### PR DESCRIPTION
This issue has been resolved, this file is now synced with upstream again.

This checks another box in #963, since this means there are no more NATFIXME entries left in the symbol folder.