### PR TITLE
Fix some compiler warnings, an integer overflow bug, a bug in our spec runner, document a compiler bug, and some other miscellaneous stuff

### DIFF
--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -62,7 +62,9 @@ public:
         size_t length = (size_t)integer->to_nat_int_t();
         char buffer[length];
 #ifdef __linux__
-        getrandom(buffer, length, 0);
+        auto result = getrandom(buffer, length, 0);
+        if (result == -1)
+            env->raise_errno();
 #else
         arc4random_buf(buffer, length);
 #endif

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -49,7 +49,6 @@ module Natalie
         [
           init_symbols.join("\n"),
           set_dollar_zero_global_in_main_to_c,
-          set_compiler_version_to_c,
         ].compact.join("\n\n")
       end
 
@@ -69,10 +68,6 @@ module Natalie
         "env->global_set(\"$0\"_s, new StringObject { #{@compiler_context[:source_path].inspect} });"
       end
 
-      # NOTE: This is just used for tests and will likely be removed in the future.
-      def set_compiler_version_to_c
-        'GlobalEnv::the()->Object()->const_set("NATALIE_COMPILER"_s, new StringObject("v2"));'
-      end
 
       def symbols_var_name
         "#{@compiler_context[:var_prefix]}symbols"

--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -14,6 +14,7 @@ module Natalie
         -Wall
         -Wextra
         -Werror
+        -Wunused-result
         -Wno-missing-field-initializers
         -Wno-unused-parameter
         -Wno-unused-variable

--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -3,8 +3,7 @@ module Natalie
     module Flags
       RELEASE_FLAGS = %w[
         -pthread
-        -g
-        -O2
+        -O3
         -Wno-unused-value
       ].freeze
 

--- a/spec/language/undef_spec.rb
+++ b/spec/language/undef_spec.rb
@@ -69,13 +69,15 @@ describe "The undef keyword" do
   end
 
   it "raises a NameError when passed a missing name" do
-    Class.new do
-      -> {
-         undef not_exist
-      }.should raise_error(NameError) { |e|
-        # a NameError and not a NoMethodError
-        e.class.should == NameError
-      }
+    NATFIXME 'should raise', exception: SpecFailedException, message: /should have raised an error/ do
+      Class.new do
+        -> {
+          undef not_exist
+        }.should raise_error(NameError) { |e|
+          # a NameError and not a NoMethodError
+          e.class.should == NameError
+        }
+      end
     end
   end
 end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -531,7 +531,8 @@ Value ArrayObject::fill(Env *env, Value obj, Value start_obj, Value length_obj, 
                 if (length <= 0)
                     return this;
 
-                max = start + length;
+                if (__builtin_add_overflow(start, length, &max))
+                    env->raise("ArgumentError", "argument too big");
             }
         }
     }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -214,8 +214,8 @@ Value IoObject::append(Env *env, Value obj) {
     if (!obj->is_string() && obj->respond_to(env, "to_str"_s))
         obj = obj.send(env, "to_s"_s);
     obj->assert_type(env, Object::Type::String, "String");
-    ::write(m_fileno, obj->as_string()->c_str(), obj->as_string()->length());
-    if (errno) env->raise_errno();
+    auto result = ::write(m_fileno, obj->as_string()->c_str(), obj->as_string()->length());
+    if (result == -1) env->raise_errno();
     return this;
 }
 

--- a/src/struct.rb
+++ b/src/struct.rb
@@ -25,6 +25,10 @@ class Struct
 
       if attrs.last.is_a?(Hash)
         options = attrs.pop
+        unknown_keys = options.keys.difference([:keyword_init])
+        if unknown_keys.any?
+          raise ArgumentError, "unknown keyword: #{unknown_keys.map(&:inspect).join(', ')}"
+        end
       else
         options = {}
       end

--- a/test/natalie/assign_test.rb
+++ b/test/natalie/assign_test.rb
@@ -150,7 +150,7 @@ describe 'assignment' do
   end
 
   it 'errors when an object responds to to_ary but returns a non-array' do
-    if RUBY_PLATFORM == 'ruby' || compiler?
+    if RUBY_PLATFORM == 'ruby'
       bal = BadArrayLike.new(1, 2)
       -> { a, b = bal }.should raise_error(TypeError)
       -> { [bal].each { |a, b, c| } }.should raise_error(TypeError)

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -201,10 +201,8 @@ describe 'method' do
     default_nils.should == [nil, nil]
     default_nils(1).should == [1, nil]
     default_nils(1, 2).should == [1, 2]
-    if compiler?
-      out = `bin/natalie -c2 -e "def circular_argument_reference(a = a); a; end" 2>&1`
-      out.should =~ /circular argument reference - a \(SyntaxError\)/
-    end
+    out = `bin/natalie -c2 -e "def circular_argument_reference(a = a); a; end" 2>&1`
+    out.should =~ /circular argument reference - a \(SyntaxError\)/
   end
 
   def default_first1(x = 1)
@@ -456,7 +454,7 @@ describe 'method with keyword args' do
     method_with_kwargs8(a: 1).should == [1, nil]
     method_with_kwargs9.should == [1, 2]
     method_with_kwargs9('a').should == ['a', 2]
-    method_with_kwargs9({ b: 'b' }).should == [{ b: 'b' }, 2] if compiler?
+    method_with_kwargs9({ b: 'b' }).should == [{ b: 'b' }, 2]
     method_with_kwargs9(b: 'b').should == [1, 'b']
     method_with_kwargs9('a', b: 'b').should == %w[a b]
     method_with_kwargs10(b: 'b').should == [1]

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -201,7 +201,7 @@ describe 'method' do
     default_nils.should == [nil, nil]
     default_nils(1).should == [1, nil]
     default_nils(1, 2).should == [1, 2]
-    out = `bin/natalie -c2 -e "def circular_argument_reference(a = a); a; end" 2>&1`
+    out = `bin/natalie -e "def circular_argument_reference(a = a); a; end" 2>&1`
     out.should =~ /circular argument reference - a \(SyntaxError\)/
   end
 

--- a/test/runner.rb
+++ b/test/runner.rb
@@ -10,7 +10,7 @@
 #
 # usage with flags:
 #
-#     bin/natalie -c2 test/runner.rb -- -c2 spec/core/array/pack/{a,b}_spec.rb
+#     bin/natalie test/runner.rb --log-load-error spec/core/array/pack/{a,b}_spec.rb
 
 require_relative 'support/nat_binary'
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,8 +1,2 @@
 require_relative 'support/spec'
 require_relative 'support/nat_binary'
-
-def compiler?
-  NATALIE_COMPILER == 'v2'
-rescue NameError
-  false
-end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -761,12 +761,19 @@ class RaiseErrorExpectation
   def match(subject)
     if @block
       # given a block, we rescue everything!
+
+      # FIXME: There is a bug here with rescue + else. See #1201.
+      caught = false
+
       begin
         subject.call
       rescue Exception => e
+        caught = true
         @block.call(e)
       else
-        raise SpecFailedException, "#{subject.inspect} should have raised an error, but instead raised nothing"
+        unless caught
+          raise SpecFailedException, "#{subject.inspect} should have raised an error, but instead raised nothing"
+        end
       end
       return
     end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -765,6 +765,8 @@ class RaiseErrorExpectation
         subject.call
       rescue Exception => e
         @block.call(e)
+      else
+        raise SpecFailedException, "#{subject.inspect} should have raised an error, but instead raised nothing"
       end
       return
     end


### PR DESCRIPTION
This was quite a yak shave, and I don't have the energy to separate it into a bunch of small PRs. So this is a grab bag.

Here is my story:

1. Notice a few warnings with the release build of Natalie, e.g. `rake build_release`.
2. Fix those warnings, one of them being an integer overflow, which should have been caught by specs.
3. Notice that some specs using the `RaiseErrorExpectation` with a block aren't failing as they should. Fix that.
4. That causes several more false-positives to start failing in the suite.
5. Find a compiler bug. See #1201.
6. Cry.