### PR TITLE
Implement Symbol#encoding

### DIFF
--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -65,6 +65,7 @@ public:
     Value ref(Env *, Value, Value);
 
     const String &string() const { return m_name; }
+    EncodingObject *encoding(Env *env) const { return name(env)->as_string()->encoding(); }
 
     virtual String dbg_inspect() const override;
 

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -94,6 +94,14 @@ private:
         , m_encoding { encoding } {
         if (m_encoding == nullptr) m_encoding = EncodingObject::default_internal();
         if (m_encoding == nullptr) m_encoding = EncodingObject::default_external();
+
+        if (m_encoding != nullptr && m_encoding->is_ascii_compatible()) {
+            bool all_ascii = true;
+            for (size_t i = 0; all_ascii && i < name.length(); i++) {
+                if (name[i] < 0) all_ascii = false;
+            }
+            if (all_ascii) m_encoding = EncodingObject::get(Encoding::US_ASCII);
+        }
     }
 
     const TM::String m_name {};

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -15,7 +15,7 @@ namespace Natalie {
 
 class SymbolObject : public Object {
 public:
-    static SymbolObject *intern(const char *, size_t length);
+    static SymbolObject *intern(const char *, const size_t length);
     static SymbolObject *intern(const String &);
 
     static ArrayObject *all_symbols(Env *);

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -19,7 +19,7 @@ public:
     static SymbolObject *intern(const String &, EncodingObject *encoding = nullptr);
 
     static ArrayObject *all_symbols(Env *);
-    StringObject *to_s(Env *env) { return new StringObject { m_name }; }
+    StringObject *to_s(Env *);
     SymbolObject *to_sym(Env *env) { return this; }
     StringObject *inspect(Env *);
     SymbolObject *succ(Env *);

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -96,9 +96,13 @@ private:
         if (m_encoding == nullptr) m_encoding = EncodingObject::default_external();
 
         if (m_encoding != nullptr && m_encoding->is_ascii_compatible()) {
+            auto us_ascii = EncodingObject::get(Encoding::US_ASCII);
             bool all_ascii = true;
             for (size_t i = 0; all_ascii && i < name.length(); i++) {
-                if (name[i] < 0) all_ascii = false;
+                if (!us_ascii->in_encoding_codepoint_range(name[i])) {
+                    all_ascii = false;
+                    break;
+                }
             }
             if (all_ascii) m_encoding = EncodingObject::get(Encoding::US_ASCII);
         }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1245,6 +1245,7 @@ gen.binding('Symbol', 'casecmp', 'SymbolObject', 'casecmp', argc: 1, pass_env: t
 gen.binding('Symbol', 'casecmp?', 'SymbolObject', 'is_casecmp', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Symbol', 'downcase', 'SymbolObject', 'downcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Symbol', 'empty?', 'SymbolObject', 'is_empty', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Symbol', 'encoding', 'SymbolObject', 'encoding', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Symbol', 'end_with?', 'SymbolObject', 'end_with', argc: :any, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Symbol', 'id2name', 'SymbolObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Symbol', 'inspect', 'SymbolObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/string/shared/to_sym.rb
+++ b/spec/core/string/shared/to_sym.rb
@@ -23,7 +23,7 @@ describe :string_to_sym, shared: true do
 
   it "returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" do
     sym = "foobar".send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       sym.encoding.should == Encoding::US_ASCII
     end
     sym.should equal :"foobar"
@@ -31,7 +31,7 @@ describe :string_to_sym, shared: true do
 
   it "returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" do
     sym = "foobar".b.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       sym.encoding.should == Encoding::US_ASCII
     end
     sym.should equal :"foobar"
@@ -39,16 +39,14 @@ describe :string_to_sym, shared: true do
 
   it "returns a UTF-8 Symbol for a UTF-8 String containing non US-ASCII characters" do
     sym = "il était une fois".send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
-      sym.encoding.should == Encoding::UTF_8
-    end
+    sym.encoding.should == Encoding::UTF_8
     sym.should equal :"il était une #{'fois'}"
   end
 
   it "returns a UTF-16LE Symbol for a UTF-16LE String containing non US-ASCII characters" do
     utf16_str = "UtéF16".encode(Encoding::UTF_16LE)
     sym = utf16_str.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       sym.encoding.should == Encoding::UTF_16LE
     end
     sym.to_s.should == utf16_str
@@ -57,7 +55,7 @@ describe :string_to_sym, shared: true do
   it "returns a binary Symbol for a binary String containing non US-ASCII characters" do
     binary_string = "binarí".b
     sym = binary_string.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       sym.encoding.should == Encoding::BINARY
     end
     sym.to_s.should == binary_string
@@ -67,11 +65,11 @@ describe :string_to_sym, shared: true do
     source = "fée"
 
     iso_symbol = source.force_encoding(Encoding::ISO_8859_1).send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       iso_symbol.encoding.should == Encoding::ISO_8859_1
     end
     binary_symbol = source.force_encoding(Encoding::BINARY).send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       binary_symbol.encoding.should == Encoding::BINARY
     end
   end

--- a/spec/core/string/shared/to_sym.rb
+++ b/spec/core/string/shared/to_sym.rb
@@ -23,17 +23,13 @@ describe :string_to_sym, shared: true do
 
   it "returns a US-ASCII Symbol for a UTF-8 String containing only US-ASCII characters" do
     sym = "foobar".send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      sym.encoding.should == Encoding::US_ASCII
-    end
+    sym.encoding.should == Encoding::US_ASCII
     sym.should equal :"foobar"
   end
 
   it "returns a US-ASCII Symbol for a binary String containing only US-ASCII characters" do
     sym = "foobar".b.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      sym.encoding.should == Encoding::US_ASCII
-    end
+    sym.encoding.should == Encoding::US_ASCII
     sym.should equal :"foobar"
   end
 

--- a/spec/core/string/shared/to_sym.rb
+++ b/spec/core/string/shared/to_sym.rb
@@ -42,18 +42,14 @@ describe :string_to_sym, shared: true do
   it "returns a UTF-16LE Symbol for a UTF-16LE String containing non US-ASCII characters" do
     utf16_str = "UtéF16".encode(Encoding::UTF_16LE)
     sym = utf16_str.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      sym.encoding.should == Encoding::UTF_16LE
-    end
+    sym.encoding.should == Encoding::UTF_16LE
     sym.to_s.should == utf16_str
   end
 
   it "returns a binary Symbol for a binary String containing non US-ASCII characters" do
     binary_string = "binarí".b
     sym = binary_string.send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      sym.encoding.should == Encoding::BINARY
-    end
+    sym.encoding.should == Encoding::BINARY
     sym.to_s.should == binary_string
   end
 
@@ -61,9 +57,7 @@ describe :string_to_sym, shared: true do
     source = "fée"
 
     iso_symbol = source.force_encoding(Encoding::ISO_8859_1).send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      iso_symbol.encoding.should == Encoding::ISO_8859_1
-    end
+    iso_symbol.encoding.should == Encoding::ISO_8859_1
     binary_symbol = source.force_encoding(Encoding::BINARY).send(@method)
     NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       binary_symbol.encoding.should == Encoding::BINARY

--- a/spec/core/string/shared/to_sym.rb
+++ b/spec/core/string/shared/to_sym.rb
@@ -59,7 +59,7 @@ describe :string_to_sym, shared: true do
     iso_symbol = source.force_encoding(Encoding::ISO_8859_1).send(@method)
     iso_symbol.encoding.should == Encoding::ISO_8859_1
     binary_symbol = source.force_encoding(Encoding::BINARY).send(@method)
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
+    NATFIXME 'Symbol lookup (s_symbols) does not check encoding', exception: SpecFailedException do
       binary_symbol.encoding.should == Encoding::BINARY
     end
   end

--- a/spec/core/symbol/encoding_spec.rb
+++ b/spec/core/symbol/encoding_spec.rb
@@ -8,9 +8,7 @@ describe "Symbol#encoding for ASCII symbols" do
   end
 
   it "is US-ASCII after converting to string" do
-    NATFIXME 'Automatically encode input as US-ASCII if input is ascii compatible', exception: SpecFailedException do
-      :foo.to_s.encoding.name.should == "US-ASCII"
-    end
+    :foo.to_s.encoding.name.should == "US-ASCII"
   end
 end
 

--- a/spec/core/symbol/encoding_spec.rb
+++ b/spec/core/symbol/encoding_spec.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+require_relative '../../spec_helper'
+
+describe "Symbol#encoding for ASCII symbols" do
+  it "is US-ASCII" do
+    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+      :foo.encoding.name.should == "US-ASCII"
+    end
+  end
+
+  it "is US-ASCII after converting to string" do
+    NATFIXME 'Automatically encode input as US-ASCII if input is ascii compatible', exception: SpecFailedException do
+      :foo.to_s.encoding.name.should == "US-ASCII"
+    end
+  end
+end
+
+describe "Symbol#encoding for UTF-8 symbols" do
+  it "is UTF-8" do
+    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+      :åäö.encoding.name.should == "UTF-8"
+    end
+  end
+
+  it "is UTF-8 after converting to string" do
+    :åäö.to_s.encoding.name.should == "UTF-8"
+  end
+end

--- a/spec/core/symbol/encoding_spec.rb
+++ b/spec/core/symbol/encoding_spec.rb
@@ -4,9 +4,7 @@ require_relative '../../spec_helper'
 
 describe "Symbol#encoding for ASCII symbols" do
   it "is US-ASCII" do
-    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
-      :foo.encoding.name.should == "US-ASCII"
-    end
+    :foo.encoding.name.should == "US-ASCII"
   end
 
   it "is US-ASCII after converting to string" do

--- a/spec/core/symbol/encoding_spec.rb
+++ b/spec/core/symbol/encoding_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 
 describe "Symbol#encoding for ASCII symbols" do
   it "is US-ASCII" do
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
+    NATFIXME 'Implement Symbol#encoding', exception: SpecFailedException do
       :foo.encoding.name.should == "US-ASCII"
     end
   end
@@ -18,9 +18,7 @@ end
 
 describe "Symbol#encoding for UTF-8 symbols" do
   it "is UTF-8" do
-    NATFIXME 'Implement Symbol#encoding', exception: NoMethodError, message: "undefined method `encoding'" do
-      :åäö.encoding.name.should == "UTF-8"
-    end
+    :åäö.encoding.name.should == "UTF-8"
   end
 
   it "is UTF-8 after converting to string" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -306,7 +306,7 @@ Value StringObject::chr(Env *env) {
 }
 
 SymbolObject *StringObject::to_symbol(Env *env) const {
-    return SymbolObject::intern(m_string);
+    return SymbolObject::intern(m_string, m_encoding);
 }
 
 Value StringObject::to_sym(Env *env) const {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -2,16 +2,16 @@
 
 namespace Natalie {
 
-SymbolObject *SymbolObject::intern(const char *name, const size_t length) {
+SymbolObject *SymbolObject::intern(const char *name, const size_t length, EncodingObject *encoding) {
     assert(name);
-    return intern(String(name, length));
+    return intern(String(name, length), encoding);
 }
 
-SymbolObject *SymbolObject::intern(const String &name) {
+SymbolObject *SymbolObject::intern(const String &name, EncodingObject *encoding) {
     SymbolObject *symbol = s_symbols.get(name);
     if (symbol)
         return symbol;
-    symbol = new SymbolObject { name };
+    symbol = new SymbolObject { name, encoding };
     s_symbols.put(name, symbol);
     return symbol;
 }

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 
-SymbolObject *SymbolObject::intern(const char *name, size_t length) {
+SymbolObject *SymbolObject::intern(const char *name, const size_t length) {
     assert(name);
     return intern(String(name, length));
 }

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -24,6 +24,14 @@ ArrayObject *SymbolObject::all_symbols(Env *env) {
     return array;
 }
 
+StringObject *SymbolObject::to_s(Env *env) {
+    if (m_encoding == nullptr) {
+        return new StringObject { m_name };
+    } else {
+        return new StringObject { m_name, m_encoding };
+    }
+}
+
 StringObject *SymbolObject::inspect(Env *env) {
     StringObject *string = new StringObject { ":" };
     // FIXME: surely we can do this without a regex


### PR DESCRIPTION
There is one issue left: the symbol strings are internally still saved as bytes, without the encoding information. This means the code can't distinguish between two symbols whose byte representation is the same but with different encodings. `spec/core/string/shared/to_sym.rb` has a disabled test for this case.