### PR TITLE
Include OpenSSL::VERSION constant

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -6,6 +6,18 @@
 using namespace Natalie;
 
 Value init(Env *env, Value self) {
+    ModuleObject *OpenSSL = new ModuleObject { "OpenSSL" };
+    GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
+
+    // OpenSSL < 3.0 does not have a OPENSSL_VERSION_STR
+    const auto openssl_version_major = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 28) & 0xFF);
+    const auto openssl_version_minor = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 20) & 0xFF);
+    const auto openssl_version_patchlevel = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 12) & 0xFF);
+    StringObject *VERSION = new StringObject {
+        TM::String::format("{}.{}.{}", openssl_version_major, openssl_version_minor, openssl_version_patchlevel)
+    };
+    OpenSSL->const_set("VERSION"_s, VERSION);
+
     return NilObject::the();
 }
 

--- a/spec/library/openssl/config/freeze_spec.rb
+++ b/spec/library/openssl/config/freeze_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require_relative '../shared/constants'
+
+require 'openssl'
+
+version_is(OpenSSL::VERSION, ""..."2.2") do
+  describe "OpenSSL::Config#freeze" do
+    it "needs to be reviewed for completeness"
+
+    it "freezes" do
+      NATFIXME 'Implement OpenSSL::Config', exception: NameError, message: 'uninitialized constant OpenSSL::Config' do
+        c = OpenSSL::Config.new
+        -> {
+          c['foo'] = [ ['key', 'value'] ]
+        }.should_not raise_error
+        c.freeze
+        c.frozen?.should be_true
+        -> {
+          c['foo'] = [ ['key', 'value'] ]
+        }.should raise_error(TypeError)
+      end
+    end
+  end
+end

--- a/spec/library/openssl/shared/constants.rb
+++ b/spec/library/openssl/shared/constants.rb
@@ -1,0 +1,11 @@
+# -*- encoding: binary -*-
+module HMACConstants
+
+  Contents = "Ipsum is simply dummy text of the printing and typesetting industry. \nLorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. \nIt has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. \nIt was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+  Key                = 'sekrit'
+
+  BlankSHA1Digest    = "\3329\243\356^kK\r2U\277\357\225`\030\220\257\330\a\t"
+  SHA1Digest         = "\236\022\323\341\037\236\262n\344\t\372:\004J\242\330\257\270\363\264"
+  BlankSHA1HexDigest = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+  SHA1Hexdigest      = "9e12d3e11f9eb26ee409fa3a044aa2d8afb8f3b4"
+end


### PR DESCRIPTION
Which is good enough to make the config/freeze_spec pass, since that once doesn't do anything on OpenSSL 3.0 and above.