### PR TITLE
File.new, File#size

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -84,6 +84,7 @@ public:
     static Value umask(Env *env, Value mask);
     static Value ftype(Env *env, Value path);
     static Value size(Env *env, Value path);
+    Value size(Env *env);
     static Value realpath(Env *, Value, Value);
     static Value world_readable(Env *env, Value path);
     static Value world_writable(Env *env, Value path);

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -24,7 +24,7 @@ public:
     FileObject()
         : IoObject { GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class() } { }
 
-    Value initialize(Env *, Value, Value, Block *);
+    Value initialize(Env *, Value, Value, Value, Block *);
 
     static Value open(Env *env, Value filename, Value flags_obj, Block *block) {
         Value args[] = { filename, flags_obj };

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -571,6 +571,7 @@ gen.binding('File', 'initialize', 'FileObject', 'initialize', argc: 1..3, pass_e
 gen.binding('File', 'lstat', 'FileObject', 'lstat', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'mtime', 'FileObject', 'mtime', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'path', 'FileObject', 'path', argc: 0, pass_env: false, pass_block: false, return_type: :String)
+gen.binding('File', 'size', 'FileObject', 'size', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('FileTest', 'blockdev?', 'FileObject', 'is_blockdev', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('FileTest', 'chardev?', 'FileObject', 'is_chardev', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -567,7 +567,7 @@ gen.static_binding('File', 'utime', 'FileObject', 'utime', argc: 2.., pass_env: 
 gen.binding('File', 'atime', 'FileObject', 'atime', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'chmod', 'FileObject', 'chmod', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'ctime', 'FileObject', 'ctime', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('File', 'initialize', 'FileObject', 'initialize', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('File', 'initialize', 'FileObject', 'initialize', argc: 1..3, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('File', 'lstat', 'FileObject', 'lstat', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'mtime', 'FileObject', 'mtime', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('File', 'path', 'FileObject', 'path', argc: 0, pass_env: false, pass_block: false, return_type: :String)

--- a/spec/core/file/new_spec.rb
+++ b/spec/core/file/new_spec.rb
@@ -1,0 +1,167 @@
+require_relative '../../spec_helper'
+require_relative 'shared/open'
+
+describe "File.new" do
+  before :each do
+    @file = tmp('test.txt')
+    @fh = nil
+    @flags = File::CREAT | File::TRUNC | File::WRONLY
+    touch @file
+  end
+
+  after :each do
+    @fh.close if @fh
+    rm_r @file
+  end
+
+  it "returns a new File with mode string" do
+    @fh = File.new(@file, 'w')
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "returns a new File with mode num" do
+    @fh = File.new(@file, @flags)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "returns a new File with modus num and permissions" do
+    rm_r @file
+    File.umask(0011)
+    @fh = File.new(@file, @flags, 0755)
+    @fh.should be_kind_of(File)
+    NATFIXME("Umask not observed on open", exception: SpecFailedException) do
+    platform_is_not :windows do
+      File.stat(@file).mode.to_s(8).should == "100744"
+    end
+    end
+    File.should.exist?(@file)
+  end
+  
+  it "creates the file and returns writable descriptor when called with 'w' mode and r-o permissions" do
+    # it should be possible to write to such a file via returned descriptor,
+    # even though the file permissions are r-r-r.
+
+    rm_r @file
+    begin
+      f = File.new(@file, "w", 0444)
+      -> { f.puts("test") }.should_not raise_error(IOError)
+    ensure
+      f.close
+    end
+    File.should.exist?(@file)
+    File.read(@file).should == "test\n"
+  end
+
+  platform_is_not :windows do
+    it "opens the existing file, does not change permissions even when they are specified" do
+      File.chmod(0644, @file)           # r-w perms
+      orig_perms = File.stat(@file).mode & 0777
+      begin
+        f = File.new(@file, "w", 0444)    # r-o perms, but they should be ignored
+        f.puts("test")
+      ensure
+        f.close
+      end
+      perms = File.stat(@file).mode & 0777
+      perms.should == orig_perms
+
+      # it should be still possible to read from the file
+      File.read(@file).should == "test\n"
+    end
+  end
+
+  #NATFIXME: Partial implementation of File.new
+  xit "returns a new File with modus fd" do
+    @fh = File.new(@file)
+    fh_copy = File.new(@fh.fileno)
+    fh_copy.autoclose = false
+    fh_copy.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "creates a new file when use File::EXCL mode" do
+    @fh = File.new(@file, File::EXCL)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "raises an Errorno::EEXIST if the file exists when create a new file with File::CREAT|File::EXCL" do
+    -> { @fh = File.new(@file, File::CREAT|File::EXCL) }.should raise_error(Errno::EEXIST)
+  end
+
+  it "creates a new file when use File::WRONLY|File::APPEND mode" do
+    @fh = File.new(@file, File::WRONLY|File::APPEND)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "returns a new File when use File::APPEND mode" do
+    @fh = File.new(@file, File::APPEND)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "returns a new File when use File::RDONLY|File::APPEND mode" do
+    @fh = File.new(@file, File::RDONLY|File::APPEND)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "returns a new File when use File::RDONLY|File::WRONLY mode" do
+    @fh = File.new(@file, File::RDONLY|File::WRONLY)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+
+  it "creates a new file when use File::WRONLY|File::TRUNC mode" do
+    @fh = File.new(@file, File::WRONLY|File::TRUNC)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+  end
+
+  it "coerces filename using to_str" do
+    name = mock("file")
+    name.should_receive(:to_str).and_return(@file)
+    @fh = File.new(name, "w")
+    File.should.exist?(@file)
+  end
+
+  it "coerces filename using #to_path" do
+    name = mock("file")
+    name.should_receive(:to_path).and_return(@file)
+    @fh = File.new(name, "w")
+    File.should.exist?(@file)
+  end
+
+  it "raises a TypeError if the first parameter can't be coerced to a string" do
+    -> { File.new(true) }.should raise_error(TypeError)
+    -> { File.new(false) }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError if the first parameter is nil" do
+    -> { File.new(nil) }.should raise_error(TypeError)
+  end
+
+  it "raises an Errno::EBADF if the first parameter is an invalid file descriptor" do
+    -> { File.new(-1) }.should raise_error(Errno::EBADF)
+  end
+
+  platform_is_not :windows do
+    it "can't alter mode or permissions when opening a file" do
+      @fh = File.new(@file)
+      NATFIXME "Autoclose and fd+flags not implemented" do
+      -> {
+        f = File.new(@fh.fileno, @flags)
+        f.autoclose = false
+      }.should raise_error(Errno::EINVAL)
+      end
+    end
+  end
+
+  platform_is_not :windows do
+    it_behaves_like :open_directory, :new
+  end
+end

--- a/spec/core/file/new_spec.rb
+++ b/spec/core/file/new_spec.rb
@@ -31,10 +31,8 @@ describe "File.new" do
     File.umask(0011)
     @fh = File.new(@file, @flags, 0755)
     @fh.should be_kind_of(File)
-    NATFIXME("Umask not observed on open", exception: SpecFailedException) do
     platform_is_not :windows do
       File.stat(@file).mode.to_s(8).should == "100744"
-    end
     end
     File.should.exist?(@file)
   end

--- a/spec/core/file/size_spec.rb
+++ b/spec/core/file/size_spec.rb
@@ -1,0 +1,119 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/file/size'
+
+describe "File.size?" do
+  it_behaves_like :file_size,                     :size?, File
+end
+
+describe "File.size?" do
+  it_behaves_like :file_size_to_io,               :size?, File
+end
+
+describe "File.size?" do
+  it_behaves_like :file_size_nil_when_missing,    :size?, File
+end
+
+describe "File.size?" do
+  it_behaves_like :file_size_nil_when_empty,      :size?, File
+end
+
+describe "File.size?" do
+  it_behaves_like :file_size_with_file_argument,  :size?, File
+end
+
+describe "File.size" do
+  it_behaves_like :file_size,                     :size,  File
+end
+
+describe "File.size" do
+  it_behaves_like :file_size_to_io,               :size, File
+end
+
+describe "File.size" do
+  it_behaves_like :file_size_raise_when_missing,  :size,  File
+end
+
+describe "File.size" do
+  it_behaves_like :file_size_0_when_empty,        :size,  File
+end
+
+describe "File.size" do
+  it_behaves_like :file_size_with_file_argument,  :size,  File
+end
+
+describe "File#size" do
+
+  before :each do
+    @name = tmp('i_exist')
+    touch(@name) { |f| f.write 'rubinius' }
+    @file = File.new @name
+    @file_org = @file
+  end
+
+  after :each do
+    @file_org.close unless @file_org.closed?
+    rm_r @name
+  end
+
+  it "is an instance method" do
+    @file.respond_to?(:size).should be_true
+  end
+
+  it "returns the file's size as an Integer" do
+    @file.size.should be_an_instance_of(Integer)
+  end
+
+  it "returns the file's size in bytes" do
+    @file.size.should == 8
+  end
+
+  platform_is_not :windows do # impossible to remove opened file on Windows
+    it "returns the cached size of the file if subsequently deleted" do
+      rm_r @file.path
+      @file.size.should == 8
+    end
+  end
+
+  it "returns the file's current size even if modified" do
+    File.open(@file.path,'a') {|f| f.write '!'}
+    @file.size.should == 9
+  end
+
+  it "raises an IOError on a closed file" do
+    @file.close
+    -> { @file.size }.should raise_error(IOError)
+  end
+
+  platform_is_not :windows do
+    it "follows symlinks if necessary" do
+      ln_file = tmp('i_exist_ln')
+      rm_r ln_file
+
+      begin
+        File.symlink(@file.path, ln_file).should == 0
+        file = File.new(ln_file)
+        file.size.should == 8
+      ensure
+        file.close if file && !file.closed?
+        rm_r ln_file
+      end
+    end
+  end
+end
+
+describe "File#size for an empty file" do
+  before :each do
+    @name = tmp('empty')
+    touch(@name)
+    @file = File.new @name
+  end
+
+  after :each do
+    @file.close unless @file.closed?
+    rm_r @name
+  end
+
+  it "returns 0" do
+    @file.size.should == 0
+  end
+end

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -616,13 +616,20 @@ Value FileObject::utime(Env *env, Args args) {
 }
 
 Value FileObject::atime(Env *env) { // inst method
+    if (is_closed()) env->raise("IOError", "closed stream");
     return as_io()->stat(env)->as_file_stat()->atime(env);
 }
 Value FileObject::ctime(Env *env) { // inst method
+    if (is_closed()) env->raise("IOError", "closed stream");
     return as_io()->stat(env)->as_file_stat()->ctime(env);
 }
 Value FileObject::mtime(Env *env) { // inst method
+    if (is_closed()) env->raise("IOError", "closed stream");
     return as_io()->stat(env)->as_file_stat()->mtime(env);
+}
+Value FileObject::size(Env *env) { // inst method
+    if (is_closed()) env->raise("IOError", "closed stream");
+    return as_io()->stat(env)->as_file_stat()->size();
 }
 
 }

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -111,7 +111,7 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value pe
 
     mode_t modenum;
     if (perm)
-        IntegerObject::convert_to_int(env, perm);
+        modenum = IntegerObject::convert_to_int(env, perm);
     else
         modenum = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH; // 0660 default
 


### PR DESCRIPTION
Add optional 3rd argument to `File.new` (perm argument)
Enhance `File.new` to pass additional specs.
Add `File#size` instance method
Add check for `is_closed()` to some instance methods (atime, ctime, mtime, size) to prevent attempted stat on a closed file-descriptor