### PR TITLE
Move includes of EnvObject from header to implementation

### DIFF
--- a/include/natalie/env_object.hpp
+++ b/include/natalie/env_object.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <assert.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-
 #include "natalie/forward.hpp"
 #include "natalie/hash_object.hpp"
 #include "natalie/integer_object.hpp"

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -2,6 +2,10 @@
 #include "natalie/env.hpp"
 #include "tm/vector.hpp"
 
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
 extern char **environ;
 
 namespace Natalie {


### PR DESCRIPTION
These do not belong in the public interface, where every file that includes the EnvObject header suddenly includes those files too.