### PR TITLE
Fix REPL input on macOS

### DIFF
--- a/lib/natalie/repl/repl.rb
+++ b/lib/natalie/repl/repl.rb
@@ -55,11 +55,15 @@ module Natalie
     end
 
     def save_cursor
-      echo "\u001B[s"
+      echo "\e7"
     end
 
     def reset_cursor
-      echo "\u001B[u"
+      echo "\e8"
+    end
+
+    def clear
+      echo "\e[J"
     end
 
     def display
@@ -80,7 +84,7 @@ module Natalie
     def get_char
       row, col = @model.cursor
       reset_cursor
-      echo "\u001b[0J" # Clear
+      clear
       echo display
       reset_cursor
       echo "\u001b[#{row}B" if row > 0


### PR DESCRIPTION
When I type `1+1` into the REPL I get messed up output like this:

    $ bin/natalie
    nat>     nat> 1      nat> 1+       nat> 1+1

Using these different escape codes for save_cursor, reset_cursor, and clear fixes the issue.

Please could someone test these work okay on BSD and Linux...? I've taken the codes from the tty-cursor gem which I'm pretty sure is platform independent (it uses different codes for Windows, but we're not supporting Windows here currently)