### PR TITLE
Continue after SyntaxError in REPL

### DIFF
--- a/lib/natalie/repl/main.rb
+++ b/lib/natalie/repl/main.rb
@@ -22,6 +22,9 @@ module Natalie
             ast = Natalie::Parser.new(cmd, '(repl)').ast
           rescue Parser::IncompleteExpression
             next :continue
+          rescue SyntaxError => e
+            STDERR.puts e
+            next :next
           end
 
           next :continue if ast == s(:block)


### PR DESCRIPTION
Without this change, a syntax error in the REPL causes it to exit. This does not match up with the upstream REPL, which continues.