### PR TITLE
Fix some spec after/after-all ordering issues

### DIFF
--- a/test/natalie/test_order_example.rb
+++ b/test/natalie/test_order_example.rb
@@ -1,0 +1,51 @@
+describe 'before/after' do
+  before :all do
+    puts '[[before all]]'
+  end
+
+  before :each do
+    puts '[[before each]]'
+  end
+
+  it 'it 1' do
+    puts '[[it 1]]'
+  end
+
+  it 'it 2' do
+    puts '[[it 2]]'
+  end
+
+  context 'context 1' do
+    before :all do
+      puts '[[before all 1]]'
+    end
+
+    before :each do
+      puts '[[before each 1]]'
+    end
+
+    it 'it 1' do
+      puts '[[it 1]]'
+    end
+
+    it 'it 2' do
+      puts '[[it 2]]'
+    end
+
+    after :each do
+      puts '[[after each 1]]'
+    end
+
+    after :all do
+      puts '[[after all 1]]'
+    end
+  end
+
+  after :each do
+    puts '[[after each]]'
+  end
+
+  after :all do
+    puts '[[after all]]'
+  end
+end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1411,7 +1411,7 @@ def run_specs
         @formatter.print_success(context, test)
       ensure
         # ensure that the after-each is executed
-        context.each { |con| con.after_each.each { |a| a.call } }
+        context.reverse_each { |con| con.after_each.reverse_each { |a| a.call } }
       end
 
 
@@ -1422,10 +1422,10 @@ def run_specs
   end
 
   # after-all
-  @specs.each do |test|
+  @specs.reverse_each do |test|
     context = test[0]
-    context.each do |con|
-      con.after_all.each do |b|
+    context.reverse_each do |con|
+      con.after_all.reverse_each do |b|
         unless after_all_done.include?(b)
           b.call
           after_all_done << b


### PR DESCRIPTION
This an attempt to fix #1020.

To compare, I downloaded [mspec](https://github.com/ruby/mspec) and ran the following command to compare the outputs:

```sh
diff -y <(../mspec/bin/mspec --format spec test/natalie/test_order_example.rb | grep -o "\[\[.*\]\]") <(bin/natalie -r./test/support/spec.rb test/natalie/test_order_example.rb | grep -o "\[\[.*\]\]")
```