### PR TITLE
Delete NativeProfiler at exit

### DIFF
--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -659,8 +659,10 @@ Value super(Env *env, Value self, Args args, Block *block) {
 }
 
 void clean_up_and_exit(int status) {
-    if (Heap::the().collect_all_at_exit())
+    if (Heap::the().collect_all_at_exit()) {
         delete &Heap::the();
+        delete NativeProfiler::the();
+    }
     exit(status);
 }
 


### PR DESCRIPTION
When running Natalie with `-d valgrind`, we weren't cleaning up NativeProfiler, so it looked like a memory leak. I don't think it's a big deal, but does clean up the output from Valgrind so it's easier to find actual memory leaks.