### PR TITLE
Random bytes buffer

### DIFF
--- a/spec/core/random/bytes_spec.rb
+++ b/spec/core/random/bytes_spec.rb
@@ -9,9 +9,7 @@ describe "Random#bytes" do
     Random.new(33).bytes(2).should == Random.new(33).bytes(2)
   end
 
-  # Should double check this is official spec
-  #           where MRI return 44 and Natalie returns 54.
-  xit "returns the same numeric output for a given seed across all implementations and platforms" do
+  it "returns the same numeric output for a given seed across all implementations and platforms" do
     rnd = Random.new(33)
     rnd.bytes(2).should == "\x14\\"
     rnd.bytes(1000) # skip some

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -31,9 +31,9 @@ Value RandomObject::bytes(Env *env, Value size) {
     if (isize < 0)
         env->raise("ArgumentError", "negative string size (or size too big)");
 
-    const auto blocks = (static_cast<size_t>(isize) + sizeof(nat_int_t) - 1) / sizeof(nat_int_t);
+    const auto blocks = (static_cast<size_t>(isize) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
     nat_int_t output[blocks];
-    std::uniform_int_distribution<nat_int_t> random_number {};
+    std::uniform_int_distribution<uint32_t> random_number {};
     for (size_t i = 0; i < blocks; i++)
         output[i] = random_number(*m_generator);
 

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -31,12 +31,13 @@ Value RandomObject::bytes(Env *env, Value size) {
     if (isize < 0)
         env->raise("ArgumentError", "negative string size (or size too big)");
 
-    TM::String output(static_cast<size_t>(isize), '\0');
+    const auto blocks = (static_cast<size_t>(isize) + sizeof(nat_int_t) - 1) / sizeof(nat_int_t);
+    nat_int_t output[blocks];
     std::uniform_int_distribution<nat_int_t> random_number {};
-    for (nat_int_t i = 0; i < isize; i++)
+    for (size_t i = 0; i < blocks; i++)
         output[i] = random_number(*m_generator);
 
-    return new StringObject { std::move(output), EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { reinterpret_cast<char *>(output), static_cast<size_t>(isize), EncodingObject::get(Encoding::ASCII_8BIT) };
 }
 
 Value RandomObject::rand(Env *env, Value arg) {


### PR DESCRIPTION
This is the future work I proposed in #1214. After playing around for a bit, it turns out that using `uint32_t` as blocks resolves the issue of #919.