### PR TITLE
perf(Symbol#inspect): Reuse onigmo regex for testing if symbol should be quoted

### DIFF
--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -66,6 +66,8 @@ public:
 
     const String &string() const { return m_name; }
 
+    bool should_be_quoted() const;
+
     virtual String dbg_inspect() const override;
 
     virtual void visit_children(Visitor &visitor) override {
@@ -85,6 +87,7 @@ public:
 
 private:
     inline static TM::Hashmap<const TM::String, SymbolObject *> s_symbols { TM::HashType::TMString, 1000 };
+    inline static regex_t *s_inspect_quote_regex { nullptr };
 
     SymbolObject(const String &name)
         : Object { Object::Type::Symbol, GlobalEnv::the()->Symbol() }

--- a/test/natalie/symbol_test.rb
+++ b/test/natalie/symbol_test.rb
@@ -47,6 +47,7 @@ describe 'symbol' do
       :$?.inspect.should == ':$?'
       :$!.inspect.should == ':$!'
       :$~.inspect.should == ':$~'
+      :"$foo!!!bar".inspect.should == ':"$foo!!!bar"'
       (:&).inspect.should == ':&'
     end
   end


### PR DESCRIPTION
This speeds up `Symbol#inspect` by quite a lot by reusing the regex object.

For this silly benchmark:

```ruby
10_000.times do |i|
  i.to_s.to_sym.inspect
end
```

...it produces about a 15x speedup:

```
→ hyperfine ./before ./after
Benchmark 1: ./before
  Time (mean ± σ):     788.0 ms ±  17.1 ms    [User: 783.7 ms, System: 4.1 ms]
  Range (min … max):   757.5 ms … 815.0 ms    10 runs
 
Benchmark 2: ./after
  Time (mean ± σ):      47.6 ms ±   0.7 ms    [User: 45.0 ms, System: 2.6 ms]
  Range (min … max):    46.2 ms …  49.6 ms    61 runs
 
Summary
  './after' ran
   16.55 ± 0.44 times faster than './before'
```