### PR TITLE
Sync before close in IO.open

### DIFF
--- a/src/io.rb
+++ b/src/io.rb
@@ -10,6 +10,7 @@ class IO
         yield(obj)
       ensure
         begin
+          obj.fsync unless obj.tty?
           obj.close
         rescue IOError => e
           raise unless e.message == 'closed stream'


### PR DESCRIPTION
I was running into weird errors with the `File.open` spec, which fails at "opens a file that no exists when use 'a' mode" with a "Bad file descriptor (Errno::EBADF)", but the error was thrown in `touch` at the setup.
The man page of `close(2)` contains the following paragraph:

> A careful programmer who wants to know about I/O errors may precede
> close() with a call to fsync(2).

Adding a call to `fsync` appears to fix the issue.