### PR TITLE
Make and_yield in the spec runner take any number of arguments

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -972,8 +972,8 @@ class Stub
     self
   end
 
-  def and_yield(value)
-    @yield_values << value
+  def and_yield(*values)
+    @yield_values << (values.size > 1 ? values : values[0])
     self
   end
 


### PR DESCRIPTION
This is seen in https://github.com/ruby/spec/blob/b8a59fda781849ddc220054d22a2750d5c5cf124/core/enumerator/chain/rewind_spec.rb#L6 where there are no arguments. 