### PR TITLE
Refresh specs for IO.open

### DIFF
--- a/spec/core/io/open_spec.rb
+++ b/spec/core/io/open_spec.rb
@@ -37,6 +37,19 @@ describe "IO.open" do
     ScratchPad.recorded.should == :called
   end
 
+  it "propagate an exception in the block after calling #close" do
+    -> do
+      IO.open(@fd, "w") do |io|
+        IOSpecs.io_mock(io, :close) do
+          super()
+          ScratchPad.record :called
+        end
+        raise Exception
+      end
+    end.should raise_error(Exception)
+    ScratchPad.recorded.should == :called
+  end
+
   it "propagates an exception raised by #close that is not a StandardError" do
     -> do
       IO.open(@fd, "w") do |io|


### PR DESCRIPTION
This is the upstream addition of checking for close if the block throws an exception (https://github.com/ruby/spec/pull/1082)