### PR TITLE
Add stub file fiber.rb to lib

### DIFF
--- a/lib/fiber.rb
+++ b/lib/fiber.rb
@@ -1,0 +1,5 @@
+# This is a stub file to help the specs that have `require "fiber"` in them. This makes it possible to remove all
+# the work arounds we have in our specs folder, and helps with displaying the actual status on the page
+# <https://natalie-lang.org/specs>.
+# Starting with Ruby 3.1, this file is no longer required and does not do anything on MRI. As soon as the Ruby
+# Specs drop support for Ruby 3.0, we can remove this file again.

--- a/spec/core/fiber/blocking_spec.rb
+++ b/spec/core/fiber/blocking_spec.rb
@@ -1,9 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'shared/blocking'
 
-NATFIXME 'Add a stub fiber.rb', exception: LoadError do
-  require "fiber"
-end
+require "fiber"
 
 describe "Fiber.blocking?" do
   it_behaves_like :non_blocking_fiber, -> { Fiber.blocking? }

--- a/spec/library/fiber/alive_spec.rb
+++ b/spec/library/fiber/alive_spec.rb
@@ -1,8 +1,6 @@
 require_relative '../../spec_helper'
 
-NATFIXME 'Add a stub fiber.rb', exception: LoadError do
-  require 'fiber'
-end
+require 'fiber'
 
 describe "Fiber#alive?" do
   it "returns true for a Fiber that hasn't had #resume called" do

--- a/spec/library/fiber/current_spec.rb
+++ b/spec/library/fiber/current_spec.rb
@@ -1,8 +1,6 @@
 require_relative '../../spec_helper'
 
-NATFIXME 'Add a stub fiber.rb', exception: LoadError do
-  require 'fiber'
-end
+require 'fiber'
 
 describe "Fiber.current" do
   ruby_version_is "3.1" do


### PR DESCRIPTION
This helps with the specs that require this file.

This feels a bit like a hack, but since support for Ruby 3.0 will probably be dropped less than a year from now, I would think this is good enough.
This really improves the overview at https://natalie-lang.org/specs, where most of the Fiber specs now simply crash on the require statement.