### PR TITLE
Implement IO#fcntl

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -51,6 +51,7 @@ public:
     Value append(Env *, Value);
     Value close(Env *);
     Value each_byte(Env *, Block *);
+    Value fcntl(Env *, Value, Value = nullptr);
     int fdatasync(Env *);
     int fileno() const;
     int fileno(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -890,6 +890,7 @@ gen.binding('IO', 'advise', 'IoObject', 'advise', argc: 1..3, pass_env: true, pa
 gen.binding('IO', 'close', 'IoObject', 'close', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'closed?', 'IoObject', 'is_closed', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('IO', 'each_byte', 'IoObject', 'each_byte', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('IO', 'fcntl', 'IoObject', 'fcntl', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'fdatasync', 'IoObject', 'fdatasync', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'fsync', 'IoObject', 'fsync', argc: 0, pass_env: true, pass_block: false, return_type: :int)

--- a/spec/core/io/fcntl_spec.rb
+++ b/spec/core/io/fcntl_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#fcntl" do
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.fcntl(5, 5) }.should raise_error(IOError)
+  end
+end


### PR DESCRIPTION
Since I had to use `fcntl` in  #1195, the generic interface to the method was pretty easy to do.