### PR TITLE
Fix macOS build error from RandomObject::bytes

### DIFF
--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -32,7 +32,7 @@ Value RandomObject::bytes(Env *env, Value size) {
         env->raise("ArgumentError", "negative string size (or size too big)");
 
     TM::String output(static_cast<size_t>(isize), '\0');
-    std::uniform_int_distribution<char> random_number {};
+    std::uniform_int_distribution<nat_int_t> random_number {};
     for (nat_int_t i = 0; i < isize; i++)
         output[i] = random_number(*m_generator);
 


### PR DESCRIPTION
I'm currently on macOS 13 with the following:

    $ gcc --version
    Apple clang version 14.0.3 (clang-1403.0.22.14.1)
    Target: arm64-apple-darwin22.5.0
    Thread model: posix
    InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

I'm seeing this build error:

    ...
    In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/algorithm:1851:
    In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/ranges_sample.h:13:
    In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/sample.h:18:
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__random/uniform_int_distribution.h:162:5: error: static_assert failed due to requirement '__libcpp_random_is_valid_inttype<char>::value' "IntType must be a supported integer type"
        static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
        ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/random_object.cpp:35:41: note: in instantiation of template class 'std::uniform_int_distribution<char>' requested here
        std::uniform_int_distribution<char> random_number {};
    ...

Digging around it seems that the behaviour of `std::uniform_int_distribution<char>` is undefined:

https://www.reddit.com/r/cpp/comments/5p6cim/stduniform_int_distribution_and_char_types/

https://reviews.llvm.org/D114920?id=400571