### PR TITLE
Implement IO#dup

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -75,6 +75,7 @@ public:
     static Value binread(Env *, Value, Value = nullptr, Value = nullptr);
     Value binmode(Env *);
     Value close(Env *);
+    Value dup(Env *) const;
     Value each_byte(Env *, Block *);
     Value external_encoding() const { return m_external_encoding; }
     Value fcntl(Env *, Value, Value = nullptr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -858,6 +858,7 @@ gen.binding('IO', 'close', 'IoObject', 'close', argc: 0, pass_env: true, pass_bl
 gen.binding('IO', 'closed?', 'IoObject', 'is_closed', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('IO', 'close_on_exec?', 'IoObject', 'is_close_on_exec', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('IO', 'close_on_exec=', 'IoObject', 'set_close_on_exec', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'dup', 'IoObject', 'dup', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'each_byte', 'IoObject', 'each_byte', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('IO', 'eof?', 'IoObject', 'is_eof', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('IO', 'external_encoding', 'IoObject', 'external_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)

--- a/spec/core/io/binmode_spec.rb
+++ b/spec/core/io/binmode_spec.rb
@@ -52,11 +52,12 @@ describe "IO#binmode?" do
     @file.binmode?.should be_true
   end
 
-  # NATFIXME: I don't know how to dup this kind of object yet File (type = 16).
-  xit "propagates to dup'ed IO objects" do
+  it "propagates to dup'ed IO objects" do
     @file.binmode
-    @duped = @file.dup
-    @duped.binmode?.should == @file.binmode?
+    NATFIXME 'Exception in File#dup', exception: Errno::EINVAL, message: 'Invalid argument' do
+      @duped = @file.dup
+      @duped.binmode?.should == @file.binmode?
+    end
   end
 
   it "raises an IOError on closed stream" do

--- a/spec/core/io/dup_spec.rb
+++ b/spec/core/io/dup_spec.rb
@@ -1,0 +1,106 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#dup" do
+  before :each do
+    @file = tmp("spec_io_dup")
+    @f = File.open @file, 'w+'
+    @i = @f.dup
+
+    @f.sync = true
+    @i.sync = true
+  end
+
+  after :each do
+    @i.close if @i && !@i.closed?
+    @f.close if @f && !@f.closed?
+    rm_r @file
+  end
+
+  it "returns a new IO instance" do
+    @i.class.should == @f.class
+  end
+
+  it "sets a new descriptor on the returned object" do
+    @i.fileno.should_not == @f.fileno
+  end
+
+quarantine! do # This does not appear to be consistent across platforms
+  it "shares the original stream between the two IOs" do
+    start = @f.pos
+    @i.pos.should == start
+
+    s =  "Hello, wo.. wait, where am I?\n"
+    s2 = "<evil voice>       Muhahahaa!"
+
+    @f.write s
+    @i.pos.should == @f.pos
+
+    @i.rewind
+    @i.gets.should == s
+
+    @i.rewind
+    @i.write s2
+
+    @f.rewind
+    @f.gets.should == "#{s2}\n"
+  end
+end
+
+  it "allows closing the new IO without affecting the original" do
+    @i.close
+    -> { @f.gets }.should_not raise_error(Exception)
+
+    @i.should.closed?
+    @f.should_not.closed?
+  end
+
+  it "allows closing the original IO without affecting the new one" do
+    @f.close
+    -> { @i.gets }.should_not raise_error(Exception)
+
+    @i.should_not.closed?
+    @f.should.closed?
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.dup }.should raise_error(IOError)
+  end
+
+  it "always sets the close-on-exec flag for the new IO object" do
+    @f.close_on_exec = true
+    dup = @f.dup
+    begin
+      dup.should.close_on_exec?
+    ensure
+      dup.close
+    end
+
+    @f.close_on_exec = false
+    dup = @f.dup
+    begin
+      dup.should.close_on_exec?
+    ensure
+      dup.close
+    end
+  end
+
+  it "always sets the autoclose flag for the new IO object" do
+    @f.autoclose = true
+    dup = @f.dup
+    begin
+      dup.should.autoclose?
+    ensure
+      dup.close
+    end
+
+    @f.autoclose = false
+    dup = @f.dup
+    begin
+      dup.should.autoclose?
+    ensure
+      dup.close
+      @f.autoclose = true
+    end
+  end
+end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -354,8 +354,13 @@ Value IoObject::binread(Env *env, Value filename, Value length, Value offset) {
 }
 
 Value IoObject::dup(Env *env) const {
-    fprintf(stderr, "Stub implementation for IO#dup\n");
-    return NilObject::the();
+    auto dup_fd = ::dup(fileno(env));
+    if (dup_fd < 0)
+        env->raise_errno();
+    auto dup_obj = _new(env, m_klass, { IntegerObject::create(dup_fd) }, nullptr)->as_io();
+    dup_obj->set_close_on_exec(env, TrueObject::the());
+    dup_obj->autoclose(env, TrueObject::the());
+    return dup_obj;
 }
 
 Value IoObject::each_byte(Env *env, Block *block) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -353,6 +353,11 @@ Value IoObject::binread(Env *env, Value filename, Value length, Value offset) {
     return data;
 }
 
+Value IoObject::dup(Env *env) const {
+    fprintf(stderr, "Stub implementation for IO#dup\n");
+    return NilObject::the();
+}
+
 Value IoObject::each_byte(Env *env, Block *block) {
     if (block == nullptr)
         return send(env, "enum_for"_s, { "each_byte"_s });


### PR DESCRIPTION
A rather unrelated test uses `File#dup` which still causes an error for some reason (which I might investigate at a later point in time), but that's still an improvement over the panic that caused the test to be aborted.
This is one of those issues that causes a lot of IO specs to crash.