### PR TITLE
Stop silently truncating bigints

### DIFF
--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "natalie/big_int.hpp"
+#include "natalie/macros.hpp"
 #include "natalie/types.hpp"
 #include "tm/string.hpp"
 
@@ -121,8 +122,8 @@ public:
     nat_int_t to_nat_int_t() const {
         if (is_fixnum())
             return m_fixnum;
-        else // FIXME: this should probably panic since the number likely won't fit in a long long
-            return m_bignum->to_long_long();
+        else
+            NAT_UNREACHABLE();
     }
     double to_double() const;
     TM::String to_string() const;

--- a/spec/core/float/coerce_spec.rb
+++ b/spec/core/float/coerce_spec.rb
@@ -8,13 +8,11 @@ describe "Float#coerce" do
     1.0.coerce("2.5").should == [2.5, 1.0]
     1.0.coerce(3.14).should == [3.14, 1.0]
 
-    NATFIXME 'Coercion of Float with Bignum', exception: SpecFailedException do
-      a, b = -0.0.coerce(bignum_value)
-      a.should be_close(18446744073709551616.0, TOLERANCE)
-      b.should be_close(-0.0, TOLERANCE)
-      a, b = 1.0.coerce(bignum_value)
-      a.should be_close(18446744073709551616.0, TOLERANCE)
-      b.should be_close(1.0, TOLERANCE)
-    end
+    a, b = -0.0.coerce(bignum_value)
+    a.should be_close(18446744073709551616.0, TOLERANCE)
+    b.should be_close(-0.0, TOLERANCE)
+    a, b = 1.0.coerce(bignum_value)
+    a.should be_close(18446744073709551616.0, TOLERANCE)
+    b.should be_close(1.0, TOLERANCE)
   end
 end

--- a/src/array_packer/integer_handler.cpp
+++ b/src/array_packer/integer_handler.cpp
@@ -81,7 +81,12 @@ namespace ArrayPacker {
     }
 
     void IntegerHandler::pack_U() {
-        auto source = m_source->to_nat_int_t();
+        nat_int_t source;
+        if (m_source->is_bignum())
+            source = (m_source->integer().to_bigint() % 256).to_long_long();
+        else
+            source = m_source->to_nat_int_t();
+
         if (source < 128) { // U+007F	    -> 1-byte last code-point
             m_packed.append_char(static_cast<unsigned char>(source));
             return;
@@ -104,25 +109,31 @@ namespace ArrayPacker {
     }
 
     void IntegerHandler::pack_c() {
-        auto source = m_source->to_nat_int_t();
+        nat_int_t source;
         if (m_source->is_bignum())
             source = (m_source->integer().to_bigint() % 256).to_long_long();
+        else
+            source = m_source->to_nat_int_t();
 
         m_packed.append_char(static_cast<signed char>(source));
     }
 
     void IntegerHandler::pack_I() {
-        auto source = (unsigned int)m_source->to_nat_int_t();
+        unsigned int source;
         if (m_source->is_bignum())
             source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(unsigned int))).to_long_long();
+        else
+            source = (unsigned int)m_source->to_nat_int_t();
 
         append_bytes((const char *)(&source), sizeof(source));
     }
 
     void IntegerHandler::pack_i() {
-        auto source = (signed int)m_source->to_nat_int_t();
+        signed int source;
         if (m_source->is_bignum())
             source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+        else
+            source = (signed int)m_source->to_nat_int_t();
 
         append_bytes((const char *)(&source), sizeof(source));
     }
@@ -208,18 +219,22 @@ namespace ArrayPacker {
     }
 
     void IntegerHandler::pack_S() {
-        auto source = (unsigned short)m_source->to_nat_int_t();
+        unsigned short source;
         if (m_source->is_bignum())
             source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+        else
+            source = (unsigned short)m_source->to_nat_int_t();
 
         auto size = m_token.native_size ? sizeof(unsigned short) : 2;
         append_bytes((const char *)&source, size);
     }
 
     void IntegerHandler::pack_s() {
-        auto source = (signed short)m_source->to_nat_int_t();
+        signed short source;
         if (m_source->is_bignum())
             source = (m_source->integer().to_bigint() % ::pow(2, 8 * sizeof(signed int))).to_long_long();
+        else
+            source = (signed short)m_source->to_nat_int_t();
 
         auto size = m_token.native_size ? sizeof(signed short) : 2;
         append_bytes((const char *)&source, size);

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -3,13 +3,19 @@
 namespace Natalie {
 BSearchCheckResult binary_search_check(Env *env, Value block_result) {
     if (block_result->is_numeric()) {
-        auto number = (block_result->is_integer() ? block_result->as_integer()->to_nat_int_t() : block_result->as_float()->to_double());
-
-        if (number == 0)
-            return BSearchCheckResult::EQUAL;
-
-        if (number < 0)
-            return BSearchCheckResult::SMALLER;
+        if (block_result->is_integer()) {
+            auto i = block_result->as_integer();
+            if (i->is_zero())
+                return BSearchCheckResult::EQUAL;
+            else if (i->is_negative())
+                return BSearchCheckResult::SMALLER;
+        } else {
+            auto f = block_result->as_float();
+            if (f->is_zero())
+                return BSearchCheckResult::EQUAL;
+            else if (f->is_negative())
+                return BSearchCheckResult::SMALLER;
+        }
 
         return BSearchCheckResult::BIGGER;
     } else if (block_result->is_boolean() || block_result->is_nil()) {

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -188,7 +188,7 @@ Value FloatObject::coerce(Env *env, Value arg) {
         ary->push(arg);
         break;
     case Object::Type::Integer:
-        ary->push(new FloatObject { arg->as_integer()->to_nat_int_t() });
+        ary->push(Value::floatingpoint(arg->as_integer()->integer().to_double()));
         break;
     default:
         ary->push(KernelModule::Float(env, arg, true));

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -216,7 +216,7 @@ Value IntegerObject::pow(Env *env, Value arg) {
 }
 
 Value IntegerObject::powmod(Env *env, Value exponent, Value mod) {
-    if (exponent->is_integer() && exponent->as_integer()->to_nat_int_t() < 0 && mod)
+    if (exponent->is_integer() && exponent->as_integer()->is_negative() && mod)
         env->raise("RangeError", "2nd argument not allowed when first argument is negative");
 
     auto powd = pow(env, exponent);

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -652,7 +652,7 @@ Value StringObject::concat(Env *env, Args args) {
         StringObject *str_obj;
         if (arg->is_string()) {
             str_obj = arg->as_string();
-        } else if (arg->is_integer() && arg->as_integer()->to_nat_int_t() < 0) {
+        } else if (arg->is_integer() && arg->as_integer()->is_negative()) {
             env->raise("RangeError", "{} out of char range", arg->as_integer()->to_s(env)->as_string()->string());
         } else if (arg->is_integer()) {
             str_obj = arg.send(env, "chr"_s, { m_encoding })->as_string();


### PR DESCRIPTION
There were several places where we were pretending we could squeeze a bigint into a long long and just carrying on with the result.

Now we will panic if this is done. If you really want to do this, you can call `integer().to_bigint().to_long_long()`.

As a bonus, this work found several bugs and let us remove a NATFIXME in Float#coerce. 🎉 