### PR TITLE
Dir.mkdir and File.chmod

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -93,7 +93,7 @@ public:
     static Value link(Env *env, Value from, Value to);
     static Value symlink(Env *env, Value from, Value to);
     static Value mkfifo(Env *env, Value path, Value mode);
-    static Value chmod(Env *env, Value mode, Value path);
+    static Value chmod(Env *env, Args args);
     Value chmod(Env *env, Value mode);
 
     static Value lstat(Env *env, Value path);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -548,7 +548,7 @@ gen.static_binding('File', 'identical?', 'FileObject', 'is_identical', argc: 2, 
 gen.static_binding('File', 'link', 'FileObject', 'link', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'symlink', 'FileObject', 'symlink', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'mkfifo', 'FileObject', 'mkfifo', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
-gen.static_binding('File', 'chmod', 'FileObject', 'chmod', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('File', 'chmod', 'FileObject', 'chmod', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'world_readable?', 'FileObject', 'world_readable', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'world_writable?', 'FileObject', 'world_writable', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'expand_path', 'FileObject', 'expand_path', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/dir/dir_spec.rb
+++ b/spec/core/dir/dir_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "Dir" do
+  it "includes Enumerable" do
+    Dir.include?(Enumerable).should == true
+  end
+end

--- a/spec/core/dir/mkdir_spec.rb
+++ b/spec/core/dir/mkdir_spec.rb
@@ -1,0 +1,107 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+
+describe "Dir.mkdir" do
+  before :all do
+    DirSpecs.create_mock_dirs
+  end
+
+  after :all do
+    DirSpecs.delete_mock_dirs
+  end
+
+  it "creates the named directory with the given permissions" do
+    DirSpecs.clear_dirs
+
+    nonexisting = DirSpecs.mock_dir('nonexisting')
+    default_perms = DirSpecs.mock_dir('default_perms')
+    reduced = DirSpecs.mock_dir('reduced')
+    begin
+      File.should_not.exist?(nonexisting)
+      Dir.mkdir nonexisting
+      File.should.exist?(nonexisting)
+      platform_is_not :windows do
+        Dir.mkdir default_perms
+        a = File.stat(default_perms).mode
+        Dir.mkdir reduced, (a - 1)
+        File.stat(reduced).mode.should_not == a
+      end
+      platform_is :windows do
+        Dir.mkdir default_perms, 0666
+        a = File.stat(default_perms).mode
+        Dir.mkdir reduced, 0444
+        File.stat(reduced).mode.should_not == a
+      end
+
+      always_returns_0 = DirSpecs.mock_dir('always_returns_0')
+      Dir.mkdir(always_returns_0).should == 0
+      platform_is_not(:windows) do
+        File.chmod(0777, nonexisting, default_perms, reduced, always_returns_0)
+      end
+      platform_is_not(:windows) do
+        File.chmod(0644, nonexisting, default_perms, reduced, always_returns_0)
+      end
+    ensure
+      DirSpecs.clear_dirs
+    end
+  end
+
+  it "calls #to_path on non-String path arguments" do
+    DirSpecs.clear_dirs
+    p = mock('path')
+    p.should_receive(:to_path).and_return(DirSpecs.mock_dir('nonexisting'))
+    Dir.mkdir(p)
+    DirSpecs.clear_dirs
+  end
+
+  it "calls #to_int on non-Integer permissions argument" do
+    DirSpecs.clear_dirs
+    path = DirSpecs.mock_dir('nonexisting')
+    permissions = mock('permissions')
+    permissions.should_receive(:to_int).and_return(0666)
+    Dir.mkdir(path, permissions)
+    DirSpecs.clear_dirs
+  end
+
+  it "raises TypeError if non-Integer permissions argument does not have #to_int method" do
+    path = DirSpecs.mock_dir('nonexisting')
+    permissions = Object.new
+
+    -> { Dir.mkdir(path, permissions) }.should raise_error(TypeError, 'no implicit conversion of Object into Integer')
+  end
+
+  it "raises a SystemCallError if any of the directories in the path before the last does not exist" do
+    -> { Dir.mkdir "#{DirSpecs.nonexistent}/subdir" }.should raise_error(SystemCallError)
+  end
+
+  it "raises Errno::EEXIST if the specified directory already exists" do
+    -> { Dir.mkdir("#{DirSpecs.mock_dir}/dir") }.should raise_error(Errno::EEXIST)
+  end
+
+  it "raises Errno::EEXIST if the argument points to the existing file" do
+    -> { Dir.mkdir("#{DirSpecs.mock_dir}/file_one.ext") }.should raise_error(Errno::EEXIST)
+  end
+end
+
+# The permissions flag are not supported on Windows as stated in documentation:
+# The permissions may be modified by the value of File.umask, and are ignored on NT.
+platform_is_not :windows do
+  as_user do
+    describe "Dir.mkdir" do
+      before :each do
+        @dir = tmp "noperms"
+      end
+
+      after :each do
+        File.chmod 0777, @dir
+        rm_r @dir
+      end
+
+      it "raises a SystemCallError when lacking adequate permissions in the parent dir" do
+        Dir.mkdir @dir, 0000
+
+        -> { Dir.mkdir "#{@dir}/subdir" }.should raise_error(SystemCallError)
+      end
+    end
+  end
+end

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -51,8 +51,7 @@ Value DirObject::chdir(Env *env, Value path, Block *block) {
 Value DirObject::mkdir(Env *env, Value path, Value mode) {
     mode_t octmode = 0777;
     if (mode) {
-        mode->assert_type(env, Object::Type::Integer, "Integer");
-        octmode = (mode_t)(mode->as_integer()->to_nat_int_t());
+        octmode = IntegerObject::convert_to_int(env, mode);
     }
     path = fileutil::convert_using_to_path(env, path);
     auto result = ::mkdir(path->as_string()->c_str(), octmode);

--- a/test/natalie/file_test.rb
+++ b/test/natalie/file_test.rb
@@ -271,4 +271,10 @@ describe 'File' do
       File.dirname('../../').should == '..'
     end
   end
+
+  describe ".chmod" do
+    it "allows a single mode argument and no files" do
+      File.chmod(0777).should == 0
+    end
+  end
 end


### PR DESCRIPTION
Fixes `Dir.mkdir` to meet the spec.

As part of this work, `File.chmod` had to be enhanced to support variable arguments.  Previously, chmod was written to take one file argument and always return `1`.  Surprisingly, the spec for `File.chmod` did not test any of the var-args, so a simple additional test was added for a mode arg with no file args, but it would be nice to add additional tests upstream for the zero-file and multi-file arg cases, though it could be argued the multi-arg case is already handled in the spec for `Dir.mkdir`.