### PR TITLE
Disable pipe in Kernel#open

### DIFF
--- a/spec/core/kernel/open_spec.rb
+++ b/spec/core/kernel/open_spec.rb
@@ -33,7 +33,7 @@ describe "Kernel#open" do
 
   platform_is_not :windows, :wasi do
     it "opens an io when path starts with a pipe" do
-      NATFIXME 'Pipes in open', exception: Errno::ENOENT, message: 'No such file or directory' do
+      NATFIXME 'Pipes in open', exception: NotImplementedError, message: 'no support for pipe in Kernel#open' do
         suppress_warning do # https://bugs.ruby-lang.org/issues/19630
           @io = open("|date")
         end
@@ -47,7 +47,7 @@ describe "Kernel#open" do
     end
 
     it "opens an io when called with a block" do
-      NATFIXME 'Pipes in open', exception: Errno::ENOENT, message: 'No such file or directory' do
+      NATFIXME 'Pipes in open', exception: NotImplementedError, message: 'no support for pipe in Kernel#open' do
         suppress_warning do # https://bugs.ruby-lang.org/issues/19630
           @output = open("|date") { |f| f.read }
         end
@@ -56,7 +56,7 @@ describe "Kernel#open" do
     end
 
     it "opens an io for writing" do
-      NATFIXME 'Pipes in open', exception: SpecFailedException do
+      NATFIXME 'Pipes in open', exception: NotImplementedError, message: 'no support for pipe in Kernel#open' do
         suppress_warning do # https://bugs.ruby-lang.org/issues/19630
           -> {
             bytes = open("|cat", "w") { |io| io.write(".") }

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -818,8 +818,14 @@ module Kernel
   end
 
   # NATFIXME: the ... syntax doesnt appear to pass the block
-  def open(*a, **kw, &blk)
-    File.open(*a, **kw, &blk)
+  def open(filename, *a, **kw, &blk)
+    if !filename.respond_to?(:to_path) && !filename.is_a?(String) && filename.respond_to?(:to_str)
+      filename = filename.to_str
+    end
+    if filename.is_a?(String) && filename.to_str.start_with?('|')
+      raise NotImplementedError, 'no support for pipe in Kernel#open'
+    end
+    File.open(filename, *a, **kw, &blk)
   end
 
   alias format sprintf


### PR DESCRIPTION
This is meant to be a way to fork a process and return an IO object to interact with its stdout/stdin, but the current tests result in a file named '|cat' that was left on your filesystem.
As this feature is a security issue that will be removed in Ruby 4.0 (https://bugs.ruby-lang.org/issues/19630), we probably shouldn't try to implement this.