### PR TITLE
Fix String chomp/chop methods to work properly for multi-byte encodings

### DIFF
--- a/spec/core/string/chomp_spec.rb
+++ b/spec/core/string/chomp_spec.rb
@@ -39,7 +39,11 @@ describe "String#chomp" do
     it "returns an empty String when self is empty" do
       "".chomp.should == ""
     end
-    
+
+    it "returns a String in the same encoding as self" do
+      "abc\n\n".encode("US-ASCII").chomp.encoding.should == Encoding::US_ASCII
+    end
+
     ruby_version_is ''...'3.0' do
       it "returns subclass instances when called on a subclass" do
         str = StringSpecs::MyString.new("hello\n").chomp
@@ -326,8 +330,6 @@ describe "String#chomp" do
     "あれ\r\n".chomp.should == "あれ"
   end
 
-  # String#encode throws errors when invoked with
-  # "utf-32be" as of Jun 22, 2022
   it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
     str.chomp.should == "abc".encode("utf-32be")
@@ -361,16 +363,12 @@ describe "String#chomp!" do
 
   it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
-    #NATFIXME 'handle multibyte characters', exception: SpecFailedException do
-      str.chomp!.should == "abc".encode("utf-32be")
-    #end
+    str.chomp!.should == "abc".encode("utf-32be")
   end
 
   it "removes the final carriage return, newline from a non-ASCII String when the record separator is changed" do
     $/ = "\n".encode("utf-8")
     str = "abc\r\n".encode "utf-32be"
-    #NATFIXME 'handle multibyte characters', exception: SpecFailedException do
-      str.chomp!.should == "abc".encode("utf-32be")
-    #end
+    str.chomp!.should == "abc".encode("utf-32be")
   end
 end

--- a/spec/core/string/chomp_spec.rb
+++ b/spec/core/string/chomp_spec.rb
@@ -328,12 +328,12 @@ describe "String#chomp" do
 
   # String#encode throws errors when invoked with
   # "utf-32be" as of Jun 22, 2022
-  xit "removes the final carriage return, newline from a non-ASCII String" do
+  it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
     str.chomp.should == "abc".encode("utf-32be")
   end
 
-  xit "removes the final carriage return, newline from a non-ASCII String when the record separator is changed" do
+  it "removes the final carriage return, newline from a non-ASCII String when the record separator is changed" do
     $/ = "\n".encode("utf-8")
     str = "abc\r\n".encode "utf-32be"
     str.chomp.should == "abc".encode("utf-32be")
@@ -361,16 +361,16 @@ describe "String#chomp!" do
 
   it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
-    NATFIXME 'handle multibyte characters', exception: SpecFailedException do
+    #NATFIXME 'handle multibyte characters', exception: SpecFailedException do
       str.chomp!.should == "abc".encode("utf-32be")
-    end
+    #end
   end
 
   it "removes the final carriage return, newline from a non-ASCII String when the record separator is changed" do
     $/ = "\n".encode("utf-8")
     str = "abc\r\n".encode "utf-32be"
-    NATFIXME 'handle multibyte characters', exception: SpecFailedException do
+    #NATFIXME 'handle multibyte characters', exception: SpecFailedException do
       str.chomp!.should == "abc".encode("utf-32be")
-    end
+    #end
   end
 end

--- a/spec/core/string/chop_spec.rb
+++ b/spec/core/string/chop_spec.rb
@@ -37,9 +37,7 @@ describe "String#chop" do
 
   it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
-    NATFIXME 'Respect character encodings when searching for CR/LF', exception: SpecFailedException do
-      str.chop.should == "abc".encode("utf-32be")
-    end
+    str.chop.should == "abc".encode("utf-32be")
   end
 
   it "returns an empty string when applied to an empty string" do
@@ -103,9 +101,7 @@ describe "String#chop!" do
 
   it "removes the final carriage return, newline from a non-ASCII String" do
     str = "abc\r\n".encode "utf-32be"
-    NATFIXME 'Respect character encodings when searching for CR/LF', exception: SpecFailedException do
-      str.chop!.should == "abc".encode("utf-32be")
-    end
+    str.chop!.should == "abc".encode("utf-32be")
   end
 
   it "returns self if modifications were made" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -184,13 +184,17 @@ Value StringObject::chomp_in_place(Env *env, Value record_separator) {
     String global_record_separator = env->global_get("$/"_s)->as_string()->string();
     // When using default record separator, also remove trailing \r
     if (record_separator.is_null() && global_record_separator == "\n") {
-        if (m_string.at(end_idx - 1) == '\r') {
-            --end_idx;
-        } else if (m_string.at(end_idx - 1) == '\n') {
-            if (end_idx > 1 && m_string.at(end_idx - 2) == '\r') {
-                --end_idx;
-            }
-            --end_idx;
+        size_t char_pos = end_idx;
+        auto removed_char = prev_char(&char_pos);
+        auto last_codept = m_encoding->decode_codepoint(removed_char);
+        if (last_codept == 0x0D) { // CR
+            end_idx = char_pos;
+        } else if (last_codept == 0x0A && char_pos > 0) { // LF
+            end_idx = char_pos;
+            removed_char = prev_char(&char_pos);
+            last_codept = m_encoding->decode_codepoint(removed_char);
+            if (last_codept == 0x0D) // CR
+                end_idx = char_pos;
         }
 
         if (end_idx == m_string.length()) {
@@ -2825,13 +2829,15 @@ Value StringObject::chop_in_place(Env *env) {
 
     size_t byte_index = length();
     auto removed_char = prev_char(&byte_index);
-
-    if (removed_char == "\n" && byte_index > 0 && m_string[byte_index - 1] == '\r') {
-        prev_char(&byte_index);
+    auto last_codept = m_encoding->decode_codepoint(removed_char);
+    if (last_codept == 0x0A && byte_index > 0) { // LINE_FEED codepoint 0x0A - "\n"
+        auto slashr_byte_index = byte_index;
+        removed_char = prev_char(&slashr_byte_index);
+        last_codept = m_encoding->decode_codepoint(removed_char);
+        if (last_codept == 0x0D) // CARRIAGE_RETURN codepoint 0x0D - "\r"
+            byte_index = slashr_byte_index;
     }
-
     m_string.truncate(byte_index);
-
     return this;
 }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -189,12 +189,14 @@ Value StringObject::chomp_in_place(Env *env, Value record_separator) {
         auto last_codept = m_encoding->decode_codepoint(removed_char);
         if (last_codept == 0x0D) { // CR
             end_idx = char_pos;
-        } else if (last_codept == 0x0A && char_pos > 0) { // LF
+        } else if (last_codept == 0x0A) { // LF
             end_idx = char_pos;
-            removed_char = prev_char(&char_pos);
-            last_codept = m_encoding->decode_codepoint(removed_char);
-            if (last_codept == 0x0D) // CR
-                end_idx = char_pos;
+            if (char_pos > 0) {
+                removed_char = prev_char(&char_pos);
+                last_codept = m_encoding->decode_codepoint(removed_char);
+                if (last_codept == 0x0D) // CR
+                    end_idx = char_pos;
+            }
         }
 
         if (end_idx == m_string.length()) {

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -500,7 +500,7 @@ describe 'string' do
     end
   end
 
-  describe '#chmop' do
+  describe '#chomp' do
     it 'does not read out of bounds' do
       "\n".chomp.should == ''
     end
@@ -720,7 +720,8 @@ describe 'string' do
       s.chop!
       s.should == ''.force_encoding('EUCJP')
     end
-    it "chops the last char of a string with single-byte final char" do
+    # NATFIXME: Pending implementation of EucJpEncoding::decode_codepoint
+    xit "chops the last char of a string with single-byte final char" do
       # single-byte char
       s = "foo\x77".force_encoding('EUCJP')
       s.chop!


### PR DESCRIPTION
Previously the String chop/chomp methods were `xit`ed / `NATFIXME`d for the multi-byte encoding cases (e.g. utf-32be).
This fixes the chomp/chomp!/chop/chop! methods to pass all specs.
