### PR TITLE
More fixes to IO#read

### DIFF
--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -295,9 +295,7 @@ describe "IO#read" do
   end
 
   it "consumes zero bytes when reading zero bytes" do
-    NATFIXME 'Empty string when reading zero bytes', exception: SpecFailedException do
-      @io.read(0).should == ''
-    end
+    @io.read(0).should == ''
     @io.pos.should == 0
 
     NATFIXME 'Implement IO#getc', exception: NoMethodError, message: "undefined method `getc'" do

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -189,6 +189,8 @@ Value IoObject::read(Env *env, Value count_value) const {
         bytes_read = ::read(m_fileno, buf, count);
         if (bytes_read == 0) {
             delete[] buf;
+            if (count == 0)
+                return new StringObject {};
             return NilObject::the();
         } else {
             Value result = new StringObject { buf, bytes_read };

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -186,15 +186,14 @@ Value IoObject::read(Env *env, Value count_value) const {
         if (count < 0)
             env->raise("ArgumentError", "negative length {} given", count);
         char *buf = new char[count + 1];
+        auto buf_cleanup = Defer([&]() { delete[] buf; });
         bytes_read = ::read(m_fileno, buf, count);
         if (bytes_read == 0) {
-            delete[] buf;
             if (count == 0)
                 return new StringObject {};
             return NilObject::the();
         } else {
             Value result = new StringObject { buf, bytes_read };
-            delete[] buf;
             return result;
         }
     }


### PR DESCRIPTION
* Return empty string instead of nil in case of explicit 0 length value.
* Simplify cleanup of allocated memory
* Handle errors in the read(2) call