### PR TITLE
Dir support for collection/iteration methods

### DIFF
--- a/include/natalie/dir_object.hpp
+++ b/include/natalie/dir_object.hpp
@@ -8,6 +8,7 @@
 
 #include "natalie/forward.hpp"
 #include "natalie/integer_object.hpp"
+#include "natalie/nil_object.hpp"
 #include "natalie/object.hpp"
 #include "natalie/regexp_object.hpp"
 #include "natalie/string_object.hpp"
@@ -28,18 +29,26 @@ public:
     virtual void visit_children(Visitor &visitor) override {
         Object::visit_children(visitor);
         visitor.visit(m_path);
+        visitor.visit(m_encoding);
     }
 
-    Value close(Env *env);
-    Value read(Env *env);
-    Value tell(Env *env);
-    Value rewind(Env *env);
-    Value seek(Env *env, Value position);
+    static Value size_fn(Env *env, Value self, Args, Block *) {
+        return Value(NilObject::the());
+    }
 
+    Value children(Env *env); // for internal use
+    Value close(Env *env);
+    Value each(Env *env, Block *block);
+    Value each_child(Env *env, Block *block);
+    Value entries(Env *env); // for internal use
     Value fileno(Env *env);
     Value initialize(Env *env, Value path, Value encoding);
-    StringObject *path(Env *env) { return m_path; }
+    Value read(Env *env);
+    Value rewind(Env *env);
+    Value seek(Env *env, Value position);
+    Value tell(Env *env);
 
+    StringObject *path(Env *env) { return m_path; }
     StringObject *inspect(Env *env);
 
     static bool is_empty(Env *, Value);
@@ -51,9 +60,13 @@ public:
     static Value pwd(Env *env);
     static Value rmdir(Env *env, Value path); // same as .delete, .unlink
 
+    static Value children(Env *env, Value path, Value encoding);
+    static Value entries(Env *env, Value path, Value encoding);
+
 private:
     DIR *m_dir { nullptr };
     StringObject *m_path { nullptr };
+    EncodingObject *m_encoding { nullptr };
 };
 
 }

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -67,6 +67,9 @@ public:
     static Value locale_charmap();
     static void initialize_defaults(Env *);
 
+    static EncodingObject *find_encoding_by_name(Env *env, String name);
+    static EncodingObject *find_encoding(Env *env, Value encoding);
+
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<EncodingObject %p>", this);
     }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -643,6 +643,8 @@ gen.static_binding('Dir', 'empty?', 'DirObject', 'is_empty', argc: 1, pass_env: 
 gen.static_binding('Dir', 'exist?', 'FileObject', 'is_directory', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('Dir', 'home', 'DirObject', 'home', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'chdir', 'DirObject', 'chdir', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
+gen.static_binding('Dir', 'children', 'DirObject', 'children', argc: 1, kwargs: [:encoding], pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Dir', 'entries', 'DirObject', 'entries', argc: 1, kwargs: [:encoding], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'chroot', 'DirObject', 'chroot', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'getwd', 'DirObject', 'pwd', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Dir', 'mkdir', 'DirObject', 'mkdir', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
@@ -652,6 +654,8 @@ gen.static_binding('Dir', 'unlink', 'DirObject', 'rmdir', argc: 1, pass_env: tru
 
 gen.static_binding('Dir', 'open', 'DirObject', 'open', argc: 1, kwargs: [:encoding], pass_env: true, pass_block: true, return_type: :Object)
 
+gen.binding('Dir', 'each', 'DirObject', 'each', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('Dir', 'each_child', 'DirObject', 'each_child', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Dir', 'initialize', 'DirObject', 'initialize', argc: 1, kwargs: [:encoding], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Dir', 'fileno', 'DirObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Dir', 'close', 'DirObject', 'close', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -11,38 +11,16 @@ class Dir
       '/tmp'
     end
 
-    __define_method__ :pwd, [], <<-END
-      char buf[MAXPATHLEN + 1];
-      if(!getcwd(buf, MAXPATHLEN + 1))
-          env->raise_errno();
-      return new StringObject { buf };
-    END
-
-    def each_child(dirname)
+    def each_child(dirname, encoding: nil)
       return enum_for(:each_child, dirname) unless block_given?
-      children(dirname).each { |name| yield name }
+      children(dirname, encoding: encoding).each { |name| yield name }
+    end
+    
+    def foreach(dirname, encoding: nil)
+      return enum_for(:foreach, dirname) unless block_given?
+      entries(dirname, encoding: encoding).each { |name| yield name }
     end
 
-    __define_method__ :children, [:dirname], <<-END
-      dirname->assert_type(env, Object::Type::String, "String");
-      auto dir = opendir(dirname->as_string()->c_str());
-      if (!dir)
-          env->raise_errno();
-      dirent *entry;
-      errno = 0;
-      auto array = new ArrayObject {};
-      for (;;) {
-          entry = readdir(dir);
-          if (!entry) break;
-          if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
-          array->push(new StringObject { entry->d_name });
-      }
-      if (errno) {
-          closedir(dir);
-          env->raise_errno();
-      }
-      closedir(dir);
-      return array;
-    END
   end
+  
 end


### PR DESCRIPTION
+ Add `Dir#children` and `Dir#entries`
+ Add `Dir#each_child` and `Dir#each`
+ Add `Dir.children` and `Dir.entries` (class method)
+ Add `Dir.foreach` and `Dir.each_child` on ruby side
+ Add encoding support for `DirObject`
+ Move `find_encoding_by_name` from string_object.cpp to encoding_object.cpp/hpp.
+ Refactor `find_encoding` code.
+ Remove duplicate ruby methods for `Dir`
   + I've noticed this happen a few times, whereby it's not obvious there is duplication, but I am unsure how easy it would be to add a lint check for this.