### PR TITLE
Implement Proc#source_location

### DIFF
--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -49,6 +49,7 @@ public:
     }
 
     Value call(Env *, Args = {}, Block * = nullptr);
+    Value source_location();
 
     Env *env() { return m_block->env(); }
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1064,6 +1064,7 @@ gen.binding('Proc', 'initialize', 'ProcObject', 'initialize', argc: 0, pass_env:
 gen.binding('Proc', 'arity', 'ProcObject', 'arity', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.binding('Proc', 'call', 'ProcObject', 'call', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Proc', 'lambda?', 'ProcObject', 'is_lambda', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Proc', 'source_location', 'ProcObject', 'source_location', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Proc', 'to_proc', 'ProcObject', 'to_proc', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Proc', 'yield', 'ProcObject', 'call', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 

--- a/spec/core/proc/fixtures/source_location.rb
+++ b/spec/core/proc/fixtures/source_location.rb
@@ -1,0 +1,55 @@
+module ProcSpecs
+  class SourceLocation
+    def self.my_proc
+      proc { true }
+    end
+
+    def self.my_lambda
+      -> { true }
+    end
+
+    def self.my_proc_new
+      Proc.new { true }
+    end
+
+    def self.my_method
+      method(__method__).to_proc
+    end
+
+    def self.my_multiline_proc
+      proc do
+        'a'.upcase
+        1 + 22
+      end
+    end
+
+    def self.my_multiline_lambda
+      -> do
+        'a'.upcase
+        1 + 22
+      end
+    end
+
+    def self.my_multiline_proc_new
+      Proc.new do
+        'a'.upcase
+        1 + 22
+      end
+    end
+
+    def self.my_detached_proc
+      body = proc { true }
+      proc(&body)
+    end
+
+    def self.my_detached_lambda
+      body = -> { true }
+      suppress_warning {lambda(&body)}
+    end
+
+    def self.my_detached_proc_new
+      body = Proc.new { true }
+      Proc.new(&body)
+    end
+  end
+end

--- a/spec/core/proc/source_location_spec.rb
+++ b/spec/core/proc/source_location_spec.rb
@@ -1,0 +1,91 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/source_location'
+
+describe "Proc#source_location" do
+  before :each do
+    @proc = ProcSpecs::SourceLocation.my_proc
+    @lambda = ProcSpecs::SourceLocation.my_lambda
+    @proc_new = ProcSpecs::SourceLocation.my_proc_new
+    @method = ProcSpecs::SourceLocation.my_method
+  end
+
+  it "returns an Array" do
+    @proc.source_location.should be_an_instance_of(Array)
+    @proc_new.source_location.should be_an_instance_of(Array)
+    @lambda.source_location.should be_an_instance_of(Array)
+    @method.source_location.should be_an_instance_of(Array)
+  end
+
+  it "sets the first value to the path of the file in which the proc was defined" do
+    file = @proc.source_location.first
+    file.should be_an_instance_of(String)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
+
+    file = @proc_new.source_location.first
+    file.should be_an_instance_of(String)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
+
+    file = @lambda.source_location.first
+    file.should be_an_instance_of(String)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
+
+    file = @method.source_location.first
+    file.should be_an_instance_of(String)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
+  end
+
+  it "sets the last value to an Integer representing the line on which the proc was defined" do
+    line = @proc.source_location.last
+    line.should be_an_instance_of(Integer)
+    line.should == 4
+
+    line = @proc_new.source_location.last
+    line.should be_an_instance_of(Integer)
+    line.should == 12
+
+    line = @lambda.source_location.last
+    line.should be_an_instance_of(Integer)
+    line.should == 8
+
+    line = @method.source_location.last
+    line.should be_an_instance_of(Integer)
+    line.should == 15
+  end
+
+  it "works even if the proc was created on the same line" do
+    proc { true }.source_location.should == [__FILE__, __LINE__]
+    Proc.new { true }.source_location.should == [__FILE__, __LINE__]
+    -> { true }.source_location.should == [__FILE__, __LINE__]
+  end
+
+  it "returns the first line of a multi-line proc (i.e. the line containing 'proc do')" do
+    ProcSpecs::SourceLocation.my_multiline_proc.source_location.last.should == 20
+    ProcSpecs::SourceLocation.my_multiline_proc_new.source_location.last.should == 34
+    ProcSpecs::SourceLocation.my_multiline_lambda.source_location.last.should == 27
+  end
+
+  it "returns the location of the proc's body; not necessarily the proc itself" do
+    ProcSpecs::SourceLocation.my_detached_proc.source_location.last.should == 41
+    ProcSpecs::SourceLocation.my_detached_proc_new.source_location.last.should == 51
+    ProcSpecs::SourceLocation.my_detached_lambda.source_location.last.should == 46
+  end
+
+  it "returns the same value for a proc-ified method as the method reports" do
+    method = ProcSpecs::SourceLocation.method(:my_proc)
+    proc = method.to_proc
+
+    method.source_location.should == proc.source_location
+  end
+
+  it "returns nil for a core method that has been proc-ified" do
+    method = [].method(:<<)
+    proc = method.to_proc
+
+    proc.source_location.should == nil
+  end
+
+  it "works for eval with a given line" do
+    proc = eval('-> {}', nil, "foo", 100)
+    proc.source_location.should == ["foo", 100]
+  end
+end

--- a/spec/core/proc/source_location_spec.rb
+++ b/spec/core/proc/source_location_spec.rb
@@ -27,7 +27,9 @@ describe "Proc#source_location" do
 
     file = @lambda.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('fixtures/source_location.rb', __dir__)
+    NATFIXME 'It currently uses a relative path for lambda', exception: SpecFailedException do
+      file.should == File.realpath('fixtures/source_location.rb', __dir__)
+    end
 
     file = @method.source_location.first
     file.should be_an_instance_of(String)
@@ -45,47 +47,63 @@ describe "Proc#source_location" do
 
     line = @lambda.source_location.last
     line.should be_an_instance_of(Integer)
-    line.should == 8
+    NATFIXME 'Fix line in Env', exception: SpecFailedException do
+      line.should == 8
+    end
 
     line = @method.source_location.last
     line.should be_an_instance_of(Integer)
-    line.should == 15
+    NATFIXME 'Fix line in Env', exception: SpecFailedException do
+      line.should == 15
+    end
   end
 
   it "works even if the proc was created on the same line" do
     proc { true }.source_location.should == [__FILE__, __LINE__]
     Proc.new { true }.source_location.should == [__FILE__, __LINE__]
-    -> { true }.source_location.should == [__FILE__, __LINE__]
+    NATFIXME 'Fix line in Env', exception: SpecFailedException do
+      -> { true }.source_location.should == [__FILE__, __LINE__]
+    end
   end
 
   it "returns the first line of a multi-line proc (i.e. the line containing 'proc do')" do
     ProcSpecs::SourceLocation.my_multiline_proc.source_location.last.should == 20
     ProcSpecs::SourceLocation.my_multiline_proc_new.source_location.last.should == 34
-    ProcSpecs::SourceLocation.my_multiline_lambda.source_location.last.should == 27
+    NATFIXME "returns the first line of a multi-line proc (i.e. the line containing 'proc do'", exception: SpecFailedException do
+      ProcSpecs::SourceLocation.my_multiline_lambda.source_location.last.should == 27
+    end
   end
 
   it "returns the location of the proc's body; not necessarily the proc itself" do
     ProcSpecs::SourceLocation.my_detached_proc.source_location.last.should == 41
     ProcSpecs::SourceLocation.my_detached_proc_new.source_location.last.should == 51
-    ProcSpecs::SourceLocation.my_detached_lambda.source_location.last.should == 46
+    NATFIXME 'Why does this call IO#source_location', exception: NoMethodError, message: /undefined method `source_location' for #\S+:IO/ do
+      ProcSpecs::SourceLocation.my_detached_lambda.source_location.last.should == 46
+    end
   end
 
   it "returns the same value for a proc-ified method as the method reports" do
     method = ProcSpecs::SourceLocation.method(:my_proc)
     proc = method.to_proc
 
-    method.source_location.should == proc.source_location
+    NATFIXME 'Implement Method#source_location', exception: NoMethodError, message: /undefined method `source_location' for .*:Method/ do
+      method.source_location.should == proc.source_location
+    end
   end
 
   it "returns nil for a core method that has been proc-ified" do
     method = [].method(:<<)
     proc = method.to_proc
 
-    proc.source_location.should == nil
+    NATFIXME 'returns nil for a core method that has been proc-ified', exception: SpecFailedException do
+      proc.source_location.should == nil
+    end
   end
 
   it "works for eval with a given line" do
     proc = eval('-> {}', nil, "foo", 100)
-    proc.source_location.should == ["foo", 100]
+    NATFIXME 'Support eval', exception: SpecFailedException do
+      proc.source_location.should == ["foo", 100]
+    end
   end
 end

--- a/spec/core/symbol/to_proc_spec.rb
+++ b/spec/core/symbol/to_proc_spec.rb
@@ -79,8 +79,6 @@ describe "Symbol#to_proc" do
 
   it "produces a proc with source location nil" do
     pr = :to_s.to_proc
-    NATFIXME 'Implement Proc#source_location', exception: NoMethodError, message: "undefined method `source_location'" do
-      pr.source_location.should == nil
-    end
+    pr.source_location.should == nil
   end
 end

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -21,4 +21,11 @@ Value ProcObject::call(Env *env, Args args, Block *block) {
     return NAT_RUN_BLOCK_WITHOUT_BREAK(env, m_block, args, block);
 }
 
+Value ProcObject::source_location() {
+    assert(m_block);
+    auto file = m_block->env()->file();
+    if (file == nullptr) return NilObject::the();
+    return new ArrayObject { new StringObject { file }, Value::integer(static_cast<nat_int_t>(m_block->env()->line())) };
+}
+
 }


### PR DESCRIPTION
I had this one in a local branch for a while, but it needed the changes of https://github.com/ruby/spec/pull/1060 before we could really merge them

The line numbers are often a few lines off, but that is simply because it gets the wrong information from Env. These FIXMEs should probably be changed somewhere in the compiler itself.
Even if the line numbers are a bit off, it's still a really useful tool to debug some things.

Before anyone gets the idea of simply copy-pasting this code to `Method#source_location`: this one does not get any line information, so it would just return `nil`.