### PR TITLE
Implement Kernel#initialize_clone

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -292,7 +292,8 @@ public:
     Method *find_method(Env *, SymbolObject *, MethodVisibility, Value) const;
 
     Value dup(Env *) const;
-    Value clone(Env *env) const;
+    Value clone(Env *env);
+    Value clone(Env *env, Value freeze);
 
     bool is_a(Env *, Value) const;
     bool respond_to(Env *, Value, bool = true);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -300,7 +300,6 @@ public:
     Value chop(Env *) const;
     Value chop_in_place(Env *);
     Value clear(Env *);
-    Value clone(Env *env);
     Value cmp(Env *, Value) const;
     Value concat(Env *env, Args args);
     Value delete_prefix(Env *, Value);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1135,7 +1135,6 @@ gen.binding('String', 'chop', 'StringObject', 'chop', argc: 0, pass_env: true, p
 gen.binding('String', 'chop!', 'StringObject', 'chop_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'chr', 'StringObject', 'chr', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'clear', 'StringObject', 'clear', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('String', 'clone', 'StringObject', 'clone', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'codepoints', 'StringObject', 'codepoints', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('String', 'concat', 'StringObject', 'concat', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'downcase', 'StringObject', 'downcase', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -880,7 +880,7 @@ gen.module_function_binding('Kernel', 'spawn', 'KernelModule', 'spawn', argc: 1.
 gen.module_function_binding('Kernel', 'srand', 'RandomObject', 'srand', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'String', 'KernelModule', 'String', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'class', 'KernelModule', 'klass_obj', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Kernel', 'clone', 'KernelModule', 'clone', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Kernel', 'clone', 'KernelModule', 'clone', argc: 0, kwargs: [:freeze], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'define_singleton_method', 'KernelModule', 'define_singleton_method', argc: 1, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Kernel', 'dup', 'KernelModule', 'dup', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', '===', 'KernelModule', 'equal', argc: 1, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/kernel/clone_spec.rb
+++ b/spec/core/kernel/clone_spec.rb
@@ -1,0 +1,211 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/dup_clone'
+
+describe "Kernel#clone" do
+  it_behaves_like :kernel_dup_clone, :clone
+
+  before :each do
+    ScratchPad.clear
+    @obj = KernelSpecs::Duplicate.new 1, :a
+  end
+
+  it "calls #initialize_copy on the new instance" do
+    clone = @obj.clone
+    ScratchPad.recorded.should_not == @obj.object_id
+    ScratchPad.recorded.should == clone.object_id
+  end
+
+  it "uses the internal allocator and does not call #allocate" do
+    klass = Class.new
+    instance = klass.new
+
+    def klass.allocate
+      raise "allocate should not be called"
+    end
+
+    clone = instance.clone
+    clone.class.should equal klass
+  end
+
+  describe "with no arguments" do
+    it "copies frozen state from the original" do
+      o2 = @obj.clone
+      o2.should_not.frozen?
+
+      @obj.freeze
+      o3 = @obj.clone
+      o3.should.frozen?
+    end
+
+    it 'copies frozen?' do
+      o = ''.freeze.clone
+      o.frozen?.should be_true
+    end
+  end
+
+  describe "with freeze: nil" do
+    ruby_version_is ""..."3.0" do
+      it "raises ArgumentError" do
+        -> { @obj.clone(freeze: nil) }.should raise_error(ArgumentError, /unexpected value for freeze: NilClass/)
+      end
+    end
+
+    ruby_version_is "3.0" do
+      it "copies frozen state from the original, like #clone without arguments" do
+        o2 = @obj.clone(freeze: nil)
+        o2.should_not.frozen?
+
+        @obj.freeze
+        o3 = @obj.clone(freeze: nil)
+        o3.should.frozen?
+      end
+
+      it "copies frozen?" do
+        o = "".freeze.clone(freeze: nil)
+        o.frozen?.should be_true
+      end
+    end
+  end
+
+  describe "with freeze: true" do
+    it 'makes a frozen copy if the original is frozen' do
+      @obj.freeze
+      @obj.clone(freeze: true).should.frozen?
+    end
+
+    ruby_version_is ''...'3.0' do
+      it 'does not freeze the copy even if the original is not frozen' do
+        @obj.clone(freeze: true).should_not.frozen?
+      end
+
+      it "calls #initialize_clone with no kwargs" do
+        obj = KernelSpecs::CloneFreeze.new
+        obj.clone(freeze: true)
+        ScratchPad.recorded.should == [obj, {}]
+      end
+    end
+
+    ruby_version_is '3.0' do
+      it 'freezes the copy even if the original was not frozen' do
+        @obj.clone(freeze: true).should.frozen?
+      end
+
+      it "calls #initialize_clone with kwargs freeze: true" do
+        obj = KernelSpecs::CloneFreeze.new
+        obj.clone(freeze: true)
+        ScratchPad.recorded.should == [obj, { freeze: true }]
+      end
+
+      it "calls #initialize_clone with kwargs freeze: true even if #initialize_clone only takes a single argument" do
+        obj = KernelSpecs::Clone.new
+        -> { obj.clone(freeze: true) }.should raise_error(ArgumentError, 'wrong number of arguments (given 2, expected 1)')
+      end
+    end
+  end
+
+  describe "with freeze: false" do
+    it 'does not freeze the copy if the original is frozen' do
+      @obj.freeze
+      @obj.clone(freeze: false).should_not.frozen?
+    end
+
+    it 'does not freeze the copy if the original is not frozen' do
+      @obj.clone(freeze: false).should_not.frozen?
+    end
+
+    ruby_version_is ''...'3.0' do
+      it "calls #initialize_clone with no kwargs" do
+        obj = KernelSpecs::CloneFreeze.new
+        obj.clone(freeze: false)
+        ScratchPad.recorded.should == [obj, {}]
+      end
+    end
+
+    ruby_version_is '3.0' do
+      it "calls #initialize_clone with kwargs freeze: false" do
+        obj = KernelSpecs::CloneFreeze.new
+        obj.clone(freeze: false)
+        ScratchPad.recorded.should == [obj, { freeze: false }]
+      end
+
+      it "calls #initialize_clone with kwargs freeze: false even if #initialize_clone only takes a single argument" do
+        obj = KernelSpecs::Clone.new
+        -> { obj.clone(freeze: false) }.should raise_error(ArgumentError, 'wrong number of arguments (given 2, expected 1)')
+      end
+    end
+  end
+
+  describe "with freeze: anything else" do
+    it 'raises ArgumentError when passed not true/false/nil' do
+      -> { @obj.clone(freeze: 1) }.should raise_error(ArgumentError, /unexpected value for freeze: Integer/)
+      -> { @obj.clone(freeze: "") }.should raise_error(ArgumentError, /unexpected value for freeze: String/)
+      -> { @obj.clone(freeze: Object.new) }.should raise_error(ArgumentError, /unexpected value for freeze: Object/)
+    end
+  end
+
+  it "copies instance variables" do
+    clone = @obj.clone
+    clone.one.should == 1
+    clone.two.should == :a
+  end
+
+  it "copies singleton methods" do
+    def @obj.special() :the_one end
+    clone = @obj.clone
+    clone.special.should == :the_one
+  end
+
+  it "copies modules included in the singleton class" do
+    class << @obj
+      include KernelSpecs::DuplicateM
+    end
+
+    clone = @obj.clone
+    clone.repr.should == "KernelSpecs::Duplicate"
+  end
+
+  it "copies constants defined in the singleton class" do
+    class << @obj
+      CLONE = :clone
+    end
+
+    clone = @obj.clone
+    class << clone
+      CLONE.should == :clone
+    end
+  end
+
+  it "replaces a singleton object's metaclass with a new copy with the same superclass" do
+    cls = Class.new do
+      def bar
+        ['a']
+      end
+    end
+
+    object = cls.new
+    object.define_singleton_method(:bar) do
+      ['b', *super()]
+    end
+    object.bar.should == ['b', 'a']
+
+    cloned = object.clone
+
+    NATFIXME 'Implement Kernel#singleton_methods', exception: NoMethodError, message: "undefined method `singleton_methods'" do
+      cloned.singleton_methods.should == [:bar]
+
+      # bar should replace previous one
+      cloned.define_singleton_method(:bar) do
+        ['c', *super()]
+      end
+      cloned.bar.should == ['c', 'a']
+
+      # bar should be removed and call through to superclass
+      cloned.singleton_class.class_eval do
+        remove_method :bar
+      end
+
+      cloned.bar.should == ['a']
+    end
+  end
+end

--- a/spec/core/kernel/initialize_clone_spec.rb
+++ b/spec/core/kernel/initialize_clone_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+
+describe "Kernel#initialize_clone" do
+  it "is a private instance method" do
+    Kernel.should have_private_instance_method(:initialize_clone)
+  end
+
+  it "returns the receiver" do
+    a = Object.new
+    b = Object.new
+    a.send(:initialize_clone, b).should == a
+  end
+
+  it "calls #initialize_copy" do
+    a = Object.new
+    b = Object.new
+    a.should_receive(:initialize_copy).with(b)
+    a.send(:initialize_clone, b)
+  end
+
+  ruby_version_is "3.0" do
+    it "accepts a :freeze keyword argument for obj.clone(freeze: value)" do
+      a = Object.new
+      b = Object.new
+      a.send(:initialize_clone, b, freeze: true).should == a
+    end
+  end
+end

--- a/spec/core/kernel/shared/dup_clone.rb
+++ b/spec/core/kernel/shared/dup_clone.rb
@@ -1,0 +1,91 @@
+class ObjectSpecDup
+  def initialize()
+    @obj = :original
+  end
+
+  attr_accessor :obj
+end
+
+class ObjectSpecDupInitCopy
+  def initialize()
+    @obj = :original
+  end
+
+  attr_accessor :obj, :original
+
+  def initialize_copy(original)
+    @obj = :init_copy
+    @original = original
+  end
+
+  private :initialize_copy
+end
+
+describe :kernel_dup_clone, shared: true do
+  it "returns a new object duplicated from the original" do
+    o = ObjectSpecDup.new
+    o2 = ObjectSpecDup.new
+
+    o.obj = 10
+
+    o3 = o.send(@method)
+
+    o3.obj.should == 10
+    o2.obj.should == :original
+  end
+
+  it "produces a shallow copy, contained objects are not recursively dupped" do
+    o = ObjectSpecDup.new
+    array = [1, 2]
+    o.obj = array
+
+    o2 = o.send(@method)
+    o2.obj.should equal(o.obj)
+  end
+
+  it "calls #initialize_copy on the NEW object if available, passing in original object" do
+    o = ObjectSpecDupInitCopy.new
+    o2 = o.send(@method)
+
+    o.obj.should == :original
+    o2.obj.should == :init_copy
+    o2.original.should equal(o)
+  end
+
+  it "does not preserve the object_id" do
+    o1 = ObjectSpecDupInitCopy.new
+    old_object_id = o1.object_id
+    o2 = o1.send(@method)
+    o2.object_id.should_not == old_object_id
+  end
+
+  it "returns nil for NilClass" do
+    nil.send(@method).should == nil
+  end
+
+  it "returns true for TrueClass" do
+    true.send(@method).should == true
+  end
+
+  it "returns false for FalseClass" do
+    false.send(@method).should == false
+  end
+
+  it "returns the same Integer for Integer" do
+    1.send(@method).should == 1
+  end
+
+  it "returns the same Symbol for Symbol" do
+    :my_symbol.send(@method).should == :my_symbol
+  end
+
+  it "returns self for Complex" do
+    c = Complex(1.3, 3.1)
+    c.send(@method).should equal c
+  end
+
+  it "returns self for Rational" do
+    r = Rational(1, 3)
+    r.send(@method).should equal r
+  end
+end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -36,6 +36,12 @@ module Kernel
   end
   private :initialize_dup
 
+  def initialize_clone(other, freeze: nil)
+    initialize_copy(other)
+    self
+  end
+  private :initialize_clone
+
   def instance_of?(clazz)
     raise TypeError, 'class or module required' unless clazz.is_a?(Module)
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -718,24 +718,6 @@ Value StringObject::b(Env *env) const {
     return new StringObject { m_string, Encoding::ASCII_8BIT };
 }
 
-Value StringObject::clone(Env *env) {
-    auto duplicate = this->dup(env);
-    auto s_class = singleton_class();
-    if (s_class) {
-        duplicate->set_singleton_class(s_class->clone(env)->as_class());
-    }
-
-    if (duplicate->respond_to(env, "initialize_copy"_s)) {
-        duplicate->send(env, "initialize_copy"_s, { duplicate });
-    }
-
-    if (this->is_frozen()) {
-        duplicate->freeze();
-    }
-
-    return duplicate;
-}
-
 Value StringObject::bytes(Env *env, Block *block) {
     if (block) {
         return each_byte(env, block);


### PR DESCRIPTION
This implements Kernel#initialize_clone and makes Kernel#clone (mostly) spec compliant.

I've removed StringObject::clone as its initialize_copy code is incorrect and it's not necessary with Kernel#clone calling Kernel#initialize_clone (which calls Kernel#initialize_copy). There's one remaining spec for Kernel#clone which isn't passing because it depends on Kernel#singleton_methods, I've added a NATFIXME block for that.