### PR TITLE
Fixed README.md Compiling part

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ bin/natalie examples/hello.rb
 **Compile a file to an executable:**
 
 ```sh
-bin/natalie examples/hello.rb -c hello
+bin/natalie -c hello examples/hello.rb
 ./hello
 ```
 


### PR DESCRIPTION
if you try to compile by putting ***-c hello*** at the end, it won't return executable output :) (in my case that was a problem) 
now it's ok