### PR TITLE
Implement IO#printf

### DIFF
--- a/spec/core/io/printf_spec.rb
+++ b/spec/core/io/printf_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#printf" do
+  before :each do
+    @name = tmp("io_printf.txt")
+    @io = new_io @name
+    @io.sync = true
+  end
+
+  after :each do
+    @io.close if @io
+    rm_r @name
+  end
+
+  it "calls #to_str to convert the format object to a String" do
+    obj = mock("printf format")
+    obj.should_receive(:to_str).and_return("%s")
+
+    @io.printf obj, "printf"
+    File.read(@name).should == "printf"
+  end
+
+  it "writes the #sprintf formatted string" do
+    @io.printf "%d %s", 5, "cookies"
+    File.read(@name).should == "5 cookies"
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.printf("stuff") }.should raise_error(IOError)
+  end
+end

--- a/spec/core/io/printf_spec.rb
+++ b/spec/core/io/printf_spec.rb
@@ -5,7 +5,9 @@ describe "IO#printf" do
   before :each do
     @name = tmp("io_printf.txt")
     @io = new_io @name
-    @io.sync = true
+    NATFIXME 'Implement IO#sync=', exception: NoMethodError, message: "undefined method `sync='" do
+      @io.sync = true
+    end
   end
 
   after :each do
@@ -15,10 +17,12 @@ describe "IO#printf" do
 
   it "calls #to_str to convert the format object to a String" do
     obj = mock("printf format")
-    obj.should_receive(:to_str).and_return("%s")
+    NATFIXME '#to_str calls should probably be done in Kernel.sprintf', exception: NoMethodError, message: "undefined method `chars'" do
+      obj.should_receive(:to_str).and_return("%s")
 
-    @io.printf obj, "printf"
-    File.read(@name).should == "printf"
+      @io.printf obj, "printf"
+      File.read(@name).should == "printf"
+    end
   end
 
   it "writes the #sprintf formatted string" do

--- a/spec/core/io/printf_spec.rb
+++ b/spec/core/io/printf_spec.rb
@@ -17,12 +17,10 @@ describe "IO#printf" do
 
   it "calls #to_str to convert the format object to a String" do
     obj = mock("printf format")
-    NATFIXME '#to_str calls should probably be done in Kernel.sprintf', exception: NoMethodError, message: "undefined method `chars'" do
-      obj.should_receive(:to_str).and_return("%s")
+    obj.should_receive(:to_str).and_return("%s")
 
-      @io.printf obj, "printf"
-      File.read(@name).should == "printf"
-    end
+    @io.printf obj, "printf"
+    File.read(@name).should == "printf"
   end
 
   it "writes the #sprintf formatted string" do

--- a/spec/core/kernel/printf_spec.rb
+++ b/spec/core/kernel/printf_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/sprintf'
+
+describe "Kernel#printf" do
+  it "is a private method" do
+    NATFIXME 'Kernel#printf is a private method', exception: SpecFailedException do
+      Kernel.should have_private_instance_method(:printf)
+    end
+  end
+end
+
+describe "Kernel.printf" do
+  before :each do
+    @stdout = $stdout
+    @name = tmp("kernel_puts.txt")
+    $stdout = new_io @name
+  end
+
+  after :each do
+    $stdout.close
+    $stdout = @stdout
+    rm_r @name
+  end
+
+  it "writes to stdout when a string is the first argument" do
+    $stdout.should_receive(:write).with("string")
+    Kernel.printf("%s", "string")
+  end
+
+  it "calls write on the first argument when it is not a string" do
+    object = mock('io')
+    object.should_receive(:write).with("string")
+    Kernel.printf(object, "%s", "string")
+  end
+end
+
+describe "Kernel.printf" do
+  describe "formatting" do
+    before :each do
+      require "stringio"
+    end
+
+    context "io is specified" do
+      it_behaves_like :kernel_sprintf, -> format, *args {
+        io = StringIO.new(+"")
+        Kernel.printf(io, format, *args)
+        io.string
+      }
+    end
+
+    context "io is not specified" do
+      it_behaves_like :kernel_sprintf, -> format, *args {
+        stdout = $stdout
+        begin
+          $stdout = io = StringIO.new(+"")
+          Kernel.printf(format, *args)
+          io.string
+        ensure
+          $stdout = stdout
+        end
+      }
+    end
+  end
+end

--- a/src/io.rb
+++ b/src/io.rb
@@ -15,6 +15,10 @@ class IO
     end
   end
 
+  def printf(format_string, *arguments)
+    print(Kernel.sprintf(format_string, *arguments))
+  end
+
   # The following are used in IO.select
 
   module WaitReadable; end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -64,7 +64,7 @@ module Kernel
 
   class SprintfFormatter
     def initialize(format_string, arguments)
-      @format_string = format_string
+      @format_string = format_string.to_str
       @arguments = arguments
       @arguments_index = 0
       @positional_argument_used = nil


### PR DESCRIPTION
@seven1m I included a call to `#to_str` in the `Kernel` module, that's what MRI does too (even though it's not in the specs of `Kernel#sprintf`. I added those specs as well, we now have support in the IO object to run those.