### PR TITLE
Implement Warning module

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -115,6 +115,10 @@ OptionParser.new do |opts|
     options[:print_objects] = true
   end
 
+  opts.on('-w', 'Turn on verbose mode / warnings') do
+    options[:warnings] = true
+  end
+
   opts.on_path do |path|
     ARGV.unshift(path)
     opts.stop_parsing!
@@ -276,6 +280,9 @@ class Runner
     else
       @repl = true
       @source_path = '.'
+    end
+    if options[:warnings] && !@code.nil?
+      @code = '$VERBOSE = true' + "\n" + @code
     end
   end
 

--- a/spec/core/module/deprecate_constant_spec.rb
+++ b/spec/core/module/deprecate_constant_spec.rb
@@ -40,7 +40,7 @@ describe "Module#deprecate_constant" do
     it "does not warn if Warning[:deprecated] is false" do
       @module.deprecate_constant :PUBLIC1
 
-      NATFIXME 'Support Warning', exception: NameError, message: 'uninitialized constant Warning' do
+      NATFIXME 'Implement warning', exception: SpecFailedException do
         deprecated = Warning[:deprecated]
         begin
           Warning[:deprecated] = false

--- a/spec/core/warning/element_reference_spec.rb
+++ b/spec/core/warning/element_reference_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../spec_helper'
+
+describe "Warning.[]" do
+  ruby_version_is '2.7.2' do
+    it "returns default values for categories :deprecated and :experimental" do
+      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
+      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it "returns default values for :performance category" do
+      ruby_exe('p Warning[:performance]').chomp.should == "false"
+      ruby_exe('p Warning[:performance]', options: "-w").chomp.should == "false"
+    end
+  end
+
+  it "raises for unknown category" do
+    -> { Warning[:noop] }.should raise_error(ArgumentError, /unknown category: noop/)
+  end
+
+  it "raises for non-Symbol category" do
+    -> { Warning[42] }.should raise_error(TypeError)
+    -> { Warning[false] }.should raise_error(TypeError)
+    -> { Warning["noop"] }.should raise_error(TypeError)
+  end
+end

--- a/spec/core/warning/element_set_spec.rb
+++ b/spec/core/warning/element_set_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../../spec_helper'
+
+describe "Warning.[]=" do
+  it "emits and suppresses warnings for :deprecated" do
+    NATFIXME 'Warning for $; is deprecated', exception: SpecFailedException do
+      ruby_exe('Warning[:deprecated] = true; $; = ""', args: "2>&1").should =~ /is deprecated/
+    end
+    ruby_exe('Warning[:deprecated] = false; $; = ""', args: "2>&1").should == ""
+  end
+
+  describe ":experimental" do
+    before do
+      @src = 'warn "This is experimental warning.", category: :experimental'
+    end
+
+    it "emits and suppresses warnings for :experimental" do
+      ruby_exe("Warning[:experimental] = true; eval('#{@src}')", args: "2>&1").should =~ /is experimental/
+      ruby_exe("Warning[:experimental] = false; eval('#{@src}')", args: "2>&1").should == ""
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it "enables or disables performance warnings" do
+      original = Warning[:performance]
+      begin
+        Warning[:performance] = !original
+        Warning[:performance].should == !original
+      ensure
+        Warning[:performance] = original
+      end
+    end
+  end
+
+  it "raises for unknown category" do
+    -> { Warning[:noop] = false }.should raise_error(ArgumentError, /unknown category: noop/)
+  end
+
+  it "raises for non-Symbol category" do
+    -> { Warning[42] = false }.should raise_error(TypeError)
+    -> { Warning[false] = false }.should raise_error(TypeError)
+    -> { Warning["noop"] = false }.should raise_error(TypeError)
+  end
+end

--- a/spec/core/warning/warn_spec.rb
+++ b/spec/core/warning/warn_spec.rb
@@ -1,0 +1,135 @@
+require_relative '../../spec_helper'
+
+describe "Warning.warn" do
+  it "complains" do
+    -> {
+      Warning.warn("Chunky bacon!")
+    }.should complain("Chunky bacon!")
+  end
+
+  it "does not add a newline" do
+    ruby_exe("Warning.warn('test')", args: "2>&1").should == "test"
+  end
+
+  it "returns nil" do
+    ruby_exe("p Warning.warn('test')", args: "2>&1").should == "testnil\n"
+  end
+
+  it "extends itself" do
+    Warning.singleton_class.ancestors.should include(Warning)
+  end
+
+  it "has Warning as the method owner" do
+    ruby_exe("p Warning.method(:warn).owner").should == "Warning\n"
+  end
+
+  it "can be overridden" do
+    code = <<-RUBY
+      $stdout.sync = true
+      $stderr.sync = true
+      def Warning.warn(msg)
+        if msg.start_with?("A")
+          puts msg.upcase
+        else
+          super
+        end
+      end
+      Warning.warn("A warning!")
+      Warning.warn("warning from stderr\n")
+    RUBY
+    ruby_exe(code, args: "2>&1").should == %Q[A WARNING!\nwarning from stderr\n]
+  end
+
+  xit "is called by parser warnings" do
+    Warning.should_receive(:warn)
+    verbose = $VERBOSE
+    $VERBOSE = false
+    begin
+      eval "{ key: :value, key: :value2 }"
+    ensure
+      $VERBOSE = verbose
+    end
+  end
+
+  it "is called by Kernel.warn with nil category keyword" do
+    Warning.should_receive(:warn).with("Chunky bacon!\n", category: nil)
+    verbose = $VERBOSE
+    $VERBOSE = false
+    begin
+      Kernel.warn("Chunky bacon!")
+    ensure
+      $VERBOSE = verbose
+    end
+  end
+
+  it "is called by Kernel.warn with given category keyword converted to a symbol" do
+    Warning.should_receive(:warn).with("Chunky bacon!\n", category: :deprecated)
+    verbose = $VERBOSE
+    $VERBOSE = false
+    begin
+      Kernel.warn("Chunky bacon!", category: "deprecated")
+    ensure
+      $VERBOSE = verbose
+    end
+  end
+
+  it "warns when category is :deprecated and Warning[:deprecated] is true" do
+    warn_deprecated = Warning[:deprecated]
+    Warning[:deprecated] = true
+    begin
+      -> {
+        Warning.warn("foo", category: :deprecated)
+      }.should complain("foo")
+    ensure
+      Warning[:deprecated] = warn_deprecated
+    end
+  end
+
+  it "warns when category is :experimental and Warning[:experimental] is true" do
+    warn_experimental = Warning[:experimental]
+    Warning[:experimental] = true
+    begin
+      -> {
+        Warning.warn("foo", category: :experimental)
+      }.should complain("foo")
+    ensure
+      Warning[:experimental] = warn_experimental
+    end
+  end
+
+  it "doesn't print message when category is :deprecated but Warning[:deprecated] is false" do
+    warn_deprecated = Warning[:deprecated]
+    Warning[:deprecated] = false
+    begin
+      -> {
+        Warning.warn("foo", category: :deprecated)
+      }.should_not complain
+    ensure
+      Warning[:deprecated] = warn_deprecated
+    end
+  end
+
+  it "doesn't print message when category is :experimental but Warning[:experimental] is false" do
+    warn_experimental = Warning[:experimental]
+    Warning[:experimental] = false
+    begin
+      -> {
+        Warning.warn("foo", category: :experimental)
+      }.should_not complain
+    ensure
+      Warning[:experimental] = warn_experimental
+    end
+  end
+
+  it "prints the message when VERBOSE is false" do
+    -> { Warning.warn("foo") }.should complain("foo")
+  end
+
+  it "prints the message when VERBOSE is nil" do
+    -> { Warning.warn("foo") }.should complain("foo", verbose: nil)
+  end
+
+  it "prints the message when VERBOSE is true" do
+    -> { Warning.warn("foo") }.should complain("foo", verbose: true)
+  end
+end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -56,9 +56,8 @@ module Kernel
     Random::DEFAULT.rand(*args)
   end
 
-  # NATFIXME: Implement Warning class, check class for severity level
-  def warn(*warnings, **)
-    warnings.each { |warning| $stderr.puts(warning) }
+  def warn(*msgs, category: nil)
+    msgs.each { |message| Warning.warn(message + "\n", category: category&.to_sym) }
     nil
   end
 

--- a/src/warning.rb
+++ b/src/warning.rb
@@ -1,0 +1,44 @@
+module Warning
+  extend self
+
+  FLAGS = {
+    deprecated: nil,
+    experimental: true
+  }
+
+  private_constant :FLAGS
+
+  def [](category)
+    unless category.is_a?(Symbol)
+      raise TypeError, "wrong argument type #{category.class.name} (expected Symbol)"
+    end
+
+    unless FLAGS.key?(category)
+      raise ArgumentError, "unknown category: #{category}"
+    end
+
+    flag = FLAGS[category]
+
+    return ($VERBOSE == true) if category == :deprecated && flag.nil?
+
+    flag
+  end
+
+  def []=(category, flag)
+    unless category.is_a?(Symbol)
+      raise TypeError, "wrong argument type #{category.class.name} (expected Symbol)"
+    end
+
+    unless FLAGS.key?(category)
+      raise ArgumentError, "unknown category: #{category}"
+    end
+
+    FLAGS[category] = flag
+  end
+
+  def warn(message, category: nil)
+    $stderr.print(message) if category.nil? || self[category]
+
+    nil
+  end
+end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -907,7 +907,7 @@ class StubRegistry
   def reset
     @stubs.values.each do |stubs|
       stub = stubs.first
-      stub.subject.singleton_class.undef_method(stub.message)
+      stub.subject.singleton_class.remove_method(stub.message)
     end
 
     @stubs.clear

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -832,8 +832,12 @@ class ComplainExpectation
         raise SpecFailedException,
               "#{subject.inspect} should have printed a warning #{@message.inspect}, but the output was #{out.inspect}"
       end
+    when String
+      unless out == @message
+        raise SpecFailedException,
+              "#{subject.inspect} should have printed a warning #{@message.inspect}, but the output was #{out.inspect}"
+      end
     else
-      # TODO: might need to implement String matching
       puts "Expected a Regexp to complain but got #{@message.inspect}"
     end
   end
@@ -847,8 +851,11 @@ class ComplainExpectation
       if out =~ @message
         raise SpecFailedException, "#{subject.inspect} should not have printed a warning #{out.inspect}"
       end
+    when String
+      if out == @message
+        raise SpecFailedException, "#{subject.inspect} should not have printed a warning #{out.inspect}"
+      end
     else
-      # TODO: might need to implement String matching
       puts "Expected a Regexp to complain but got #{@message.inspect}"
     end
   end


### PR DESCRIPTION
This adds the `Warning` module and a few other bits of functionality required to get the specs passing:

* ~`IO#sync=` which doesn't really do anything yet but is used in `spec/core/warning/warn_spec.rb`~
* The `-w` command line option which is used in `spec/core/warning/element_reference_spec.rb`
* A couple of fixes for `test/support/spec.rb`

Let me know if you want those pulling off into separate pull requests to make this easier to review! I've used NATFIXME for a couple of the specs which also depend on specific warnings that aren't implemented yet