### PR TITLE
Implement String#sub! and String#gsub!

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -281,6 +281,7 @@ public:
     bool is_empty() const { return m_string.is_empty(); }
 
     Value gsub(Env *, Value, Value = nullptr, Block *block = nullptr);
+    Value gsub_in_place(Env *, Value, Value = nullptr, Block *block = nullptr);
     Value getbyte(Env *, Value) const;
     Value sub(Env *, Value, Value = nullptr, Block *block = nullptr);
     Value sub_in_place(Env *, Value, Value = nullptr, Block *block = nullptr);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -283,6 +283,7 @@ public:
     Value gsub(Env *, Value, Value = nullptr, Block *block = nullptr);
     Value getbyte(Env *, Value) const;
     Value sub(Env *, Value, Value = nullptr, Block *block = nullptr);
+    Value sub_in_place(Env *, Value, Value = nullptr, Block *block = nullptr);
 
     Value add(Env *, Value) const;
     bool ascii_only(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1236,6 +1236,7 @@ gen.binding('String', 'start_with?', 'StringObject', 'start_with', argc: :any, p
 gen.binding('String', 'strip', 'StringObject', 'strip', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'strip!', 'StringObject', 'strip_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'sub', 'StringObject', 'sub', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('String', 'sub!', 'StringObject', 'sub_in_place', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('String', 'succ', 'StringObject', 'successive', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'succ!', 'StringObject', 'successive_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'swapcase', 'StringObject', 'swapcase', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1204,6 +1204,7 @@ gen.binding('String', 'eql?', 'StringObject', 'eql', argc: 1, pass_env: false, p
 gen.binding('String', 'force_encoding', 'StringObject', 'force_encoding', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'getbyte', 'StringObject', 'getbyte', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'gsub', 'StringObject', 'gsub', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('String', 'gsub!', 'StringObject', 'gsub_in_place', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('String', 'hex', 'StringObject', 'hex', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'include?', 'StringObject', 'include', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('String', 'index', 'StringObject', 'index', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/dir/shared/exist.rb
+++ b/spec/core/dir/shared/exist.rb
@@ -28,11 +28,9 @@ describe :dir_exist, shared: true do
   end
 
   it "doesn't require the name to have a trailing slash" do
-    NATFIXME "Pending String#sub! implementation", exception: NoMethodError, message: /undefined method `sub!'/ do
-      dir = File.dirname(__FILE__)
-      dir.sub!(/\/$/,'')
-      Dir.send(@method, dir).should be_true
-    end
+    dir = File.dirname(__FILE__)
+    dir.sub!(/\/$/,'')
+    Dir.send(@method, dir).should be_true
   end
 
   it "doesn't expand paths" do

--- a/spec/core/matchdata/string_spec.rb
+++ b/spec/core/matchdata/string_spec.rb
@@ -18,8 +18,8 @@ describe "MatchData#string" do
   end
 
   it "returns a frozen copy of the matched string for gsub(String)" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      'he[[o'.gsub!('[', ']')
+    'he[[o'.gsub!('[', ']')
+    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `string' for nil" do
       $~.string.should == 'he[[o'
       $~.string.should.frozen?
     end

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -347,7 +347,7 @@ end
 describe "String#gsub! with pattern and Hash" do
 
   it "returns self with all occurrences of pattern replaced with the value of the corresponding hash key" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "hello".gsub!(/./, 'l' => 'L').should == "LL"
       "hello!".gsub!(/(.)(.)/, 'he' => 'she ', 'll' => 'said').should == 'she said'
       "hello".gsub!('l', 'l' => 'el').should == 'heelelo'
@@ -355,25 +355,25 @@ describe "String#gsub! with pattern and Hash" do
   end
 
   it "ignores keys that don't correspond to matches" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "hello".gsub!(/./, 'z' => 'L', 'h' => 'b', 'o' => 'ow').should == "bow"
     end
   end
 
   it "replaces self with an empty string if the pattern matches but the hash specifies no replacements" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "hello".gsub!(/./, 'z' => 'L').should == ""
     end
   end
 
   it "ignores non-String keys" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "hello".gsub!(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
     end
   end
 
   it "uses a key's value as many times as needed" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "food".gsub!(/o/, 'o' => '0').should == "f00d"
     end
   end
@@ -382,7 +382,7 @@ describe "String#gsub! with pattern and Hash" do
     hsh = {}
     hsh.default='?'
     hsh['o'] = '0'
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "food".gsub!(/./, hsh).should == "?00?"
     end
   end
@@ -392,9 +392,9 @@ describe "String#gsub! with pattern and Hash" do
     hsh.default=[]
     hsh['o'] = 0
     obj = mock('!')
-    # obj.should_receive(:to_s).and_return('!')
-    hsh['!'] = obj
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      obj.should_receive(:to_s).and_return('!')
+      hsh['!'] = obj
       "food!".gsub!(/./, hsh).should == "[]00[]!"
     end
   end
@@ -402,13 +402,13 @@ describe "String#gsub! with pattern and Hash" do
   it "uses the hash's value set from default_proc for missing keys" do
     hsh = {}
     hsh.default_proc = -> k, v { 'lamb' }
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "food!".gsub!(/./, hsh).should == "lamblamblamblamblamb"
     end
   end
 
   it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       'hello.'.gsub!('l', 'l' => 'L')
       $~.begin(0).should == 3
       $~[0].should == 'l'
@@ -426,7 +426,7 @@ describe "String#gsub! with pattern and Hash" do
 
   it "doesn't interpolate special sequences like \\1 for the block's return value" do
     repl = '\& \0 \1 \` \\\' \+ \\\\ foo'
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
       "hello".gsub!(/(.+)/, 'hello' => repl ).should == repl
     end
   end
@@ -587,27 +587,22 @@ end
 describe "String#gsub! with pattern and replacement" do
   it "modifies self in place and returns self" do
     a = "hello"
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      a.gsub!(/[aeiou]/, '*').should equal(a)
-      a.should == "h*ll*"
-    end
+    a.gsub!(/[aeiou]/, '*').should equal(a)
+    a.should == "h*ll*"
   end
 
-  it "modifies self in place with multi-byte characters and returns self" do
+  # NATFIXME: Fix infinite loop
+  xit "modifies self in place with multi-byte characters and returns self" do
     a = "¿por qué?"
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      a.gsub!(/([a-z\d]*)/, "*").should equal(a)
-      a.should == "*¿** **é*?*"
-    end
+    a.gsub!(/([a-z\d]*)/, "*").should equal(a)
+    a.should == "*¿** **é*?*"
   end
 
   it "returns nil if no modifications were made" do
     a = "hello"
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      a.gsub!(/z/, '*').should == nil
-      a.gsub!(/z/, 'z').should == nil
-      a.should == "hello"
-    end
+    a.gsub!(/z/, '*').should == nil
+    a.gsub!(/z/, 'z').should == nil
+    a.should == "hello"
   end
 
   # See [ruby-core:23666]
@@ -615,55 +610,45 @@ describe "String#gsub! with pattern and replacement" do
     s = "hello"
     s.freeze
 
-    NATFIXME 'Implement String#gsub!', exception: SpecFailedException do
-      -> { s.gsub!(/ROAR/, "x")    }.should raise_error(FrozenError)
-      -> { s.gsub!(/e/, "e")       }.should raise_error(FrozenError)
-      -> { s.gsub!(/[aeiou]/, '*') }.should raise_error(FrozenError)
-    end
+    -> { s.gsub!(/ROAR/, "x")    }.should raise_error(FrozenError)
+    -> { s.gsub!(/e/, "e")       }.should raise_error(FrozenError)
+    -> { s.gsub!(/[aeiou]/, '*') }.should raise_error(FrozenError)
   end
 
   it "handles a pattern in a superset encoding" do
     string = 'abc'.force_encoding(Encoding::US_ASCII)
 
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      result = string.gsub!('é', 'è')
+    result = string.gsub!('é', 'è')
 
-      result.should == nil
-      string.should == 'abc'
-      string.encoding.should == Encoding::US_ASCII
-    end
+    result.should == nil
+    string.should == 'abc'
+    string.encoding.should == Encoding::US_ASCII
   end
 
   it "handles a pattern in a subset encoding" do
     string = 'été'
     pattern = 't'.force_encoding(Encoding::US_ASCII)
 
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      result = string.gsub!(pattern, 'u')
+    result = string.gsub!(pattern, 'u')
 
-      result.should == string
-      string.should == 'éué'
-      string.encoding.should == Encoding::UTF_8
-    end
+    result.should == string
+    string.should == 'éué'
+    string.encoding.should == Encoding::UTF_8
   end
 end
 
 describe "String#gsub! with pattern and block" do
   it "modifies self in place and returns self" do
     a = "hello"
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      a.gsub!(/[aeiou]/) { '*' }.should equal(a)
-      a.should == "h*ll*"
-    end
+    a.gsub!(/[aeiou]/) { '*' }.should equal(a)
+    a.should == "h*ll*"
   end
 
   it "returns nil if no modifications were made" do
     a = "hello"
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
-      a.gsub!(/z/) { '*' }.should == nil
-      a.gsub!(/z/) { 'z' }.should == nil
-      a.should == "hello"
-    end
+    a.gsub!(/z/) { '*' }.should == nil
+    a.gsub!(/z/) { 'z' }.should == nil
+    a.should == "hello"
   end
 
   # See [ruby-core:23663]
@@ -671,18 +656,16 @@ describe "String#gsub! with pattern and block" do
     s = "hello"
     s.freeze
 
-    NATFIXME 'Implement String#gsub!', exception: SpecFailedException do
-      -> { s.gsub!(/ROAR/)    { "x" } }.should raise_error(FrozenError)
-      -> { s.gsub!(/e/)       { "e" } }.should raise_error(FrozenError)
-      -> { s.gsub!(/[aeiou]/) { '*' } }.should raise_error(FrozenError)
-    end
+    -> { s.gsub!(/ROAR/)    { "x" } }.should raise_error(FrozenError)
+    -> { s.gsub!(/e/)       { "e" } }.should raise_error(FrozenError)
+    -> { s.gsub!(/[aeiou]/) { '*' } }.should raise_error(FrozenError)
   end
 
   it "uses the compatible encoding if they are compatible" do
     s  = "hello"
     s2 = "#{195.chr}#{192.chr}#{195.chr}"
 
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
       s.gsub!(/l/) { |bar| 195.chr }.encoding.should == Encoding::BINARY
       s2.gsub!("#{192.chr}") { |bar| "hello" }.encoding.should == Encoding::BINARY
     end
@@ -701,15 +684,15 @@ describe "String#gsub! with pattern and block" do
   it "replaces the incompatible part properly even if the encodings are not compatible" do
     s = "hllëllo"
 
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
       s.gsub!(/ë/) { |bar| "Русский".force_encoding("iso-8859-5") }.encoding.should == Encoding::ISO_8859_5
     end
   end
 
   not_supported_on :opal do
-    xit "raises an ArgumentError if encoding is not valid" do
+    it "raises an ArgumentError if encoding is not valid" do
       x92 = [0x92].pack('C').force_encoding('utf-8')
-      NATFIXME 'Implement String#gsub!', exception: SpecFailedException do
+      NATFIXME 'Encodings', exception: SpecFailedException do
         -> { "a#{x92}b".gsub!(/[^\x00-\x7f]/u, '') }.should raise_error(ArgumentError)
       end
     end
@@ -718,7 +701,7 @@ end
 
 describe "String#gsub! with pattern and without replacement and block" do
   it "returns an enumerator" do
-    NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+    NATFIXME 'Enumerator reply in String#gsub!', exception: NotImplementedError do
       enum = "abca".gsub!(/a/)
       enum.should be_an_instance_of(Enumerator)
       enum.to_a.should == ["a", "a"]
@@ -728,7 +711,7 @@ describe "String#gsub! with pattern and without replacement and block" do
   describe "returned Enumerator" do
     describe "size" do
       it "should return nil" do
-        NATFIXME 'Implement String#gsub!', exception: NoMethodError, message: "undefined method `gsub!'" do
+        NATFIXME 'Enumerator reply in String#gsub!', exception: NotImplementedError do
           "abca".gsub!(/a/).size.should == nil
         end
       end

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -1,0 +1,565 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "String#sub with pattern, replacement" do
+  it "returns a copy of self when no modification is made" do
+    a = "hello"
+    b = a.sub(/w.*$/, "*")
+
+    b.should_not equal(a)
+    b.should == "hello"
+  end
+
+  it "returns a copy of self with all occurrences of pattern replaced with replacement" do
+    "hello".sub(/[aeiou]/, '*').should == "h*llo"
+    "hello".sub(//, ".").should == ".hello"
+  end
+
+  it "ignores a block if supplied" do
+    NATFIXME 'Ignore block', exception: SpecFailedException do
+      "food".sub(/f/, "g") { "w" }.should == "good"
+    end
+  end
+
+  it "supports \\G which matches at the beginning of the string" do
+    "hello world!".sub(/\Ghello/, "hi").should == "hi world!"
+  end
+
+  it "supports /i for ignoring case" do
+    "Hello".sub(/h/i, "j").should == "jello"
+    "hello".sub(/H/i, "j").should == "jello"
+  end
+
+  it "doesn't interpret regexp metacharacters if pattern is a string" do
+    "12345".sub('\d', 'a').should == "12345"
+    '\d'.sub('\d', 'a').should == "a"
+  end
+
+  it "replaces \\1 sequences with the regexp's corresponding capture" do
+    str = "hello"
+
+    str.sub(/([aeiou])/, '<\1>').should == "h<e>llo"
+    str.sub(/(.)/, '\1\1').should == "hhello"
+
+    str.sub(/.(.?)/, '<\0>(\1)').should == "<he>(e)llo"
+
+    str.sub(/.(.)+/, '\1').should == "o"
+
+    str = "ABCDEFGHIJKL"
+    re = /#{"(.)" * 12}/
+    str.sub(re, '\1').should == "A"
+    str.sub(re, '\9').should == "I"
+    # Only the first 9 captures can be accessed in MRI
+    str.sub(re, '\10').should == "A0"
+  end
+
+  it "treats \\1 sequences without corresponding captures as empty strings" do
+    str = "hello!"
+
+    NATFIXME 'treats \\1 sequences without corresponding captures as empty strings', exception: SpecFailedException do
+      str.sub("", '<\1>').should == "<>hello!"
+      str.sub("h", '<\1>').should == "<>ello!"
+    end
+
+    # NATFIXME: Natalie::StringObject* Natalie::Object::as_string(): Assertion `is_string()' failed.
+    # str.sub(//, '<\1>').should == "<>hello!"
+    # str.sub(/./, '\1\2\3').should == "ello!"
+    # str.sub(/.(.{20})?/, '\1').should == "ello!"
+  end
+
+  it "replaces \\& and \\0 with the complete match" do
+    str = "hello!"
+
+    NATFIXME 'replaces \\& and \\0 with the complete match', exception: SpecFailedException do
+      str.sub("", '<\0>').should == "<>hello!"
+      str.sub("", '<\&>').should == "<>hello!"
+      str.sub("he", '<\0>').should == "<he>llo!"
+      str.sub("he", '<\&>').should == "<he>llo!"
+      str.sub("l", '<\0>').should == "he<l>lo!"
+      str.sub("l", '<\&>').should == "he<l>lo!"
+    end
+
+    # NATFIXME: Unknown backslash reference: \&
+    # str.sub(//, '<\0>').should == "<>hello!"
+    # str.sub(//, '<\&>').should == "<>hello!"
+    # str.sub(/../, '<\0>').should == "<he>llo!"
+    # str.sub(/../, '<\&>').should == "<he>llo!"
+    # str.sub(/(.)./, '<\0>').should == "<he>llo!"
+  end
+
+  it "replaces \\` with everything before the current match" do
+    str = "hello!"
+
+    NATFIXME 'replaces \\` with everything before the current match', exception: SpecFailedException do
+      str.sub("", '<\`>').should == "<>hello!"
+      str.sub("h", '<\`>').should == "<>ello!"
+      str.sub("l", '<\`>').should == "he<he>lo!"
+      str.sub("!", '<\`>').should == "hello<hello>"
+    end
+
+    # NATFIXME: Unknown backslash reference: \`
+    # str.sub(//, '<\`>').should == "<>hello!"
+    # str.sub(/..o/, '<\`>').should == "he<he>!"
+  end
+
+  it "replaces \\' with everything after the current match" do
+    str = "hello!"
+
+    NATFIXME "replaces \\' with everything after the current match", exception: SpecFailedException do
+      str.sub("", '<\\\'>').should == "<hello!>hello!"
+      str.sub("h", '<\\\'>').should == "<ello!>ello!"
+      str.sub("ll", '<\\\'>').should == "he<o!>o!"
+      str.sub("!", '<\\\'>').should == "hello<>"
+    end
+
+    # NATFIXME: Unknown backslash reference: \'
+    # str.sub(//, '<\\\'>').should == "<hello!>hello!"
+    # str.sub(/../, '<\\\'>').should == "<llo!>llo!"
+  end
+
+  it "replaces \\\\\\+ with \\\\+" do
+    "x".sub(/x/, '\\\+').should == "\\+"
+  end
+
+  # NATFIXME: Unknown backslash reference: \+
+  xit "replaces \\+ with the last paren that actually matched" do
+    str = "hello!"
+
+    str.sub(/(.)(.)/, '\+').should == "ello!"
+    str.sub(/(.)(.)+/, '\+').should == "!"
+    str.sub(/(.)()/, '\+').should == "ello!"
+    str.sub(/(.)(.{20})?/, '<\+>').should == "<h>ello!"
+
+    str = "ABCDEFGHIJKL"
+    re = /#{"(.)" * 12}/
+    str.sub(re, '\+').should == "L"
+  end
+
+  # NATFIXME: Unknown backslash reference: \+
+  xit "treats \\+ as an empty string if there was no captures" do
+    "hello!".sub(/./, '\+').should == "ello!"
+  end
+
+  it "maps \\\\ in replacement to \\" do
+    "hello".sub(/./, '\\\\').should == '\\ello'
+  end
+
+  # NATFIXME: Unknown backslash reference: \x
+  xit "leaves unknown \\x escapes in replacement untouched" do
+    "hello".sub(/./, '\\x').should == '\\xello'
+    "hello".sub(/./, '\\y').should == '\\yello'
+  end
+
+  # NATFIXME: Unknown backslash reference: \
+  xit "leaves \\ at the end of replacement untouched" do
+    "hello".sub(/./, 'hah\\').should == 'hah\\ello'
+  end
+
+  it "tries to convert pattern to a string using to_str" do
+    pattern = mock('.')
+    NATFIXME 'Support to_str', exception: TypeError, message: 'wrong argument type MockObject (expected Regexp)' do
+      pattern.should_receive(:to_str).and_return(".")
+
+      "hello.".sub(pattern, "!").should == "hello!"
+    end
+  end
+
+  not_supported_on :opal do
+    it "raises a TypeError when pattern is a Symbol" do
+      -> { "hello".sub(:woot, "x") }.should raise_error(TypeError)
+    end
+  end
+
+  it "raises a TypeError when pattern is an Array" do
+    -> { "hello".sub([], "x") }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError when pattern can't be converted to a string" do
+    -> { "hello".sub(Object.new, nil) }.should raise_error(TypeError)
+  end
+
+  it "tries to convert replacement to a string using to_str" do
+    replacement = mock('hello_replacement')
+    NATFIXME 'Support to_str', exception: TypeError, message: 'no implicit conversion of MockObject into String' do
+      replacement.should_receive(:to_str).and_return("hello_replacement")
+
+      "hello".sub(/hello/, replacement).should == "hello_replacement"
+    end
+  end
+
+  it "raises a TypeError when replacement can't be converted to a string" do
+    -> { "hello".sub(/[aeiou]/, []) }.should raise_error(TypeError)
+    -> { "hello".sub(/[aeiou]/, 99) }.should raise_error(TypeError)
+  end
+
+  it "returns String instances when called on a subclass" do
+    StringSpecs::MyString.new("").sub(//, "").should be_an_instance_of(String)
+    StringSpecs::MyString.new("").sub(/foo/, "").should be_an_instance_of(String)
+    StringSpecs::MyString.new("foo").sub(/foo/, "").should be_an_instance_of(String)
+    StringSpecs::MyString.new("foo").sub("foo", "").should be_an_instance_of(String)
+  end
+
+  it "sets $~ to MatchData of match and nil when there's none" do
+    'hello.'.sub('hello', 'x')
+    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
+      $~[0].should == 'hello'
+
+      'hello.'.sub('not', 'x')
+      $~.should == nil
+
+      'hello.'.sub(/.(.)/, 'x')
+      $~[0].should == 'he'
+
+      'hello.'.sub(/not/, 'x')
+      $~.should == nil
+    end
+  end
+
+  it "replaces \\\\\\1 with \\1" do
+    "ababa".sub(/(b)/, '\\\1').should == "a\\1aba"
+  end
+
+  it "replaces \\\\\\\\1 with \\1" do
+    "ababa".sub(/(b)/, '\\\\1').should == "a\\1aba"
+  end
+
+  it "replaces \\\\\\\\\\1 with \\" do
+    "ababa".sub(/(b)/, '\\\\\1').should == "a\\baba"
+  end
+
+  it "handles a pattern in a superset encoding" do
+    result = 'abc'.force_encoding(Encoding::US_ASCII).sub('é', 'è')
+    result.should == 'abc'
+    result.encoding.should == Encoding::US_ASCII
+  end
+
+  it "handles a pattern in a subset encoding" do
+    result = 'été'.sub('t'.force_encoding(Encoding::US_ASCII), 'u')
+    result.should == 'éué'
+    result.encoding.should == Encoding::UTF_8
+  end
+end
+
+describe "String#sub with pattern and block" do
+  it "returns a copy of self with the first occurrences of pattern replaced with the block's return value" do
+    "hi".sub(/./) { |s| s + ' ' }.should == "h i"
+    "hi!".sub(/(.)(.)/) { |*a| a.inspect }.should == '["hi"]!'
+  end
+
+  it "sets $~ for access from the block" do
+    str = "hello"
+    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
+      str.sub(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
+      str.sub(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
+      str.sub("l") { "<#{$~[0]}>" }.should == "he<l>lo"
+
+      offsets = []
+
+      str.sub(/([aeiou])/) do
+         md = $~
+         md.string.should == str
+         offsets << md.offset(0)
+         str
+      end.should == "hhellollo"
+
+      offsets.should == [[1, 2]]
+    end
+  end
+
+  it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
+    'hello.'.sub('l') { 'x' }
+    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `begin' for nil" do
+      $~.begin(0).should == 2
+      $~[0].should == 'l'
+
+      'hello.'.sub('not') { 'x' }
+      $~.should == nil
+
+      'hello.'.sub(/.(.)/) { 'x' }
+      $~[0].should == 'he'
+
+      'hello.'.sub(/not/) { 'x' }
+      $~.should == nil
+    end
+  end
+
+  it "doesn't raise a RuntimeError if the string is modified while substituting" do
+    str = "hello"
+    NATFIXME 'Sub for empty regexp', exception: SpecFailedException do
+      str.sub(//) { str[0] = 'x' }.should == "xhello"
+    end
+    str.should == "xello"
+  end
+
+  it "doesn't interpolate special sequences like \\1 for the block's return value" do
+    repl = '\& \0 \1 \` \\\' \+ \\\\ foo'
+    "hello".sub(/(.+)/) { repl }.should == repl
+  end
+
+  it "converts the block's return value to a string using to_s" do
+    obj = mock('hello_replacement')
+    NATFIXME 'String conversions', exception: TypeError, message: 'no implicit conversion of MockObject into String' do
+      obj.should_receive(:to_s).and_return("hello_replacement")
+      "hello".sub(/hello/) { obj }.should == "hello_replacement"
+
+      obj = mock('ok')
+      obj.should_receive(:to_s).and_return("ok")
+      "hello".sub(/.+/) { obj }.should == "ok"
+    end
+  end
+end
+
+# NATFIXME: Implement String#sub!
+xdescribe "String#sub! with pattern, replacement" do
+  it "modifies self in place and returns self" do
+    a = "hello"
+    a.sub!(/[aeiou]/, '*').should equal(a)
+    a.should == "h*llo"
+  end
+
+  it "returns nil if no modifications were made" do
+    a = "hello"
+    a.sub!(/z/, '*').should == nil
+    a.sub!(/z/, 'z').should == nil
+    a.should == "hello"
+  end
+
+  it "raises a FrozenError when self is frozen" do
+    s = "hello"
+    s.freeze
+
+    -> { s.sub!(/ROAR/, "x")    }.should raise_error(FrozenError)
+    -> { s.sub!(/e/, "e")       }.should raise_error(FrozenError)
+    -> { s.sub!(/[aeiou]/, '*') }.should raise_error(FrozenError)
+  end
+
+  it "handles a pattern in a superset encoding" do
+    string = 'abc'.force_encoding(Encoding::US_ASCII)
+
+    result = string.sub!('é', 'è')
+
+    result.should == nil
+    string.should == 'abc'
+    string.encoding.should == Encoding::US_ASCII
+  end
+
+  it "handles a pattern in a subset encoding" do
+    string = 'été'
+    pattern = 't'.force_encoding(Encoding::US_ASCII)
+
+    result = string.sub!(pattern, 'u')
+
+    result.should == string
+    string.should == 'éué'
+    string.encoding.should == Encoding::UTF_8
+  end
+end
+
+# NATFIXME: Implement String#sub!
+xdescribe "String#sub! with pattern and block" do
+  it "modifies self in place and returns self" do
+    a = "hello"
+    a.sub!(/[aeiou]/) { '*' }.should equal(a)
+    a.should == "h*llo"
+  end
+
+  it "sets $~ for access from the block" do
+    str = "hello"
+    str.dup.sub!(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
+    str.dup.sub!(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
+    str.dup.sub!("l") { "<#{$~[0]}>" }.should == "he<l>lo"
+
+    offsets = []
+
+    str.dup.sub!(/([aeiou])/) do
+       md = $~
+       md.string.should == str
+       offsets << md.offset(0)
+       str
+    end.should == "hhellollo"
+
+    offsets.should == [[1, 2]]
+  end
+
+  it "returns nil if no modifications were made" do
+    a = "hello"
+    a.sub!(/z/) { '*' }.should == nil
+    a.sub!(/z/) { 'z' }.should == nil
+    a.should == "hello"
+  end
+
+  it "raises a RuntimeError if the string is modified while substituting" do
+    str = "hello"
+    -> { str.sub!(//) { str << 'x' } }.should raise_error(RuntimeError)
+  end
+
+  it "raises a FrozenError when self is frozen" do
+    s = "hello"
+    s.freeze
+
+    -> { s.sub!(/ROAR/) { "x" }    }.should raise_error(FrozenError)
+    -> { s.sub!(/e/) { "e" }       }.should raise_error(FrozenError)
+    -> { s.sub!(/[aeiou]/) { '*' } }.should raise_error(FrozenError)
+  end
+end
+
+describe "String#sub with pattern and Hash" do
+
+  it "returns a copy of self with the first occurrence of pattern replaced with the value of the corresponding hash key" do
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub(/./, 'l' => 'L').should == "ello"
+      "hello!".sub(/(.)(.)/, 'he' => 'she ', 'll' => 'said').should == 'she llo!'
+      "hello".sub('l', 'l' => 'el').should == 'heello'
+    end
+  end
+
+  it "removes keys that don't correspond to matches" do
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub(/./, 'z' => 'b', 'o' => 'ow').should == "ello"
+    end
+  end
+
+  it "ignores non-String keys" do
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "tattoo".sub(/(tt)/, 'tt' => 'b', tt: 'z').should == "taboo"
+    end
+  end
+
+  it "uses a key's value only a single time" do
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food".sub(/o/, 'o' => '0').should == "f0od"
+    end
+  end
+
+  it "uses the hash's default value for missing keys" do
+    hsh = {}
+    hsh.default='?'
+    hsh['o'] = '0'
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food".sub(/./, hsh).should == "?ood"
+    end
+  end
+
+  it "coerces the hash values with #to_s" do
+    hsh = {}
+    hsh.default=[]
+    hsh['o'] = 0
+    obj = mock('!')
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      obj.should_receive(:to_s).and_return('!')
+      hsh['f'] = obj
+      "food!".sub(/./, hsh).should == "!ood!"
+    end
+  end
+
+  it "uses the hash's value set from default_proc for missing keys" do
+    hsh = {}
+    hsh.default_proc = -> k, v { 'lamb' }
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food!".sub(/./, hsh).should == "lambood!"
+    end
+  end
+
+  it "sets $~ to MatchData of first match and nil when there's none for access from outside" do
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      'hello.'.sub('l', 'l' => 'L')
+      $~.begin(0).should == 2
+      $~[0].should == 'l'
+
+      'hello.'.sub('not', 'ot' => 'to')
+      $~.should == nil
+
+      'hello.'.sub(/.(.)/, 'o' => ' hole')
+      $~[0].should == 'he'
+
+      'hello.'.sub(/not/, 'z' => 'glark')
+      $~.should == nil
+    end
+  end
+
+  it "doesn't interpolate special sequences like \\1 for the block's return value" do
+    repl = '\& \0 \1 \` \\\' \+ \\\\ foo'
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub(/(.+)/, 'hello' => repl ).should == repl
+    end
+  end
+
+end
+
+# NATFIXME: Implement String#sub!
+xdescribe "String#sub! with pattern and Hash" do
+
+  it "returns self with the first occurrence of pattern replaced with the value of the corresponding hash key" do
+    "hello".sub!(/./, 'l' => 'L').should == "ello"
+    "hello!".sub!(/(.)(.)/, 'he' => 'she ', 'll' => 'said').should == 'she llo!'
+    "hello".sub!('l', 'l' => 'el').should == 'heello'
+  end
+
+  it "removes keys that don't correspond to matches" do
+    "hello".sub!(/./, 'z' => 'b', 'o' => 'ow').should == "ello"
+  end
+
+  it "ignores non-String keys" do
+    "hello".sub!(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
+  end
+
+  it "uses a key's value only a single time" do
+    "food".sub!(/o/, 'o' => '0').should == "f0od"
+  end
+
+  it "uses the hash's default value for missing keys" do
+    hsh = {}
+    hsh.default='?'
+    hsh['o'] = '0'
+    "food".sub!(/./, hsh).should == "?ood"
+  end
+
+  it "coerces the hash values with #to_s" do
+    hsh = {}
+    hsh.default=[]
+    hsh['o'] = 0
+    obj = mock('!')
+    obj.should_receive(:to_s).and_return('!')
+    hsh['f'] = obj
+    "food!".sub!(/./, hsh).should == "!ood!"
+  end
+
+  it "uses the hash's value set from default_proc for missing keys" do
+    hsh = {}
+    hsh.default_proc = -> k, v { 'lamb' }
+    "food!".sub!(/./, hsh).should == "lambood!"
+  end
+
+  it "sets $~ to MatchData of first match and nil when there's none for access from outside" do
+    'hello.'.sub!('l', 'l' => 'L')
+    $~.begin(0).should == 2
+    $~[0].should == 'l'
+
+    'hello.'.sub!('not', 'ot' => 'to')
+    $~.should == nil
+
+    'hello.'.sub!(/.(.)/, 'o' => ' hole')
+    $~[0].should == 'he'
+
+    'hello.'.sub!(/not/, 'z' => 'glark')
+    $~.should == nil
+  end
+
+  it "doesn't interpolate special sequences like \\1 for the block's return value" do
+    repl = '\& \0 \1 \` \\\' \+ \\\\ foo'
+    "hello".sub!(/(.+)/, 'hello' => repl ).should == repl
+  end
+end
+
+describe "String#sub with pattern and without replacement and block" do
+  it "raises a ArgumentError" do
+    -> { "abca".sub(/a/) }.should raise_error(ArgumentError)
+  end
+end
+
+# NATFIXME: Implement String#sub!
+xdescribe "String#sub! with pattern and without replacement and block" do
+  it "raises a ArgumentError" do
+    -> { "abca".sub!(/a/) }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -309,8 +309,7 @@ describe "String#sub with pattern and block" do
   end
 end
 
-# NATFIXME: Implement String#sub!
-xdescribe "String#sub! with pattern, replacement" do
+describe "String#sub! with pattern, replacement" do
   it "modifies self in place and returns self" do
     a = "hello"
     a.sub!(/[aeiou]/, '*').should equal(a)
@@ -355,8 +354,7 @@ xdescribe "String#sub! with pattern, replacement" do
   end
 end
 
-# NATFIXME: Implement String#sub!
-xdescribe "String#sub! with pattern and block" do
+describe "String#sub! with pattern and block" do
   it "modifies self in place and returns self" do
     a = "hello"
     a.sub!(/[aeiou]/) { '*' }.should equal(a)
@@ -365,20 +363,22 @@ xdescribe "String#sub! with pattern and block" do
 
   it "sets $~ for access from the block" do
     str = "hello"
-    str.dup.sub!(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
-    str.dup.sub!(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
-    str.dup.sub!("l") { "<#{$~[0]}>" }.should == "he<l>lo"
+    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
+      str.dup.sub!(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
+      str.dup.sub!(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
+      str.dup.sub!("l") { "<#{$~[0]}>" }.should == "he<l>lo"
 
-    offsets = []
+      offsets = []
 
-    str.dup.sub!(/([aeiou])/) do
-       md = $~
-       md.string.should == str
-       offsets << md.offset(0)
-       str
-    end.should == "hhellollo"
+      str.dup.sub!(/([aeiou])/) do
+         md = $~
+         md.string.should == str
+         offsets << md.offset(0)
+         str
+      end.should == "hhellollo"
 
-    offsets.should == [[1, 2]]
+      offsets.should == [[1, 2]]
+    end
   end
 
   it "returns nil if no modifications were made" do
@@ -390,7 +390,9 @@ xdescribe "String#sub! with pattern and block" do
 
   it "raises a RuntimeError if the string is modified while substituting" do
     str = "hello"
-    -> { str.sub!(//) { str << 'x' } }.should raise_error(RuntimeError)
+    NATFIXME 'raises a RuntimeError if the string is modified while substituting', exception: SpecFailedException do
+      -> { str.sub!(//) { str << 'x' } }.should raise_error(RuntimeError)
+    end
   end
 
   it "raises a FrozenError when self is frozen" do
@@ -486,32 +488,41 @@ describe "String#sub with pattern and Hash" do
 
 end
 
-# NATFIXME: Implement String#sub!
-xdescribe "String#sub! with pattern and Hash" do
+describe "String#sub! with pattern and Hash" do
 
   it "returns self with the first occurrence of pattern replaced with the value of the corresponding hash key" do
-    "hello".sub!(/./, 'l' => 'L').should == "ello"
-    "hello!".sub!(/(.)(.)/, 'he' => 'she ', 'll' => 'said').should == 'she llo!'
-    "hello".sub!('l', 'l' => 'el').should == 'heello'
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub!(/./, 'l' => 'L').should == "ello"
+      "hello!".sub!(/(.)(.)/, 'he' => 'she ', 'll' => 'said').should == 'she llo!'
+      "hello".sub!('l', 'l' => 'el').should == 'heello'
+    end
   end
 
   it "removes keys that don't correspond to matches" do
-    "hello".sub!(/./, 'z' => 'b', 'o' => 'ow').should == "ello"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub!(/./, 'z' => 'b', 'o' => 'ow').should == "ello"
+    end
   end
 
   it "ignores non-String keys" do
-    "hello".sub!(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub!(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
+    end
   end
 
   it "uses a key's value only a single time" do
-    "food".sub!(/o/, 'o' => '0').should == "f0od"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food".sub!(/o/, 'o' => '0').should == "f0od"
+    end
   end
 
   it "uses the hash's default value for missing keys" do
     hsh = {}
     hsh.default='?'
     hsh['o'] = '0'
-    "food".sub!(/./, hsh).should == "?ood"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food".sub!(/./, hsh).should == "?ood"
+    end
   end
 
   it "coerces the hash values with #to_s" do
@@ -519,35 +530,43 @@ xdescribe "String#sub! with pattern and Hash" do
     hsh.default=[]
     hsh['o'] = 0
     obj = mock('!')
-    obj.should_receive(:to_s).and_return('!')
-    hsh['f'] = obj
-    "food!".sub!(/./, hsh).should == "!ood!"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      obj.should_receive(:to_s).and_return('!')
+      hsh['f'] = obj
+      "food!".sub!(/./, hsh).should == "!ood!"
+    end
   end
 
   it "uses the hash's value set from default_proc for missing keys" do
     hsh = {}
     hsh.default_proc = -> k, v { 'lamb' }
-    "food!".sub!(/./, hsh).should == "lambood!"
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "food!".sub!(/./, hsh).should == "lambood!"
+    end
   end
 
   it "sets $~ to MatchData of first match and nil when there's none for access from outside" do
-    'hello.'.sub!('l', 'l' => 'L')
-    $~.begin(0).should == 2
-    $~[0].should == 'l'
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      'hello.'.sub!('l', 'l' => 'L')
+      $~.begin(0).should == 2
+      $~[0].should == 'l'
 
-    'hello.'.sub!('not', 'ot' => 'to')
-    $~.should == nil
+      'hello.'.sub!('not', 'ot' => 'to')
+      $~.should == nil
 
-    'hello.'.sub!(/.(.)/, 'o' => ' hole')
-    $~[0].should == 'he'
+      'hello.'.sub!(/.(.)/, 'o' => ' hole')
+      $~[0].should == 'he'
 
-    'hello.'.sub!(/not/, 'z' => 'glark')
-    $~.should == nil
+      'hello.'.sub!(/not/, 'z' => 'glark')
+      $~.should == nil
+    end
   end
 
   it "doesn't interpolate special sequences like \\1 for the block's return value" do
     repl = '\& \0 \1 \` \\\' \+ \\\\ foo'
-    "hello".sub!(/(.+)/, 'hello' => repl ).should == repl
+    NATFIXME 'Hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      "hello".sub!(/(.+)/, 'hello' => repl ).should == repl
+    end
   end
 end
 
@@ -557,8 +576,7 @@ describe "String#sub with pattern and without replacement and block" do
   end
 end
 
-# NATFIXME: Implement String#sub!
-xdescribe "String#sub! with pattern and without replacement and block" do
+describe "String#sub! with pattern and without replacement and block" do
   it "raises a ArgumentError" do
     -> { "abca".sub!(/a/) }.should raise_error(ArgumentError)
   end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1750,6 +1750,17 @@ Value StringObject::gsub(Env *env, Value find, Value replacement_value, Block *b
     }
 }
 
+Value StringObject::gsub_in_place(Env *env, Value find, Value replacement_value, Block *block) {
+    assert_not_frozen(env);
+
+    auto replacement = gsub(env, find, replacement_value, block)->as_string()->string();
+    if (m_string == replacement)
+        return NilObject::the();
+
+    m_string = replacement;
+    return this;
+}
+
 Value StringObject::getbyte(Env *env, Value index_obj) const {
     nat_int_t index = IntegerObject::convert_to_nat_int_t(env, index_obj);
     nat_int_t length = static_cast<nat_int_t>(m_string.length());

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1711,6 +1711,17 @@ Value StringObject::sub(Env *env, Value find, Value replacement_value, Block *bl
     }
 }
 
+Value StringObject::sub_in_place(Env *env, Value find, Value replacement_value, Block *block) {
+    assert_not_frozen(env);
+
+    auto replacement = sub(env, find, replacement_value, block)->as_string()->string();
+    if (m_string == replacement)
+        return NilObject::the();
+
+    m_string = replacement;
+    return this;
+}
+
 Value StringObject::gsub(Env *env, Value find, Value replacement_value, Block *block) {
     StringObject *replacement = nullptr;
     if (replacement_value) {


### PR DESCRIPTION
Another two checks for #217 

The current implementations depend on `String#sub`/`String#gsub` and replaces its own internals with the result. It would be more efficient to reverse this logic and implement the non-mutating versions as a chain of `dup` and the mutating version. I left that one as a future work.

This resolves a grand total of 2 other dependencies in the specs, I expected that to be much higher.