### PR TITLE
Make attr spec-compliant (for real this time)

### DIFF
--- a/spec/core/module/attr_spec.rb
+++ b/spec/core/module/attr_spec.rb
@@ -137,11 +137,9 @@ describe "Module#attr" do
   end
 
   it "with a boolean argument emits a warning when $VERBOSE is true" do
-    NATFIXME 'Warnings', exception: SpecFailedException do
-      -> {
-        Class.new { attr :foo, true }
-      }.should complain(/boolean argument is obsoleted/, verbose: true)
-    end
+    -> {
+      Class.new { attr :foo, true }
+    }.should complain(/boolean argument is obsoleted/, verbose: true)
   end
 
   it "is a public method" do

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -547,6 +547,8 @@ ArrayObject *ModuleObject::attr(Env *env, Args args) {
     bool accessor = false;
     auto size = args.size();
     if (args.size() > 1 && args[size - 1]->is_boolean()) {
+        if (env->global_get("$VERBOSE"_s)->is_truthy())
+            env->warn("optional boolean argument is obsoleted");
         accessor = args[size - 1]->is_truthy();
         size--;
     }


### PR DESCRIPTION
Show a warning in verbose mode.

The code checking for `env->global_get("$VERBOSE"_s)->is_truthy()` is something that screams for an abstraction.