### PR TITLE
Fix error message for double resume of Fiber

### DIFF
--- a/spec/core/fiber/resume_spec.rb
+++ b/spec/core/fiber/resume_spec.rb
@@ -30,9 +30,7 @@ describe "Fiber#resume" do
 
   it "raises a FiberError if the Fiber tries to resume itself" do
     fiber = Fiber.new { fiber.resume }
-    NATFIXME 'Incorrect error message', exception: SpecFailedException do
-      -> { fiber.resume }.should raise_error(FiberError, /current fiber/)
-    end
+    -> { fiber.resume }.should raise_error(FiberError, /current fiber/)
   end
 
   it "returns control to the calling Fiber if called from one" do

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -40,7 +40,7 @@ Value FiberObject::resume(Env *env, Args args) {
     if (m_status == Status::Terminated)
         env->raise("FiberError", "dead fiber called");
     if (m_previous_fiber)
-        env->raise("FiberError", "double resume");
+        env->raise("FiberError", "attempt to resume the current fiber");
     auto previous_fiber = FiberObject::current();
     m_previous_fiber = s_current;
     s_current = this;

--- a/test/natalie/fiber_test.rb
+++ b/test/natalie/fiber_test.rb
@@ -47,14 +47,6 @@ describe 'Fiber' do
     f.resume.should == 'hi from f2'
   end
 
-  it 'raises an error if resumed twice' do
-    f2 = Fiber.new { |f| f.resume }
-
-    f = Fiber.new { f2.resume(f) }
-
-    -> { f.resume }.should raise_error(FiberError, /double resume/)
-  end
-
   it 'raises an error when attempting to yield from the main fiber' do
     -> { Fiber.yield 'foo' }.should raise_error(
                                       FiberError,


### PR DESCRIPTION
And removed this check from the test/natalie folder, since it is checked in the specs folder.