### PR TITLE
Implement IO.pipe

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -91,6 +91,7 @@ public:
     bool is_closed() const { return m_closed; }
     bool is_eof(Env *);
     bool isatty(Env *) const;
+    static Value pipe(Env *, Args, Block *, ClassObject *);
     int pos(Env *);
     Value pread(Env *, Value, Value, Value = nullptr);
     Value puts(Env *, Args);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -843,6 +843,7 @@ gen.binding('Integer', '|', 'IntegerObject', 'bitwise_or', argc: 1, pass_env: tr
 gen.binding('Integer', 'zero?', 'IntegerObject', 'is_zero', argc: 0, pass_env: false, pass_block: false, return_type: :bool, optimized: true)
 
 gen.static_binding('IO', 'binread', 'IoObject', 'binread', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('IO', 'pipe', 'IoObject', 'pipe', argc: :any, pass_env: true, pass_block: true, pass_klass: true, return_type: :Object)
 gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'sysopen', 'IoObject', 'sysopen', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/eof_spec.rb
+++ b/spec/core/io/eof_spec.rb
@@ -98,22 +98,18 @@ describe "IO#eof?" do
   end
 
   it "returns true on receiving side of Pipe when writing side is closed" do
-    NATFIXME 'Implement IO.pipe', exception: NoMethodError, message: "undefined method `pipe' for IO:Class" do
-      @r, @w = IO.pipe
-      @w.close
-      @r.should.eof?
-    end
+    @r, @w = IO.pipe
+    @w.close
+    @r.should.eof?
   end
 
   it "returns false on receiving side of Pipe when writing side wrote some data" do
-    NATFIXME 'Implement IO.pipe', exception: NoMethodError, message: "undefined method `pipe' for IO:Class" do
-      @r, @w = IO.pipe
-      @w.puts "hello"
-      @r.should_not.eof?
-      @w.close
-      @r.should_not.eof?
-      @r.read
-      @r.should.eof?
-    end
+    @r, @w = IO.pipe
+    @w.puts "hello"
+    @r.should_not.eof?
+    @w.close
+    @r.should_not.eof?
+    @r.read
+    @r.should.eof?
   end
 end

--- a/spec/core/io/inspect_spec.rb
+++ b/spec/core/io/inspect_spec.rb
@@ -1,30 +1,18 @@
 require_relative '../../spec_helper'
 
 describe "IO#inspect" do
-  before :each do
-    @name = tmp("io_inspect.txt")
-    touch @name
-  end
-
   after :each do
     @r.close if @r && !@r.closed?
     @w.close if @w && !@w.closed?
-    rm_r @name
   end
 
   it "contains the file descriptor number" do
-    NATFIXME 'Implement IO.pipe', exception: NoMethodError, message: "undefined method `pipe' for IO:Class" do
-      @r, @w = IO.pipe
-    end
-    @r = IO.new(IO.sysopen(@name))
+    @r, @w = IO.pipe
     @r.inspect.should include("fd #{@r.fileno}")
   end
 
   it "contains \"(closed)\" if the stream is closed" do
-    NATFIXME 'Implement IO.pipe', exception: NoMethodError, message: "undefined method `pipe' for IO:Class" do
-      @r, @w = IO.pipe
-    end
-    @r = IO.new(IO.sysopen(@name))
+    @r, @w = IO.pipe
     @r.close
     @r.inspect.should include("(closed)")
   end

--- a/spec/core/io/pipe_spec.rb
+++ b/spec/core/io/pipe_spec.rb
@@ -1,0 +1,225 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO.pipe" do
+  after :each do
+    @r.close if @r && !@r.closed?
+    @w.close if @w && !@w.closed?
+  end
+
+  it "creates a two-ended pipe" do
+    @r, @w = IO.pipe
+    @w.puts "test_create_pipe\\n"
+    @w.close
+    @r.read(16).should == "test_create_pipe"
+  end
+
+  it "returns two IO objects" do
+    @r, @w = IO.pipe
+    @r.should be_kind_of(IO)
+    @w.should be_kind_of(IO)
+  end
+
+  it "returns instances of a subclass when called on a subclass" do
+    @r, @w = IOSpecs::SubIO.pipe
+    @r.should be_an_instance_of(IOSpecs::SubIO)
+    @w.should be_an_instance_of(IOSpecs::SubIO)
+  end
+
+  it "does not use IO.new method to create pipes and allows its overriding" do
+    ScratchPad.record []
+
+    # so redefined .new is not called, but original #initialize is
+    @r, @w = IOSpecs::SubIOWithRedefinedNew.pipe
+    ScratchPad.recorded.should == [:call_original_initialize, :call_original_initialize] # called 2 times - for each pipe (r and w)
+
+    @r.should be_an_instance_of(IOSpecs::SubIOWithRedefinedNew)
+    @w.should be_an_instance_of(IOSpecs::SubIOWithRedefinedNew)
+  end
+end
+
+describe "IO.pipe" do
+  describe "passed a block" do
+    it "yields two IO objects" do
+      IO.pipe do |r, w|
+        r.should be_kind_of(IO)
+        w.should be_kind_of(IO)
+      end
+    end
+
+    it "returns the result of the block" do
+      IO.pipe { |r, w| :result }.should == :result
+    end
+
+    it "closes both IO objects" do
+      r, w = IO.pipe do |_r, _w|
+        [_r, _w]
+      end
+      r.should.closed?
+      w.should.closed?
+    end
+
+    it "closes both IO objects when the block raises" do
+      r = w = nil
+      -> do
+        IO.pipe do |_r, _w|
+          r = _r
+          w = _w
+          raise RuntimeError
+        end
+      end.should raise_error(RuntimeError)
+      r.should.closed?
+      w.should.closed?
+    end
+
+    it "allows IO objects to be closed within the block" do
+      r, w = IO.pipe do |_r, _w|
+        _r.close
+        _w.close
+        [_r, _w]
+      end
+      r.should.closed?
+      w.should.closed?
+    end
+  end
+end
+
+describe "IO.pipe" do
+  before :each do
+    @default_external = Encoding.default_external
+    @default_internal = Encoding.default_internal
+  end
+
+  after :each do
+    Encoding.default_external = @default_external
+    Encoding.default_internal = @default_internal
+  end
+
+  it "sets the external encoding of the read end to the default when passed no arguments" do
+    Encoding.default_external = Encoding::ISO_8859_1
+
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::ISO_8859_1
+      r.internal_encoding.should be_nil
+    end
+  end
+
+  it "sets the internal encoding of the read end to the default when passed no arguments" do
+    Encoding.default_external = Encoding::ISO_8859_1
+    Encoding.default_internal = Encoding::UTF_8
+
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::ISO_8859_1
+      r.internal_encoding.should == Encoding::UTF_8
+    end
+  end
+
+  it "sets the internal encoding to nil if the same as the external" do
+    Encoding.default_external = Encoding::UTF_8
+    Encoding.default_internal = Encoding::UTF_8
+
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should be_nil
+    end
+  end
+
+  it "sets the external encoding of the read end when passed an Encoding argument" do
+    IO.pipe(Encoding::UTF_8) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should be_nil
+    end
+  end
+
+  it "sets the external and internal encodings of the read end when passed two Encoding arguments" do
+    IO.pipe(Encoding::UTF_8, Encoding::UTF_16BE) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::UTF_16BE
+    end
+  end
+
+  it "sets the external encoding of the read end when passed the name of an Encoding" do
+    IO.pipe("UTF-8") do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should be_nil
+    end
+  end
+
+  it "accepts 'bom|' prefix for external encoding" do
+    IO.pipe("BOM|UTF-8") do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should be_nil
+    end
+  end
+
+  it "sets the external and internal encodings specified as a String and separated with a colon" do
+    IO.pipe("UTF-8:ISO-8859-1") do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::ISO_8859_1
+    end
+  end
+
+  it "accepts 'bom|' prefix for external encoding when specifying 'external:internal'" do
+    IO.pipe("BOM|UTF-8:ISO-8859-1") do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::ISO_8859_1
+    end
+  end
+
+  it "sets the external and internal encoding when passed two String arguments" do
+    IO.pipe("UTF-8", "UTF-16BE") do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::UTF_16BE
+    end
+  end
+
+  it "accepts an options Hash with one String encoding argument" do
+    IO.pipe("BOM|UTF-8:ISO-8859-1", invalid: :replace) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::ISO_8859_1
+    end
+  end
+
+  it "accepts an options Hash with two String encoding arguments" do
+    IO.pipe("UTF-8", "ISO-8859-1", invalid: :replace) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::ISO_8859_1
+    end
+  end
+
+  it "calls #to_hash to convert an options argument" do
+    options = mock("io pipe encoding options")
+    options.should_receive(:to_hash).and_return({ invalid: :replace })
+    IO.pipe("UTF-8", "ISO-8859-1", **options) { |r, w| }
+  end
+
+  it "calls #to_str to convert the first argument to a String" do
+    obj = mock("io_pipe_encoding")
+    obj.should_receive(:to_str).and_return("UTF-8:UTF-16BE")
+    IO.pipe(obj) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::UTF_16BE
+    end
+  end
+
+  it "calls #to_str to convert the second argument to a String" do
+    obj = mock("io_pipe_encoding")
+    obj.should_receive(:to_str).at_least(1).times.and_return("UTF-16BE")
+    IO.pipe(Encoding::UTF_8, obj) do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should == Encoding::UTF_16BE
+    end
+  end
+
+  it "sets no external encoding for the write end" do
+    IO.pipe(Encoding::UTF_8) do |r, w|
+      w.external_encoding.should be_nil
+    end
+  end
+
+  it "sets no internal encoding for the write end" do
+    IO.pipe(Encoding::UTF_8) do |r, w|
+      w.external_encoding.should be_nil
+    end
+  end
+end

--- a/spec/core/io/pipe_spec.rb
+++ b/spec/core/io/pipe_spec.rb
@@ -52,28 +52,24 @@ describe "IO.pipe" do
     end
 
     it "closes both IO objects" do
-      NATFIXME 'Close file descriptors in block', exception: SpecFailedException do
-        r, w = IO.pipe do |_r, _w|
-          [_r, _w]
-        end
-        r.should.closed?
-        w.should.closed?
+      r, w = IO.pipe do |_r, _w|
+        [_r, _w]
       end
+      r.should.closed?
+      w.should.closed?
     end
 
     it "closes both IO objects when the block raises" do
-      NATFIXME 'Close file descriptors in block', exception: SpecFailedException do
-        r = w = nil
-        -> do
-          IO.pipe do |_r, _w|
-            r = _r
-            w = _w
-            raise RuntimeError
-          end
-        end.should raise_error(RuntimeError)
-        r.should.closed?
-        w.should.closed?
-      end
+      r = w = nil
+      -> do
+        IO.pipe do |_r, _w|
+          r = _r
+          w = _w
+          raise RuntimeError
+        end
+      end.should raise_error(RuntimeError)
+      r.should.closed?
+      w.should.closed?
     end
 
     it "allows IO objects to be closed within the block" do

--- a/spec/core/io/pipe_spec.rb
+++ b/spec/core/io/pipe_spec.rb
@@ -52,24 +52,28 @@ describe "IO.pipe" do
     end
 
     it "closes both IO objects" do
-      r, w = IO.pipe do |_r, _w|
-        [_r, _w]
+      NATFIXME 'Close file descriptors in block', exception: SpecFailedException do
+        r, w = IO.pipe do |_r, _w|
+          [_r, _w]
+        end
+        r.should.closed?
+        w.should.closed?
       end
-      r.should.closed?
-      w.should.closed?
     end
 
     it "closes both IO objects when the block raises" do
-      r = w = nil
-      -> do
-        IO.pipe do |_r, _w|
-          r = _r
-          w = _w
-          raise RuntimeError
-        end
-      end.should raise_error(RuntimeError)
-      r.should.closed?
-      w.should.closed?
+      NATFIXME 'Close file descriptors in block', exception: SpecFailedException do
+        r = w = nil
+        -> do
+          IO.pipe do |_r, _w|
+            r = _r
+            w = _w
+            raise RuntimeError
+          end
+        end.should raise_error(RuntimeError)
+        r.should.closed?
+        w.should.closed?
+      end
     end
 
     it "allows IO objects to be closed within the block" do
@@ -96,94 +100,118 @@ describe "IO.pipe" do
   end
 
   it "sets the external encoding of the read end to the default when passed no arguments" do
-    Encoding.default_external = Encoding::ISO_8859_1
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Encoding.default_external = Encoding::ISO_8859_1
 
-    IO.pipe do |r, w|
-      r.external_encoding.should == Encoding::ISO_8859_1
-      r.internal_encoding.should be_nil
+      IO.pipe do |r, w|
+        r.external_encoding.should == Encoding::ISO_8859_1
+        r.internal_encoding.should be_nil
+      end
     end
   end
 
   it "sets the internal encoding of the read end to the default when passed no arguments" do
-    Encoding.default_external = Encoding::ISO_8859_1
-    Encoding.default_internal = Encoding::UTF_8
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Encoding.default_external = Encoding::ISO_8859_1
+      Encoding.default_internal = Encoding::UTF_8
 
-    IO.pipe do |r, w|
-      r.external_encoding.should == Encoding::ISO_8859_1
-      r.internal_encoding.should == Encoding::UTF_8
+      IO.pipe do |r, w|
+        r.external_encoding.should == Encoding::ISO_8859_1
+        r.internal_encoding.should == Encoding::UTF_8
+      end
     end
   end
 
   it "sets the internal encoding to nil if the same as the external" do
-    Encoding.default_external = Encoding::UTF_8
-    Encoding.default_internal = Encoding::UTF_8
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Encoding.default_external = Encoding::UTF_8
+      Encoding.default_internal = Encoding::UTF_8
 
-    IO.pipe do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should be_nil
+      IO.pipe do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should be_nil
+      end
     end
   end
 
   it "sets the external encoding of the read end when passed an Encoding argument" do
-    IO.pipe(Encoding::UTF_8) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should be_nil
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe(Encoding::UTF_8) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should be_nil
+      end
     end
   end
 
   it "sets the external and internal encodings of the read end when passed two Encoding arguments" do
-    IO.pipe(Encoding::UTF_8, Encoding::UTF_16BE) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::UTF_16BE
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe(Encoding::UTF_8, Encoding::UTF_16BE) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::UTF_16BE
+      end
     end
   end
 
   it "sets the external encoding of the read end when passed the name of an Encoding" do
-    IO.pipe("UTF-8") do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should be_nil
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("UTF-8") do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should be_nil
+      end
     end
   end
 
   it "accepts 'bom|' prefix for external encoding" do
-    IO.pipe("BOM|UTF-8") do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should be_nil
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("BOM|UTF-8") do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should be_nil
+      end
     end
   end
 
   it "sets the external and internal encodings specified as a String and separated with a colon" do
-    IO.pipe("UTF-8:ISO-8859-1") do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::ISO_8859_1
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("UTF-8:ISO-8859-1") do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::ISO_8859_1
+      end
     end
   end
 
   it "accepts 'bom|' prefix for external encoding when specifying 'external:internal'" do
-    IO.pipe("BOM|UTF-8:ISO-8859-1") do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::ISO_8859_1
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("BOM|UTF-8:ISO-8859-1") do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::ISO_8859_1
+      end
     end
   end
 
   it "sets the external and internal encoding when passed two String arguments" do
-    IO.pipe("UTF-8", "UTF-16BE") do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::UTF_16BE
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("UTF-8", "UTF-16BE") do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::UTF_16BE
+      end
     end
   end
 
   it "accepts an options Hash with one String encoding argument" do
-    IO.pipe("BOM|UTF-8:ISO-8859-1", invalid: :replace) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::ISO_8859_1
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("BOM|UTF-8:ISO-8859-1", invalid: :replace) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::ISO_8859_1
+      end
     end
   end
 
   it "accepts an options Hash with two String encoding arguments" do
-    IO.pipe("UTF-8", "ISO-8859-1", invalid: :replace) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::ISO_8859_1
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      IO.pipe("UTF-8", "ISO-8859-1", invalid: :replace) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::ISO_8859_1
+      end
     end
   end
 
@@ -194,20 +222,24 @@ describe "IO.pipe" do
   end
 
   it "calls #to_str to convert the first argument to a String" do
-    obj = mock("io_pipe_encoding")
-    obj.should_receive(:to_str).and_return("UTF-8:UTF-16BE")
-    IO.pipe(obj) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::UTF_16BE
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      obj = mock("io_pipe_encoding")
+      obj.should_receive(:to_str).and_return("UTF-8:UTF-16BE")
+      IO.pipe(obj) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::UTF_16BE
+      end
     end
   end
 
   it "calls #to_str to convert the second argument to a String" do
-    obj = mock("io_pipe_encoding")
-    obj.should_receive(:to_str).at_least(1).times.and_return("UTF-16BE")
-    IO.pipe(Encoding::UTF_8, obj) do |r, w|
-      r.external_encoding.should == Encoding::UTF_8
-      r.internal_encoding.should == Encoding::UTF_16BE
+    NATFIXME 'Encoding arguments', exception: SpecFailedException do
+      obj = mock("io_pipe_encoding")
+      obj.should_receive(:to_str).at_least(1).times.and_return("UTF-16BE")
+      IO.pipe(Encoding::UTF_8, obj) do |r, w|
+        r.external_encoding.should == Encoding::UTF_8
+        r.internal_encoding.should == Encoding::UTF_16BE
+      end
     end
   end
 

--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -427,7 +427,7 @@ describe "IO#read" do
 
   platform_is_not :windows do
     it "raises IOError when stream is closed by another thread" do
-      NATFIXME 'Implement IO.pipe', exception: NoMethodError, message: "undefined method `pipe' for IO:Class" do
+      NATFIXME 'Thread', exception: NameError, message: 'uninitialized constant Thread' do
         r, w = IO.pipe
         t = Thread.new do
           begin

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -812,6 +812,14 @@ int IoObject::set_pos(Env *env, Value position) {
     return result;
 }
 
+Value IoObject::pipe(Env *env, Args args, Block *block, ClassObject *klass) {
+    Value pipes = new ArrayObject { NilObject::the(), NilObject::the() };
+    if (!block)
+        return pipes;
+
+    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { pipes }, nullptr);
+}
+
 int IoObject::pos(Env *env) {
     raise_if_closed(env);
     errno = 0;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -813,7 +813,7 @@ int IoObject::set_pos(Env *env, Value position) {
 }
 
 Value IoObject::pipe(Env *env, Args args, Block *block, ClassObject *klass) {
-    auto kwargs = args.pop_keyword_hash();
+    /* auto kwargs = */ args.pop_keyword_hash();
     args.ensure_argc_between(env, 0, 2);
 
     int pipefd[2];


### PR DESCRIPTION
This is one of those things that is used in a lot of specs (I see 37 occurrences in the specs folder when I exclude the `pipe_spec.rb` file). Most relevant for me is `IO.select`, which is one of the things I need for  #1184.

For now the only issue in the specs is the encoding, but that is partially because we don't acknowledge the `Encoding.default_external`/`Encoding.default_internal` in the generic code of the IO object. Since character encoding hardly works in Natalie, this shouldn't be too much of an issue for the first version.
Another issue: if you run this with a subclass of IO, and that subclass has a `close` method that throws an error, your program will probably crash. The `Defer` code has been copied from the old implementation of `File.open`, which had this issue too when I moved that to `IO.open` and ran the specs that actually test that. I'll try to add those tests to the upstream specs soon-ish.