### PR TITLE
Move responsibility of GC visiting members into MethodInfo class

### DIFF
--- a/include/natalie/method_info.hpp
+++ b/include/natalie/method_info.hpp
@@ -30,9 +30,9 @@ public:
 
     bool is_defined() const { return !m_undefined && m_method; }
 
+    void visit_children(Cell::Visitor &);
+
 private:
-    // WARNING: do not add more members to this object without making sure
-    // they are visited by ModuleObject::visit_children().
     MethodVisibility m_visibility { MethodVisibility::Public };
     Method *m_method { nullptr };
     bool m_undefined { false };

--- a/src/method_info.cpp
+++ b/src/method_info.cpp
@@ -1,0 +1,9 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+void MethodInfo::visit_children(Cell::Visitor &visitor) {
+    visitor.visit(m_method);
+}
+
+}

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -845,8 +845,7 @@ void ModuleObject::visit_children(Visitor &visitor) {
     }
     for (auto pair : m_methods) {
         visitor.visit(pair.first);
-        if (pair.second.is_defined())
-            visitor.visit(pair.second.method());
+        pair.second.visit_children(visitor);
     }
     for (auto pair : m_class_vars) {
         visitor.visit(pair.first);

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -5,9 +5,6 @@ SKIP_CLASS_MEMBERS = {
   # NOTE: Args cannot be heap-allocated, so pointers inside are seen on the stack
   'Natalie::Args' => '*',
 
-  # NOTE: visited via ModuleObject
-  'Natalie::MethodInfo' => '*',
-
   # NOTE: each key is already visited via m_hashmap
   'Natalie::HashObject' => %w[m_key_list],
 


### PR DESCRIPTION
That way we can let our GC lint script do the work to catch mistakes.