### PR TITLE
Implement Fiber#storage and friends

### DIFF
--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -145,6 +145,7 @@ public:
     bool is_blocking() const;
     static Value is_blocking_current();
     Value resume(Env *env, Args args);
+    Value storage(Env *) const;
     void yield_back(Env *env, Args args);
 
     void *start_of_stack() { return m_start_of_stack; }

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -145,6 +145,7 @@ public:
     bool is_blocking() const;
     static Value is_blocking_current();
     Value resume(Env *env, Args args);
+    Value set_storage(Env *, Value);
     Value storage(Env *) const;
     void yield_back(Env *env, Args args);
 

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -89,7 +89,7 @@ public:
 
     constexpr static int STACK_SIZE = 1024 * 1024;
 
-    FiberObject *initialize(Env *env, Value, Block *block);
+    FiberObject *initialize(Env *env, Value, Value, Block *block);
 
     static Value yield(Env *env, Args args);
 
@@ -193,6 +193,7 @@ public:
 private:
     Block *m_block { nullptr };
     bool m_blocking { false };
+    HashObject *m_storage { nullptr };
     ::fiber_stack_struct m_fiber {};
     void *m_stack_memory { nullptr };
     void *m_start_of_stack { nullptr };

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -144,6 +144,7 @@ public:
     bool is_alive() const;
     bool is_blocking() const;
     static Value is_blocking_current();
+    static Value ref(Env *env, Value);
     Value resume(Env *env, Args args);
     Value set_storage(Env *, Value);
     Value storage(Env *) const;

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -145,6 +145,7 @@ public:
     bool is_blocking() const;
     static Value is_blocking_current();
     static Value ref(Env *env, Value);
+    static Value refeq(Env *env, Value, Value);
     Value resume(Env *env, Args args);
     Value set_storage(Env *, Value);
     Value storage(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -555,7 +555,7 @@ gen.static_binding('Fiber', 'current', 'FiberObject', 'current', argc: 0, pass_e
 gen.static_binding('Fiber', 'yield', 'FiberObject', 'yield', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'alive?', 'FiberObject', 'is_alive', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Fiber', 'blocking?', 'FiberObject', 'is_blocking', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
-gen.binding('Fiber', 'initialize', 'FiberObject', 'initialize', argc: 0, kwargs: [:blocking], pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('Fiber', 'initialize', 'FiberObject', 'initialize', argc: 0, kwargs: [:blocking, :storage], pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Fiber', 'inspect', 'FiberObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'resume', 'FiberObject', 'resume', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'status', 'FiberObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -551,6 +551,7 @@ gen.binding('FalseClass', 'inspect', 'FalseObject', 'to_s', argc: 0, pass_env: t
 gen.binding('FalseClass', 'to_s', 'FalseObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('Fiber', '[]', 'FiberObject', 'ref', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('Fiber', '[]=', 'FiberObject', 'refeq', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'blocking?', 'FiberObject', 'is_blocking_current', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'current', 'FiberObject', 'current', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'yield', 'FiberObject', 'yield', argc: :any, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -560,6 +560,7 @@ gen.binding('Fiber', 'inspect', 'FiberObject', 'inspect', argc: 0, pass_env: tru
 gen.binding('Fiber', 'resume', 'FiberObject', 'resume', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'status', 'FiberObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'storage', 'FiberObject', 'storage', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Fiber', 'storage=', 'FiberObject', 'set_storage', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'to_s', 'FiberObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('File', 'atime', 'FileObject', 'atime', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -550,6 +550,7 @@ gen.binding('FalseClass', '^', 'FalseObject', 'or_method', argc: 1, pass_env: tr
 gen.binding('FalseClass', 'inspect', 'FalseObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('FalseClass', 'to_s', 'FalseObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
+gen.static_binding('Fiber', '[]', 'FiberObject', 'ref', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'blocking?', 'FiberObject', 'is_blocking_current', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'current', 'FiberObject', 'current', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Fiber', 'yield', 'FiberObject', 'yield', argc: :any, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -559,6 +559,7 @@ gen.binding('Fiber', 'initialize', 'FiberObject', 'initialize', argc: 0, kwargs:
 gen.binding('Fiber', 'inspect', 'FiberObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'resume', 'FiberObject', 'resume', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'status', 'FiberObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Fiber', 'storage', 'FiberObject', 'storage', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'to_s', 'FiberObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('File', 'atime', 'FileObject', 'atime', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -231,8 +231,14 @@ class Set
   alias === include?
 
   def inspect
-    items = to_a.map { |e| equal?(e) ? '#<Set: {...}>' : e.inspect }
-    "#<Set: {#{items.join(', ')}}>"
+    if !Fiber[:__set_inspect_current]
+      Fiber.new(storage: { __set_inspect_current: [] }, &method(:inspect)).resume
+    elsif Fiber[:__set_inspect_current].include?(object_id)
+      '#<Set: {...}>'
+    else
+      Fiber[:__set_inspect_current] << object_id
+      "#<Set: {#{map(&:inspect).join(', ')}}>"
+    end
   end
   alias to_s inspect
 

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -78,32 +78,42 @@ describe "Fiber#storage=" do
   end
 end
 
-ruby_version_is "3.2" do
-  describe "Fiber.[]" do
-    it "returns the value of the given key in the storage of the current fiber" do
+describe "Fiber.[]" do
+  it "returns the value of the given key in the storage of the current fiber" do
+    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
       Fiber.new(storage: {life: 42}) { Fiber[:life] }.resume.should == 42
     end
+  end
 
-    it "returns nil if the key is not present in the storage of the current fiber" do
+  it "returns nil if the key is not present in the storage of the current fiber" do
+    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
       Fiber.new(storage: {life: 42}) { Fiber[:death] }.resume.should be_nil
     end
+  end
 
-    it "returns nil if the current fiber has no storage" do
+  it "returns nil if the current fiber has no storage" do
+    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
       Fiber.new { Fiber[:life] }.resume.should be_nil
     end
+  end
 
-    it "can access the storage of the parent fiber" do
+  it "can access the storage of the parent fiber" do
+    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
       f = Fiber.new(storage: {life: 42}) do
         Fiber.new { Fiber[:life] }.resume
       end
       f.resume.should == 42
     end
+  end
 
-    it "can't access the storage of the fiber with non-symbol keys" do
+  it "can't access the storage of the fiber with non-symbol keys" do
+    NATFIXME 'Implement Fiber.[]', exception: SpecFailedException do
       -> { Fiber[Object.new] }.should raise_error(TypeError)
     end
   end
+end
 
+ruby_version_is "3.2" do
   describe "Fiber.[]=" do
     it "sets the value of the given key in the storage of the current fiber" do
       Fiber.new(storage: {life: 42}) { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -6,20 +6,20 @@ require_relative '../../spec_helper'
 describe "Fiber.new(storage:)" do
   it "creates a Fiber with the given storage" do
     storage = {life: 42}
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
+    NATFIXME 'Implement Fiber#storage', exception: NoMethodError, message: "undefined method `storage'" do
       fiber = Fiber.new(storage: storage) { Fiber.current.storage }
       fiber.resume.should == storage
     end
   end
 
   it "creates a fiber with lazily initialized storage" do
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       Fiber.new(storage: nil) { Fiber[:x] = 10; Fiber.current.storage }.resume.should == {x: 10}
     end
   end
 
   it "creates a fiber by inheriting the storage of the parent fiber" do
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
+    NATFIXME 'Implement Fiber#storage', exception: NoMethodError, message: "undefined method `storage'" do
       fiber = Fiber.new(storage: {life: 42}) do
         Fiber.new { Fiber.current.storage }.resume
       end
@@ -28,21 +28,15 @@ describe "Fiber.new(storage:)" do
   end
 
   it "cannot create a fiber with non-hash storage" do
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
-      -> { Fiber.new(storage: 42) {} }.should raise_error(TypeError)
-    end
+    -> { Fiber.new(storage: 42) {} }.should raise_error(TypeError)
   end
 
   it "cannot create a fiber with a frozen hash as storage" do
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
-      -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
-    end
+    -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
   end
 
   it "cannot create a fiber with a storage hash with non-symbol keys" do
-    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
-      -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
-    end
+    -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
   end
 end
 

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -6,10 +6,8 @@ require_relative '../../spec_helper'
 describe "Fiber.new(storage:)" do
   it "creates a Fiber with the given storage" do
     storage = {life: 42}
-    NATFIXME 'Implement Fiber#storage', exception: NoMethodError, message: "undefined method `storage'" do
-      fiber = Fiber.new(storage: storage) { Fiber.current.storage }
-      fiber.resume.should == storage
-    end
+    fiber = Fiber.new(storage: storage) { Fiber.current.storage }
+    fiber.resume.should == storage
   end
 
   it "creates a fiber with lazily initialized storage" do
@@ -19,10 +17,10 @@ describe "Fiber.new(storage:)" do
   end
 
   it "creates a fiber by inheriting the storage of the parent fiber" do
-    NATFIXME 'Implement Fiber#storage', exception: NoMethodError, message: "undefined method `storage'" do
-      fiber = Fiber.new(storage: {life: 42}) do
-        Fiber.new { Fiber.current.storage }.resume
-      end
+    fiber = Fiber.new(storage: {life: 42}) do
+      Fiber.new { Fiber.current.storage }.resume
+    end
+    NATFIXME 'creates a fiber by inheriting the storage of the parent fiber', exception: SpecFailedException do
       fiber.resume.should == {life: 42}
     end
   end
@@ -40,16 +38,18 @@ describe "Fiber.new(storage:)" do
   end
 end
 
-ruby_version_is "3.2" do
-  describe "Fiber#storage" do
-    it "cannot be accessed from a different fiber" do
+describe "Fiber#storage" do
+  it "cannot be accessed from a different fiber" do
+    NATFIXME 'Access checks onf Fiber#storage', exception: SpecFailedException do
       f = Fiber.new(storage: {life: 42}) { nil }
       -> {
         f.storage
       }.should raise_error(ArgumentError, /Fiber storage can only be accessed from the Fiber it belongs to/)
     end
   end
+end
 
+ruby_version_is "3.2" do
   describe "Fiber#storage=" do
     it "can clear the storage of the fiber" do
       fiber = Fiber.new(storage: {life: 42}) do

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -47,7 +47,7 @@ end
 
 describe "Fiber#storage=" do
   it "can clear the storage of the fiber" do
-    NATFIXME 'Implement Fiber#storage=', exception: NoMethodError, message: "undefined method `storage='" do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       fiber = Fiber.new(storage: {life: 42}) do
         Fiber.current.storage = nil
         Fiber[:x] = 10
@@ -58,31 +58,23 @@ describe "Fiber#storage=" do
   end
 
   it "can set the storage of the fiber" do
-    NATFIXME 'Implement Fiber#storage=', exception: NoMethodError, message: "undefined method `storage='" do
-      fiber = Fiber.new(storage: {life: 42}) do
-        Fiber.current.storage = {life: 43}
-        Fiber.current.storage
-      end
-      fiber.resume.should == {life: 43}
+    fiber = Fiber.new(storage: {life: 42}) do
+      Fiber.current.storage = {life: 43}
+      Fiber.current.storage
     end
+    fiber.resume.should == {life: 43}
   end
 
   it "can't set the storage of the fiber to non-hash" do
-    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
-      -> { Fiber.current.storage = 42 }.should raise_error(TypeError)
-    end
+    -> { Fiber.current.storage = 42 }.should raise_error(TypeError)
   end
 
   it "can't set the storage of the fiber to a frozen hash" do
-    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
-      -> { Fiber.current.storage = {life: 43}.freeze }.should raise_error(FrozenError)
-    end
+    -> { Fiber.current.storage = {life: 43}.freeze }.should raise_error(FrozenError)
   end
 
   it "can't set the storage of the fiber to a hash with non-symbol keys" do
-    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
-      -> { Fiber.current.storage = {life: 43, Object.new => 44} }.should raise_error(TypeError)
-    end
+    -> { Fiber.current.storage = {life: 43, Object.new => 44} }.should raise_error(TypeError)
   end
 end
 

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -80,36 +80,26 @@ end
 
 describe "Fiber.[]" do
   it "returns the value of the given key in the storage of the current fiber" do
-    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
-      Fiber.new(storage: {life: 42}) { Fiber[:life] }.resume.should == 42
-    end
+    Fiber.new(storage: {life: 42}) { Fiber[:life] }.resume.should == 42
   end
 
   it "returns nil if the key is not present in the storage of the current fiber" do
-    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
-      Fiber.new(storage: {life: 42}) { Fiber[:death] }.resume.should be_nil
-    end
+    Fiber.new(storage: {life: 42}) { Fiber[:death] }.resume.should be_nil
   end
 
   it "returns nil if the current fiber has no storage" do
-    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
-      Fiber.new { Fiber[:life] }.resume.should be_nil
-    end
+    Fiber.new { Fiber[:life] }.resume.should be_nil
   end
 
   it "can access the storage of the parent fiber" do
-    NATFIXME 'Implement Fiber.[]', exception: NoMethodError, message: "undefined method `[]' for Fiber:Class" do
-      f = Fiber.new(storage: {life: 42}) do
-        Fiber.new { Fiber[:life] }.resume
-      end
-      f.resume.should == 42
+    f = Fiber.new(storage: {life: 42}) do
+      Fiber.new { Fiber[:life] }.resume
     end
+    f.resume.should == 42
   end
 
   it "can't access the storage of the fiber with non-symbol keys" do
-    NATFIXME 'Implement Fiber.[]', exception: SpecFailedException do
-      -> { Fiber[Object.new] }.should raise_error(TypeError)
-    end
+    -> { Fiber[Object.new] }.should raise_error(TypeError)
   end
 end
 

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -1,37 +1,52 @@
+# NATFIXME: Even though this is a spec for Ruby 3.2, we're going to implement parts of
+# it to help with detecting cycling data structures.
+
 require_relative '../../spec_helper'
 
-ruby_version_is "3.2" do
-  describe "Fiber.new(storage:)" do
-    it "creates a Fiber with the given storage" do
-      storage = {life: 42}
+describe "Fiber.new(storage:)" do
+  it "creates a Fiber with the given storage" do
+    storage = {life: 42}
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
       fiber = Fiber.new(storage: storage) { Fiber.current.storage }
       fiber.resume.should == storage
     end
+  end
 
-    it "creates a fiber with lazily initialized storage" do
+  it "creates a fiber with lazily initialized storage" do
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
       Fiber.new(storage: nil) { Fiber[:x] = 10; Fiber.current.storage }.resume.should == {x: 10}
     end
+  end
 
-    it "creates a fiber by inheriting the storage of the parent fiber" do
+  it "creates a fiber by inheriting the storage of the parent fiber" do
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: ArgumentError, message: 'unknown keyword: :storage' do
       fiber = Fiber.new(storage: {life: 42}) do
         Fiber.new { Fiber.current.storage }.resume
       end
       fiber.resume.should == {life: 42}
     end
+  end
 
-    it "cannot create a fiber with non-hash storage" do
+  it "cannot create a fiber with non-hash storage" do
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
       -> { Fiber.new(storage: 42) {} }.should raise_error(TypeError)
-    end
-
-    it "cannot create a fiber with a frozen hash as storage" do
-      -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
-    end
-
-    it "cannot create a fiber with a storage hash with non-symbol keys" do
-      -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
     end
   end
 
+  it "cannot create a fiber with a frozen hash as storage" do
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
+      -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
+    end
+  end
+
+  it "cannot create a fiber with a storage hash with non-symbol keys" do
+    NATFIXME 'Add storage: keyword to Fiber.new', exception: SpecFailedException do
+      -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
+    end
+  end
+end
+
+ruby_version_is "3.2" do
   describe "Fiber#storage" do
     it "cannot be accessed from a different fiber" do
       f = Fiber.new(storage: {life: 42}) { nil }

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -103,21 +103,27 @@ describe "Fiber.[]" do
   end
 end
 
-ruby_version_is "3.2" do
-  describe "Fiber.[]=" do
-    it "sets the value of the given key in the storage of the current fiber" do
+describe "Fiber.[]=" do
+  it "sets the value of the given key in the storage of the current fiber" do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       Fiber.new(storage: {life: 42}) { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
     end
+  end
 
-    it "sets the value of the given key in the storage of the current fiber" do
+  it "sets the value of the given key in the storage of the current fiber" do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       Fiber.new(storage: {life: 42}) { Fiber[:death] = 43; Fiber[:death] }.resume.should == 43
     end
+  end
 
-    it "sets the value of the given key in the storage of the current fiber" do
+  it "sets the value of the given key in the storage of the current fiber" do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
     end
+  end
 
-    it "does not overwrite the storage of the parent fiber" do
+  it "does not overwrite the storage of the parent fiber" do
+    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
       f = Fiber.new(storage: {life: 42}) do
         Fiber.yield Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume
         Fiber[:life]
@@ -125,8 +131,10 @@ ruby_version_is "3.2" do
       f.resume.should == 43 # Value of the inner fiber
       f.resume.should == 42 # Value of the outer fiber
     end
+  end
 
-    it "can't access the storage of the fiber with non-symbol keys" do
+  it "can't access the storage of the fiber with non-symbol keys" do
+    NATFIXME 'Implement Fiber.[]=', exception: SpecFailedException do
       -> { Fiber[Object.new] = 44 }.should raise_error(TypeError)
     end
   end
@@ -136,7 +144,9 @@ ruby_version_is "3.2" do
       Fiber.new(storage: {life: 42}) { Fiber[:life] = nil; Fiber.current.storage }.resume.should == {}
     end
   end
+end
 
+ruby_version_is "3.2" do
   describe "Thread.new" do
     it "creates a thread with the storage of the current fiber" do
       fiber = Fiber.new(storage: {life: 42}) do

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -11,9 +11,7 @@ describe "Fiber.new(storage:)" do
   end
 
   it "creates a fiber with lazily initialized storage" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      Fiber.new(storage: nil) { Fiber[:x] = 10; Fiber.current.storage }.resume.should == {x: 10}
-    end
+    Fiber.new(storage: nil) { Fiber[:x] = 10; Fiber.current.storage }.resume.should == {x: 10}
   end
 
   it "creates a fiber by inheriting the storage of the parent fiber" do
@@ -47,14 +45,12 @@ end
 
 describe "Fiber#storage=" do
   it "can clear the storage of the fiber" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      fiber = Fiber.new(storage: {life: 42}) do
-        Fiber.current.storage = nil
-        Fiber[:x] = 10
-        Fiber.current.storage
-      end
-      fiber.resume.should == {x: 10}
+    fiber = Fiber.new(storage: {life: 42}) do
+      Fiber.current.storage = nil
+      Fiber[:x] = 10
+      Fiber.current.storage
     end
+    fiber.resume.should == {x: 10}
   end
 
   it "can set the storage of the fiber" do
@@ -105,38 +101,28 @@ end
 
 describe "Fiber.[]=" do
   it "sets the value of the given key in the storage of the current fiber" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      Fiber.new(storage: {life: 42}) { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
-    end
+    Fiber.new(storage: {life: 42}) { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
   end
 
   it "sets the value of the given key in the storage of the current fiber" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      Fiber.new(storage: {life: 42}) { Fiber[:death] = 43; Fiber[:death] }.resume.should == 43
-    end
+    Fiber.new(storage: {life: 42}) { Fiber[:death] = 43; Fiber[:death] }.resume.should == 43
   end
 
   it "sets the value of the given key in the storage of the current fiber" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
-    end
+    Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
   end
 
   it "does not overwrite the storage of the parent fiber" do
-    NATFIXME 'Implement Fiber.[]=', exception: NoMethodError, message: "undefined method `[]=' for Fiber:Class" do
-      f = Fiber.new(storage: {life: 42}) do
-        Fiber.yield Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume
-        Fiber[:life]
-      end
-      f.resume.should == 43 # Value of the inner fiber
-      f.resume.should == 42 # Value of the outer fiber
+    f = Fiber.new(storage: {life: 42}) do
+      Fiber.yield Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume
+      Fiber[:life]
     end
+    f.resume.should == 43 # Value of the inner fiber
+    f.resume.should == 42 # Value of the outer fiber
   end
 
   it "can't access the storage of the fiber with non-symbol keys" do
-    NATFIXME 'Implement Fiber.[]=', exception: SpecFailedException do
-      -> { Fiber[Object.new] = 44 }.should raise_error(TypeError)
-    end
+    -> { Fiber[Object.new] = 44 }.should raise_error(TypeError)
   end
 
   ruby_version_is "3.3" do

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -45,9 +45,9 @@ describe "Fiber#storage" do
   end
 end
 
-ruby_version_is "3.2" do
-  describe "Fiber#storage=" do
-    it "can clear the storage of the fiber" do
+describe "Fiber#storage=" do
+  it "can clear the storage of the fiber" do
+    NATFIXME 'Implement Fiber#storage=', exception: NoMethodError, message: "undefined method `storage='" do
       fiber = Fiber.new(storage: {life: 42}) do
         Fiber.current.storage = nil
         Fiber[:x] = 10
@@ -55,28 +55,38 @@ ruby_version_is "3.2" do
       end
       fiber.resume.should == {x: 10}
     end
+  end
 
-    it "can set the storage of the fiber" do
+  it "can set the storage of the fiber" do
+    NATFIXME 'Implement Fiber#storage=', exception: NoMethodError, message: "undefined method `storage='" do
       fiber = Fiber.new(storage: {life: 42}) do
         Fiber.current.storage = {life: 43}
         Fiber.current.storage
       end
       fiber.resume.should == {life: 43}
     end
+  end
 
-    it "can't set the storage of the fiber to non-hash" do
+  it "can't set the storage of the fiber to non-hash" do
+    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
       -> { Fiber.current.storage = 42 }.should raise_error(TypeError)
-    end
-
-    it "can't set the storage of the fiber to a frozen hash" do
-      -> { Fiber.current.storage = {life: 43}.freeze }.should raise_error(FrozenError)
-    end
-
-    it "can't set the storage of the fiber to a hash with non-symbol keys" do
-      -> { Fiber.current.storage = {life: 43, Object.new => 44} }.should raise_error(TypeError)
     end
   end
 
+  it "can't set the storage of the fiber to a frozen hash" do
+    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
+      -> { Fiber.current.storage = {life: 43}.freeze }.should raise_error(FrozenError)
+    end
+  end
+
+  it "can't set the storage of the fiber to a hash with non-symbol keys" do
+    NATFIXME 'Implement Fiber#storage=', exception: SpecFailedException do
+      -> { Fiber.current.storage = {life: 43, Object.new => 44} }.should raise_error(TypeError)
+    end
+  end
+end
+
+ruby_version_is "3.2" do
   describe "Fiber.[]" do
     it "returns the value of the given key in the storage of the current fiber" do
       Fiber.new(storage: {life: 42}) { Fiber[:life] }.resume.should == 42

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -20,9 +20,7 @@ describe "Fiber.new(storage:)" do
     fiber = Fiber.new(storage: {life: 42}) do
       Fiber.new { Fiber.current.storage }.resume
     end
-    NATFIXME 'creates a fiber by inheriting the storage of the parent fiber', exception: SpecFailedException do
-      fiber.resume.should == {life: 42}
-    end
+    fiber.resume.should == {life: 42}
   end
 
   it "cannot create a fiber with non-hash storage" do

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -40,12 +40,10 @@ end
 
 describe "Fiber#storage" do
   it "cannot be accessed from a different fiber" do
-    NATFIXME 'Access checks onf Fiber#storage', exception: SpecFailedException do
-      f = Fiber.new(storage: {life: 42}) { nil }
-      -> {
-        f.storage
-      }.should raise_error(ArgumentError, /Fiber storage can only be accessed from the Fiber it belongs to/)
-    end
+    f = Fiber.new(storage: {life: 42}) { nil }
+    -> {
+      f.storage
+    }.should raise_error(ArgumentError, /Fiber storage can only be accessed from the Fiber it belongs to/)
   end
 end
 

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -1,0 +1,141 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.2" do
+  describe "Fiber.new(storage:)" do
+    it "creates a Fiber with the given storage" do
+      storage = {life: 42}
+      fiber = Fiber.new(storage: storage) { Fiber.current.storage }
+      fiber.resume.should == storage
+    end
+
+    it "creates a fiber with lazily initialized storage" do
+      Fiber.new(storage: nil) { Fiber[:x] = 10; Fiber.current.storage }.resume.should == {x: 10}
+    end
+
+    it "creates a fiber by inheriting the storage of the parent fiber" do
+      fiber = Fiber.new(storage: {life: 42}) do
+        Fiber.new { Fiber.current.storage }.resume
+      end
+      fiber.resume.should == {life: 42}
+    end
+
+    it "cannot create a fiber with non-hash storage" do
+      -> { Fiber.new(storage: 42) {} }.should raise_error(TypeError)
+    end
+
+    it "cannot create a fiber with a frozen hash as storage" do
+      -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
+    end
+
+    it "cannot create a fiber with a storage hash with non-symbol keys" do
+      -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
+    end
+  end
+
+  describe "Fiber#storage" do
+    it "cannot be accessed from a different fiber" do
+      f = Fiber.new(storage: {life: 42}) { nil }
+      -> {
+        f.storage
+      }.should raise_error(ArgumentError, /Fiber storage can only be accessed from the Fiber it belongs to/)
+    end
+  end
+
+  describe "Fiber#storage=" do
+    it "can clear the storage of the fiber" do
+      fiber = Fiber.new(storage: {life: 42}) do
+        Fiber.current.storage = nil
+        Fiber[:x] = 10
+        Fiber.current.storage
+      end
+      fiber.resume.should == {x: 10}
+    end
+
+    it "can set the storage of the fiber" do
+      fiber = Fiber.new(storage: {life: 42}) do
+        Fiber.current.storage = {life: 43}
+        Fiber.current.storage
+      end
+      fiber.resume.should == {life: 43}
+    end
+
+    it "can't set the storage of the fiber to non-hash" do
+      -> { Fiber.current.storage = 42 }.should raise_error(TypeError)
+    end
+
+    it "can't set the storage of the fiber to a frozen hash" do
+      -> { Fiber.current.storage = {life: 43}.freeze }.should raise_error(FrozenError)
+    end
+
+    it "can't set the storage of the fiber to a hash with non-symbol keys" do
+      -> { Fiber.current.storage = {life: 43, Object.new => 44} }.should raise_error(TypeError)
+    end
+  end
+
+  describe "Fiber.[]" do
+    it "returns the value of the given key in the storage of the current fiber" do
+      Fiber.new(storage: {life: 42}) { Fiber[:life] }.resume.should == 42
+    end
+
+    it "returns nil if the key is not present in the storage of the current fiber" do
+      Fiber.new(storage: {life: 42}) { Fiber[:death] }.resume.should be_nil
+    end
+
+    it "returns nil if the current fiber has no storage" do
+      Fiber.new { Fiber[:life] }.resume.should be_nil
+    end
+
+    it "can access the storage of the parent fiber" do
+      f = Fiber.new(storage: {life: 42}) do
+        Fiber.new { Fiber[:life] }.resume
+      end
+      f.resume.should == 42
+    end
+
+    it "can't access the storage of the fiber with non-symbol keys" do
+      -> { Fiber[Object.new] }.should raise_error(TypeError)
+    end
+  end
+
+  describe "Fiber.[]=" do
+    it "sets the value of the given key in the storage of the current fiber" do
+      Fiber.new(storage: {life: 42}) { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
+    end
+
+    it "sets the value of the given key in the storage of the current fiber" do
+      Fiber.new(storage: {life: 42}) { Fiber[:death] = 43; Fiber[:death] }.resume.should == 43
+    end
+
+    it "sets the value of the given key in the storage of the current fiber" do
+      Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
+    end
+
+    it "does not overwrite the storage of the parent fiber" do
+      f = Fiber.new(storage: {life: 42}) do
+        Fiber.yield Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume
+        Fiber[:life]
+      end
+      f.resume.should == 43 # Value of the inner fiber
+      f.resume.should == 42 # Value of the outer fiber
+    end
+
+    it "can't access the storage of the fiber with non-symbol keys" do
+      -> { Fiber[Object.new] = 44 }.should raise_error(TypeError)
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "deletes the fiber storage key when assigning nil" do
+      Fiber.new(storage: {life: 42}) { Fiber[:life] = nil; Fiber.current.storage }.resume.should == {}
+    end
+  end
+
+  describe "Thread.new" do
+    it "creates a thread with the storage of the current fiber" do
+      fiber = Fiber.new(storage: {life: 42}) do
+        Thread.new { Fiber.current.storage }.value
+      end
+      fiber.resume.should == {life: 42}
+    end
+  end
+end

--- a/spec/core/fiber/storage_spec.rb
+++ b/spec/core/fiber/storage_spec.rb
@@ -132,9 +132,9 @@ describe "Fiber.[]=" do
   end
 end
 
-ruby_version_is "3.2" do
-  describe "Thread.new" do
-    it "creates a thread with the storage of the current fiber" do
+describe "Thread.new" do
+  it "creates a thread with the storage of the current fiber" do
+    NATFIXME 'Threads', exception: NameError, message: 'uninitialized constant Thread' do
       fiber = Fiber.new(storage: {life: 42}) do
         Thread.new { Fiber.current.storage }.value
       end

--- a/spec/library/set/shared/inspect.rb
+++ b/spec/library/set/shared/inspect.rb
@@ -15,9 +15,11 @@ describe :set_inspect, shared: true do
     Set["1", "2"].send(@method).should include('", "')
   end
 
-  it "correctly handles self-references" do
-    (set = Set[]) << set
-    set.send(@method).should be_kind_of(String)
-    set.send(@method).should include("#<Set: {...}>")
+  it "correctly handles cyclic-references" do
+    set1 = Set[]
+    set2 = Set[set1]
+    set1 << set2
+    set1.send(@method).should be_kind_of(String)
+    set1.send(@method).should include("#<Set: {...}>")
   end
 end

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -80,6 +80,15 @@ Value FiberObject::ref(Env *env, Value key) {
     return fiber->m_storage->ref(env, key);
 }
 
+Value FiberObject::refeq(Env *env, Value key, Value value) {
+    if (!key->is_symbol())
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key->klass()->inspect_str());
+    if (s_current->m_storage == nullptr)
+        s_current->m_storage = new HashObject {};
+    s_current->m_storage->refeq(env, key, value);
+    return value;
+}
+
 Value FiberObject::resume(Env *env, Args args) {
     if (m_status == Status::Terminated)
         env->raise("FiberError", "dead fiber called");

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -69,6 +69,17 @@ Value FiberObject::is_blocking_current() {
     return s_current->is_blocking() ? IntegerObject::create(1) : FalseObject::the();
 }
 
+Value FiberObject::ref(Env *env, Value key) {
+    if (!key->is_symbol())
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key->klass()->inspect_str());
+    auto fiber = s_current;
+    while ((fiber->m_storage == nullptr || !fiber->m_storage->has_key(env, key)) && fiber->m_previous_fiber != nullptr)
+        fiber = fiber->m_previous_fiber;
+    if (fiber->m_storage == nullptr)
+        return NilObject::the();
+    return fiber->m_storage->ref(env, key);
+}
+
 Value FiberObject::resume(Env *env, Args args) {
     if (m_status == Status::Terminated)
         env->raise("FiberError", "dead fiber called");

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -97,9 +97,14 @@ Value FiberObject::resume(Env *env, Args args) {
 }
 
 Value FiberObject::storage(Env *env) const {
-    if (this != FiberObject::current())
+    auto fiber = FiberObject::current();
+    if (this != fiber)
         env->raise("ArgumentError", "Fiber storage can only be accessed from the Fiber it belongs to");
-    return m_storage;
+    while (fiber->m_storage == nullptr && fiber->m_previous_fiber != nullptr)
+        fiber = fiber->m_previous_fiber;
+    if (fiber->m_storage == nullptr)
+        return NilObject::the();
+    return fiber->m_storage;
 }
 
 Value FiberObject::yield(Env *env, Args args) {

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -96,7 +96,9 @@ Value FiberObject::resume(Env *env, Args args) {
     }
 }
 
-Value FiberObject::storage(Env *) const {
+Value FiberObject::storage(Env *env) const {
+    if (this != FiberObject::current())
+        env->raise("ArgumentError", "Fiber storage can only be accessed from the Fiber it belongs to");
     return m_storage;
 }
 

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -96,6 +96,24 @@ Value FiberObject::resume(Env *env, Args args) {
     }
 }
 
+Value FiberObject::set_storage(Env *env, Value storage) {
+    if (storage == nullptr || storage->is_nil()) {
+        m_storage = nullptr;
+    } else if (!storage->is_hash()) {
+        env->raise("TypeError", "storage must be a hash");
+    } else {
+        if (storage->is_frozen())
+            env->raise("FrozenError", "storage must not be frozen");
+        auto *hash = storage->as_hash();
+        for (auto it = hash->begin(); it != hash->end(); it++) {
+            if (!it->key->is_symbol())
+                env->raise("TypeError", "wrong argument type Object (expected Symbol)");
+        }
+        m_storage = hash;
+    }
+    return m_storage;
+}
+
 Value FiberObject::storage(Env *env) const {
     auto fiber = FiberObject::current();
     if (this != fiber)

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -96,6 +96,10 @@ Value FiberObject::resume(Env *env, Args args) {
     }
 }
 
+Value FiberObject::storage(Env *) const {
+    return m_storage;
+}
+
 Value FiberObject::yield(Env *env, Args args) {
     auto current_fiber = FiberObject::current();
     if (!current_fiber->m_previous_fiber)


### PR DESCRIPTION
Even though this is a Ruby 3.2 feature, it can be a very useful tool to handle some issues with cyclic data structures in our code. For example, the cycle detection of `Set#inspect` only works for 1 level depth:
```ruby
def inspect
  items = to_a.map { |e| equal?(e) ? '#<Set: {...}>' : e.inspect }
  "#<Set: {#{items.join(', ')}}>"
end 
```
This passes the specs because the specs are simply 1 level deep:
```ruby
it "correctly handles self-references" do
  (set = Set[]) << set
  set.send(@method).should be_kind_of(String)
  set.send(@method).should include("#<Set: {...}>")
end
```
It would result in an infinite loop if we had a depth of more than 1:
```ruby
a = Set[]
b = Set[a]
a << b
a.inspect
```
With Fiber storage, we could resolve this with something like this:
```ruby
def inspect
  if Fiber[:set_inspect_current]
    if Fiber[:set_inspect_current].include?(object_id)
      "<Set {....}>" # Cycle detected 
    else
      Fiber[:set_inspect_current] << object_id
      "<Set: #{each(&:inspect).join(', ')}>" # Current inspect
    end
  else
    # This is the first in a non-recursive call:
    f = Fiber.new(storage: { set_inspect_current: [object_id] }) do
      result = "<Set: #{each(&:inspect).join(', ')}>" # Current inspect
      Fiber[:set_inspect_current] = nil
      result
    end
    f.resume
  end
end
```

We have a number of this kind of issues in the current code base.