### PR TITLE
Import specs for File#printf

### DIFF
--- a/spec/core/file/printf_spec.rb
+++ b/spec/core/file/printf_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require_relative '../kernel/shared/sprintf'
+
+describe "File#printf" do
+  it_behaves_like :kernel_sprintf, -> format, *args {
+    begin
+      @filename = tmp("printf.txt")
+
+      File.open(@filename, "w", encoding: "utf-8") do |f|
+        f.printf(format, *args)
+      end
+
+      File.read(@filename, encoding: "utf-8")
+    ensure
+      rm_r @filename
+    end
+  }
+end


### PR DESCRIPTION
These pass, since we now support keyword arguments in File.open and have implemented IO#printf.