### PR TITLE
Rework flags_obj_to_flags

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -21,6 +21,8 @@ namespace ioutil {
     int object_stat(Env *env, Value io, struct stat *sb);
     struct flags_struct {
         int flags { O_RDONLY };
+        EncodingObject *external_encoding { nullptr };
+        EncodingObject *internal_encoding { nullptr };
     };
     flags_struct flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
     mode_t perm_to_mode(Env *env, Value perm);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -23,8 +23,9 @@ namespace ioutil {
         int flags { O_RDONLY };
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };
+
+        flags_struct(Env *env, Value flags_obj);
     };
-    flags_struct flags_obj_to_flags(Env *env, Value flags_obj);
     mode_t perm_to_mode(Env *env, Value perm);
 }
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -19,7 +19,10 @@ namespace ioutil {
     // Utility Functions Common to File, Dir and Io
     StringObject *convert_using_to_path(Env *env, Value path);
     int object_stat(Env *env, Value io, struct stat *sb);
-    int flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
+    struct flags_struct {
+        int flags { O_RDONLY };
+    };
+    flags_struct flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
     mode_t perm_to_mode(Env *env, Value perm);
 }
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -24,7 +24,7 @@ namespace ioutil {
         EncodingObject *external_encoding { nullptr };
         EncodingObject *internal_encoding { nullptr };
     };
-    flags_struct flags_obj_to_flags(Env *env, IoObject *self, Value flags_obj);
+    flags_struct flags_obj_to_flags(Env *env, Value flags_obj);
     mode_t perm_to_mode(Env *env, Value perm);
 }
 

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -35,7 +35,7 @@ static int effective_uid_access(const char *path_name, int type) {
 
 // NATFIXME : block form is not used, option-hash arg not implemented.
 Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value perm, Block *block) {
-    const auto flags = ioutil::flags_obj_to_flags(env, nullptr, flags_obj);
+    const auto flags = ioutil::flags_obj_to_flags(env, flags_obj);
     const auto modenum = ioutil::perm_to_mode(env, perm);
 
     if (filename->is_integer()) { // passing in a number uses fd number

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -51,7 +51,7 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value pe
         return this;
     } else {
         filename = ioutil::convert_using_to_path(env, filename);
-        int fileno = ::open(filename->as_string()->c_str(), flags, modenum);
+        int fileno = ::open(filename->as_string()->c_str(), flags.flags, modenum);
         if (fileno == -1) env->raise_errno();
         set_fileno(fileno);
         set_path(filename->as_string());

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -35,7 +35,7 @@ static int effective_uid_access(const char *path_name, int type) {
 
 // NATFIXME : block form is not used, option-hash arg not implemented.
 Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value perm, Block *block) {
-    const auto flags = ioutil::flags_obj_to_flags(env, flags_obj);
+    const ioutil::flags_struct flags { env, flags_obj };
     const auto modenum = ioutil::perm_to_mode(env, perm);
 
     if (filename->is_integer()) { // passing in a number uses fd number

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -35,7 +35,7 @@ static int effective_uid_access(const char *path_name, int type) {
 
 // NATFIXME : block form is not used, option-hash arg not implemented.
 Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value perm, Block *block) {
-    const auto flags = ioutil::flags_obj_to_flags(env, this, flags_obj);
+    const auto flags = ioutil::flags_obj_to_flags(env, nullptr, flags_obj);
     const auto modenum = ioutil::perm_to_mode(env, perm);
 
     if (filename->is_integer()) { // passing in a number uses fd number
@@ -48,15 +48,15 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Value pe
         FILE *fptr = ::fdopen(fileno, flags_str.c_str());
         if (fptr == nullptr) env->raise_errno();
         set_fileno(fileno);
-        return this;
     } else {
         filename = ioutil::convert_using_to_path(env, filename);
         int fileno = ::open(filename->as_string()->c_str(), flags.flags, modenum);
         if (fileno == -1) env->raise_errno();
         set_fileno(fileno);
         set_path(filename->as_string());
-        return this;
     }
+    set_encoding(env, flags.external_encoding, flags.internal_encoding);
+    return this;
 }
 
 Value FileObject::open(Env *env, Value filename, Value flags_obj, Value perm, Block *block) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -159,11 +159,12 @@ Value IoObject::initialize(Env *env, Value file_number, Value flags_obj) {
     if (actual_flags < 0)
         env->raise_errno();
     if (flags_obj != nullptr && !flags_obj->is_nil()) {
-        const auto wanted_flags = ioutil::flags_obj_to_flags(env, this, flags_obj);
+        const auto wanted_flags = ioutil::flags_obj_to_flags(env, nullptr, flags_obj);
         if ((flags_is_readable(wanted_flags.flags) && !flags_is_readable(actual_flags)) || (flags_is_writable(wanted_flags.flags) && !flags_is_writable(actual_flags))) {
             errno = EINVAL;
             env->raise_errno();
         }
+        set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     }
     set_fileno(fileno);
     return this;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -95,6 +95,8 @@ namespace ioutil {
             auto flags_str = flagsplit->fetch(env, IntegerObject::create(static_cast<nat_int_t>(0)), new StringObject { "" }, nullptr)->as_string()->string();
             auto extenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(1)), nullptr);
             auto intenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(2)), nullptr);
+            if (!extenc->is_nil()) flags.external_encoding = EncodingObject::find_encoding(env, extenc);
+            if (!intenc->is_nil()) flags.internal_encoding = EncodingObject::find_encoding(env, intenc);
             if (self)
                 self->set_encoding(env, extenc, intenc);
 
@@ -113,9 +115,11 @@ namespace ioutil {
             if (binary_text_mode && binary_text_mode != 'b' && binary_text_mode != 't')
                 env->raise("ArgumentError", "invalid access mode {}", flags_str);
 
-            if (binary_text_mode == 'b' && self && extenc->is_nil()) {
+            if (binary_text_mode == 'b' && self && !flags.external_encoding) {
+                flags.external_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
                 self->set_encoding(env, EncodingObject::get(Encoding::ASCII_8BIT));
-            } else if (binary_text_mode == 't' && self && extenc->is_nil()) {
+            } else if (binary_text_mode == 't' && self && !flags.external_encoding) {
+                flags.external_encoding = EncodingObject::get(Encoding::UTF_8);
                 self->set_encoding(env, EncodingObject::get(Encoding::UTF_8));
             }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -115,12 +115,12 @@ namespace ioutil {
             if (binary_text_mode && binary_text_mode != 'b' && binary_text_mode != 't')
                 env->raise("ArgumentError", "invalid access mode {}", flags_str);
 
-            if (binary_text_mode == 'b' && self && !flags.external_encoding) {
+            if (binary_text_mode == 'b' && !flags.external_encoding) {
                 flags.external_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
-                self->set_encoding(env, EncodingObject::get(Encoding::ASCII_8BIT));
-            } else if (binary_text_mode == 't' && self && !flags.external_encoding) {
+                if (self) self->set_encoding(env, EncodingObject::get(Encoding::ASCII_8BIT));
+            } else if (binary_text_mode == 't' && !flags.external_encoding) {
                 flags.external_encoding = EncodingObject::get(Encoding::UTF_8);
-                self->set_encoding(env, EncodingObject::get(Encoding::UTF_8));
+                if (self) self->set_encoding(env, EncodingObject::get(Encoding::UTF_8));
             }
 
             if (main_mode == 'r' && !read_write_mode)


### PR DESCRIPTION
The old version worked at two different levels of abstraction:
* Parse the input mode and return that as a bitmask for the file descriptor
* Parse some encoding references and change these on the IoObject argument

The changing the object part is getting in the way of the keyword arguments (#1225), where it would be better to parse all the information before setting anything.

This change is a(nother) preparation for the keyword arguments: create a struct to return the parsed string as three values (the file access mode and the two encodings), and move the application of these settings to the callers.
This class will be extended with the keyword parsing.