### PR TITLE
Openssl digest improvements

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -74,15 +74,3 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
     name->assert_type(env, Object::Type::String, "String");
     return digest_wrapper(env, args, name->as_string()->c_str());
 }
-
-Value OpenSSL_Digest_SHA256_digest(Env *env, Value self, Args args, Block *) {
-    return digest_wrapper(env, args, "SHA256");
-}
-
-Value OpenSSL_Digest_SHA384_digest(Env *env, Value self, Args args, Block *) {
-    return digest_wrapper(env, args, "SHA384");
-}
-
-Value OpenSSL_Digest_SHA512_digest(Env *env, Value self, Args args, Block *) {
-    return digest_wrapper(env, args, "SHA512");
-}

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -8,42 +8,22 @@
 
 using namespace Natalie;
 
-Value init(Env *env, Value self) {
-    ModuleObject *OpenSSL = new ModuleObject { "OpenSSL" };
-    GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
+Value OpenSSL_Digest_block_length(Env *env, Value self, Args args, Block *) {
+    auto name = self->send(env, "name"_s);
+    name->assert_type(env, Object::Type::String, "String");
 
-    // OpenSSL < 3.0 does not have a OPENSSL_VERSION_STR
-    const auto openssl_version_major = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 28) & 0xFF);
-    const auto openssl_version_minor = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 20) & 0xFF);
-    const auto openssl_version_patchlevel = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 12) & 0xFF);
-    StringObject *VERSION = new StringObject {
-        TM::String::format("{}.{}.{}", openssl_version_major, openssl_version_minor, openssl_version_patchlevel)
-    };
-    OpenSSL->const_set("VERSION"_s, VERSION);
+    args.ensure_argc_is(env, 0);
+    const EVP_MD *md = EVP_get_digestbyname(name->as_string()->c_str());
+    if (!md)
+        env->raise("RuntimeError", "Unsupported digest algorithm ({}).: unknown object name", name);
 
-    return NilObject::the();
-}
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+    auto mdctx_destructor = TM::Defer([&]() { EVP_MD_CTX_free(mdctx); });
+    if (!EVP_DigestInit_ex(mdctx, md, nullptr))
+        env->raise("RuntimeError", "Internal OpenSSL error");
 
-Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
-    args.ensure_argc_is(env, 1);
-    Value length = args[0];
-    const auto to_int = "to_int"_s;
-    if (!length->is_integer() && length->respond_to(env, to_int))
-        length = length->send(env, to_int);
-    length->assert_type(env, ObjectType::Integer, "Integer");
-    const auto num = static_cast<int>(length->as_integer()->to_nat_int_t());
-    if (num < 0)
-        env->raise("ArgumentError", "negative string size (or size too big)");
-
-    unsigned char buf[num];
-    if (RAND_bytes(buf, num) != 1) {
-        const auto err = ERR_get_error();
-        char err_buf[256];
-        ERR_error_string_n(err, err_buf, 256);
-        env->raise("RuntimeError", err_buf);
-    }
-
-    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), EncodingObject::get(Encoding::ASCII_8BIT) };
+    const int block_size = EVP_MD_CTX_block_size(mdctx);
+    return IntegerObject::create(block_size);
 }
 
 Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
@@ -72,20 +52,45 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
     return new StringObject { reinterpret_cast<const char *>(buf), md_len };
 }
 
-Value OpenSSL_Digest_block_length(Env *env, Value self, Args args, Block *) {
-    auto name = self->send(env, "name"_s);
-    name->assert_type(env, Object::Type::String, "String");
+Value init(Env *env, Value self) {
+    ModuleObject *OpenSSL = new ModuleObject { "OpenSSL" };
+    GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
 
-    args.ensure_argc_is(env, 0);
-    const EVP_MD *md = EVP_get_digestbyname(name->as_string()->c_str());
-    if (!md)
-        env->raise("RuntimeError", "Unsupported digest algorithm ({}).: unknown object name", name);
+    // OpenSSL < 3.0 does not have a OPENSSL_VERSION_STR
+    const auto openssl_version_major = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 28) & 0xFF);
+    const auto openssl_version_minor = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 20) & 0xFF);
+    const auto openssl_version_patchlevel = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 12) & 0xFF);
+    StringObject *VERSION = new StringObject {
+        TM::String::format("{}.{}.{}", openssl_version_major, openssl_version_minor, openssl_version_patchlevel)
+    };
+    OpenSSL->const_set("VERSION"_s, VERSION);
 
-    EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-    auto mdctx_destructor = TM::Defer([&]() { EVP_MD_CTX_free(mdctx); });
-    if (!EVP_DigestInit_ex(mdctx, md, nullptr))
-        env->raise("RuntimeError", "Internal OpenSSL error");
+    ClassObject *Digest = GlobalEnv::the()->Object()->subclass(env, "Digest");
+    OpenSSL->const_set("Digest"_s, Digest);
+    Digest->define_method(env, "block_length"_s, OpenSSL_Digest_block_length, 0);
+    Digest->define_method(env, "digest"_s, OpenSSL_Digest_digest, 1);
 
-    const int block_size = EVP_MD_CTX_block_size(mdctx);
-    return IntegerObject::create(block_size);
+    return NilObject::the();
+}
+
+Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    Value length = args[0];
+    const auto to_int = "to_int"_s;
+    if (!length->is_integer() && length->respond_to(env, to_int))
+        length = length->send(env, to_int);
+    length->assert_type(env, ObjectType::Integer, "Integer");
+    const auto num = static_cast<int>(length->as_integer()->to_nat_int_t());
+    if (num < 0)
+        env->raise("ArgumentError", "negative string size (or size too big)");
+
+    unsigned char buf[num];
+    if (RAND_bytes(buf, num) != 1) {
+        const auto err = ERR_get_error();
+        char err_buf[256];
+        ERR_error_string_n(err, err_buf, 256);
+        env->raise("RuntimeError", err_buf);
+    }
+
+    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), EncodingObject::get(Encoding::ASCII_8BIT) };
 }

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -37,6 +37,7 @@ Value OpenSSL_Digest_initialize(Env *env, Value self, Args args, Block *) {
 }
 
 Value OpenSSL_Digest_block_length(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
     auto mdctx = static_cast<EVP_MD_CTX *>(self->ivar_get(env, "@mdctx"_s)->as_void_p()->void_ptr());
     const int block_size = EVP_MD_CTX_block_size(mdctx);
     return IntegerObject::create(block_size);
@@ -68,6 +69,13 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
     return new StringObject { reinterpret_cast<const char *>(buf), md_len };
 }
 
+Value OpenSSL_Digest_digest_length(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+    auto mdctx = static_cast<EVP_MD_CTX *>(self->ivar_get(env, "@mdctx"_s)->as_void_p()->void_ptr());
+    const int digest_length = EVP_MD_CTX_size(mdctx);
+    return IntegerObject::create(digest_length);
+}
+
 Value init(Env *env, Value self) {
     auto OpenSSL = GlobalEnv::the()->Object()->const_get("OpenSSL"_s);
     if (!OpenSSL) {
@@ -92,6 +100,7 @@ Value init(Env *env, Value self) {
     Digest->define_method(env, "initialize"_s, OpenSSL_Digest_initialize, 1);
     Digest->define_method(env, "block_length"_s, OpenSSL_Digest_block_length, 0);
     Digest->define_method(env, "digest"_s, OpenSSL_Digest_digest, 1);
+    Digest->define_method(env, "digest_length"_s, OpenSSL_Digest_digest_length, 0);
 
     return NilObject::the();
 }

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -47,7 +47,7 @@ Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
 }
 
 Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
-    auto name = self->ivar_get(env, "@name"_s);
+    auto name = self->send(env, "name"_s);
     name->assert_type(env, Object::Type::String, "String");
 
     args.ensure_argc_is(env, 1);

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -69,8 +69,10 @@ static inline Value digest_wrapper(Env *env, Args args, const char *name) {
     return new StringObject { reinterpret_cast<const char *>(buf), md_len };
 }
 
-Value OpenSSL_Digest_SHA1_digest(Env *env, Value self, Args args, Block *) {
-    return digest_wrapper(env, args, "SHA1");
+Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
+    auto name = self->ivar_get(env, "@name"_s);
+    name->assert_type(env, Object::Type::String, "String");
+    return digest_wrapper(env, args, name->as_string()->c_str());
 }
 
 Value OpenSSL_Digest_SHA256_digest(Env *env, Value self, Args args, Block *) {

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -53,8 +53,11 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
 }
 
 Value init(Env *env, Value self) {
-    ModuleObject *OpenSSL = new ModuleObject { "OpenSSL" };
-    GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
+    auto OpenSSL = GlobalEnv::the()->Object()->const_get("OpenSSL"_s);
+    if (!OpenSSL) {
+        OpenSSL = new ModuleObject { "OpenSSL" };
+        GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
+    }
 
     // OpenSSL < 3.0 does not have a OPENSSL_VERSION_STR
     const auto openssl_version_major = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 28) & 0xFF);
@@ -65,8 +68,11 @@ Value init(Env *env, Value self) {
     };
     OpenSSL->const_set("VERSION"_s, VERSION);
 
-    ClassObject *Digest = GlobalEnv::the()->Object()->subclass(env, "Digest");
-    OpenSSL->const_set("Digest"_s, Digest);
+    auto Digest = OpenSSL->const_get("Digest"_s);
+    if (!Digest) {
+        Digest = GlobalEnv::the()->Object()->subclass(env, "Digest");
+        OpenSSL->const_set("Digest"_s, Digest);
+    }
     Digest->define_method(env, "block_length"_s, OpenSSL_Digest_block_length, 0);
     Digest->define_method(env, "digest"_s, OpenSSL_Digest_digest, 1);
 

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -24,6 +24,7 @@ module OpenSSL
     end
 
     def initialize(name)
+      name = name.name if name.is_a?(self.class)
       klass = self.class.const_get(name.to_s.upcase.to_sym)
       raise NameError unless klass.ancestors[1] == self.class
       @name = name.to_s.upcase

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -9,6 +9,8 @@ module OpenSSL
   end
 
   class Digest
+    attr_reader :name
+
     def self.digest(name, data)
       new(name).digest(data)
     end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -32,26 +32,26 @@ module OpenSSL
     end
 
     class SHA1 < Digest
-      def initialize()
-        super('SHA1')
+      def initialize(*args)
+        super('SHA1', *args)
       end
     end
 
     class SHA256 < Digest
-      def initialize()
-        super('SHA256')
+      def initialize(*args)
+        super('SHA256', *args)
       end
     end
 
     class SHA384 < Digest
-      def initialize()
-        super('SHA384')
+      def initialize(*args)
+        super('SHA384', *args)
       end
     end
 
     class SHA512 < Digest
-      def initialize()
-        super('SHA512')
+      def initialize(*args)
+        super('SHA512', *args)
       end
     end
   end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -9,20 +9,20 @@ module OpenSSL
   end
 
   class Digest
-    def self.digest(digest, data)
-      klass = const_get(digest.to_s.upcase.to_sym)
+    def self.digest(name, data)
+      klass = const_get(name.to_s.upcase.to_sym)
       raise NameError unless klass.ancestors[1] == self
       klass.new.digest(data)
     rescue NameError
-      raise "Unsupported digest algorithm (#{digest}).: unknown object name"
+      raise "Unsupported digest algorithm (#{name}).: unknown object name"
     end
 
-    def self.base64digest(digest, data)
-      [digest(digest, data)].pack('m0')
+    def self.base64digest(name, data)
+      [digest(name, data)].pack('m0')
     end
 
-    def self.hexdigest(digest, data)
-      digest(digest, data).unpack1('H*')
+    def self.hexdigest(name, data)
+      digest(name, data).unpack1('H*')
     end
 
     class SHA1 < Digest

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -33,25 +33,25 @@ module OpenSSL
 
     class SHA1 < Digest
       def initialize()
-        @name = 'SHA1'
+        super('SHA1')
       end
     end
 
     class SHA256 < Digest
       def initialize()
-        @name = 'SHA256'
+        super('SHA256')
       end
     end
 
     class SHA384 < Digest
       def initialize()
-        @name = 'SHA384'
+        super('SHA384')
       end
     end
 
     class SHA512 < Digest
       def initialize()
-        @name = 'SHA512'
+        super('SHA512')
       end
     end
   end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -33,9 +33,6 @@ module OpenSSL
       raise "Unsupported digest algorithm (#{name}).: unknown object name"
     end
 
-    __bind_method__ :block_length, :OpenSSL_Digest_block_length
-    __bind_method__ :digest, :OpenSSL_Digest_digest
-
     def base64digest(data)
       [digest(data)].pack('m0')
     end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -10,11 +10,7 @@ module OpenSSL
 
   class Digest
     def self.digest(name, data)
-      klass = const_get(name.to_s.upcase.to_sym)
-      raise NameError unless klass.ancestors[1] == self
-      klass.new.digest(data)
-    rescue NameError
-      raise "Unsupported digest algorithm (#{name}).: unknown object name"
+      new(name).digest(data)
     end
 
     def self.base64digest(name, data)
@@ -28,47 +24,35 @@ module OpenSSL
     def initialize(name)
       klass = self.class.const_get(name.to_s.upcase.to_sym)
       raise NameError unless klass.ancestors[1] == self.class
-      @name = name.to_s.upcase.to_sym
+      @name = name.to_s.upcase
     rescue NameError
       raise "Unsupported digest algorithm (#{name}).: unknown object name"
     end
 
-    def digest(data)
-      self.class.const_get(@name).new.digest(data)
-    rescue NameError
-      raise "Unsupported digest algorithm (#{@name}).: unknown object name"
-    end
+    __bind_method__ :digest, :OpenSSL_Digest_digest
 
     class SHA1 < Digest
       def initialize()
         @name = 'SHA1'
       end
-
-      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA256 < Digest
       def initialize()
         @name = 'SHA256'
       end
-
-      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA384 < Digest
       def initialize()
         @name = 'SHA384'
       end
-
-      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA512 < Digest
       def initialize()
         @name = 'SHA512'
       end
-
-      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -25,19 +25,35 @@ module OpenSSL
       digest(name, data).unpack1('H*')
     end
 
+    def initialize(name)
+      klass = self.class.const_get(name.to_s.upcase.to_sym)
+      raise NameError unless klass.ancestors[1] == self.class
+      klass.new
+    rescue NameError
+      raise "Unsupported digest algorithm (#{name}).: unknown object name"
+    end
+
     class SHA1 < Digest
+      def initialize() end
+
       __bind_method__ :digest, :OpenSSL_Digest_SHA1_digest
     end
 
     class SHA256 < Digest
+      def initialize() end
+
       __bind_method__ :digest, :OpenSSL_Digest_SHA256_digest
     end
 
     class SHA384 < Digest
+      def initialize() end
+
       __bind_method__ :digest, :OpenSSL_Digest_SHA384_digest
     end
 
     class SHA512 < Digest
+      def initialize() end
+
       __bind_method__ :digest, :OpenSSL_Digest_SHA512_digest
     end
   end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -40,9 +40,11 @@ module OpenSSL
     end
 
     class SHA1 < Digest
-      def initialize() end
+      def initialize()
+        @name = 'SHA1'
+      end
 
-      __bind_method__ :digest, :OpenSSL_Digest_SHA1_digest
+      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA256 < Digest

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -23,16 +23,6 @@ module OpenSSL
       new(name).hexdigest(data)
     end
 
-    def initialize(name)
-      name = name.name if name.is_a?(self.class)
-      raise TypeError, "wrong argument type #{name.class} (expected OpenSSL/Digest)" unless name.is_a?(String)
-      klass = self.class.const_get(name.upcase.to_sym)
-      raise NameError unless klass.ancestors[1] == self.class
-      @name = name.upcase
-    rescue NameError
-      raise "Unsupported digest algorithm (#{name}).: unknown object name"
-    end
-
     def base64digest(data)
       [digest(data)].pack('m0')
     end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -48,21 +48,27 @@ module OpenSSL
     end
 
     class SHA256 < Digest
-      def initialize() end
+      def initialize()
+        @name = 'SHA256'
+      end
 
-      __bind_method__ :digest, :OpenSSL_Digest_SHA256_digest
+      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA384 < Digest
-      def initialize() end
+      def initialize()
+        @name = 'SHA384'
+      end
 
-      __bind_method__ :digest, :OpenSSL_Digest_SHA384_digest
+      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
 
     class SHA512 < Digest
-      def initialize() end
+      def initialize()
+        @name = 'SHA512'
+      end
 
-      __bind_method__ :digest, :OpenSSL_Digest_SHA512_digest
+      __bind_method__ :digest, :OpenSSL_Digest_digest
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -14,11 +14,11 @@ module OpenSSL
     end
 
     def self.base64digest(name, data)
-      [digest(name, data)].pack('m0')
+      new(name).base64digest(data)
     end
 
     def self.hexdigest(name, data)
-      digest(name, data).unpack1('H*')
+      new(name).hexdigest(data)
     end
 
     def initialize(name)
@@ -30,6 +30,14 @@ module OpenSSL
     end
 
     __bind_method__ :digest, :OpenSSL_Digest_digest
+
+    def base64digest(data)
+      [digest(data)].pack('m0')
+    end
+
+    def hexdigest(data)
+      digest(data).unpack1('H*')
+    end
 
     class SHA1 < Digest
       def initialize()

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -33,6 +33,7 @@ module OpenSSL
       raise "Unsupported digest algorithm (#{name}).: unknown object name"
     end
 
+    __bind_method__ :block_length, :OpenSSL_Digest_block_length
     __bind_method__ :digest, :OpenSSL_Digest_digest
 
     def base64digest(data)

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -25,9 +25,10 @@ module OpenSSL
 
     def initialize(name)
       name = name.name if name.is_a?(self.class)
-      klass = self.class.const_get(name.to_s.upcase.to_sym)
+      raise TypeError, "wrong argument type #{name.class} (expected OpenSSL/Digest)" unless name.is_a?(String)
+      klass = self.class.const_get(name.upcase.to_sym)
       raise NameError unless klass.ancestors[1] == self.class
-      @name = name.to_s.upcase
+      @name = name.upcase
     rescue NameError
       raise "Unsupported digest algorithm (#{name}).: unknown object name"
     end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -28,9 +28,15 @@ module OpenSSL
     def initialize(name)
       klass = self.class.const_get(name.to_s.upcase.to_sym)
       raise NameError unless klass.ancestors[1] == self.class
-      klass.new
+      @name = name.to_s.upcase.to_sym
     rescue NameError
       raise "Unsupported digest algorithm (#{name}).: unknown object name"
+    end
+
+    def digest(data)
+      self.class.const_get(@name).new.digest(data)
+    rescue NameError
+      raise "Unsupported digest algorithm (#{@name}).: unknown object name"
     end
 
     class SHA1 < Digest

--- a/test/natalie/openssl_digest/append_test.rb
+++ b/test/natalie/openssl_digest/append_test.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec/spec_helper'
+require_relative 'shared/update'
+
+describe "OpenSSL::Digest#<<" do
+  it_behaves_like :openssl_digest_update, :<<
+end

--- a/test/natalie/openssl_digest/block_length_test.rb
+++ b/test/natalie/openssl_digest/block_length_test.rb
@@ -8,53 +8,37 @@ require 'openssl'
 describe "OpenSSL::Digest#block_length" do
   describe "block_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
-      end
+      OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
-      end
+      OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
     end
 
     it "returns a SHA384 block_length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
-      end
+      OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
     end
 
     it "returns a SHA512 block_length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
-      end
+      OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
     end
   end
 
   describe "block_length of subclasses" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest::SHA1.new.block_length.should == SHA1Constants::BlockLength
-      end
+      OpenSSL::Digest::SHA1.new.block_length.should == SHA1Constants::BlockLength
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest::SHA256.new.block_length.should == SHA256Constants::BlockLength
-      end
+      OpenSSL::Digest::SHA256.new.block_length.should == SHA256Constants::BlockLength
     end
 
     it "returns a SHA384 block_length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest::SHA384.new.block_length.should == SHA384Constants::BlockLength
-      end
+      OpenSSL::Digest::SHA384.new.block_length.should == SHA384Constants::BlockLength
     end
 
     it "returns a SHA512 block_length" do
-      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
-        OpenSSL::Digest::SHA512.new.block_length.should == SHA512Constants::BlockLength
-      end
+      OpenSSL::Digest::SHA512.new.block_length.should == SHA512Constants::BlockLength
     end
   end
 end

--- a/test/natalie/openssl_digest/block_length_test.rb
+++ b/test/natalie/openssl_digest/block_length_test.rb
@@ -8,37 +8,53 @@ require 'openssl'
 describe "OpenSSL::Digest#block_length" do
   describe "block_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
+      end
     end
 
     it "returns a SHA256 block length" do
-      OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
+      end
     end
 
     it "returns a SHA384 block_length" do
-      OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
+      end
     end
 
     it "returns a SHA512 block_length" do
-      OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
+      end
     end
   end
 
   describe "block_length of subclasses" do
     it "returns a SHA1 block length" do
-      OpenSSL::Digest::SHA1.new.block_length.should == SHA1Constants::BlockLength
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
+        OpenSSL::Digest::SHA1.new.block_length.should == SHA1Constants::BlockLength
+      end
     end
 
     it "returns a SHA256 block length" do
-      OpenSSL::Digest::SHA256.new.block_length.should == SHA256Constants::BlockLength
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
+        OpenSSL::Digest::SHA256.new.block_length.should == SHA256Constants::BlockLength
+      end
     end
 
     it "returns a SHA384 block_length" do
-      OpenSSL::Digest::SHA384.new.block_length.should == SHA384Constants::BlockLength
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
+        OpenSSL::Digest::SHA384.new.block_length.should == SHA384Constants::BlockLength
+      end
     end
 
     it "returns a SHA512 block_length" do
-      OpenSSL::Digest::SHA512.new.block_length.should == SHA512Constants::BlockLength
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
+        OpenSSL::Digest::SHA512.new.block_length.should == SHA512Constants::BlockLength
+      end
     end
   end
 end

--- a/test/natalie/openssl_digest/block_length_test.rb
+++ b/test/natalie/openssl_digest/block_length_test.rb
@@ -8,25 +8,25 @@ require 'openssl'
 describe "OpenSSL::Digest#block_length" do
   describe "block_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
         OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
       end
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
         OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
       end
     end
 
     it "returns a SHA384 block_length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
         OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
       end
     end
 
     it "returns a SHA512 block_length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#block_length', exception: NoMethodError, message: "undefined method `block_length'" do
         OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
       end
     end

--- a/test/natalie/openssl_digest/block_length_test.rb
+++ b/test/natalie/openssl_digest/block_length_test.rb
@@ -1,0 +1,44 @@
+require_relative '../../../spec/spec_helper'
+require_relative '../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe "OpenSSL::Digest#block_length" do
+  describe "block_length of OpenSSL::Digest.new(name)" do
+    it "returns a SHA1 block length" do
+      OpenSSL::Digest.new('sha1').block_length.should == SHA1Constants::BlockLength
+    end
+
+    it "returns a SHA256 block length" do
+      OpenSSL::Digest.new('sha256').block_length.should == SHA256Constants::BlockLength
+    end
+
+    it "returns a SHA384 block_length" do
+      OpenSSL::Digest.new('sha384').block_length.should == SHA384Constants::BlockLength
+    end
+
+    it "returns a SHA512 block_length" do
+      OpenSSL::Digest.new('sha512').block_length.should == SHA512Constants::BlockLength
+    end
+  end
+
+  describe "block_length of subclasses" do
+    it "returns a SHA1 block length" do
+      OpenSSL::Digest::SHA1.new.block_length.should == SHA1Constants::BlockLength
+    end
+
+    it "returns a SHA256 block length" do
+      OpenSSL::Digest::SHA256.new.block_length.should == SHA256Constants::BlockLength
+    end
+
+    it "returns a SHA384 block_length" do
+      OpenSSL::Digest::SHA384.new.block_length.should == SHA384Constants::BlockLength
+    end
+
+    it "returns a SHA512 block_length" do
+      OpenSSL::Digest::SHA512.new.block_length.should == SHA512Constants::BlockLength
+    end
+  end
+end

--- a/test/natalie/openssl_digest/digest_length_test.rb
+++ b/test/natalie/openssl_digest/digest_length_test.rb
@@ -1,0 +1,44 @@
+require_relative '../../../spec/spec_helper'
+require_relative '../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe "OpenSSL::Digest#digest_length" do
+  describe "digest_length of OpenSSL::Digest.new(name)" do
+    it "returns a SHA1 block length" do
+      OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
+    end
+
+    it "returns a SHA256 block length" do
+      OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
+    end
+
+    it "returns a SHA384 digest_length" do
+      OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
+    end
+
+    it "returns a SHA512 digest_length" do
+      OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
+    end
+  end
+
+  describe "digest_length of subclasses" do
+    it "returns a SHA1 block length" do
+      OpenSSL::Digest::SHA1.new.digest_length.should == SHA1Constants::DigestLength
+    end
+
+    it "returns a SHA256 block length" do
+      OpenSSL::Digest::SHA256.new.digest_length.should == SHA256Constants::DigestLength
+    end
+
+    it "returns a SHA384 digest_length" do
+      OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
+    end
+
+    it "returns a SHA512 digest_length" do
+      OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
+    end
+  end
+end

--- a/test/natalie/openssl_digest/digest_length_test.rb
+++ b/test/natalie/openssl_digest/digest_length_test.rb
@@ -8,53 +8,37 @@ require 'openssl'
 describe "OpenSSL::Digest#digest_length" do
   describe "digest_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
-      end
+      OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
-      end
+      OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
     end
 
     it "returns a SHA384 digest_length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
-      end
+      OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
     end
 
     it "returns a SHA512 digest_length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
-      end
+      OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
     end
   end
 
   describe "digest_length of subclasses" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest::SHA1.new.digest_length.should == SHA1Constants::DigestLength
-      end
+      OpenSSL::Digest::SHA1.new.digest_length.should == SHA1Constants::DigestLength
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest::SHA256.new.digest_length.should == SHA256Constants::DigestLength
-      end
+      OpenSSL::Digest::SHA256.new.digest_length.should == SHA256Constants::DigestLength
     end
 
     it "returns a SHA384 digest_length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
-      end
+      OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
     end
 
     it "returns a SHA512 digest_length" do
-      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
-        OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
-      end
+      OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
     end
   end
 end

--- a/test/natalie/openssl_digest/digest_length_test.rb
+++ b/test/natalie/openssl_digest/digest_length_test.rb
@@ -8,37 +8,53 @@ require 'openssl'
 describe "OpenSSL::Digest#digest_length" do
   describe "digest_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
+      end
     end
 
     it "returns a SHA256 block length" do
-      OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
+      end
     end
 
     it "returns a SHA384 digest_length" do
-      OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
+      end
     end
 
     it "returns a SHA512 digest_length" do
-      OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
+      end
     end
   end
 
   describe "digest_length of subclasses" do
     it "returns a SHA1 block length" do
-      OpenSSL::Digest::SHA1.new.digest_length.should == SHA1Constants::DigestLength
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
+        OpenSSL::Digest::SHA1.new.digest_length.should == SHA1Constants::DigestLength
+      end
     end
 
     it "returns a SHA256 block length" do
-      OpenSSL::Digest::SHA256.new.digest_length.should == SHA256Constants::DigestLength
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
+        OpenSSL::Digest::SHA256.new.digest_length.should == SHA256Constants::DigestLength
+      end
     end
 
     it "returns a SHA384 digest_length" do
-      OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
+        OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
+      end
     end
 
     it "returns a SHA512 digest_length" do
-      OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
+        OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
+      end
     end
   end
 end

--- a/test/natalie/openssl_digest/digest_length_test.rb
+++ b/test/natalie/openssl_digest/digest_length_test.rb
@@ -8,25 +8,25 @@ require 'openssl'
 describe "OpenSSL::Digest#digest_length" do
   describe "digest_length of OpenSSL::Digest.new(name)" do
     it "returns a SHA1 block length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
         OpenSSL::Digest.new('sha1').digest_length.should == SHA1Constants::DigestLength
       end
     end
 
     it "returns a SHA256 block length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
         OpenSSL::Digest.new('sha256').digest_length.should == SHA256Constants::DigestLength
       end
     end
 
     it "returns a SHA384 digest_length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
         OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
       end
     end
 
     it "returns a SHA512 digest_length" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#digest_length', exception: NoMethodError, message: "undefined method `digest_length'" do
         OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
       end
     end

--- a/test/natalie/openssl_digest/digest_test.rb
+++ b/test/natalie/openssl_digest/digest_test.rb
@@ -1,0 +1,62 @@
+require_relative '../../../spec/spec_helper'
+require_relative '../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe "OpenSSL::Digest class methods" do
+  describe ".digest" do
+    it "returns a SHA1 digest" do
+      OpenSSL::Digest.digest('sha1', SHA1Constants::Contents).should == SHA1Constants::Digest
+    end
+
+    it "returns a SHA256 digest" do
+      OpenSSL::Digest.digest('sha256', SHA256Constants::Contents).should == SHA256Constants::Digest
+    end
+
+    it "returns a SHA384 digest" do
+      OpenSSL::Digest.digest('sha384', SHA384Constants::Contents).should == SHA384Constants::Digest
+    end
+
+    it "returns a SHA512 digest" do
+      OpenSSL::Digest.digest('sha512', SHA512Constants::Contents).should == SHA512Constants::Digest
+    end
+  end
+
+  describe ".hexdigest" do
+    it "returns a SHA1 hexdigest" do
+      OpenSSL::Digest.hexdigest('sha1', SHA1Constants::Contents).should == SHA1Constants::Hexdigest
+    end
+
+    it "returns a SHA256 hexdigest" do
+      OpenSSL::Digest.hexdigest('sha256', SHA256Constants::Contents).should == SHA256Constants::Hexdigest
+    end
+
+    it "returns a SHA384 hexdigest" do
+      OpenSSL::Digest.hexdigest('sha384', SHA384Constants::Contents).should == SHA384Constants::Hexdigest
+    end
+
+    it "returns a SHA512 hexdigest" do
+      OpenSSL::Digest.hexdigest('sha512', SHA512Constants::Contents).should == SHA512Constants::Hexdigest
+    end
+  end
+
+  describe ".base64digest" do
+    it "returns a SHA1 base64digest" do
+      OpenSSL::Digest.base64digest('sha1', SHA1Constants::Contents).should == SHA1Constants::Base64digest
+    end
+
+    it "returns a SHA256 base64digest" do
+      OpenSSL::Digest.base64digest('sha256', SHA256Constants::Contents).should == SHA256Constants::Base64digest
+    end
+
+    it "returns a SHA384 base64digest" do
+      OpenSSL::Digest.base64digest('sha384', SHA384Constants::Contents).should == SHA384Constants::Base64digest
+    end
+
+    it "returns a SHA512 base64digest" do
+      OpenSSL::Digest.base64digest('sha512', SHA512Constants::Contents).should == SHA512Constants::Base64digest
+    end
+  end
+end

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -60,10 +60,8 @@ describe "OpenSSL::Digest initialization" do
     end
 
     it "ignores the state of the name object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-        sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
-        OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
-      end
+      sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+      OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
     end
   end
 
@@ -87,27 +85,19 @@ describe "OpenSSL::Digest initialization" do
 
   describe "can be called with a digest name and data" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-        OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
-      end
+      OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-        OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
-      end
+      OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-        OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
-      end
+      OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-        OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
-      end
+      OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
     end
   end
 

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -44,27 +44,19 @@ describe "OpenSSL::Digest initialization" do
 
   describe "can be called with a digest object" do
     it "returns a SHA1 object" do
-      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
-        OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
-      end
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
     end
 
     it "returns a SHA256 object" do
-      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
-        OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
-      end
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
     end
 
     it "returns a SHA384 object" do
-      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
-        OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
-      end
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
     end
 
     it "returns a SHA512 object" do
-      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
-        OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
-      end
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
     end
 
     it "cannot be called with a digest class" do

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -1,0 +1,141 @@
+require_relative '../../../spec/spec_helper'
+require_relative '../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe "OpenSSL::Digest initialization" do
+  describe "can be called with a digest name" do
+    it "returns a SHA1 object" do
+      OpenSSL::Digest.new("sha1").name.should == "SHA1"
+    end
+
+    it "returns a SHA256 object" do
+      OpenSSL::Digest.new("sha256").name.should == "SHA256"
+    end
+
+    it "returns a SHA384 object" do
+      OpenSSL::Digest.new("sha384").name.should == "SHA384"
+    end
+
+    it "returns a SHA512 object" do
+      OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
+    end
+
+    it "throws an error when called with an unknown digest" do
+      -> { OpenSSL::Digest.new("wd40") }.should raise_error(RuntimeError, /Unsupported digest algorithm \(wd40\)/)
+    end
+
+    it "cannot be called with a symbol" do
+      -> { OpenSSL::Digest.new(:SHA1) }.should raise_error(TypeError, /wrong argument type Symbol/)
+    end
+
+    it "doest not call #to_str on the argument" do
+      name = mock("digest name")
+      name.should_not_receive(:to_str)
+      -> { OpenSSL::Digest.new(name) }.should raise_error(TypeError, /wrong argument type/)
+    end
+  end
+
+  describe "can be called with a digest object" do
+    it "returns a SHA1 object" do
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
+    end
+
+    it "returns a SHA256 object" do
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
+    end
+
+    it "returns a SHA384 object" do
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
+    end
+
+    it "returns a SHA512 object" do
+      OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
+    end
+
+    it "cannot be called with a digest class" do
+      -> { OpenSSL::Digest.new(OpenSSL::Digest::SHA1) }.should raise_error(TypeError, /wrong argument type Class/)
+    end
+
+    it "ignores the state of the name object" do
+      sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+      OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
+    end
+  end
+
+  describe "ititialization with an empty string" do
+    it "returns a SHA1 digest" do
+      OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
+    end
+
+    it "returns a SHA256 digest" do
+      OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
+    end
+
+    it "returns a SHA384 digest" do
+      OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
+    end
+
+    it "returns a SHA512 digest" do
+      OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
+    end
+  end
+
+  describe "can be called with a digest name and data" do
+    it "returns a SHA1 digest" do
+      OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+    end
+
+    it "returns a SHA256 digest" do
+      OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+    end
+
+    it "returns a SHA384 digest" do
+      OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+    end
+
+    it "returns a SHA512 digest" do
+      OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+    end
+  end
+
+  context "can be called on subclasses" do
+    describe "can be called without data on subclasses" do
+      it "returns a SHA1 digest" do
+        OpenSSL::Digest::SHA1.new.digest.should == SHA1Constants::BlankDigest
+      end
+
+      it "returns a SHA256 digest" do
+        OpenSSL::Digest::SHA256.new.digest.should == SHA256Constants::BlankDigest
+      end
+
+      it "returns a SHA384 digest" do
+        OpenSSL::Digest::SHA384.new.digest.should == SHA384Constants::BlankDigest
+      end
+
+      it "returns a SHA512 digest" do
+        OpenSSL::Digest::SHA512.new.digest.should == SHA512Constants::BlankDigest
+      end
+    end
+
+    describe "can be called with data on subclasses" do
+      it "returns a SHA1 digest" do
+        OpenSSL::Digest::SHA1.new(SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+      end
+
+      it "returns a SHA256 digest" do
+        OpenSSL::Digest::SHA256.new(SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+      end
+
+      it "returns a SHA384 digest" do
+        OpenSSL::Digest::SHA384.new(SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+      end
+
+      it "returns a SHA512 digest" do
+        OpenSSL::Digest::SHA512.new(SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+      end
+    end
+  end
+end

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -122,27 +122,19 @@ describe "OpenSSL::Digest initialization" do
 
     describe "can be called with data on subclasses" do
       it "returns a SHA1 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          OpenSSL::Digest::SHA1.new(SHA1Constants::Contents).digest.should == SHA1Constants::Digest
-        end
+        OpenSSL::Digest::SHA1.new(SHA1Constants::Contents).digest.should == SHA1Constants::Digest
       end
 
       it "returns a SHA256 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          OpenSSL::Digest::SHA256.new(SHA256Constants::Contents).digest.should == SHA256Constants::Digest
-        end
+        OpenSSL::Digest::SHA256.new(SHA256Constants::Contents).digest.should == SHA256Constants::Digest
       end
 
       it "returns a SHA384 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          OpenSSL::Digest::SHA384.new(SHA384Constants::Contents).digest.should == SHA384Constants::Digest
-        end
+        OpenSSL::Digest::SHA384.new(SHA384Constants::Contents).digest.should == SHA384Constants::Digest
       end
 
       it "returns a SHA512 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          OpenSSL::Digest::SHA512.new(SHA512Constants::Contents).digest.should == SHA512Constants::Digest
-        end
+        OpenSSL::Digest::SHA512.new(SHA512Constants::Contents).digest.should == SHA512Constants::Digest
       end
     end
   end

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -91,25 +91,25 @@ describe "OpenSSL::Digest initialization" do
 
   describe "ititialization with an empty string" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
+      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
         OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
       end
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
+      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
         OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
       end
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
+      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
         OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
       end
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
+      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
         OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
       end
     end

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -8,27 +8,19 @@ require 'openssl'
 describe "OpenSSL::Digest initialization" do
   describe "can be called with a digest name" do
     it "returns a SHA1 object" do
-      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-        OpenSSL::Digest.new("sha1").name.should == "SHA1"
-      end
+      OpenSSL::Digest.new("sha1").name.should == "SHA1"
     end
 
     it "returns a SHA256 object" do
-      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-        OpenSSL::Digest.new("sha256").name.should == "SHA256"
-      end
+      OpenSSL::Digest.new("sha256").name.should == "SHA256"
     end
 
     it "returns a SHA384 object" do
-      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-        OpenSSL::Digest.new("sha384").name.should == "SHA384"
-      end
+      OpenSSL::Digest.new("sha384").name.should == "SHA384"
     end
 
     it "returns a SHA512 object" do
-      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-        OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
-      end
+      OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
     end
 
     it "throws an error when called with an unknown digest" do

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -8,33 +8,31 @@ require 'openssl'
 describe "OpenSSL::Digest initialization" do
   describe "can be called with a digest name" do
     it "returns a SHA1 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
         OpenSSL::Digest.new("sha1").name.should == "SHA1"
       end
     end
 
     it "returns a SHA256 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
         OpenSSL::Digest.new("sha256").name.should == "SHA256"
       end
     end
 
     it "returns a SHA384 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
         OpenSSL::Digest.new("sha384").name.should == "SHA384"
       end
     end
 
     it "returns a SHA512 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
         OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
       end
     end
 
     it "throws an error when called with an unknown digest" do
-      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
-        -> { OpenSSL::Digest.new("wd40") }.should raise_error(RuntimeError, /Unsupported digest algorithm \(wd40\)/)
-      end
+      -> { OpenSSL::Digest.new("wd40") }.should raise_error(RuntimeError, /Unsupported digest algorithm \(wd40\)/)
     end
 
     it "cannot be called with a symbol" do
@@ -54,25 +52,25 @@ describe "OpenSSL::Digest initialization" do
 
   describe "can be called with a digest object" do
     it "returns a SHA1 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
         OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
       end
     end
 
     it "returns a SHA256 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
         OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
       end
     end
 
     it "returns a SHA384 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
         OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
       end
     end
 
     it "returns a SHA512 object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Allow OpenSSL::Digest instance in constructor', exception: RuntimeError, message: 'Unsupported digest algorithm' do
         OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
       end
     end
@@ -84,7 +82,7 @@ describe "OpenSSL::Digest initialization" do
     end
 
     it "ignores the state of the name object" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
         OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
       end
@@ -93,25 +91,25 @@ describe "OpenSSL::Digest initialization" do
 
   describe "ititialization with an empty string" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
         OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
       end
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
         OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
       end
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
         OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
       end
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `digest'" do
         OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
       end
     end
@@ -119,25 +117,25 @@ describe "OpenSSL::Digest initialization" do
 
   describe "can be called with a digest name and data" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
       end
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
       end
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
       end
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
       end
     end

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -28,17 +28,13 @@ describe "OpenSSL::Digest initialization" do
     end
 
     it "cannot be called with a symbol" do
-      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
-        -> { OpenSSL::Digest.new(:SHA1) }.should raise_error(TypeError, /wrong argument type Symbol/)
-      end
+      -> { OpenSSL::Digest.new(:SHA1) }.should raise_error(TypeError, /wrong argument type Symbol/)
     end
 
     it "doest not call #to_str on the argument" do
       name = mock("digest name")
       name.should_not_receive(:to_str)
-      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
-        -> { OpenSSL::Digest.new(name) }.should raise_error(TypeError, /wrong argument type/)
-      end
+      -> { OpenSSL::Digest.new(name) }.should raise_error(TypeError, /wrong argument type/)
     end
   end
 
@@ -60,9 +56,7 @@ describe "OpenSSL::Digest initialization" do
     end
 
     it "cannot be called with a digest class" do
-      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
-        -> { OpenSSL::Digest.new(OpenSSL::Digest::SHA1) }.should raise_error(TypeError, /wrong argument type Class/)
-      end
+      -> { OpenSSL::Digest.new(OpenSSL::Digest::SHA1) }.should raise_error(TypeError, /wrong argument type Class/)
     end
 
     it "ignores the state of the name object" do

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -69,27 +69,19 @@ describe "OpenSSL::Digest initialization" do
 
   describe "ititialization with an empty string" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-        OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
-      end
+      OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-        OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
-      end
+      OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-        OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
-      end
+      OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Fix empty string of OpenSSL::Digest#digest', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-        OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
-      end
+      OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
     end
   end
 
@@ -122,27 +114,19 @@ describe "OpenSSL::Digest initialization" do
   context "can be called on subclasses" do
     describe "can be called without data on subclasses" do
       it "returns a SHA1 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-          OpenSSL::Digest::SHA1.new.digest.should == SHA1Constants::BlankDigest
-        end
+        OpenSSL::Digest::SHA1.new.digest.should == SHA1Constants::BlankDigest
       end
 
       it "returns a SHA256 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-          OpenSSL::Digest::SHA256.new.digest.should == SHA256Constants::BlankDigest
-        end
+        OpenSSL::Digest::SHA256.new.digest.should == SHA256Constants::BlankDigest
       end
 
       it "returns a SHA384 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-          OpenSSL::Digest::SHA384.new.digest.should == SHA384Constants::BlankDigest
-        end
+        OpenSSL::Digest::SHA384.new.digest.should == SHA384Constants::BlankDigest
       end
 
       it "returns a SHA512 digest" do
-        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-          OpenSSL::Digest::SHA512.new.digest.should == SHA512Constants::BlankDigest
-        end
+        OpenSSL::Digest::SHA512.new.digest.should == SHA512Constants::BlankDigest
       end
     end
 

--- a/test/natalie/openssl_digest/initialize_test.rb
+++ b/test/natalie/openssl_digest/initialize_test.rb
@@ -8,133 +8,191 @@ require 'openssl'
 describe "OpenSSL::Digest initialization" do
   describe "can be called with a digest name" do
     it "returns a SHA1 object" do
-      OpenSSL::Digest.new("sha1").name.should == "SHA1"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha1").name.should == "SHA1"
+      end
     end
 
     it "returns a SHA256 object" do
-      OpenSSL::Digest.new("sha256").name.should == "SHA256"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha256").name.should == "SHA256"
+      end
     end
 
     it "returns a SHA384 object" do
-      OpenSSL::Digest.new("sha384").name.should == "SHA384"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha384").name.should == "SHA384"
+      end
     end
 
     it "returns a SHA512 object" do
-      OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha512").name.should ==  "SHA512"
+      end
     end
 
     it "throws an error when called with an unknown digest" do
-      -> { OpenSSL::Digest.new("wd40") }.should raise_error(RuntimeError, /Unsupported digest algorithm \(wd40\)/)
+      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
+        -> { OpenSSL::Digest.new("wd40") }.should raise_error(RuntimeError, /Unsupported digest algorithm \(wd40\)/)
+      end
     end
 
     it "cannot be called with a symbol" do
-      -> { OpenSSL::Digest.new(:SHA1) }.should raise_error(TypeError, /wrong argument type Symbol/)
+      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
+        -> { OpenSSL::Digest.new(:SHA1) }.should raise_error(TypeError, /wrong argument type Symbol/)
+      end
     end
 
     it "doest not call #to_str on the argument" do
       name = mock("digest name")
       name.should_not_receive(:to_str)
-      -> { OpenSSL::Digest.new(name) }.should raise_error(TypeError, /wrong argument type/)
+      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
+        -> { OpenSSL::Digest.new(name) }.should raise_error(TypeError, /wrong argument type/)
+      end
     end
   end
 
   describe "can be called with a digest object" do
     it "returns a SHA1 object" do
-      OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new(OpenSSL::Digest::SHA1.new).name.should == "SHA1"
+      end
     end
 
     it "returns a SHA256 object" do
-      OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new(OpenSSL::Digest::SHA256.new).name.should == "SHA256"
+      end
     end
 
     it "returns a SHA384 object" do
-      OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new(OpenSSL::Digest::SHA384.new).name.should == "SHA384"
+      end
     end
 
     it "returns a SHA512 object" do
-      OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new(OpenSSL::Digest::SHA512.new).name.should ==  "SHA512"
+      end
     end
 
     it "cannot be called with a digest class" do
-      -> { OpenSSL::Digest.new(OpenSSL::Digest::SHA1) }.should raise_error(TypeError, /wrong argument type Class/)
+      NATFIXME 'Argument type check in constructor', exception: SpecFailedException do
+        -> { OpenSSL::Digest.new(OpenSSL::Digest::SHA1) }.should raise_error(TypeError, /wrong argument type Class/)
+      end
     end
 
     it "ignores the state of the name object" do
-      sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
-      OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        sha1 = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+        OpenSSL::Digest.new(sha1).digest.should == SHA1Constants::BlankDigest
+      end
     end
   end
 
   describe "ititialization with an empty string" do
     it "returns a SHA1 digest" do
-      OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha1").digest.should == SHA1Constants::BlankDigest
+      end
     end
 
     it "returns a SHA256 digest" do
-      OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha256").digest.should == SHA256Constants::BlankDigest
+      end
     end
 
     it "returns a SHA384 digest" do
-      OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha384").digest.should == SHA384Constants::BlankDigest
+      end
     end
 
     it "returns a SHA512 digest" do
-      OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        OpenSSL::Digest.new("sha512").digest.should == SHA512Constants::BlankDigest
+      end
     end
   end
 
   describe "can be called with a digest name and data" do
     it "returns a SHA1 digest" do
-      OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        OpenSSL::Digest.new("sha1", SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+      end
     end
 
     it "returns a SHA256 digest" do
-      OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        OpenSSL::Digest.new("sha256", SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+      end
     end
 
     it "returns a SHA384 digest" do
-      OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        OpenSSL::Digest.new("sha384", SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+      end
     end
 
     it "returns a SHA512 digest" do
-      OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        OpenSSL::Digest.new("sha512", SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+      end
     end
   end
 
   context "can be called on subclasses" do
     describe "can be called without data on subclasses" do
       it "returns a SHA1 digest" do
-        OpenSSL::Digest::SHA1.new.digest.should == SHA1Constants::BlankDigest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+          OpenSSL::Digest::SHA1.new.digest.should == SHA1Constants::BlankDigest
+        end
       end
 
       it "returns a SHA256 digest" do
-        OpenSSL::Digest::SHA256.new.digest.should == SHA256Constants::BlankDigest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+          OpenSSL::Digest::SHA256.new.digest.should == SHA256Constants::BlankDigest
+        end
       end
 
       it "returns a SHA384 digest" do
-        OpenSSL::Digest::SHA384.new.digest.should == SHA384Constants::BlankDigest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+          OpenSSL::Digest::SHA384.new.digest.should == SHA384Constants::BlankDigest
+        end
       end
 
       it "returns a SHA512 digest" do
-        OpenSSL::Digest::SHA512.new.digest.should == SHA512Constants::BlankDigest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+          OpenSSL::Digest::SHA512.new.digest.should == SHA512Constants::BlankDigest
+        end
       end
     end
 
     describe "can be called with data on subclasses" do
       it "returns a SHA1 digest" do
-        OpenSSL::Digest::SHA1.new(SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+          OpenSSL::Digest::SHA1.new(SHA1Constants::Contents).digest.should == SHA1Constants::Digest
+        end
       end
 
       it "returns a SHA256 digest" do
-        OpenSSL::Digest::SHA256.new(SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+          OpenSSL::Digest::SHA256.new(SHA256Constants::Contents).digest.should == SHA256Constants::Digest
+        end
       end
 
       it "returns a SHA384 digest" do
-        OpenSSL::Digest::SHA384.new(SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+          OpenSSL::Digest::SHA384.new(SHA384Constants::Contents).digest.should == SHA384Constants::Digest
+        end
       end
 
       it "returns a SHA512 digest" do
-        OpenSSL::Digest::SHA512.new(SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+        NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+          OpenSSL::Digest::SHA512.new(SHA512Constants::Contents).digest.should == SHA512Constants::Digest
+        end
       end
     end
   end

--- a/test/natalie/openssl_digest/name_test.rb
+++ b/test/natalie/openssl_digest/name_test.rb
@@ -3,13 +3,13 @@ require 'openssl'
 
 describe "OpenSSL::Digest#name" do
   it "returns the name of digest when called on an instance" do
-    NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
       OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
     end
   end
 
   it "converts the name to the internal representation of OpenSSL" do
-    NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
       OpenSSL::Digest.new('sha1').name.should == 'SHA1'
     end
   end

--- a/test/natalie/openssl_digest/name_test.rb
+++ b/test/natalie/openssl_digest/name_test.rb
@@ -3,20 +3,14 @@ require 'openssl'
 
 describe "OpenSSL::Digest#name" do
   it "returns the name of digest when called on an instance" do
-    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-      OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
-    end
+    OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
   end
 
   it "converts the name to the internal representation of OpenSSL" do
-    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-      OpenSSL::Digest.new('sha1').name.should == 'SHA1'
-    end
+    OpenSSL::Digest.new('sha1').name.should == 'SHA1'
   end
 
   it "works on subclasses too" do
-    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
-      OpenSSL::Digest::SHA1.new.name.should == 'SHA1'
-    end
+    OpenSSL::Digest::SHA1.new.name.should == 'SHA1'
   end
 end

--- a/test/natalie/openssl_digest/name_test.rb
+++ b/test/natalie/openssl_digest/name_test.rb
@@ -3,14 +3,20 @@ require 'openssl'
 
 describe "OpenSSL::Digest#name" do
   it "returns the name of digest when called on an instance" do
-    OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
+    NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
+    end
   end
 
   it "converts the name to the internal representation of OpenSSL" do
-    OpenSSL::Digest.new('sha1').name.should == 'SHA1'
+    NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      OpenSSL::Digest.new('sha1').name.should == 'SHA1'
+    end
   end
 
   it "works on subclasses too" do
-    OpenSSL::Digest::SHA1.new.name.should == 'SHA1'
+    NATFIXME 'Implement OpenSSL::Digest#name', exception: NoMethodError, message: "undefined method `name'" do
+      OpenSSL::Digest::SHA1.new.name.should == 'SHA1'
+    end
   end
 end

--- a/test/natalie/openssl_digest/name_test.rb
+++ b/test/natalie/openssl_digest/name_test.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec/spec_helper'
+require 'openssl'
+
+describe "OpenSSL::Digest#name" do
+  it "returns the name of digest when called on an instance" do
+    OpenSSL::Digest.new('SHA1').name.should == 'SHA1'
+  end
+
+  it "converts the name to the internal representation of OpenSSL" do
+    OpenSSL::Digest.new('sha1').name.should == 'SHA1'
+  end
+
+  it "works on subclasses too" do
+    OpenSSL::Digest::SHA1.new.name.should == 'SHA1'
+  end
+end

--- a/test/natalie/openssl_digest/reset_test.rb
+++ b/test/natalie/openssl_digest/reset_test.rb
@@ -8,7 +8,7 @@ require 'openssl'
 describe "OpenSSL::Digest#reset" do
   describe "resets the state of the digest" do
     it "works for a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
         digest.reset
         digest.update(SHA1Constants::Contents)
@@ -17,7 +17,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
         digest.reset
         digest.update(SHA256Constants::Contents)
@@ -26,7 +26,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
         digest.reset
         digest.update(SHA384Constants::Contents)
@@ -35,7 +35,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
         digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
         digest.reset
         digest.update(SHA512Constants::Contents)

--- a/test/natalie/openssl_digest/reset_test.rb
+++ b/test/natalie/openssl_digest/reset_test.rb
@@ -8,39 +8,31 @@ require 'openssl'
 describe "OpenSSL::Digest#reset" do
   describe "resets the state of the digest" do
     it "works for a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
-        digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
-        digest.reset
-        digest.update(SHA1Constants::Contents)
-        digest.digest.should == SHA1Constants::Digest
-      end
+      digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+      digest.reset
+      digest.update(SHA1Constants::Contents)
+      digest.digest.should == SHA1Constants::Digest
     end
 
     it "works for a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
-        digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
-        digest.reset
-        digest.update(SHA256Constants::Contents)
-        digest.digest.should == SHA256Constants::Digest
-      end
+      digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
+      digest.reset
+      digest.update(SHA256Constants::Contents)
+      digest.digest.should == SHA256Constants::Digest
     end
 
     it "works for a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
-        digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
-        digest.reset
-        digest.update(SHA384Constants::Contents)
-        digest.digest.should == SHA384Constants::Digest
-      end
+      digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
+      digest.reset
+      digest.update(SHA384Constants::Contents)
+      digest.digest.should == SHA384Constants::Digest
     end
 
     it "works for a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
-        digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
-        digest.reset
-        digest.update(SHA512Constants::Contents)
-        digest.digest.should == SHA512Constants::Digest
-      end
+      digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
+      digest.reset
+      digest.update(SHA512Constants::Contents)
+      digest.digest.should == SHA512Constants::Digest
     end
   end
 end

--- a/test/natalie/openssl_digest/reset_test.rb
+++ b/test/natalie/openssl_digest/reset_test.rb
@@ -8,31 +8,39 @@ require 'openssl'
 describe "OpenSSL::Digest#reset" do
   describe "resets the state of the digest" do
     it "works for a SHA1 digest" do
-      digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
-      digest.reset
-      digest.update(SHA1Constants::Contents)
-      digest.digest.should == SHA1Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+        digest.reset
+        digest.update(SHA1Constants::Contents)
+        digest.digest.should == SHA1Constants::Digest
+      end
     end
 
     it "works for a SHA256 digest" do
-      digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
-      digest.reset
-      digest.update(SHA256Constants::Contents)
-      digest.digest.should == SHA256Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
+        digest.reset
+        digest.update(SHA256Constants::Contents)
+        digest.digest.should == SHA256Constants::Digest
+      end
     end
 
     it "works for a SHA384 digest" do
-      digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
-      digest.reset
-      digest.update(SHA384Constants::Contents)
-      digest.digest.should == SHA384Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
+        digest.reset
+        digest.update(SHA384Constants::Contents)
+        digest.digest.should == SHA384Constants::Digest
+      end
     end
 
     it "works for a SHA512 digest" do
-      digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
-      digest.reset
-      digest.update(SHA512Constants::Contents)
-      digest.digest.should == SHA512Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+        digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
+        digest.reset
+        digest.update(SHA512Constants::Contents)
+        digest.digest.should == SHA512Constants::Digest
+      end
     end
   end
 end

--- a/test/natalie/openssl_digest/reset_test.rb
+++ b/test/natalie/openssl_digest/reset_test.rb
@@ -1,0 +1,38 @@
+require_relative '../../../spec/spec_helper'
+require_relative '../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe "OpenSSL::Digest#reset" do
+  describe "resets the state of the digest" do
+    it "works for a SHA1 digest" do
+      digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
+      digest.reset
+      digest.update(SHA1Constants::Contents)
+      digest.digest.should == SHA1Constants::Digest
+    end
+
+    it "works for a SHA256 digest" do
+      digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
+      digest.reset
+      digest.update(SHA256Constants::Contents)
+      digest.digest.should == SHA256Constants::Digest
+    end
+
+    it "works for a SHA384 digest" do
+      digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
+      digest.reset
+      digest.update(SHA384Constants::Contents)
+      digest.digest.should == SHA384Constants::Digest
+    end
+
+    it "works for a SHA512 digest" do
+      digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
+      digest.reset
+      digest.update(SHA512Constants::Contents)
+      digest.digest.should == SHA512Constants::Digest
+    end
+  end
+end

--- a/test/natalie/openssl_digest/reset_test.rb
+++ b/test/natalie/openssl_digest/reset_test.rb
@@ -8,7 +8,7 @@ require 'openssl'
 describe "OpenSSL::Digest#reset" do
   describe "resets the state of the digest" do
     it "works for a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
         digest = OpenSSL::Digest.new('sha1', SHA1Constants::Contents)
         digest.reset
         digest.update(SHA1Constants::Contents)
@@ -17,7 +17,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
         digest = OpenSSL::Digest.new('sha256', SHA256Constants::Contents)
         digest.reset
         digest.update(SHA256Constants::Contents)
@@ -26,7 +26,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
         digest = OpenSSL::Digest.new('sha384', SHA384Constants::Contents)
         digest.reset
         digest.update(SHA384Constants::Contents)
@@ -35,7 +35,7 @@ describe "OpenSSL::Digest#reset" do
     end
 
     it "works for a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+      NATFIXME 'Enable constructors', exception: NoMethodError, message: "undefined method `reset'" do
         digest = OpenSSL::Digest.new('sha512', SHA512Constants::Contents)
         digest.reset
         digest.update(SHA512Constants::Contents)

--- a/test/natalie/openssl_digest/shared/update.rb
+++ b/test/natalie/openssl_digest/shared/update.rb
@@ -1,0 +1,59 @@
+require_relative '../../../../spec/library/digest/sha1/shared/constants'
+require_relative '../../../../spec/library/digest/sha256/shared/constants'
+require_relative '../../../../spec/library/digest/sha384/shared/constants'
+require_relative '../../../../spec/library/digest/sha512/shared/constants'
+require 'openssl'
+
+describe :openssl_digest_update, shared: true do
+  context "it supports full data chunks" do
+    it "returns a SHA1 digest" do
+      digest = OpenSSL::Digest.new('sha1')
+      digest.send(@method, SHA1Constants::Contents)
+      digest.digest.should == SHA1Constants::Digest
+    end
+
+    it "returns a SHA256 digest" do
+      digest = OpenSSL::Digest.new('sha256')
+      digest.send(@method, SHA256Constants::Contents)
+      digest.digest.should == SHA256Constants::Digest
+    end
+
+    it "returns a SHA384 digest" do
+      digest = OpenSSL::Digest.new('sha384')
+      digest.send(@method, SHA384Constants::Contents)
+      digest.digest.should == SHA384Constants::Digest
+    end
+
+    it "returns a SHA512 digest" do
+      digest = OpenSSL::Digest.new('sha512')
+      digest.send(@method, SHA512Constants::Contents)
+      digest.digest.should == SHA512Constants::Digest
+    end
+  end
+
+  context "it support smaller chunks" do
+    it "returns a SHA1 digest" do
+      digest = OpenSSL::Digest.new('sha1')
+      SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA1Constants::Digest
+    end
+
+    it "returns a SHA256 digest" do
+      digest = OpenSSL::Digest.new('sha256')
+      SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA256Constants::Digest
+    end
+
+    it "returns a SHA384 digest" do
+      digest = OpenSSL::Digest.new('sha384')
+      SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA384Constants::Digest
+    end
+
+    it "returns a SHA512 digest" do
+      digest = OpenSSL::Digest.new('sha512')
+      SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA512Constants::Digest
+    end
+  end
+end

--- a/test/natalie/openssl_digest/shared/update.rb
+++ b/test/natalie/openssl_digest/shared/update.rb
@@ -8,68 +8,52 @@ describe :openssl_digest_update, shared: true do
   context "it supports full data chunks" do
     it "returns a SHA1 digest" do
       digest = OpenSSL::Digest.new('sha1')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        digest.send(@method, SHA1Constants::Contents)
-        digest.digest.should == SHA1Constants::Digest
-      end
+      digest.send(@method, SHA1Constants::Contents)
+      digest.digest.should == SHA1Constants::Digest
     end
 
     it "returns a SHA256 digest" do
       digest = OpenSSL::Digest.new('sha256')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        digest.send(@method, SHA256Constants::Contents)
-        digest.digest.should == SHA256Constants::Digest
-      end
+      digest.send(@method, SHA256Constants::Contents)
+      digest.digest.should == SHA256Constants::Digest
     end
 
     it "returns a SHA384 digest" do
       digest = OpenSSL::Digest.new('sha384')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        digest.send(@method, SHA384Constants::Contents)
-        digest.digest.should == SHA384Constants::Digest
-      end
+      digest.send(@method, SHA384Constants::Contents)
+      digest.digest.should == SHA384Constants::Digest
     end
 
     it "returns a SHA512 digest" do
       digest = OpenSSL::Digest.new('sha512')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        digest.send(@method, SHA512Constants::Contents)
-        digest.digest.should == SHA512Constants::Digest
-      end
+      digest.send(@method, SHA512Constants::Contents)
+      digest.digest.should == SHA512Constants::Digest
     end
   end
 
   context "it support smaller chunks" do
     it "returns a SHA1 digest" do
       digest = OpenSSL::Digest.new('sha1')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
-        digest.digest.should == SHA1Constants::Digest
-      end
+      SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA1Constants::Digest
     end
 
     it "returns a SHA256 digest" do
       digest = OpenSSL::Digest.new('sha256')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
-        digest.digest.should == SHA256Constants::Digest
-      end
+      SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA256Constants::Digest
     end
 
     it "returns a SHA384 digest" do
       digest = OpenSSL::Digest.new('sha384')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
-        digest.digest.should == SHA384Constants::Digest
-      end
+      SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA384Constants::Digest
     end
 
     it "returns a SHA512 digest" do
       digest = OpenSSL::Digest.new('sha512')
-      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
-        SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
-        digest.digest.should == SHA512Constants::Digest
-      end
+      SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
+      digest.digest.should == SHA512Constants::Digest
     end
   end
 end

--- a/test/natalie/openssl_digest/shared/update.rb
+++ b/test/natalie/openssl_digest/shared/update.rb
@@ -7,32 +7,32 @@ require 'openssl'
 describe :openssl_digest_update, shared: true do
   context "it supports full data chunks" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha1')
+      digest = OpenSSL::Digest.new('sha1')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         digest.send(@method, SHA1Constants::Contents)
         digest.digest.should == SHA1Constants::Digest
       end
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         digest.send(@method, SHA256Constants::Contents)
         digest.digest.should == SHA256Constants::Digest
       end
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha384')
+      digest = OpenSSL::Digest.new('sha384')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         digest.send(@method, SHA384Constants::Contents)
         digest.digest.should == SHA384Constants::Digest
       end
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha512')
+      digest = OpenSSL::Digest.new('sha512')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         digest.send(@method, SHA512Constants::Contents)
         digest.digest.should == SHA512Constants::Digest
       end
@@ -41,32 +41,32 @@ describe :openssl_digest_update, shared: true do
 
   context "it support smaller chunks" do
     it "returns a SHA1 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha1')
+      digest = OpenSSL::Digest.new('sha1')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
         digest.digest.should == SHA1Constants::Digest
       end
     end
 
     it "returns a SHA256 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
         digest.digest.should == SHA256Constants::Digest
       end
     end
 
     it "returns a SHA384 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha384')
+      digest = OpenSSL::Digest.new('sha384')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
         digest.digest.should == SHA384Constants::Digest
       end
     end
 
     it "returns a SHA512 digest" do
-      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        digest = OpenSSL::Digest.new('sha512')
+      digest = OpenSSL::Digest.new('sha512')
+      NATFIXME 'Implement OpenSSL::Digest#<< and OpenSSL::Digest#update', exception: NoMethodError, message: "undefined method `#{@method}'" do
         SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
         digest.digest.should == SHA512Constants::Digest
       end

--- a/test/natalie/openssl_digest/shared/update.rb
+++ b/test/natalie/openssl_digest/shared/update.rb
@@ -7,53 +7,69 @@ require 'openssl'
 describe :openssl_digest_update, shared: true do
   context "it supports full data chunks" do
     it "returns a SHA1 digest" do
-      digest = OpenSSL::Digest.new('sha1')
-      digest.send(@method, SHA1Constants::Contents)
-      digest.digest.should == SHA1Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha1')
+        digest.send(@method, SHA1Constants::Contents)
+        digest.digest.should == SHA1Constants::Digest
+      end
     end
 
     it "returns a SHA256 digest" do
-      digest = OpenSSL::Digest.new('sha256')
-      digest.send(@method, SHA256Constants::Contents)
-      digest.digest.should == SHA256Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha256')
+        digest.send(@method, SHA256Constants::Contents)
+        digest.digest.should == SHA256Constants::Digest
+      end
     end
 
     it "returns a SHA384 digest" do
-      digest = OpenSSL::Digest.new('sha384')
-      digest.send(@method, SHA384Constants::Contents)
-      digest.digest.should == SHA384Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha384')
+        digest.send(@method, SHA384Constants::Contents)
+        digest.digest.should == SHA384Constants::Digest
+      end
     end
 
     it "returns a SHA512 digest" do
-      digest = OpenSSL::Digest.new('sha512')
-      digest.send(@method, SHA512Constants::Contents)
-      digest.digest.should == SHA512Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha512')
+        digest.send(@method, SHA512Constants::Contents)
+        digest.digest.should == SHA512Constants::Digest
+      end
     end
   end
 
   context "it support smaller chunks" do
     it "returns a SHA1 digest" do
-      digest = OpenSSL::Digest.new('sha1')
-      SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
-      digest.digest.should == SHA1Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha1')
+        SHA1Constants::Contents.each_char { |b| digest.send(@method, b) }
+        digest.digest.should == SHA1Constants::Digest
+      end
     end
 
     it "returns a SHA256 digest" do
-      digest = OpenSSL::Digest.new('sha256')
-      SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
-      digest.digest.should == SHA256Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha256')
+        SHA256Constants::Contents.each_char { |b| digest.send(@method, b) }
+        digest.digest.should == SHA256Constants::Digest
+      end
     end
 
     it "returns a SHA384 digest" do
-      digest = OpenSSL::Digest.new('sha384')
-      SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
-      digest.digest.should == SHA384Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha384')
+        SHA384Constants::Contents.each_char { |b| digest.send(@method, b) }
+        digest.digest.should == SHA384Constants::Digest
+      end
     end
 
     it "returns a SHA512 digest" do
-      digest = OpenSSL::Digest.new('sha512')
-      SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
-      digest.digest.should == SHA512Constants::Digest
+      NATFIXME 'Enable constructors', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        digest = OpenSSL::Digest.new('sha512')
+        SHA512Constants::Contents.each_char { |b| digest.send(@method, b) }
+        digest.digest.should == SHA512Constants::Digest
+      end
     end
   end
 end

--- a/test/natalie/openssl_digest/update_test.rb
+++ b/test/natalie/openssl_digest/update_test.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec/spec_helper'
+require_relative 'shared/update'
+
+describe "OpenSSL::Digest#update" do
+  it_behaves_like :openssl_digest_update, :update
+end


### PR DESCRIPTION
This is still very much a work in progress. The final version of probably going to contain another 5 refactors of the C++ part of this implementation.

My 2 goals for this project (except for the obvious one of implementing the missing methods in Natalie):

* [x] Extend the ruby-specs for `OpenSSL::Digest`. The current specs are woefully incomplete (https://github.com/ruby/spec/pull/1054)
* [X] ~~Autogenerate the subclasses by looping through the available digests of OpenSSL. For example, we don't have a MD5 digest, because the specs don't include that. By looping through the data of OpenSSL we can ensure that all digest available on the system are available as subclasses. This might be an OpenSSL 3.0 feature (`EVP_MD_do_all_provided`)~~