### PR TITLE
Rename fileutil to ioutil

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -14,13 +14,6 @@
 
 namespace Natalie {
 
-namespace fileutil {
-    // Utility Functions Common to File, Dir and Io
-    StringObject *convert_using_to_path(Env *env, Value path);
-    int flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
-    mode_t perm_to_mode(Env *env, Value perm);
-}
-
 class FileObject : public IoObject {
 public:
     FileObject()

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -15,6 +15,14 @@
 
 namespace Natalie {
 
+namespace ioutil {
+    // Utility Functions Common to File, Dir and Io
+    StringObject *convert_using_to_path(Env *env, Value path);
+    int object_stat(Env *env, Value io, struct stat *sb);
+    int flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
+    mode_t perm_to_mode(Env *env, Value perm);
+}
+
 class IoObject : public Object {
 public:
     IoObject()

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -21,7 +21,7 @@ Value DirObject::open(Env *env, Value path, Value encoding, Block *block) {
 }
 
 Value DirObject::initialize(Env *env, Value path, Value encoding) {
-    path = fileutil::convert_using_to_path(env, path);
+    path = ioutil::convert_using_to_path(env, path);
     m_dir = ::opendir(path->as_string()->c_str());
     if (!m_dir) env->raise_errno();
     if (encoding && !encoding->is_nil()) {
@@ -105,7 +105,7 @@ Value DirObject::chdir(Env *env, Value path, Block *block) {
 
         path = new StringObject { path_str };
     } else {
-        path = fileutil::convert_using_to_path(env, path);
+        path = ioutil::convert_using_to_path(env, path);
     }
 
     std::error_code ec;
@@ -226,7 +226,7 @@ Value DirObject::foreach (Env *env, Value path, Value encoding, Block * block) {
 }
 
 Value DirObject::chroot(Env *env, Value path) {
-    path = fileutil::convert_using_to_path(env, path);
+    path = ioutil::convert_using_to_path(env, path);
     auto result = ::chroot(path->as_string()->c_str());
     if (result < 0) env->raise_errno();
     return Value::integer(0);
@@ -237,7 +237,7 @@ Value DirObject::mkdir(Env *env, Value path, Value mode) {
     if (mode) {
         octmode = IntegerObject::convert_to_int(env, mode);
     }
-    path = fileutil::convert_using_to_path(env, path);
+    path = ioutil::convert_using_to_path(env, path);
     auto result = ::mkdir(path->as_string()->c_str(), octmode);
     if (result < 0) env->raise_errno();
     // need to check dir exists and return nil if mkdir was unsuccessful.
@@ -249,7 +249,7 @@ Value DirObject::pwd(Env *env) {
 }
 
 Value DirObject::rmdir(Env *env, Value path) {
-    path = fileutil::convert_using_to_path(env, path);
+    path = ioutil::convert_using_to_path(env, path);
     auto result = ::rmdir(path->as_string()->c_str());
     if (result < 0) env->raise_errno();
     return Value::integer(0);

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -13,7 +13,7 @@ namespace Natalie {
 
 // wrapper to implement euidaccess() for certain systems which
 // do not have it.
-int effective_uid_access(const char *path_name, int type) {
+static int effective_uid_access(const char *path_name, int type) {
 #if defined(__OpenBSD__) or defined(__APPLE__)
     uid_t real_uid = ::getuid();
     uid_t effective_uid = ::geteuid();


### PR DESCRIPTION
These functions are not specific to File IO, but are in use for generic IO. The io_object file seems like a better place.

This is part of the preparation for #1225 