### PR TITLE
Use `inspect` instead of `to_s` for Set entries stringification

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -200,7 +200,7 @@ class Set
   alias === include?
 
   def inspect
-    items = to_a.map { |e| equal?(e) ? '#<Set: {...}>' : e.to_s }
+    items = to_a.map { |e| equal?(e) ? '#<Set: {...}>' : e.inspect }
     "#<Set: {#{items.join(', ')}}>"
   end
   alias to_s inspect

--- a/spec/library/set/shared/inspect.rb
+++ b/spec/library/set/shared/inspect.rb
@@ -7,6 +7,14 @@ describe :set_inspect, shared: true do
     Set[:a, "b", Set[?c]].send(@method).should be_kind_of(String)
   end
 
+  it "does include the elements of the set" do
+    Set["1"].send(@method).should == '#<Set: {"1"}>'
+  end
+
+  it "puts spaces between the elements" do
+    Set["1", "2"].send(@method).should include('", "')
+  end
+
   it "correctly handles self-references" do
     # NATFIXME: Support this syntax
     # (set = Set[]) << set


### PR DESCRIPTION
This is de default behaviour for Ruby containers. This resolves some recent issues in the specs of `Set#inspect` and `Set#to_s`.