### PR TITLE
Throw a NotImplementedError im String#gsub without block

### DIFF
--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -568,18 +568,21 @@ describe "String#gsub with pattern and block" do
   end
 end
 
-# NATFIXME: NOT YET IMPLEMENTED: Enumerator reply in String#gsub
-xdescribe "String#gsub with pattern and without replacement and block" do
+describe "String#gsub with pattern and without replacement and block" do
   it "returns an enumerator" do
-    enum = "abca".gsub(/a/)
-    enum.should be_an_instance_of(Enumerator)
-    enum.to_a.should == ["a", "a"]
+    NATFIXME 'Enumerator reply in String#gsub', exception: NotImplementedError do
+      enum = "abca".gsub(/a/)
+      enum.should be_an_instance_of(Enumerator)
+      enum.to_a.should == ["a", "a"]
+    end
   end
 
   describe "returned Enumerator" do
     describe "size" do
       it "should return nil" do
-        "abca".gsub(/a/).size.should == nil
+        NATFIXME 'Enumerator reply in String#gsub', exception: NotImplementedError do
+          "abca".gsub(/a/).size.should == nil
+        end
       end
     end
   end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1775,7 +1775,7 @@ StringObject *StringObject::regexp_sub(Env *env, RegexpObject *find, StringObjec
         if (index + length < m_string.length())
             out->append(m_string.substring(index + length));
     } else {
-        NAT_NOT_YET_IMPLEMENTED("Enumerator reply in String#gsub");
+        env->raise("NotImplementedError", "Enumerator reply in String#gsub");
     }
     return out;
 }


### PR DESCRIPTION
This replaces the NAT_NOT_YET_IMPLEMENTED, which aborts the run. This means we can use the NATFIXME block style in the specs without aborting the executable.