### PR TITLE
Make Proc#binding public

### DIFF
--- a/spec/core/proc/binding_spec.rb
+++ b/spec/core/proc/binding_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../spec_helper'
+
+describe "Proc#binding" do
+  it "returns a Binding instance" do
+    [Proc.new{}, -> {}, proc {}].each { |p|
+      p.binding.should be_kind_of(Binding)
+    }
+  end
+
+  it "returns the binding associated with self" do
+    obj = mock('binding')
+    def obj.test_binding(some, params)
+      -> {}
+    end
+
+    lambdas_binding = obj.test_binding(1, 2).binding
+
+    # NATFIXME: binding passed to eval() will be ignored.
+    # eval("some", lambdas_binding).should == 1
+    # eval("params", lambdas_binding).should == 2
+  end
+end

--- a/src/proc.rb
+++ b/src/proc.rb
@@ -1,0 +1,3 @@
+class Proc
+  public :binding
+end


### PR DESCRIPTION
The code in the `eval` statements results in a warning and has been disabled for now.