### PR TITLE
Fix Dir.rmdir and add spec

### DIFF
--- a/spec/core/dir/rmdir_spec.rb
+++ b/spec/core/dir/rmdir_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+require_relative 'shared/delete'
+
+describe "Dir.rmdir" do
+  before :all do
+    DirSpecs.create_mock_dirs
+  end
+
+  after :all do
+    DirSpecs.delete_mock_dirs
+  end
+
+  it_behaves_like :dir_delete, :rmdir
+end

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -44,13 +44,5 @@ class Dir
       closedir(dir);
       return array;
     END
-
-    __define_method__ :rmdir, [:dirname], <<-END
-      dirname->assert_type(env, Object::Type::String, "String");
-      auto result = rmdir(dirname->as_string()->c_str());
-      if (result == -1)
-          env->raise_errno();
-      return Value::integer(result);
-    END
   end
 end


### PR DESCRIPTION
I pulled in the spec for `core/dir/rmdir_spec.rb` and noticed 5 of the 6 tests were passing, but the existing C++ code looked correct by inspection.  Then I realized that we had a duplicate definition of `Dir.rmdir` in `dir.rb`.  The C++ one passed all specs; removing the slightly less-functional ruby version made the tests pass 🎉 
