### PR TITLE
Add IO#autoclose? and IO#autoclose=

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -49,6 +49,7 @@ public:
 
     Value advise(Env *, Value, Value, Value);
     Value append(Env *, Value);
+    Value autoclose(Env *, Value);
     static Value binread(Env *, Value, Value = nullptr, Value = nullptr);
     Value binmode(Env *);
     Value close(Env *);
@@ -64,6 +65,7 @@ public:
     Value initialize(Env *, Value, Value = nullptr);
     Value inspect() const;
     Value internal_encoding() const { return m_internal_encoding; }
+    bool is_autoclose(Env *) const;
     bool is_binmode(Env *) const;
     bool is_closed() const { return m_closed; }
     bool is_eof(Env *);
@@ -104,6 +106,7 @@ private:
     EncodingObject *m_internal_encoding { nullptr };
     int m_fileno { -1 };
     bool m_closed { false };
+    bool m_autoclose { false };
     StringObject *m_path { nullptr };
 };
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -847,6 +847,8 @@ gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass
 gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', '<<', 'IoObject', 'append', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'advise', 'IoObject', 'advise', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'autoclose?', 'IoObject', 'is_autoclose', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('IO', 'autoclose=', 'IoObject', 'autoclose', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'binmode', 'IoObject', 'binmode', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'binmode?', 'IoObject', 'is_binmode', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('IO', 'close', 'IoObject', 'close', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/dir/shared/open.rb
+++ b/spec/core/dir/shared/open.rb
@@ -63,7 +63,7 @@ describe :dir_open, shared: true do
 
   platform_is_not :windows do
     it 'sets the close-on-exec flag for the directory file descriptor' do
-      NATFIXME "Pending implementation of IO#autoclose=", exception: NoMethodError, message: /undefined method `autoclose='/ do
+      NATFIXME "Pending implementation of IO#close_on_exec?", exception: NoMethodError, message: "undefined method `close_on_exec?'" do
       Dir.send(@method, DirSpecs.mock_dir) do |dir|
         io = IO.for_fd(dir.fileno)
         io.autoclose = false

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -171,6 +171,11 @@ Value IoObject::inspect() const {
     return StringObject::format("#<{}:{}>", klass()->inspect_str(), details);
 }
 
+bool IoObject::is_autoclose(Env *env) const {
+    raise_if_closed(env);
+    return m_autoclose;
+}
+
 bool IoObject::is_binmode(Env *env) const {
     raise_if_closed(env);
     return m_external_encoding == EncodingObject::get(Encoding::ASCII_8BIT);
@@ -283,6 +288,12 @@ Value IoObject::append(Env *env, Value obj) {
     auto result = ::write(m_fileno, obj->as_string()->c_str(), obj->as_string()->length());
     if (result == -1) env->raise_errno();
     return this;
+}
+
+Value IoObject::autoclose(Env *env, Value value) {
+    raise_if_closed(env);
+    m_autoclose = value->is_truthy();
+    return value;
 }
 
 Value IoObject::binmode(Env *env) {

--- a/test/natalie/io_test.rb
+++ b/test/natalie/io_test.rb
@@ -1,0 +1,50 @@
+require_relative '../spec_helper'
+require_relative '../../spec/core/io/fixtures/classes'
+
+# Upstream pull request: https://github.com/ruby/spec/pull/1077
+describe "IO#autoclose" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.autoclose = true unless @io.closed?
+    @io.close unless @io.closed?
+  end
+
+  it "can be set to true" do
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "can be set to false" do
+    @io.autoclose = false
+    @io.should_not.autoclose?
+  end
+
+  it "can be set to any truthy value" do
+    @io.autoclose = 42
+    @io.should.autoclose?
+  end
+
+  it "can be set multple times" do
+    @io.autoclose = true
+    @io.should.autoclose?
+
+    @io.autoclose = false
+    @io.should_not.autoclose?
+
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "cannot be queried on a closed IO object" do
+    @io.close
+    -> { @io.autoclose? }.should raise_error(IOError, /closed stream/)
+  end
+
+  it "cannot be set on a closed IO object" do
+    @io.close
+    -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
+  end
+end


### PR DESCRIPTION
For now they're just stub values that don't actually do anything, but they're getting in the way of keyword arguments for IO creation and duplication.