### PR TITLE
Prefer String#unpack1 over chaining unpack and first

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -4,7 +4,7 @@ module Base64
   end
 
   def self.decode64(str)
-    str.unpack("m").first
+    str.unpack1("m")
   end
 
   def self.strict_encode64(str)
@@ -12,7 +12,7 @@ module Base64
   end
 
   def self.strict_decode64(str)
-    str.unpack("m0").first
+    str.unpack1("m0")
   end
 
   def self.urlsafe_encode64(bin, padding: true)


### PR DESCRIPTION
This is in line with the Style/UnpackFirst rule of Rubocop. This is faster by removing the temporary array (except in the current state of Natalie)