### PR TITLE
Use value of Warning[:deprecated]

### DIFF
--- a/spec/core/module/deprecate_constant_spec.rb
+++ b/spec/core/module/deprecate_constant_spec.rb
@@ -36,14 +36,12 @@ describe "Module#deprecate_constant" do
     it "does not warn if Warning[:deprecated] is false" do
       @module.deprecate_constant :PUBLIC1
 
-      NATFIXME 'Implement warning', exception: SpecFailedException do
-        deprecated = Warning[:deprecated]
-        begin
-          Warning[:deprecated] = false
-          -> { @module::PUBLIC1 }.should_not complain
-        ensure
-          Warning[:deprecated] = deprecated
-        end
+      deprecated = Warning[:deprecated]
+      begin
+        Warning[:deprecated] = false
+        -> { @module::PUBLIC1 }.should_not complain
+      ensure
+        Warning[:deprecated] = deprecated
       end
     end
   end

--- a/spec/core/module/deprecate_constant_spec.rb
+++ b/spec/core/module/deprecate_constant_spec.rb
@@ -7,10 +7,6 @@ describe "Module#deprecate_constant" do
     @module::PUBLIC1 = @value
     @module::PUBLIC2 = @value
     @module::PRIVATE = @value
-    @module.const_set(:PUBLIC1, @value)
-    @module.const_set(:PUBLIC2, @value)
-    @module.const_set(:PRIVATE, @value)
-
     @module.private_constant :PRIVATE
     @module.deprecate_constant :PRIVATE
   end

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -105,6 +105,8 @@ Value ModuleObject::const_find(Env *env, SymbolObject *name, ConstLookupSearchMo
                 env->raise_name_error(name, "private constant ::{} referenced", name->string());
         }
         if (constant->is_deprecated()) {
+            const auto warn_deprecated = GlobalEnv::the()->Object()->const_get("Warning"_s)->send(env, "[]"_s, { "deprecated"_s })->is_truthy();
+            if (!warn_deprecated) return;
             if (search_parent && search_parent != GlobalEnv::the()->Object())
                 env->warn("constant {}::{} is deprecated", search_parent->inspect_str(), name->string());
             else

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -8,6 +8,7 @@ require_relative 'spec_helpers/fs'
 require_relative 'spec_helpers/io'
 require_relative 'spec_helpers/mock_to_path'
 require_relative 'spec_helpers/tmp'
+require_relative 'spec_utils/warnings'
 require 'tempfile'
 
 class SpecFailedException < StandardError

--- a/test/support/spec_utils/warnings.rb
+++ b/test/support/spec_utils/warnings.rb
@@ -1,0 +1,33 @@
+=begin
+Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+=end
+
+# Always enable deprecation warnings when running MSpec, as ruby/spec tests for them,
+# and like in most test frameworks, deprecation warnings should be enabled by default,
+# so that deprecations are noticed before the breaking change.
+# Disable experimental warnings, we want to test new experimental features in ruby/spec.
+if Object.const_defined?(:Warning) and Warning.respond_to?(:[]=)
+  Warning[:deprecated] = true
+  Warning[:experimental] = false
+end


### PR DESCRIPTION
This is one of the turtles on the way down from #1260. It required a bit of extra setup for the tests, since the tests are ran with different values than Ruby normally does.