### PR TITLE
IO output fixes

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -148,6 +148,11 @@ public:
         snprintf(buf, len, "<Env %p>", this);
     }
 
+    Value output_file_separator();
+    Value output_record_separator();
+    Value last_line();
+    Value set_last_line(Value);
+
 private:
     ManagedVector<Value> *m_vars { nullptr };
     Env *m_outer { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -71,6 +71,9 @@ public:
         m_internal_encoding = enc;
     }
 
+protected:
+    int write(Env *, Value) const;
+
 private:
     EncodingObject *m_external_encoding { nullptr };
     EncodingObject *m_internal_encoding { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -57,7 +57,12 @@ public:
     Value read(Env *, Value) const;
     Value write(Env *, Args) const;
     Value gets(Env *) const;
-    Value puts(Env *, Args) const;
+
+    Value puts(Env *, Args);
+    void puts(Env *, Value);
+    void putstr(Env *, StringObject *);
+    void putary(Env *, ArrayObject *);
+
     Value print(Env *, Args) const;
     Value close(Env *);
     Value seek(Env *, Value, Value) const;

--- a/spec/core/io/print_spec.rb
+++ b/spec/core/io/print_spec.rb
@@ -1,0 +1,66 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#print" do
+  before :each do
+    @old_record_separator = $\
+    @old_field_separator = $,
+    suppress_warning {
+      $\ = '->'
+      $, = '^^'
+    }
+    @name = tmp("io_print")
+  end
+
+  after :each do
+    suppress_warning {
+      $\ = @old_record_separator
+      $, = @old_field_separator
+    }
+    rm_r @name
+  end
+
+  it "returns nil" do
+    touch(@name) { |f| f.print.should be_nil }
+  end
+
+  it "writes $_.to_s followed by $\\ (if any) to the stream if no arguments given" do
+    o = mock('o')
+    o.should_receive(:to_s).and_return("mockmockmock")
+    $_ = o
+
+    touch(@name) { |f| f.print }
+    IO.read(@name).should == "mockmockmock#{$\}"
+
+    # Set $_ to something known
+    string = File.open(__FILE__) {|f| f.gets }
+
+    touch(@name) { |f| f.print }
+    IO.read(@name).should == "#{string}#{$\}"
+  end
+
+  it "calls obj.to_s and not obj.to_str then writes the record separator" do
+    o = mock('o')
+    o.should_not_receive(:to_str)
+    o.should_receive(:to_s).and_return("hello")
+
+    touch(@name) { |f| f.print(o) }
+
+    IO.read(@name).should == "hello#{$\}"
+  end
+
+  it "writes each obj.to_s to the stream separated by $, (if any) and appends $\\ (if any) given multiple objects" do
+    o, o2 = Object.new, Object.new
+    def o.to_s(); 'o'; end
+    def o2.to_s(); 'o2'; end
+
+    suppress_warning {
+      touch(@name) { |f| f.print(o, o2) }
+    }
+    IO.read(@name).should == "#{o.to_s}#{$,}#{o2.to_s}#{$\}"
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.print("stuff") }.should raise_error(IOError)
+  end
+end

--- a/spec/core/io/puts_spec.rb
+++ b/spec/core/io/puts_spec.rb
@@ -1,0 +1,148 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#puts" do
+  before :each do
+    @before_separator = $/
+    @name = tmp("io_puts.txt")
+    @io = new_io @name
+    ScratchPad.record ""
+    def @io.write(str)
+      ScratchPad << str
+    end
+  end
+
+  after :each do
+    ScratchPad.clear
+    @io.close if @io
+    rm_r @name
+    suppress_warning {$/ = @before_separator}
+  end
+
+  it "writes just a newline when given no args" do
+    @io.puts.should == nil
+    ScratchPad.recorded.should == "\n"
+  end
+
+  it "writes just a newline when given just a newline" do
+    -> { $stdout.puts "\n" }.should output_to_fd("\n", $stdout)
+  end
+
+  it "writes empty string with a newline when given nil as an arg" do
+    @io.puts(nil).should == nil
+    ScratchPad.recorded.should == "\n"
+  end
+
+  it "writes empty string with a newline when when given nil as multiple args" do
+    @io.puts(nil, nil).should == nil
+    ScratchPad.recorded.should == "\n\n"
+  end
+
+  # NATFIXME: This test fails thinking it should receive method_missing, but when
+  # wrapped with NATFIXME() it thinks the test passed, so had to be xit'd
+  xit "calls :to_ary before writing non-string objects, regardless of it being implemented in the receiver" do
+    object = mock('hola')
+    object.should_receive(:method_missing).with(:to_ary)
+    object.should_receive(:to_s).and_return("#<Object:0x...>")
+    @io.puts(object).should == nil
+    ScratchPad.recorded.should == "#<Object:0x...>\n"
+  end
+
+  it "calls :to_ary before writing non-string objects" do
+    object = mock('hola')
+    object.should_receive(:to_ary).and_return(["hola"])
+
+    @io.puts(object).should == nil
+    ScratchPad.recorded.should == "hola\n"
+  end
+
+  it "calls :to_s before writing non-string objects that don't respond to :to_ary" do
+    object = mock('hola')
+    object.should_receive(:to_s).and_return("hola")
+
+    @io.puts(object).should == nil
+    ScratchPad.recorded.should == "hola\n"
+  end
+
+  it "returns general object info if :to_s does not return a string" do
+    object = mock('hola')
+    object.should_receive(:to_s).and_return(false)
+    @io.puts(object).should == nil
+    NATFIXME "Object#inspect missing instance-variables causes this to break" do
+      ScratchPad.recorded.should == object.inspect.split(" ")[0] + ">\n"
+    end
+  end
+
+  it "writes each arg if given several" do
+    @io.puts(1, "two", 3).should == nil
+    ScratchPad.recorded.should == "1\ntwo\n3\n"
+  end
+
+  it "flattens a nested array before writing it" do
+    @io.puts([1, 2, [3]]).should == nil
+    ScratchPad.recorded.should == "1\n2\n3\n"
+  end
+
+  it "writes nothing for an empty array" do
+    x = []
+    @io.should_not_receive(:write)
+    @io.puts(x).should == nil
+  end
+
+  # NATFIXME: recursion case not handled yet
+  xit "writes [...] for a recursive array arg" do
+    x = []
+    x << 2 << x
+    @io.puts(x).should == nil
+    ScratchPad.recorded.should == "2\n[...]\n"
+  end
+
+  it "writes a newline after objects that do not end in newlines" do
+    @io.puts(5).should == nil
+    ScratchPad.recorded.should == "5\n"
+  end
+
+  it "does not write a newline after objects that end in newlines" do
+    @io.puts("5\n").should == nil
+    ScratchPad.recorded.should == "5\n"
+  end
+
+  it "ignores the $/ separator global" do
+    suppress_warning {$/ = ":"}
+    @io.puts(5).should == nil
+    ScratchPad.recorded.should == "5\n"
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.puts("stuff") }.should raise_error(IOError)
+  end
+
+  it "writes crlf when IO is opened with newline: :crlf" do
+    NATFIXME "File.open newline arg unsupported", exception: TypeError, message: "Hash into Integer" do
+      File.open(@name, 'wt', newline: :crlf) do |file|
+        file.puts
+      end
+      File.binread(@name).should == "\r\n"
+    end
+  end
+
+  it "writes cr when IO is opened with newline: :cr" do
+    NATFIXME "File.open newline arg unsupported", exception: TypeError, message: "Hash into Integer" do
+      File.open(@name, 'wt', newline: :cr) do |file|
+        file.puts
+      end
+      File.binread(@name).should == "\r"
+    end
+  end
+  
+  platform_is_not :windows do # https://bugs.ruby-lang.org/issues/12436
+    it "writes lf when IO is opened with newline: :lf" do
+      NATFIXME "File.open newline arg unsupported", exception: TypeError, message: "Hash into Integer" do
+        File.open(@name, 'wt', newline: :lf) do |file|
+          file.puts
+        end
+        File.binread(@name).should == "\n"
+      end
+    end
+  end
+end

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -23,6 +23,31 @@ Value Env::global_set(SymbolObject *name, Value val) {
     return GlobalEnv::the()->global_set(this, name, val);
 }
 
+// Return the file separator `$,` or nil
+Value Env::output_file_separator() {
+    Value fsep = global_get("$,"_s);
+    if (fsep) return fsep;
+    return NilObject::the();
+}
+
+// Return the record separator `$\` or nil
+Value Env::output_record_separator() {
+    Value rsep = global_get("$\\"_s);
+    if (rsep) return rsep;
+    return NilObject::the();
+}
+
+// Return the last line `$_` or nil
+Value Env::last_line() {
+    Value fsep = global_get("$_"_s);
+    if (fsep) return fsep;
+    return NilObject::the();
+}
+
+Value Env::set_last_line(Value val) {
+    return global_set("$_"_s, val);
+}
+
 const Method *Env::current_method() {
     Env *env = this;
     while (!env->method() && env->outer()) {


### PR DESCRIPTION
This PR mostly contains fixes for output related methods in IO:
+  `IO#write` : A method variant that takes a single `Value` was added.  This is called by the `Args` variant.
+  `IO#print` : Now supports using global record and file separators and last-line.
+  `IO#puts` : Non-ruby-side exposed C++ helper methods `putstr` and `putary` were also added.  I had initially tried to do this with polymorphism by writing functions that took `StringObject*` or `ArrayObject*` arguments, but the compiler got confused between these and `Value`, so I renamed them accordingly.
   + Note that there was a test that I had to `xit` for running `puts` on a recursively defined Array.  MRI is doing some sort of check to handle this but I was not sure what the most appropriate way to handle this is in Natalie.  If we have existing code somewhere else to handle infinite object recursion, i have not found it yet - any advice appreciated.

+ `IO#gets` : Sets the env global last-line (`$_`).  Some tests for `print` relied on this functionality to set the last-line before printing it. 

Some additional methods were added to `Env` in order to simplify readability for accessing some of the global variables (e.g., $_ == last-line and the global output record/file separators)