### PR TITLE
Implement basic version of Process.clock_gettime

### DIFF
--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -115,6 +115,8 @@ public:
         return sid;
     }
 
+    static Value clock_gettime(Env *, Value);
+
 private:
     static uid_t value_to_uid(Env *env, Value idval) {
         uid_t uid;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1048,6 +1048,7 @@ gen.binding('Proc', 'to_proc', 'ProcObject', 'to_proc', argc: 0, pass_env: true,
 gen.binding('Proc', 'yield', 'ProcObject', 'call', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 
 gen.module_function_binding('Process', 'abort', 'KernelModule', 'abort_method', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
+gen.module_function_binding('Process', 'clock_gettime', 'ProcessModule', 'clock_gettime', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'egid', 'ProcessModule', 'egid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'egid=', 'ProcessModule', 'setegid', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Process', 'euid', 'ProcessModule', 'euid', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/process/clock_gettime_spec.rb
+++ b/spec/core/process/clock_gettime_spec.rb
@@ -1,0 +1,152 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/clocks'
+
+describe "Process.clock_gettime" do
+  ProcessSpecs.clock_constants.each do |name, value|
+    it "can be called with Process::#{name}" do
+      Process.clock_gettime(value).should be_an_instance_of(Float)
+    end
+  end
+
+  describe 'time units' do
+    it 'handles a fixed set of time units' do
+      [:nanosecond, :microsecond, :millisecond, :second].each do |unit|
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_kind_of(Integer)
+      end
+
+      [:float_microsecond, :float_millisecond, :float_second].each do |unit|
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_an_instance_of(Float)
+      end
+    end
+
+    it 'raises an ArgumentError for an invalid time unit' do
+      -> { Process.clock_gettime(Process::CLOCK_MONOTONIC, :bad) }.should raise_error(ArgumentError)
+    end
+
+    it 'defaults to :float_second' do
+      t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+
+      t1.should be_an_instance_of(Float)
+      t2.should be_an_instance_of(Float)
+      t2.should be_close(t1, TIME_TOLERANCE)
+    end
+
+    it 'uses the default time unit (:float_second) when passed nil' do
+      t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC, nil)
+      t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+
+      t1.should be_an_instance_of(Float)
+      t2.should be_an_instance_of(Float)
+      t2.should be_close(t1, TIME_TOLERANCE)
+    end
+  end
+
+  describe "supports the platform clocks mentioned in the documentation" do
+    it "CLOCK_REALTIME" do
+      Process.clock_gettime(Process::CLOCK_REALTIME).should be_an_instance_of(Float)
+    end
+
+    it "CLOCK_MONOTONIC" do
+      Process.clock_gettime(Process::CLOCK_MONOTONIC).should be_an_instance_of(Float)
+    end
+
+    # These specs need macOS 10.12+ / darwin 16+
+    guard -> { platform_is_not(:darwin) or kernel_version_is '16' } do
+      platform_is :linux, :openbsd, :darwin do
+        it "CLOCK_PROCESS_CPUTIME_ID" do
+          Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID).should be_an_instance_of(Float)
+        end
+      end
+
+      platform_is :linux, :freebsd, :openbsd, :darwin do
+        it "CLOCK_THREAD_CPUTIME_ID" do
+          Process.clock_gettime(Process::CLOCK_THREAD_CPUTIME_ID).should be_an_instance_of(Float)
+        end
+      end
+
+      platform_is :linux, :darwin do
+        it "CLOCK_MONOTONIC_RAW" do
+          Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW).should be_an_instance_of(Float)
+        end
+      end
+
+      platform_is :darwin do
+        it "CLOCK_MONOTONIC_RAW_APPROX" do
+          Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW_APPROX).should be_an_instance_of(Float)
+        end
+
+        it "CLOCK_UPTIME_RAW and CLOCK_UPTIME_RAW_APPROX" do
+          Process.clock_gettime(Process::CLOCK_UPTIME_RAW).should be_an_instance_of(Float)
+          Process.clock_gettime(Process::CLOCK_UPTIME_RAW_APPROX).should be_an_instance_of(Float)
+        end
+      end
+    end
+
+    platform_is :freebsd do
+      it "CLOCK_VIRTUAL" do
+        Process.clock_gettime(Process::CLOCK_VIRTUAL).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_PROF" do
+        Process.clock_gettime(Process::CLOCK_PROF).should be_an_instance_of(Float)
+      end
+    end
+
+    platform_is :freebsd, :openbsd do
+      it "CLOCK_UPTIME" do
+        Process.clock_gettime(Process::CLOCK_UPTIME).should be_an_instance_of(Float)
+      end
+    end
+
+    platform_is :freebsd do
+      it "CLOCK_REALTIME_FAST and CLOCK_REALTIME_PRECISE" do
+        Process.clock_gettime(Process::CLOCK_REALTIME_FAST).should be_an_instance_of(Float)
+        Process.clock_gettime(Process::CLOCK_REALTIME_PRECISE).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_MONOTONIC_FAST and CLOCK_MONOTONIC_PRECISE" do
+        Process.clock_gettime(Process::CLOCK_MONOTONIC_FAST).should be_an_instance_of(Float)
+        Process.clock_gettime(Process::CLOCK_MONOTONIC_PRECISE).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_UPTIME_FAST and CLOCK_UPTIME_PRECISE" do
+        Process.clock_gettime(Process::CLOCK_UPTIME_FAST).should be_an_instance_of(Float)
+        Process.clock_gettime(Process::CLOCK_UPTIME_PRECISE).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_SECOND" do
+        Process.clock_gettime(Process::CLOCK_SECOND).should be_an_instance_of(Float)
+      end
+    end
+
+    guard -> { platform_is :linux and kernel_version_is '2.6.32' } do
+      it "CLOCK_REALTIME_COARSE" do
+        Process.clock_gettime(Process::CLOCK_REALTIME_COARSE).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_MONOTONIC_COARSE" do
+        Process.clock_gettime(Process::CLOCK_MONOTONIC_COARSE).should be_an_instance_of(Float)
+      end
+    end
+
+    guard -> { platform_is :linux and kernel_version_is '2.6.39' } do
+      it "CLOCK_BOOTTIME" do
+        skip "No Process::CLOCK_BOOTTIME" unless defined?(Process::CLOCK_BOOTTIME)
+        Process.clock_gettime(Process::CLOCK_BOOTTIME).should be_an_instance_of(Float)
+      end
+    end
+
+    guard -> { platform_is "x86_64-linux" and kernel_version_is '3.0' } do
+      it "CLOCK_REALTIME_ALARM" do
+        skip "No Process::CLOCK_REALTIME_ALARM" unless defined?(Process::CLOCK_REALTIME_ALARM)
+        Process.clock_gettime(Process::CLOCK_REALTIME_ALARM).should be_an_instance_of(Float)
+      end
+
+      it "CLOCK_BOOTTIME_ALARM" do
+        skip "No Process::CLOCK_BOOTTIME_ALARM" unless defined?(Process::CLOCK_BOOTTIME_ALARM)
+        Process.clock_gettime(Process::CLOCK_BOOTTIME_ALARM).should be_an_instance_of(Float)
+      end
+    end
+  end
+end

--- a/spec/core/process/clock_gettime_spec.rb
+++ b/spec/core/process/clock_gettime_spec.rb
@@ -10,12 +10,14 @@ describe "Process.clock_gettime" do
 
   describe 'time units' do
     it 'handles a fixed set of time units' do
-      [:nanosecond, :microsecond, :millisecond, :second].each do |unit|
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_kind_of(Integer)
-      end
+      NATFIXME 'Support time unit argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+        [:nanosecond, :microsecond, :millisecond, :second].each do |unit|
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_kind_of(Integer)
+        end
 
-      [:float_microsecond, :float_millisecond, :float_second].each do |unit|
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_an_instance_of(Float)
+        [:float_microsecond, :float_millisecond, :float_second].each do |unit|
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).should be_an_instance_of(Float)
+        end
       end
     end
 
@@ -25,20 +27,24 @@ describe "Process.clock_gettime" do
 
     it 'defaults to :float_second' do
       t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+      NATFIXME 'Support time unit argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+        t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
 
-      t1.should be_an_instance_of(Float)
-      t2.should be_an_instance_of(Float)
-      t2.should be_close(t1, TIME_TOLERANCE)
+        t1.should be_an_instance_of(Float)
+        t2.should be_an_instance_of(Float)
+        t2.should be_close(t1, TIME_TOLERANCE)
+      end
     end
 
     it 'uses the default time unit (:float_second) when passed nil' do
-      t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC, nil)
-      t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+      NATFIXME 'Support time unit argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+        t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC, nil)
+        t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
 
-      t1.should be_an_instance_of(Float)
-      t2.should be_an_instance_of(Float)
-      t2.should be_close(t1, TIME_TOLERANCE)
+        t1.should be_an_instance_of(Float)
+        t2.should be_an_instance_of(Float)
+        t2.should be_close(t1, TIME_TOLERANCE)
+      end
     end
   end
 

--- a/spec/core/process/fixtures/clocks.rb
+++ b/spec/core/process/fixtures/clocks.rb
@@ -1,0 +1,18 @@
+module ProcessSpecs
+  def self.clock_constants
+    clocks = []
+
+    platform_is_not :windows, :solaris do
+      clocks += Process.constants.select { |c| c.to_s.start_with?('CLOCK_') }
+
+      # These require CAP_WAKE_ALARM and are not documented in
+      # Process#clock_gettime. They return EINVAL if the permission
+      # is not granted.
+      clocks -= [:CLOCK_BOOTTIME_ALARM, :CLOCK_REALTIME_ALARM]
+    end
+
+    clocks.sort.map { |c|
+      [c, Process.const_get(c)]
+    }
+  end
+end

--- a/spec/core/time/now_spec.rb
+++ b/spec/core/time/now_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../spec_helper'
+require_relative 'shared/now'
+
+describe "Time.now" do
+  it_behaves_like :time_now, :now
+
+  ruby_version_is '3.1' do # https://bugs.ruby-lang.org/issues/17485
+    describe ":in keyword argument" do
+      it "could be UTC offset as a String in '+HH:MM or '-HH:MM' format" do
+        time = Time.now(in: "+05:00")
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+
+        time = Time.now(in: "-09:00")
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+      end
+
+      it "could be UTC offset as a number of seconds" do
+        time = Time.now(in: 5*60*60)
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+
+        time = Time.now(in: -9*60*60)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+      end
+
+      it "returns a Time with UTC offset specified as a single letter military timezone" do
+        Time.now(in: "W").utc_offset.should == 3600 * -10
+      end
+
+      it "could be a timezone object" do
+        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo")
+        time = Time.now(in: zone)
+
+        time.utc_offset.should == 5*3600+30*60
+        time.zone.should == zone
+
+        zone = TimeSpecs::TimezoneWithName.new(name: "PST")
+        time = Time.now(in: zone)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == zone
+      end
+
+      it "raises ArgumentError if format is invalid" do
+        -> { Time.now(in: "+09:99") }.should raise_error(ArgumentError)
+        -> { Time.now(in: "ABC") }.should raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/core/time/now_spec.rb
+++ b/spec/core/time/now_spec.rb
@@ -35,17 +35,19 @@ describe "Time.now" do
       end
 
       it "could be a timezone object" do
-        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo")
-        time = Time.now(in: zone)
+        NATFIXME 'Support Timezone objects', exception: NotImplementedError, message: 'Not implemented for non String/Integer arg' do
+          zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo")
+          time = Time.now(in: zone)
 
-        time.utc_offset.should == 5*3600+30*60
-        time.zone.should == zone
+          time.utc_offset.should == 5*3600+30*60
+          time.zone.should == zone
 
-        zone = TimeSpecs::TimezoneWithName.new(name: "PST")
-        time = Time.now(in: zone)
+          zone = TimeSpecs::TimezoneWithName.new(name: "PST")
+          time = Time.now(in: zone)
 
-        time.utc_offset.should == -9*60*60
-        time.zone.should == zone
+          time.utc_offset.should == -9*60*60
+          time.zone.should == zone
+        end
       end
 
       it "raises ArgumentError if format is invalid" do

--- a/spec/core/time/shared/now.rb
+++ b/spec/core/time/shared/now.rb
@@ -10,9 +10,7 @@ describe :time_now, shared: true do
 
   it "sets the current time" do
     now = TimeSpecs::MethodHolder.send(@method)
-    NATFIXME 'Implement Process.clock_gettime', exception: NoMethodError, message: "undefined method `clock_gettime' for Process" do
-      now.to_f.should be_close(Process.clock_gettime(Process::CLOCK_REALTIME), TIME_TOLERANCE)
-    end
+    now.to_f.should be_close(Process.clock_gettime(Process::CLOCK_REALTIME), TIME_TOLERANCE)
   end
 
   it "uses the local timezone" do

--- a/spec/core/time/shared/now.rb
+++ b/spec/core/time/shared/now.rb
@@ -2,13 +2,17 @@ require_relative '../fixtures/classes'
 
 describe :time_now, shared: true do
   it "creates a subclass instance if called on a subclass" do
-    TimeSpecs::SubTime.send(@method).should be_an_instance_of(TimeSpecs::SubTime)
+    NATFIXME 'creates a subclass instance if called on a subclass', exception: SpecFailedException do
+      TimeSpecs::SubTime.send(@method).should be_an_instance_of(TimeSpecs::SubTime)
+    end
     TimeSpecs::MethodHolder.send(@method).should be_an_instance_of(Time)
   end
 
   it "sets the current time" do
     now = TimeSpecs::MethodHolder.send(@method)
-    now.to_f.should be_close(Process.clock_gettime(Process::CLOCK_REALTIME), TIME_TOLERANCE)
+    NATFIXME 'Implement Process.clock_gettime', exception: NoMethodError, message: "undefined method `clock_gettime' for Process" do
+      now.to_f.should be_close(Process.clock_gettime(Process::CLOCK_REALTIME), TIME_TOLERANCE)
+    end
   end
 
   it "uses the local timezone" do

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -1,0 +1,17 @@
+#include "natalie.hpp"
+
+#include <time.h>
+
+namespace Natalie {
+
+Value ProcessModule::clock_gettime(Env *env, Value clock_id) {
+    timespec tp;
+    const auto clk_id = static_cast<clockid_t>(IntegerObject::convert_to_nat_int_t(env, clock_id));
+    if (::clock_gettime(clk_id, &tp) < 0)
+        env->raise_errno();
+
+    double result = static_cast<double>(tp.tv_sec) + tp.tv_nsec / static_cast<double>(1000000000);
+    return new FloatObject { result };
+}
+
+}


### PR DESCRIPTION
It still needs support for the second (optional) argument, but this works for most use cases.