### PR TITLE
Keyword arguments for IO.new

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -24,6 +24,7 @@ namespace ioutil {
         int flags { O_RDONLY };
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };
+        bool autoclose { false };
 
         flags_struct(Env *env, Value flags_obj, HashObject *kwargs);
     };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -20,6 +20,7 @@ namespace ioutil {
     StringObject *convert_using_to_path(Env *env, Value path);
     int object_stat(Env *env, Value io, struct stat *sb);
     struct flags_struct {
+        bool has_mode { false };
         int flags { O_RDONLY };
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -104,7 +104,7 @@ public:
     Value stat(Env *) const;
     static Value sysopen(Env *, Value, Value = nullptr, Value = nullptr);
     Value read(Env *, Value, Value) const;
-    static Value read_file(Env *, Value, Value = nullptr, Value = nullptr);
+    static Value read_file(Env *, Args);
     Value readbyte(Env *);
     Value readline(Env *) const;
     int rewind(Env *);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -20,7 +20,9 @@ namespace ioutil {
     StringObject *convert_using_to_path(Env *env, Value path);
     int object_stat(Env *env, Value io, struct stat *sb);
     struct flags_struct {
-        enum class read_mode { none, text, binary };
+        enum class read_mode { none,
+            text,
+            binary };
 
         bool has_mode { false };
         int flags { O_RDONLY };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -76,7 +76,7 @@ public:
     int fsync(Env *);
     Value getbyte(Env *);
     Value gets(Env *) const;
-    Value initialize(Env *, Value, Value = nullptr);
+    Value initialize(Env *, Args);
     Value inspect() const;
     Value internal_encoding() const { return m_internal_encoding; }
     bool is_autoclose(Env *) const;

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -20,8 +20,11 @@ namespace ioutil {
     StringObject *convert_using_to_path(Env *env, Value path);
     int object_stat(Env *env, Value io, struct stat *sb);
     struct flags_struct {
+        enum class read_mode { none, text, binary };
+
         bool has_mode { false };
         int flags { O_RDONLY };
+        read_mode read_mode { read_mode::none };
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };
         bool autoclose { false };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -24,7 +24,7 @@ namespace ioutil {
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };
 
-        flags_struct(Env *env, Value flags_obj);
+        flags_struct(Env *env, Value flags_obj, HashObject *kwargs);
     };
     mode_t perm_to_mode(Env *env, Value perm);
 }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -864,7 +864,7 @@ gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_
 gen.binding('IO', 'fsync', 'IoObject', 'fsync', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'getbyte', 'IoObject', 'getbyte', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'inspect', 'IoObject', 'inspect', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'internal_encoding', 'IoObject', 'internal_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'isatty', 'IoObject', 'isatty', argc: 0, pass_env: true, pass_block: false, aliases: ['tty?'], return_type: :bool)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -843,7 +843,7 @@ gen.binding('Integer', '|', 'IntegerObject', 'bitwise_or', argc: 1, pass_env: tr
 gen.binding('Integer', 'zero?', 'IntegerObject', 'is_zero', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)
 
 gen.static_binding('IO', 'binread', 'IoObject', 'binread', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
-gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'sysopen', 'IoObject', 'sysopen', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -291,7 +291,7 @@ Value BasicSocket_s_for_fd(Env *env, Value self, Args args, Block *) {
     auto BasicSocket = find_top_level_const(env, "BasicSocket"_s);
 
     auto sock = BasicSocket.send(env, "new"_s);
-    sock->as_io()->initialize(env, fd);
+    sock->as_io()->initialize(env, { fd });
 
     return self;
 }
@@ -563,7 +563,7 @@ Value Socket_initialize(Env *env, Value self, Args args, Block *block) {
     if (fd == -1)
         env->raise_errno();
 
-    self->as_io()->initialize(env, Value::integer(fd));
+    self->as_io()->initialize(env, { Value::integer(fd) });
 
     return self;
 }
@@ -995,7 +995,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args args, Block *block) {
     auto fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1)
         env->raise_errno();
-    self->as_io()->initialize(env, Value::integer(fd));
+    self->as_io()->initialize(env, { Value::integer(fd) });
     self->as_io()->binmode(env);
 
     auto Socket = find_top_level_const(env, "Socket"_s);
@@ -1034,7 +1034,7 @@ Value TCPServer_initialize(Env *env, Value self, Args args, Block *) {
     auto fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (fd == -1)
         env->raise_errno();
-    self->as_io()->initialize(env, Value::integer(fd));
+    self->as_io()->initialize(env, { Value::integer(fd) });
 
     self.send(env, "setsockopt"_s, { "SOCKET"_s, "REUSEADDR"_s, TrueObject::the() });
 

--- a/spec/core/io/initialize_spec.rb
+++ b/spec/core/io/initialize_spec.rb
@@ -30,10 +30,8 @@ describe "IO#initialize" do
   it "accepts options as keyword arguments" do
     fd = new_fd @name, "w:utf-8"
 
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :flags' do
-      @io.send(:initialize, fd, "w", flags: File::CREAT)
-      @io.fileno.should == fd
-    end
+    @io.send(:initialize, fd, "w", flags: File::CREAT)
+    @io.fileno.should == fd
 
     -> {
       @io.send(:initialize, fd, "w", {flags: File::CREAT})

--- a/spec/core/io/initialize_spec.rb
+++ b/spec/core/io/initialize_spec.rb
@@ -30,7 +30,7 @@ describe "IO#initialize" do
   it "accepts options as keyword arguments" do
     fd = new_fd @name, "w:utf-8"
 
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :flags' do
       @io.send(:initialize, fd, "w", flags: File::CREAT)
       @io.fileno.should == fd
     end

--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -25,9 +25,7 @@ describe "IO.read" do
 
   # https://bugs.ruby-lang.org/issues/19354
   it "accepts options as keyword arguments" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
-      IO.read(@fname, 3, 0, mode: "r+").should == @contents[0, 3]
-    end
+    IO.read(@fname, 3, 0, mode: "r+").should == @contents[0, 3]
 
     -> {
       IO.read(@fname, 3, 0, {mode: "r+"})
@@ -47,39 +45,29 @@ describe "IO.read" do
   end
 
   it "raises an IOError if the options Hash specifies write mode" do
-    NATFIXME 'Keyword arguments', exception: SpecFailedException do
-      -> { IO.read(@fname, 3, 0, mode: "w") }.should raise_error(IOError)
-    end
+    -> { IO.read(@fname, 3, 0, mode: "w") }.should raise_error(IOError)
   end
 
   it "raises an IOError if the options Hash specifies append only mode" do
-    NATFIXME 'Keyword arguments', exception: SpecFailedException do
-      -> { IO.read(@fname, mode: "a") }.should raise_error(IOError)
-    end
+    -> { IO.read(@fname, mode: "a") }.should raise_error(IOError)
   end
 
   it "reads the file if the options Hash includes read mode" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
-      IO.read(@fname, mode: "r").should == @contents
-    end
+    IO.read(@fname, mode: "r").should == @contents
   end
 
   it "reads the file if the options Hash includes read/write mode" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
-      IO.read(@fname, mode: "r+").should == @contents
-    end
+    IO.read(@fname, mode: "r+").should == @contents
   end
 
   it "reads the file if the options Hash includes read/write append mode" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
-      IO.read(@fname, mode: "a+").should == @contents
-    end
+    IO.read(@fname, mode: "a+").should == @contents
   end
 
   platform_is_not :windows do
     ruby_version_is ""..."3.3" do
       it "uses an :open_args option" do
-        NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
+        NATFIXME 'open-args keyword arguments', exception: ArgumentError, message: 'unknown keyword: :open_args' do
           string = IO.read(@fname, nil, 0, open_args: ["r", nil, {encoding: Encoding::US_ASCII}])
           string.encoding.should == Encoding::US_ASCII
 
@@ -91,21 +79,21 @@ describe "IO.read" do
   end
 
   it "disregards other options if :open_args is given" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'open_args keyword argument', exception: ArgumentError, message: 'unknown keyword: :open_args' do
       string = IO.read(@fname,mode: "w", encoding: Encoding::UTF_32LE, open_args: ["r", encoding: Encoding::UTF_8])
       string.encoding.should == Encoding::UTF_8
     end
   end
 
   it "doesn't require mode to be specified in :open_args" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
+    NATFIXME 'open_args keyword argument', exception: ArgumentError, message: 'unknown keyword: :open_args' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII}])
       string.encoding.should == Encoding::US_ASCII
     end
   end
 
   it "doesn't require mode to be specified in :open_args even if flags option passed" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 1..3)' do
+    NATFIXME 'open_args keyword argument', exception: ArgumentError, message: 'unknown keyword: :open_args' do
       string = IO.read(@fname, nil, 0, open_args: [{encoding: Encoding::US_ASCII, flags: File::CREAT}])
       string.encoding.should == Encoding::US_ASCII
     end
@@ -170,17 +158,13 @@ describe "IO.read" do
   end
 
   it "uses the external encoding specified via the :external_encoding option" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
-      str = IO.read(@fname, external_encoding: Encoding::ISO_8859_1)
-      str.encoding.should == Encoding::ISO_8859_1
-    end
+    str = IO.read(@fname, external_encoding: Encoding::ISO_8859_1)
+    str.encoding.should == Encoding::ISO_8859_1
   end
 
   it "uses the external encoding specified via the :encoding option" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
-      str = IO.read(@fname, encoding: Encoding::ISO_8859_1)
-      str.encoding.should == Encoding::ISO_8859_1
-    end
+    str = IO.read(@fname, encoding: Encoding::ISO_8859_1)
+    str.encoding.should == Encoding::ISO_8859_1
   end
 
   platform_is :windows do
@@ -550,7 +534,7 @@ end
 describe "IO.read with BOM" do
   it "reads a file without a bom" do
     name = fixture __FILE__, "no_bom_UTF-8.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-8 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-8"' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "UTF-8\n"
     end
@@ -558,7 +542,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-8 bom" do
     name = fixture __FILE__, "bom_UTF-8.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-16 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-16le"' do
       result = File.read(name, mode: "rb:BOM|utf-16le")
       result.force_encoding("binary").should == "UTF-8\n"
     end
@@ -566,7 +550,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-16le bom" do
     name = fixture __FILE__, "bom_UTF-16LE.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-8 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-8"' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "U\x00T\x00F\x00-\x001\x006\x00L\x00E\x00\n\x00"
     end
@@ -574,7 +558,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-16be bom" do
     name = fixture __FILE__, "bom_UTF-16BE.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-8 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-8"' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "\x00U\x00T\x00F\x00-\x001\x006\x00B\x00E\x00\n"
     end
@@ -582,7 +566,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-32le bom" do
     name = fixture __FILE__, "bom_UTF-32LE.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-8 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-8"' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "U\x00\x00\x00T\x00\x00\x00F\x00\x00\x00-\x00\x00\x003\x00\x00\x002\x00\x00\x00L\x00\x00\x00E\x00\x00\x00\n\x00\x00\x00"
     end
@@ -590,7 +574,7 @@ describe "IO.read with BOM" do
 
   it "reads a file with a utf-32be bom" do
     name = fixture __FILE__, "bom_UTF-32BE.txt"
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'BOM UTF-8 encoding', exception: ArgumentError, message: 'unknown encoding name - "BOM|utf-8"' do
       result = File.read(name, mode: "rb:BOM|utf-8")
       result.force_encoding("binary").should == "\x00\x00\x00U\x00\x00\x00T\x00\x00\x00F\x00\x00\x00-\x00\x00\x003\x00\x00\x002\x00\x00\x00B\x00\x00\x00E\x00\x00\x00\n"
     end

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -65,10 +65,8 @@ describe :io_new, shared: true do
   end
 
   it "accepts options as keyword arguments" do
-    NATFIXME 'Flag keyword argument', exception: ArgumentError, message: 'unknown keyword: :flags' do
-      @io = IO.send(@method, @fd, "w", flags: File::CREAT)
-      @io.write("foo").should == 3
-    end
+    @io = IO.send(@method, @fd, "w", flags: File::CREAT)
+    @io.write("foo").should == 3
 
     -> {
       IO.send(@method, @fd, "w", {flags: File::CREAT})

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -307,18 +307,14 @@ describe :io_new, shared: true do
   end
 
   it "accepts an :autoclose option" do
-    NATFIXME 'Autoclose keyword argument', exception: ArgumentError, message: 'unknown keyword: :autoclose' do
-      @io = IO.send(@method, @fd, 'w', autoclose: false)
-      @io.should_not.autoclose?
-      @io.autoclose = true
-    end
+    @io = IO.send(@method, @fd, 'w', autoclose: false)
+    @io.should_not.autoclose?
+    @io.autoclose = true
   end
 
   it "accepts any truthy option :autoclose" do
-    NATFIXME 'Autoclose keyword argument', exception: ArgumentError, message: 'unknown keyword: :autoclose' do
-      @io = IO.send(@method, @fd, 'w', autoclose: 42)
-      @io.should.autoclose?
-    end
+    @io = IO.send(@method, @fd, 'w', autoclose: 42)
+    @io.should.autoclose?
   end
 end
 

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -110,43 +110,33 @@ describe :io_new, shared: true do
   end
 
   it "uses the colon-separated encodings specified via the :encoding option" do
-    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      @io = IO.send(@method, @fd, 'w', encoding: 'utf-8:ISO-8859-1')
-      @io.external_encoding.to_s.should == 'UTF-8'
-      @io.internal_encoding.to_s.should == 'ISO-8859-1'
-    end
+    @io = IO.send(@method, @fd, 'w', encoding: 'utf-8:ISO-8859-1')
+    @io.external_encoding.to_s.should == 'UTF-8'
+    @io.internal_encoding.to_s.should == 'ISO-8859-1'
   end
 
   it "uses the :encoding option as the external encoding when only one is given" do
-    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      @io = IO.send(@method, @fd, 'w', encoding: 'ISO-8859-1')
-      @io.external_encoding.to_s.should == 'ISO-8859-1'
-    end
+    @io = IO.send(@method, @fd, 'w', encoding: 'ISO-8859-1')
+    @io.external_encoding.to_s.should == 'ISO-8859-1'
   end
 
   it "uses the :encoding options as the external encoding when it's an Encoding object" do
-    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      @io = IO.send(@method, @fd, 'w', encoding: Encoding::ISO_8859_1)
-      @io.external_encoding.should == Encoding::ISO_8859_1
-    end
+    @io = IO.send(@method, @fd, 'w', encoding: Encoding::ISO_8859_1)
+    @io.external_encoding.should == Encoding::ISO_8859_1
   end
 
   it "ignores the :encoding option when the :external_encoding option is present" do
-    NATFIXME 'Encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      -> {
-        @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', encoding: 'iso-8859-1:iso-8859-1')
-      }.should complain(/Ignoring encoding parameter/)
-      @io.external_encoding.to_s.should == 'UTF-8'
-    end
+    -> {
+      @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', encoding: 'iso-8859-1:iso-8859-1')
+    }.should complain(/Ignoring encoding parameter/)
+    @io.external_encoding.to_s.should == 'UTF-8'
   end
 
   it "ignores the :encoding option when the :internal_encoding option is present" do
-    NATFIXME 'Encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      -> {
-        @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
-      }.should complain(/Ignoring encoding parameter/)
-      @io.internal_encoding.to_s.should == 'IBM866'
-    end
+    -> {
+      @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
+    }.should complain(/Ignoring encoding parameter/)
+    @io.internal_encoding.to_s.should == 'IBM866'
   end
 
   it "uses the encoding specified via the :mode option hash" do
@@ -204,10 +194,8 @@ describe :io_new, shared: true do
   end
 
   it "does not use binary encoding when :encoding option is specified" do
-    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      @io = IO.send(@method, @fd, 'wb', encoding: "iso-8859-1")
-      @io.external_encoding.to_s.should == 'ISO-8859-1'
-    end
+    @io = IO.send(@method, @fd, 'wb', encoding: "iso-8859-1")
+    @io.external_encoding.to_s.should == 'ISO-8859-1'
   end
 
   it "does not use binary encoding when :external_encoding option is specified" do
@@ -252,10 +240,8 @@ describe :io_new, shared: true do
 
   it "coerces :encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
-      encoding.should_receive(:to_str).and_return('utf-8')
-      @io = IO.send(@method, @fd, 'w', encoding: encoding)
-    end
+    encoding.should_receive(:to_str).and_return('utf-8')
+    @io = IO.send(@method, @fd, 'w', encoding: encoding)
   end
 
   it "coerces :external_encoding option with #to_str" do

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -105,10 +105,8 @@ describe :io_new, shared: true do
   end
 
   it "uses the internal encoding specified via the :internal_encoding option" do
-    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
-      @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866')
-      @io.internal_encoding.to_s.should == 'IBM866'
-    end
+    @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866')
+    @io.internal_encoding.to_s.should == 'IBM866'
   end
 
   it "uses the colon-separated encodings specified via the :encoding option" do
@@ -143,7 +141,7 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :encoding option when the :internal_encoding option is present" do
-    NATFIXME 'Internal and regular encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :internal_encoding, :encoding' do
+    NATFIXME 'Encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       -> {
         @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
       }.should complain(/Ignoring encoding parameter/)
@@ -158,19 +156,15 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :internal_encoding option when the same as the external encoding" do
-    NATFIXME 'Internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
-      @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: 'utf-8')
-      @io.external_encoding.to_s.should == 'UTF-8'
-      @io.internal_encoding.to_s.should == ''
-    end
+    @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: 'utf-8')
+    @io.external_encoding.to_s.should == 'UTF-8'
+    @io.internal_encoding.to_s.should == ''
   end
 
   it "sets internal encoding to nil when passed '-'" do
-    NATFIXME 'Internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
-      @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: '-')
-      @io.external_encoding.to_s.should == 'UTF-8'
-      @io.internal_encoding.to_s.should == ''
-    end
+    @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: '-')
+    @io.external_encoding.to_s.should == 'UTF-8'
+    @io.internal_encoding.to_s.should == ''
   end
 
   it "sets binmode from mode string" do
@@ -222,10 +216,8 @@ describe :io_new, shared: true do
   end
 
   it "does not use binary encoding when :internal_encoding option is specified" do
-    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
-      @io = IO.send(@method, @fd, 'wb', internal_encoding: "ibm866")
-      @io.internal_encoding.to_s.should == 'IBM866'
-    end
+    @io = IO.send(@method, @fd, 'wb', internal_encoding: "ibm866")
+    @io.internal_encoding.to_s.should == 'IBM866'
   end
 
   it "raises ArgumentError for nil options" do
@@ -274,10 +266,8 @@ describe :io_new, shared: true do
 
   it "coerces :internal_encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
-      encoding.should_receive(:to_str).at_least(:once).and_return('utf-8')
-      @io = IO.send(@method, @fd, 'w', internal_encoding: encoding)
-    end
+    encoding.should_receive(:to_str).at_least(:once).and_return('utf-8')
+    @io = IO.send(@method, @fd, 'w', internal_encoding: encoding)
   end
 
   it "coerces options as third argument with #to_hash" do

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -76,24 +76,18 @@ describe :io_new, shared: true do
   end
 
   it "accepts a :mode option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      @io = IO.send(@method, @fd, mode: "w")
-      @io.write("foo").should == 3
-    end
+    @io = IO.send(@method, @fd, mode: "w")
+    @io.write("foo").should == 3
   end
 
   it "accepts a mode argument set to nil with a valid :mode option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      @io = IO.send(@method, @fd, nil, mode: "w")
-      @io.write("foo").should == 3
-    end
+    @io = IO.send(@method, @fd, nil, mode: "w")
+    @io.write("foo").should == 3
   end
 
   it "accepts a mode argument with a :mode option set to nil" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      @io = IO.send(@method, @fd, "w", mode: nil)
-      @io.write("foo").should == 3
-    end
+    @io = IO.send(@method, @fd, "w", mode: nil)
+    @io.write("foo").should == 3
   end
 
   it "uses the external encoding specified in the mode argument" do
@@ -162,11 +156,9 @@ describe :io_new, shared: true do
   end
 
   it "uses the encoding specified via the :mode option hash" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      @io = IO.send(@method, @fd, mode: 'w:utf-8:ISO-8859-1')
-      @io.external_encoding.to_s.should == 'UTF-8'
-      @io.internal_encoding.to_s.should == 'ISO-8859-1'
-    end
+    @io = IO.send(@method, @fd, mode: 'w:utf-8:ISO-8859-1')
+    @io.external_encoding.to_s.should == 'UTF-8'
+    @io.internal_encoding.to_s.should == 'ISO-8859-1'
   end
 
   it "ignores the :internal_encoding option when the same as the external encoding" do
@@ -268,18 +260,14 @@ describe :io_new, shared: true do
 
   it "coerces mode with #to_str when passed in options" do
     mode = mock("mode")
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      mode.should_receive(:to_str).and_return('w')
-      @io = IO.send(@method, @fd, mode: mode)
-    end
+    mode.should_receive(:to_str).and_return('w')
+    @io = IO.send(@method, @fd, mode: mode)
   end
 
   it "coerces mode with #to_int when passed in options" do
     mode = mock("mode")
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
-      mode.should_receive(:to_int).and_return(File::WRONLY)
-      @io = IO.send(@method, @fd, mode: mode)
-    end
+    mode.should_receive(:to_int).and_return(File::WRONLY)
+    @io = IO.send(@method, @fd, mode: mode)
   end
 
   it "coerces :encoding option with #to_str" do

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -186,17 +186,13 @@ describe :io_new, shared: true do
   end
 
   it "sets binmode from :binmode option" do
-    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
-      @io = IO.send(@method, @fd, 'w', binmode: true)
-      @io.should.binmode?
-    end
+    @io = IO.send(@method, @fd, 'w', binmode: true)
+    @io.should.binmode?
   end
 
   it "does not set binmode from false :binmode" do
-    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
-      @io = IO.send(@method, @fd, 'w', binmode: false)
-      @io.should_not.binmode?
-    end
+    @io = IO.send(@method, @fd, 'w', binmode: false)
+    @io.should_not.binmode?
   end
 
   it "sets external encoding to binary with binmode in mode string" do
@@ -206,10 +202,8 @@ describe :io_new, shared: true do
 
   # #5917
   it "sets external encoding to binary with :binmode option" do
-    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
-      @io = IO.send(@method, @fd, 'w', binmode: true)
-      @io.external_encoding.should == Encoding::BINARY
-    end
+    @io = IO.send(@method, @fd, 'w', binmode: true)
+    @io.external_encoding.should == Encoding::BINARY
   end
 
   it "does not use binary encoding when mode encoding is specified" do

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -65,7 +65,7 @@ describe :io_new, shared: true do
   end
 
   it "accepts options as keyword arguments" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Flag keyword argument', exception: ArgumentError, message: 'unknown keyword: :flags' do
       @io = IO.send(@method, @fd, "w", flags: File::CREAT)
       @io.write("foo").should == 3
     end
@@ -76,21 +76,21 @@ describe :io_new, shared: true do
   end
 
   it "accepts a :mode option" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       @io = IO.send(@method, @fd, mode: "w")
       @io.write("foo").should == 3
     end
   end
 
   it "accepts a mode argument set to nil with a valid :mode option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       @io = IO.send(@method, @fd, nil, mode: "w")
       @io.write("foo").should == 3
     end
   end
 
   it "accepts a mode argument with a :mode option set to nil" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       @io = IO.send(@method, @fd, "w", mode: nil)
       @io.write("foo").should == 3
     end
@@ -108,21 +108,21 @@ describe :io_new, shared: true do
   end
 
   it "uses the external encoding specified via the :external_encoding option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
       @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8')
       @io.external_encoding.to_s.should == 'UTF-8'
     end
   end
 
   it "uses the internal encoding specified via the :internal_encoding option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
       @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866')
       @io.internal_encoding.to_s.should == 'IBM866'
     end
   end
 
   it "uses the colon-separated encodings specified via the :encoding option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       @io = IO.send(@method, @fd, 'w', encoding: 'utf-8:ISO-8859-1')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == 'ISO-8859-1'
@@ -130,21 +130,21 @@ describe :io_new, shared: true do
   end
 
   it "uses the :encoding option as the external encoding when only one is given" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       @io = IO.send(@method, @fd, 'w', encoding: 'ISO-8859-1')
       @io.external_encoding.to_s.should == 'ISO-8859-1'
     end
   end
 
   it "uses the :encoding options as the external encoding when it's an Encoding object" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       @io = IO.send(@method, @fd, 'w', encoding: Encoding::ISO_8859_1)
       @io.external_encoding.should == Encoding::ISO_8859_1
     end
   end
 
   it "ignores the :encoding option when the :external_encoding option is present" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External and regular encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :encoding' do
       -> {
         @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', encoding: 'iso-8859-1:iso-8859-1')
       }.should complain(/Ignoring encoding parameter/)
@@ -153,7 +153,7 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :encoding option when the :internal_encoding option is present" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Internal and regular encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :internal_encoding, :encoding' do
       -> {
         @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
       }.should complain(/Ignoring encoding parameter/)
@@ -162,7 +162,7 @@ describe :io_new, shared: true do
   end
 
   it "uses the encoding specified via the :mode option hash" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       @io = IO.send(@method, @fd, mode: 'w:utf-8:ISO-8859-1')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == 'ISO-8859-1'
@@ -170,7 +170,7 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :internal_encoding option when the same as the external encoding" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External and internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :internal_encoding' do
       @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: 'utf-8')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == ''
@@ -178,7 +178,7 @@ describe :io_new, shared: true do
   end
 
   it "sets internal encoding to nil when passed '-'" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External and internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :internal_encoding' do
       @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: '-')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == ''
@@ -196,14 +196,14 @@ describe :io_new, shared: true do
   end
 
   it "sets binmode from :binmode option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
       @io = IO.send(@method, @fd, 'w', binmode: true)
       @io.should.binmode?
     end
   end
 
   it "does not set binmode from false :binmode" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
       @io = IO.send(@method, @fd, 'w', binmode: false)
       @io.should_not.binmode?
     end
@@ -216,7 +216,7 @@ describe :io_new, shared: true do
 
   # #5917
   it "sets external encoding to binary with :binmode option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Binmode keyword argument', exception: ArgumentError, message: 'unknown keyword: :binmode' do
       @io = IO.send(@method, @fd, 'w', binmode: true)
       @io.external_encoding.should == Encoding::BINARY
     end
@@ -228,21 +228,21 @@ describe :io_new, shared: true do
   end
 
   it "does not use binary encoding when :encoding option is specified" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       @io = IO.send(@method, @fd, 'wb', encoding: "iso-8859-1")
       @io.external_encoding.to_s.should == 'ISO-8859-1'
     end
   end
 
   it "does not use binary encoding when :external_encoding option is specified" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
       @io = IO.send(@method, @fd, 'wb', external_encoding: "iso-8859-1")
       @io.external_encoding.to_s.should == 'ISO-8859-1'
     end
   end
 
   it "does not use binary encoding when :internal_encoding option is specified" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
       @io = IO.send(@method, @fd, 'wb', internal_encoding: "ibm866")
       @io.internal_encoding.to_s.should == 'IBM866'
     end
@@ -268,7 +268,7 @@ describe :io_new, shared: true do
 
   it "coerces mode with #to_str when passed in options" do
     mode = mock("mode")
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       mode.should_receive(:to_str).and_return('w')
       @io = IO.send(@method, @fd, mode: mode)
     end
@@ -276,7 +276,7 @@ describe :io_new, shared: true do
 
   it "coerces mode with #to_int when passed in options" do
     mode = mock("mode")
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'unknown keyword: :mode' do
       mode.should_receive(:to_int).and_return(File::WRONLY)
       @io = IO.send(@method, @fd, mode: mode)
     end
@@ -284,7 +284,7 @@ describe :io_new, shared: true do
 
   it "coerces :encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       encoding.should_receive(:to_str).and_return('utf-8')
       @io = IO.send(@method, @fd, 'w', encoding: encoding)
     end
@@ -292,7 +292,7 @@ describe :io_new, shared: true do
 
   it "coerces :external_encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
       encoding.should_receive(:to_str).and_return('utf-8')
       @io = IO.send(@method, @fd, 'w', external_encoding: encoding)
     end
@@ -300,7 +300,7 @@ describe :io_new, shared: true do
 
   it "coerces :internal_encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Internal encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
       encoding.should_receive(:to_str).at_least(:once).and_return('utf-8')
       @io = IO.send(@method, @fd, 'w', internal_encoding: encoding)
     end
@@ -319,7 +319,7 @@ describe :io_new, shared: true do
   end
 
   it "accepts an :autoclose option" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Autoclose keyword argument', exception: ArgumentError, message: 'unknown keyword: :autoclose' do
       @io = IO.send(@method, @fd, 'w', autoclose: false)
       @io.should_not.autoclose?
       @io.autoclose = true
@@ -327,7 +327,7 @@ describe :io_new, shared: true do
   end
 
   it "accepts any truthy option :autoclose" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 1..2)' do
+    NATFIXME 'Autoclose keyword argument', exception: ArgumentError, message: 'unknown keyword: :autoclose' do
       @io = IO.send(@method, @fd, 'w', autoclose: 42)
       @io.should.autoclose?
     end

--- a/spec/core/io/shared/new.rb
+++ b/spec/core/io/shared/new.rb
@@ -100,10 +100,8 @@ describe :io_new, shared: true do
   end
 
   it "uses the external encoding specified via the :external_encoding option" do
-    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
-      @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8')
-      @io.external_encoding.to_s.should == 'UTF-8'
-    end
+    @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8')
+    @io.external_encoding.to_s.should == 'UTF-8'
   end
 
   it "uses the internal encoding specified via the :internal_encoding option" do
@@ -136,7 +134,7 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :encoding option when the :external_encoding option is present" do
-    NATFIXME 'External and regular encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :encoding' do
+    NATFIXME 'Encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :encoding' do
       -> {
         @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', encoding: 'iso-8859-1:iso-8859-1')
       }.should complain(/Ignoring encoding parameter/)
@@ -160,7 +158,7 @@ describe :io_new, shared: true do
   end
 
   it "ignores the :internal_encoding option when the same as the external encoding" do
-    NATFIXME 'External and internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :internal_encoding' do
+    NATFIXME 'Internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
       @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: 'utf-8')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == ''
@@ -168,7 +166,7 @@ describe :io_new, shared: true do
   end
 
   it "sets internal encoding to nil when passed '-'" do
-    NATFIXME 'External and internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keywords: :external_encoding, :internal_encoding' do
+    NATFIXME 'Internal encoding keyword arguments', exception: ArgumentError, message: 'unknown keyword: :internal_encoding' do
       @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', internal_encoding: '-')
       @io.external_encoding.to_s.should == 'UTF-8'
       @io.internal_encoding.to_s.should == ''
@@ -219,10 +217,8 @@ describe :io_new, shared: true do
   end
 
   it "does not use binary encoding when :external_encoding option is specified" do
-    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
-      @io = IO.send(@method, @fd, 'wb', external_encoding: "iso-8859-1")
-      @io.external_encoding.to_s.should == 'ISO-8859-1'
-    end
+    @io = IO.send(@method, @fd, 'wb', external_encoding: "iso-8859-1")
+    @io.external_encoding.to_s.should == 'ISO-8859-1'
   end
 
   it "does not use binary encoding when :internal_encoding option is specified" do
@@ -272,10 +268,8 @@ describe :io_new, shared: true do
 
   it "coerces :external_encoding option with #to_str" do
     encoding = mock("encoding")
-    NATFIXME 'External encoding keyword argument', exception: ArgumentError, message: 'unknown keyword: :external_encoding' do
-      encoding.should_receive(:to_str).and_return('utf-8')
-      @io = IO.send(@method, @fd, 'w', external_encoding: encoding)
-    end
+    encoding.should_receive(:to_str).and_return('utf-8')
+    @io = IO.send(@method, @fd, 'w', external_encoding: encoding)
   end
 
   it "coerces :internal_encoding option with #to_str" do

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -35,7 +35,7 @@ static int effective_uid_access(const char *path_name, int type) {
 
 // NATFIXME : block form is not used, option-hash arg not implemented.
 Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value perm, Block *block) {
-    const ioutil::flags_struct flags { env, flags_obj };
+    const ioutil::flags_struct flags { env, flags_obj, nullptr };
     const auto modenum = ioutil::perm_to_mode(env, perm);
 
     if (filename->is_integer()) { // passing in a number uses fd number

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -76,6 +76,8 @@ namespace ioutil {
         if (!flags_obj || flags_obj->is_nil())
             return;
 
+        has_mode = true;
+
         if (!flags_obj->is_integer() && !flags_obj->is_string()) {
             if (flags_obj->respond_to(env, "to_str"_s)) {
                 flags_obj = flags_obj->to_str(env);
@@ -159,13 +161,13 @@ Value IoObject::initialize(Env *env, Args args) {
     const auto actual_flags = ::fcntl(fileno, F_GETFL);
     if (actual_flags < 0)
         env->raise_errno();
-    if (flags_obj != nullptr && !flags_obj->is_nil()) {
+    if (wanted_flags.has_mode) {
         if ((flags_is_readable(wanted_flags.flags) && !flags_is_readable(actual_flags)) || (flags_is_writable(wanted_flags.flags) && !flags_is_writable(actual_flags))) {
             errno = EINVAL;
             env->raise_errno();
         }
-        set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     }
+    set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     set_fileno(fileno);
     return this;
 }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -148,9 +148,11 @@ namespace ioutil {
 }
 
 Value IoObject::initialize(Env *env, Args args) {
+    auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 1, 2);
     Value file_number = args.at(0);
     Value flags_obj = args.at(1, nullptr);
+    env->ensure_no_extra_keywords(kwargs);
     nat_int_t fileno = file_number->to_int(env)->to_nat_int_t();
     assert(fileno >= INT_MIN && fileno <= INT_MAX);
     const auto actual_flags = ::fcntl(fileno, F_GETFL);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -150,11 +150,19 @@ namespace ioutil {
                 env->raise("ArgumentError", "mode specified twice");
             parse_flags_obj(env, self, mode);
         }
+
+        void parse_autoclose(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto autoclose = kwargs->remove(env, "autoclose"_s);
+            if (!autoclose) return;
+            self->autoclose = autoclose->is_truthy();
+        }
     };
 
     flags_struct::flags_struct(Env *env, Value flags_obj, HashObject *kwargs) {
         parse_flags_obj(env, this, flags_obj);
         parse_mode(env, this, kwargs);
+        parse_autoclose(env, this, kwargs);
         env->ensure_no_extra_keywords(kwargs);
     }
 
@@ -183,8 +191,9 @@ Value IoObject::initialize(Env *env, Args args) {
             env->raise_errno();
         }
     }
-    set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     set_fileno(fileno);
+    set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
+    m_autoclose = wanted_flags.autoclose;
     return this;
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -157,12 +157,18 @@ namespace ioutil {
             if (!autoclose) return;
             self->autoclose = autoclose->is_truthy();
         }
+
+        void parse_path(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            kwargs->remove(env, "path"_s);
+        }
     };
 
     flags_struct::flags_struct(Env *env, Value flags_obj, HashObject *kwargs) {
         parse_flags_obj(env, this, flags_obj);
         parse_mode(env, this, kwargs);
         parse_autoclose(env, this, kwargs);
+        parse_path(env, this, kwargs);
         env->ensure_no_extra_keywords(kwargs);
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -115,10 +115,10 @@ namespace ioutil {
                 if (binary_text_mode && binary_text_mode != 'b' && binary_text_mode != 't')
                     env->raise("ArgumentError", "invalid access mode {}", flags_str);
 
-                if (binary_text_mode == 'b' && !self->external_encoding) {
-                    self->external_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
-                } else if (binary_text_mode == 't' && !self->external_encoding) {
-                    self->external_encoding = EncodingObject::get(Encoding::UTF_8);
+                if (binary_text_mode == 'b') {
+                    self->read_mode = flags_struct::read_mode::binary;
+                } else if (binary_text_mode == 't') {
+                    self->read_mode = flags_struct::read_mode::text;
                 }
 
                 if (main_mode == 'r' && !read_write_mode)
@@ -177,6 +177,13 @@ namespace ioutil {
         parse_flags(env, this, kwargs);
         parse_autoclose(env, this, kwargs);
         parse_path(env, this, kwargs);
+        if (!external_encoding) {
+            if (read_mode == read_mode::binary) {
+                external_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
+            } else if (read_mode == read_mode::text) {
+                external_encoding = EncodingObject::get(Encoding::UTF_8);
+            }
+        }
         env->ensure_no_extra_keywords(kwargs);
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -141,10 +141,20 @@ namespace ioutil {
                 env->raise("TypeError", "no implicit conversion of {} into String", flags_obj->klass()->inspect_str());
             }
         }
+
+        void parse_mode(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto mode = kwargs->remove(env, "mode"_s);
+            if (!mode || mode->is_nil()) return;
+            if (self->has_mode)
+                env->raise("ArgumentError", "mode specified twice");
+            parse_flags_obj(env, self, mode);
+        }
     };
 
     flags_struct::flags_struct(Env *env, Value flags_obj, HashObject *kwargs) {
         parse_flags_obj(env, this, flags_obj);
+        parse_mode(env, this, kwargs);
         env->ensure_no_extra_keywords(kwargs);
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -147,7 +147,10 @@ namespace ioutil {
     }
 }
 
-Value IoObject::initialize(Env *env, Value file_number, Value flags_obj) {
+Value IoObject::initialize(Env *env, Args args) {
+    args.ensure_argc_between(env, 1, 2);
+    Value file_number = args.at(0);
+    Value flags_obj = args.at(1, nullptr);
     nat_int_t fileno = file_number->to_int(env)->to_nat_int_t();
     assert(fileno >= INT_MIN && fileno <= INT_MAX);
     const auto actual_flags = ::fcntl(fileno, F_GETFL);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -145,6 +145,7 @@ namespace ioutil {
 
     flags_struct::flags_struct(Env *env, Value flags_obj, HashObject *kwargs) {
         parse_flags_obj(env, this, flags_obj);
+        env->ensure_no_extra_keywords(kwargs);
     }
 
     mode_t perm_to_mode(Env *env, Value perm) {
@@ -161,7 +162,6 @@ Value IoObject::initialize(Env *env, Args args) {
     Value file_number = args.at(0);
     Value flags_obj = args.at(1, nullptr);
     const ioutil::flags_struct wanted_flags { env, flags_obj, kwargs };
-    env->ensure_no_extra_keywords(kwargs);
     nat_int_t fileno = file_number->to_int(env)->to_nat_int_t();
     assert(fileno >= INT_MIN && fileno <= INT_MAX);
     const auto actual_flags = ::fcntl(fileno, F_GETFL);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -158,6 +158,32 @@ namespace ioutil {
             self->flags |= static_cast<int>(flags->to_int(env)->to_nat_int_t());
         }
 
+        void parse_textmode(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto textmode = kwargs->remove(env, "textmode"_s);
+            if (!textmode || textmode->is_nil()) return;
+            if (self->read_mode == flags_struct::read_mode::binary) {
+                env->raise("ArgumentError", "both textmode and binmode specified");
+            } else if (self->read_mode == flags_struct::read_mode::text) {
+                env->raise("ArgumentError", "textmode specified twice");
+            }
+            if (textmode->is_truthy())
+                self->read_mode = flags_struct::read_mode::text;
+        }
+
+        void parse_binmode(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto binmode = kwargs->remove(env, "binmode"_s);
+            if (!binmode || binmode->is_nil()) return;
+            if (self->read_mode == flags_struct::read_mode::binary) {
+                env->raise("ArgumentError", "binmode specified twice");
+            } else if (self->read_mode == flags_struct::read_mode::text) {
+                env->raise("ArgumentError", "both textmode and binmode specified");
+            }
+            if (binmode->is_truthy())
+                self->read_mode = flags_struct::read_mode::binary;
+        }
+
         void parse_autoclose(Env *env, flags_struct *self, HashObject *kwargs) {
             if (!kwargs) return;
             auto autoclose = kwargs->remove(env, "autoclose"_s);
@@ -175,6 +201,8 @@ namespace ioutil {
         parse_flags_obj(env, this, flags_obj);
         parse_mode(env, this, kwargs);
         parse_flags(env, this, kwargs);
+        parse_textmode(env, this, kwargs);
+        parse_binmode(env, this, kwargs);
         parse_autoclose(env, this, kwargs);
         parse_path(env, this, kwargs);
         if (!external_encoding) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -151,6 +151,13 @@ namespace ioutil {
             parse_flags_obj(env, self, mode);
         }
 
+        void parse_flags(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto flags = kwargs->remove(env, "flags"_s);
+            if (!flags || flags->is_nil()) return;
+            self->flags |= static_cast<int>(flags->to_int(env)->to_nat_int_t());
+        }
+
         void parse_autoclose(Env *env, flags_struct *self, HashObject *kwargs) {
             if (!kwargs) return;
             auto autoclose = kwargs->remove(env, "autoclose"_s);
@@ -167,6 +174,7 @@ namespace ioutil {
     flags_struct::flags_struct(Env *env, Value flags_obj, HashObject *kwargs) {
         parse_flags_obj(env, this, flags_obj);
         parse_mode(env, this, kwargs);
+        parse_flags(env, this, kwargs);
         parse_autoclose(env, this, kwargs);
         parse_path(env, this, kwargs);
         env->ensure_no_extra_keywords(kwargs);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -171,6 +171,24 @@ namespace ioutil {
             }
         }
 
+        void parse_internal_encoding(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto internal_encoding = kwargs->remove(env, "internal_encoding"_s);
+            if (!internal_encoding || internal_encoding->is_nil()) return;
+            if (self->internal_encoding)
+                env->raise("ArgumentError", "encoding specified twice");
+            if (internal_encoding->is_encoding()) {
+                self->internal_encoding = internal_encoding->as_encoding();
+            } else {
+                internal_encoding = internal_encoding->to_str(env);
+                if (internal_encoding->as_string()->string() != "-") {
+                    self->internal_encoding = EncodingObject::find_encoding(env, internal_encoding);
+                    if (self->external_encoding == self->internal_encoding)
+                        self->internal_encoding = nullptr;
+                }
+            }
+        }
+
         void parse_textmode(Env *env, flags_struct *self, HashObject *kwargs) {
             if (!kwargs) return;
             auto textmode = kwargs->remove(env, "textmode"_s);
@@ -215,6 +233,7 @@ namespace ioutil {
         parse_mode(env, this, kwargs);
         parse_flags(env, this, kwargs);
         parse_external_encoding(env, this, kwargs);
+        parse_internal_encoding(env, this, kwargs);
         parse_textmode(env, this, kwargs);
         parse_binmode(env, this, kwargs);
         parse_autoclose(env, this, kwargs);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -158,6 +158,19 @@ namespace ioutil {
             self->flags |= static_cast<int>(flags->to_int(env)->to_nat_int_t());
         }
 
+        void parse_external_encoding(Env *env, flags_struct *self, HashObject *kwargs) {
+            if (!kwargs) return;
+            auto external_encoding = kwargs->remove(env, "external_encoding"_s);
+            if (!external_encoding || external_encoding->is_nil()) return;
+            if (self->external_encoding)
+                env->raise("ArgumentError", "encoding specified twice");
+            if (external_encoding->is_encoding()) {
+                self->external_encoding = external_encoding->as_encoding();
+            } else {
+                self->external_encoding = EncodingObject::find_encoding(env, external_encoding->to_str(env));
+            }
+        }
+
         void parse_textmode(Env *env, flags_struct *self, HashObject *kwargs) {
             if (!kwargs) return;
             auto textmode = kwargs->remove(env, "textmode"_s);
@@ -201,6 +214,7 @@ namespace ioutil {
         parse_flags_obj(env, this, flags_obj);
         parse_mode(env, this, kwargs);
         parse_flags(env, this, kwargs);
+        parse_external_encoding(env, this, kwargs);
         parse_textmode(env, this, kwargs);
         parse_binmode(env, this, kwargs);
         parse_autoclose(env, this, kwargs);


### PR DESCRIPTION
This code is a mess, I don't think I've ever written so many nested if-statements without a deadline. And it's only partially because the Ruby code has to keep backwards compatibility in the options and provides like 4 different ways to set the encoding, which may clash, or might just overwrite things.

Another issue is that we extract the keyword arguments in the bindings, which results in 8 extra arguments to `initialize`, and we'll have to repeat that for every other method that uses these keyword arguments. This should be refactored to pass along the complete keywords arguments structure. Next, the interpretation of these keyword arguments should be extracted or combined with `fileutil::flags_obj_to_flags`, so we can reuse this code.