### PR TITLE
Remove incorrect TODO from IoObject::fsync

### DIFF
--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -125,7 +125,6 @@ int IoObject::fdatasync(Env *env) {
     return 0;
 }
 
-// TODO: check if this IO is writable
 int IoObject::fsync(Env *env) {
     raise_if_closed(env);
     if (::fsync(m_fileno) < 0) env->raise_errno();


### PR DESCRIPTION
It turns out you can call fsync in read only streams in MRI as well.

According to fsync(2): On some UNIX systems (but not Linux), fd must be a writable file descriptor.