### PR TITLE
Add length and offset parameters to IO.read

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -73,7 +73,7 @@ public:
     Value stat(Env *) const;
     static Value sysopen(Env *, Value, Value = nullptr, Value = nullptr);
     Value read(Env *, Value) const;
-    static Value read_file(Env *, Value);
+    static Value read_file(Env *, Value, Value = nullptr);
     Value readbyte(Env *);
     Value readline(Env *) const;
     int rewind(Env *);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -73,7 +73,7 @@ public:
     Value stat(Env *) const;
     static Value sysopen(Env *, Value, Value = nullptr, Value = nullptr);
     Value read(Env *, Value) const;
-    static Value read_file(Env *, Value, Value = nullptr);
+    static Value read_file(Env *, Value, Value = nullptr, Value = nullptr);
     Value readbyte(Env *);
     Value readline(Env *) const;
     int rewind(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -881,7 +881,7 @@ gen.binding('Integer', 'truncate', 'IntegerObject', 'truncate', argc: 0..1, pass
 gen.binding('Integer', '|', 'IntegerObject', 'bitwise_or', argc: 1, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Integer', 'zero?', 'IntegerObject', 'is_zero', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)
 
-gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'sysopen', 'IoObject', 'sysopen', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -881,7 +881,7 @@ gen.binding('Integer', 'truncate', 'IntegerObject', 'truncate', argc: 0..1, pass
 gen.binding('Integer', '|', 'IntegerObject', 'bitwise_or', argc: 1, pass_env: true, pass_block: false, return_type: :Object, optimized: true)
 gen.binding('Integer', 'zero?', 'IntegerObject', 'is_zero', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)
 
-gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'sysopen', 'IoObject', 'sysopen', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -114,9 +114,7 @@ describe "IO.read" do
   end
 
   it "treats second nil argument as no length limit" do
-    NATFIXME 'nil length arguments', exception: TypeError, message: 'no implicit conversion from nil to integer' do
-      IO.read(@fname, nil).should == @contents
-    end
+    IO.read(@fname, nil).should == @contents
     NATFIXME 'nil length arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, nil, 5).should == IO.read(@fname, @contents.length, 5)
     end

--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -25,7 +25,7 @@ describe "IO.read" do
 
   # https://bugs.ruby-lang.org/issues/19354
   it "accepts options as keyword arguments" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
       IO.read(@fname, 3, 0, mode: "r+").should == @contents[0, 3]
     end
 
@@ -43,9 +43,7 @@ describe "IO.read" do
   end
 
   it "accepts a length, offset, and empty options Hash" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
-      IO.read(@fname, 3, 0, **{}).should == @contents[0, 3]
-    end
+    IO.read(@fname, 3, 0, **{}).should == @contents[0, 3]
   end
 
   it "raises an IOError if the options Hash specifies write mode" do
@@ -81,7 +79,7 @@ describe "IO.read" do
   platform_is_not :windows do
     ruby_version_is ""..."3.3" do
       it "uses an :open_args option" do
-        NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
+        NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
           string = IO.read(@fname, nil, 0, open_args: ["r", nil, {encoding: Encoding::US_ASCII}])
           string.encoding.should == Encoding::US_ASCII
 
@@ -100,14 +98,14 @@ describe "IO.read" do
   end
 
   it "doesn't require mode to be specified in :open_args" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII}])
       string.encoding.should == Encoding::US_ASCII
     end
   end
 
   it "doesn't require mode to be specified in :open_args even if flags option passed" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII, flags: File::CREAT}])
       string.encoding.should == Encoding::US_ASCII
     end
@@ -115,16 +113,12 @@ describe "IO.read" do
 
   it "treats second nil argument as no length limit" do
     IO.read(@fname, nil).should == @contents
-    NATFIXME 'nil length arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
-      IO.read(@fname, nil, 5).should == IO.read(@fname, @contents.length, 5)
-    end
+    IO.read(@fname, nil, 5).should == IO.read(@fname, @contents.length, 5)
   end
 
   it "treats third nil argument as 0" do
-    NATFIXME 'Offset argument', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
-      IO.read(@fname, nil, nil).should == @contents
-      IO.read(@fname, 5, nil).should == IO.read(@fname, 5, 0)
-    end
+    IO.read(@fname, nil, nil).should == @contents
+    IO.read(@fname, 5, nil).should == IO.read(@fname, 5, 0)
   end
 
   it "reads the contents of a file up to a certain size when specified" do
@@ -132,15 +126,11 @@ describe "IO.read" do
   end
 
   it "reads the contents of a file from an offset of a specific size when specified" do
-    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
-      IO.read(@fname, 5, 3).should == @contents.slice(3, 5)
-    end
+    IO.read(@fname, 5, 3).should == @contents.slice(3, 5)
   end
 
   it "returns nil at end-of-file when length is passed" do
-    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
-      IO.read(@fname, 1, 10).should == nil
-    end
+    IO.read(@fname, 1, 10).should == nil
   end
 
   it "raises an Errno::ENOENT when the requested file does not exist" do
@@ -158,10 +148,8 @@ describe "IO.read" do
 
   ruby_version_is ''...'3.3' do
     it "raises an Errno::EINVAL when not passed a valid offset" do
-      NATFIXME 'Length and offset arguments', exception: SpecFailedException do
-        -> { IO.read @fname, 0, -1  }.should raise_error(Errno::EINVAL)
-        -> { IO.read @fname, -1, -1 }.should raise_error(Errno::EINVAL)
-      end
+      -> { IO.read @fname, 0, -1  }.should raise_error(Errno::EINVAL)
+      -> { IO.read @fname, -1, -1 }.should raise_error(Errno::EINVAL)
     end
   end
 

--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -25,7 +25,7 @@ describe "IO.read" do
 
   # https://bugs.ruby-lang.org/issues/19354
   it "accepts options as keyword arguments" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
       IO.read(@fname, 3, 0, mode: "r+").should == @contents[0, 3]
     end
 
@@ -39,13 +39,11 @@ describe "IO.read" do
   end
 
   it "accepts a length, and empty options Hash" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-      IO.read(@fname, 3, **{}).should == @contents[0, 3]
-    end
+    IO.read(@fname, 3, **{}).should == @contents[0, 3]
   end
 
   it "accepts a length, offset, and empty options Hash" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, 3, 0, **{}).should == @contents[0, 3]
     end
   end
@@ -63,19 +61,19 @@ describe "IO.read" do
   end
 
   it "reads the file if the options Hash includes read mode" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       IO.read(@fname, mode: "r").should == @contents
     end
   end
 
   it "reads the file if the options Hash includes read/write mode" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       IO.read(@fname, mode: "r+").should == @contents
     end
   end
 
   it "reads the file if the options Hash includes read/write append mode" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       IO.read(@fname, mode: "a+").should == @contents
     end
   end
@@ -83,7 +81,7 @@ describe "IO.read" do
   platform_is_not :windows do
     ruby_version_is ""..."3.3" do
       it "uses an :open_args option" do
-        NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1)' do
+        NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
           string = IO.read(@fname, nil, 0, open_args: ["r", nil, {encoding: Encoding::US_ASCII}])
           string.encoding.should == Encoding::US_ASCII
 
@@ -95,56 +93,54 @@ describe "IO.read" do
   end
 
   it "disregards other options if :open_args is given" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       string = IO.read(@fname,mode: "w", encoding: Encoding::UTF_32LE, open_args: ["r", encoding: Encoding::UTF_8])
       string.encoding.should == Encoding::UTF_8
     end
   end
 
   it "doesn't require mode to be specified in :open_args" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII}])
       string.encoding.should == Encoding::US_ASCII
     end
   end
 
   it "doesn't require mode to be specified in :open_args even if flags option passed" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..2)' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII, flags: File::CREAT}])
       string.encoding.should == Encoding::US_ASCII
     end
   end
 
   it "treats second nil argument as no length limit" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'nil length arguments', exception: TypeError, message: 'no implicit conversion from nil to integer' do
       IO.read(@fname, nil).should == @contents
     end
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1)' do
+    NATFIXME 'nil length arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, nil, 5).should == IO.read(@fname, @contents.length, 5)
     end
   end
 
   it "treats third nil argument as 0" do
-    NATFIXME 'Offset argument', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1)' do
+    NATFIXME 'Offset argument', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, nil, nil).should == @contents
       IO.read(@fname, 5, nil).should == IO.read(@fname, 5, 0)
     end
   end
 
   it "reads the contents of a file up to a certain size when specified" do
-    NATFIXME 'Length argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-      IO.read(@fname, 5).should == @contents.slice(0..4)
-    end
+    IO.read(@fname, 5).should == @contents.slice(0..4)
   end
 
   it "reads the contents of a file from an offset of a specific size when specified" do
-    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1)' do
+    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, 5, 3).should == @contents.slice(3, 5)
     end
   end
 
   it "returns nil at end-of-file when length is passed" do
-    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1)' do
+    NATFIXME 'Length and offset arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
       IO.read(@fname, 1, 10).should == nil
     end
   end
@@ -179,14 +175,14 @@ describe "IO.read" do
   end
 
   it "uses the external encoding specified via the :external_encoding option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       str = IO.read(@fname, external_encoding: Encoding::ISO_8859_1)
       str.encoding.should == Encoding::ISO_8859_1
     end
   end
 
   it "uses the external encoding specified via the :encoding option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       str = IO.read(@fname, encoding: Encoding::ISO_8859_1)
       str.encoding.should == Encoding::ISO_8859_1
     end
@@ -231,7 +227,7 @@ describe "IO.read from a pipe" do
     platform_is :windows do
       cmd = "|cmd.exe /C echo hello"
     end
-    NATFIXME 'Implement pipe in IO.read', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Implement pipe in IO.read', exception: Errno::ENOENT, message: 'No such file or directory' do
       IO.read(cmd, 1).should == "h"
     end
   end
@@ -270,9 +266,7 @@ describe "IO.read on an empty file" do
   end
 
   it "returns nil when length is passed" do
-    NATFIXME 'Length argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
-      IO.read(@fname, 1).should == nil
-    end
+    IO.read(@fname, 1).should == nil
   end
 
   it "returns an empty string when no length is passed" do
@@ -551,7 +545,7 @@ end
 describe "IO.read with BOM" do
   it "reads a file without a bom" do
     name = fixture __FILE__, "no_bom_UTF-8.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "UTF-8\n"
     end
@@ -559,7 +553,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-8 bom" do
     name = fixture __FILE__, "bom_UTF-8.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-16le")
       result.force_encoding("binary").should == "UTF-8\n"
     end
@@ -567,7 +561,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-16le bom" do
     name = fixture __FILE__, "bom_UTF-16LE.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "U\x00T\x00F\x00-\x001\x006\x00L\x00E\x00\n\x00"
     end
@@ -575,7 +569,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-16be bom" do
     name = fixture __FILE__, "bom_UTF-16BE.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "\x00U\x00T\x00F\x00-\x001\x006\x00B\x00E\x00\n"
     end
@@ -583,7 +577,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-32le bom" do
     name = fixture __FILE__, "bom_UTF-32LE.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "U\x00\x00\x00T\x00\x00\x00F\x00\x00\x00-\x00\x00\x003\x00\x00\x002\x00\x00\x00L\x00\x00\x00E\x00\x00\x00\n\x00\x00\x00"
     end
@@ -591,7 +585,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-32be bom" do
     name = fixture __FILE__, "bom_UTF-32BE.txt"
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 1)' do
+    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "\x00\x00\x00U\x00\x00\x00T\x00\x00\x00F\x00\x00\x00-\x00\x00\x003\x00\x00\x002\x00\x00\x00B\x00\x00\x00E\x00\x00\x00\n"
     end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -156,9 +156,11 @@ bool IoObject::isatty(Env *env) const {
     return ::isatty(m_fileno) == 1;
 }
 
-Value IoObject::read_file(Env *env, Value filename, Value length) {
+Value IoObject::read_file(Env *env, Value filename, Value length, Value offset) {
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, { filename }, nullptr)->as_file();
+    if (offset && !offset->is_nil())
+        file->set_pos(env, offset);
     auto data = file->read(env, length);
     file->close(env);
     return data;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -178,7 +178,7 @@ Value IoObject::write_file(Env *env, Value filename, Value string) {
 Value IoObject::read(Env *env, Value count_value) const {
     raise_if_closed(env);
     size_t bytes_read;
-    if (count_value) {
+    if (count_value && !count_value->is_nil()) {
         count_value->assert_type(env, Object::Type::Integer, "Integer");
         int count = count_value->as_integer()->to_nat_int_t();
         if (count < 0)

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -156,10 +156,10 @@ bool IoObject::isatty(Env *env) const {
     return ::isatty(m_fileno) == 1;
 }
 
-Value IoObject::read_file(Env *env, Value filename) {
+Value IoObject::read_file(Env *env, Value filename, Value length) {
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, { filename }, nullptr)->as_file();
-    auto data = file->read(env, nullptr);
+    auto data = file->read(env, length);
     file->close(env);
     return data;
 }


### PR DESCRIPTION
This accidentally fixes an issue with `IO#read` too, where a `nil` length argument would cause an error.