### PR TITLE
IO updates

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -48,8 +48,8 @@ public:
 
     static Value read_file(Env *, Value);
     static Value write_file(Env *, Value, Value);
-
-    int fileno() const { return m_fileno; }
+    int fileno() const;
+    int fileno(Env *) const;
     void set_fileno(int fileno) { m_fileno = fileno; }
 
     Value append(Env *, Value);
@@ -78,6 +78,7 @@ public:
 
 protected:
     int write(Env *, Value) const;
+    void raise_if_closed(Env *) const;
 
 private:
     EncodingObject *m_external_encoding { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -54,6 +54,7 @@ public:
 
     Value append(Env *, Value);
     Value initialize(Env *, Value);
+    bool isatty(Env *) const;
     Value read(Env *, Value) const;
     Value write(Env *, Args) const;
     Value gets(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -851,7 +851,7 @@ gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: t
 gen.binding('IO', '<<', 'IoObject', 'append', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'close', 'IoObject', 'close', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'closed?', 'IoObject', 'is_closed', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
-gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: false, pass_block: false, return_type: :int)
+gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'print', 'IoObject', 'print', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
@@ -859,7 +859,7 @@ gen.binding('IO', 'puts', 'IoObject', 'puts', argc: :any, pass_env: true, pass_b
 gen.binding('IO', 'read', 'IoObject', 'read', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'seek', 'IoObject', 'seek', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'stat', 'IoObject', 'stat', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('IO', 'to_i', 'IoObject', 'fileno', argc: 0, pass_env: false, pass_block: false, return_type: :int)
+gen.binding('IO', 'to_i', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -853,6 +853,7 @@ gen.binding('IO', 'close', 'IoObject', 'close', argc: 0, pass_env: true, pass_bl
 gen.binding('IO', 'closed?', 'IoObject', 'is_closed', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'isatty', 'IoObject', 'isatty', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('IO', 'print', 'IoObject', 'print', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'puts', 'IoObject', 'puts', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
@@ -860,6 +861,7 @@ gen.binding('IO', 'read', 'IoObject', 'read', argc: 0..1, pass_env: true, pass_b
 gen.binding('IO', 'seek', 'IoObject', 'seek', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'stat', 'IoObject', 'stat', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'to_i', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
+gen.binding('IO', 'tty?', 'IoObject', 'isatty', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/fileno_spec.rb
+++ b/spec/core/io/fileno_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#fileno" do
+  it "returns the numeric file descriptor of the given IO object" do
+    $stdout.fileno.should == 1
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.fileno }.should raise_error(IOError)
+  end
+end

--- a/spec/core/io/isatty_spec.rb
+++ b/spec/core/io/isatty_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/tty'
+
+describe "IO#isatty" do
+  it_behaves_like :io_tty, :isatty
+end

--- a/spec/core/io/shared/tty.rb
+++ b/spec/core/io/shared/tty.rb
@@ -1,0 +1,24 @@
+require_relative '../fixtures/classes'
+
+describe :io_tty, shared: true do
+  platform_is_not :windows do
+    it "returns true if this stream is a terminal device (TTY)" do
+      begin
+        # check to enabled tty
+        File.open('/dev/tty') {}
+      rescue Errno::ENXIO
+        skip "workaround for not configured environment like OS X"
+      else
+        File.open('/dev/tty') { |f| f.send(@method) }.should == true
+      end
+    end
+  end
+
+  it "returns false if this stream is not a terminal device (TTY)" do
+    File.open(__FILE__) { |f| f.send(@method) }.should == false
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.send @method }.should raise_error(IOError)
+  end
+end

--- a/spec/core/io/to_i_spec.rb
+++ b/spec/core/io/to_i_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#to_i" do
+  it "returns the numeric file descriptor of the given IO object" do
+    $stdout.to_i.should == 1
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.to_i }.should raise_error(IOError)
+  end
+end

--- a/spec/core/io/tty_spec.rb
+++ b/spec/core/io/tty_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/tty'
+
+describe "IO#tty?" do
+  it_behaves_like :io_tty, :tty?
+end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -47,8 +47,7 @@ Value IoObject::write_file(Env *env, Value filename, Value string) {
 #define NAT_READ_BYTES 1024
 
 Value IoObject::read(Env *env, Value count_value) const {
-    if (m_closed)
-        env->raise("IOError", "closed stream");
+    raise_if_closed(env);
     size_t bytes_read;
     if (count_value) {
         count_value->assert_type(env, Object::Type::Integer, "Integer");
@@ -80,8 +79,7 @@ Value IoObject::read(Env *env, Value count_value) const {
 }
 
 Value IoObject::append(Env *env, Value obj) {
-    if (is_closed())
-        env->raise("IOError", "cannot read closed stream");
+    raise_if_closed(env);
     if (!obj->is_string() && obj->respond_to(env, "to_str"_s))
         obj = obj.send(env, "to_s"_s);
     obj->assert_type(env, Object::Type::String, "String");
@@ -91,8 +89,7 @@ Value IoObject::append(Env *env, Value obj) {
 }
 
 int IoObject::write(Env *env, Value obj) const {
-    if (is_closed())
-        env->raise("IOError", "cannot write closed stream");
+    raise_if_closed(env);
     if (obj->type() != Object::Type::String) {
         obj = obj.send(env, "to_s"_s);
     }
@@ -118,8 +115,7 @@ Value IoObject::write(Env *env, Args args) const {
 
 // NATFIXME: Make this spec compliant and maybe more performant?
 Value IoObject::gets(Env *env) const {
-    if (is_closed())
-        env->raise("IOError", "cannot read closed stream");
+    raise_if_closed(env);
     char buffer[NAT_READ_BYTES + 1];
     size_t index;
     for (index = 0; index < NAT_READ_BYTES; ++index) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -27,6 +27,11 @@ int IoObject::fileno(Env *env) const {
     return m_fileno;
 }
 
+bool IoObject::isatty(Env *env) const {
+    raise_if_closed(env);
+    return ::isatty(m_fileno) == 1;
+}
+
 Value IoObject::read_file(Env *env, Value filename) {
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, { filename }, nullptr)->as_file();


### PR DESCRIPTION
+ Add `IO#isatty` and `IO#tty?`
+ Refactor the check IO closed + raise `IOError` in a few methods. Noting that this changes some of the error-messages so that they are common and slightly less specific, but I think that is okay and consistent with MRI.
+ Fix `IO#fileno` to raise when the IO is closed.
