### PR TITLE
Refresh spec for File#new

### DIFF
--- a/spec/core/file/new_spec.rb
+++ b/spec/core/file/new_spec.rb
@@ -36,7 +36,7 @@ describe "File.new" do
     end
     File.should.exist?(@file)
   end
-  
+
   it "creates the file and returns writable descriptor when called with 'w' mode and r-o permissions" do
     # it should be possible to write to such a file via returned descriptor,
     # even though the file permissions are r-r-r.
@@ -79,6 +79,26 @@ describe "File.new" do
     File.should.exist?(@file)
   end
 
+  it "returns a new read-only File when mode is not specified" do
+    @fh = File.new(@file)
+
+    NATFIXME 'Raise correct exception (possible issue in IO#puts)', exception: SpecFailedException do
+      -> { @fh.puts("test") }.should raise_error(IOError)
+      @fh.read.should == ""
+      File.should.exist?(@file)
+    end
+  end
+
+  it "returns a new read-only File when mode is not specified but flags option is present" do
+    NATFIXME 'Keyword options', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      @fh = File.new(@file, flags: File::CREAT)
+
+      -> { @fh.puts("test") }.should raise_error(IOError)
+      @fh.read.should == ""
+      File.should.exist?(@file)
+    end
+  end
+
   it "creates a new file when use File::EXCL mode" do
     @fh = File.new(@file, File::EXCL)
     @fh.should be_kind_of(File)
@@ -113,11 +133,34 @@ describe "File.new" do
     File.should.exist?(@file)
   end
 
-
   it "creates a new file when use File::WRONLY|File::TRUNC mode" do
     @fh = File.new(@file, File::WRONLY|File::TRUNC)
     @fh.should be_kind_of(File)
     File.should.exist?(@file)
+  end
+
+  it "returns a new read-only File when use File::RDONLY|File::CREAT mode" do
+    @fh = File.new(@file, File::RDONLY|File::CREAT)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+
+    # it's read-only
+    NATFIXME 'Raise correct exception (possible issue in IO#puts)', exception: SpecFailedException do
+      -> { @fh.puts("test") }.should raise_error(IOError)
+    end
+    @fh.read.should == ""
+  end
+
+  it "returns a new read-only File when use File::CREAT mode" do
+    @fh = File.new(@file, File::CREAT)
+    @fh.should be_kind_of(File)
+    File.should.exist?(@file)
+
+    # it's read-only
+    NATFIXME 'Raise correct exception (possible issue in IO#puts)', exception: SpecFailedException do
+      -> { @fh.puts("test") }.should raise_error(IOError)
+    end
+    @fh.read.should == ""
   end
 
   it "coerces filename using to_str" do
@@ -132,6 +175,30 @@ describe "File.new" do
     name.should_receive(:to_path).and_return(@file)
     @fh = File.new(name, "w")
     File.should.exist?(@file)
+  end
+
+  it "accepts options as a keyword argument" do
+    NATFIXME 'Keyword options', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
+      @fh = File.new(@file, 'w', 0755, flags: @flags)
+      @fh.should be_kind_of(File)
+      @fh.close
+
+      -> {
+        @fh = File.new(@file, 'w', 0755, {flags: @flags})
+      }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 1..3)")
+    end
+  end
+
+  it "bitwise-ORs mode and flags option" do
+    NATFIXME 'Keyword options', exception: SpecFailedException do
+      -> {
+        @fh = File.new(@file, 'w', flags: File::EXCL)
+      }.should raise_error(Errno::EEXIST, /File exists/)
+
+      -> {
+        @fh = File.new(@file, mode: 'w', flags: File::EXCL)
+      }.should raise_error(Errno::EEXIST, /File exists/)
+    end
   end
 
   it "raises a TypeError if the first parameter can't be coerced to a string" do


### PR DESCRIPTION
This includes some new tests, e.g. keyword arguments and access checks.

It turns out the issues mentioned in #1176 do get tested with `File.new`