### PR TITLE
Fixes to StringScanner

### DIFF
--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -173,12 +173,7 @@ class StringScanner
 
   def [](index)
     return nil unless @match
-    if index.is_a?(Integer) || index.is_a?(String)
-      return nil unless index.is_a?(Integer) # FIXME
-      @match[index]
-    else
-      raise TypeError, "Bad index: #{index.inspect}"
-    end
+    @match[index]
   end
 
   def exist?(pattern)

--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -78,6 +78,11 @@ class StringScanner
   end
 
   def scan(pattern)
+    unless pattern.is_a?(Regexp)
+      pattern = pattern.to_str if !pattern.is_a?(String) && pattern.respond_to?(:to_str)
+      raise TypeError, "no implicit conversion of #{pattern.class} into String" unless pattern.is_a?(String)
+      pattern = Regexp.new(Regexp.quote(pattern))
+    end
     anchored_pattern = Regexp.new('^' + pattern.source, pattern.options)
     if (@match = rest.match(anchored_pattern))
       @matched = @match.to_s

--- a/spec/library/stringscanner/element_reference_spec.rb
+++ b/spec/library/stringscanner/element_reference_spec.rb
@@ -29,9 +29,7 @@ describe "StringScanner#[]" do
 
   it "calls to_int on the given index" do
     @s.scan(/(\w+) (\w+) (\d+) /)
-    NATFIXME 'Support float index', exception: TypeError, message: 'Bad index: 0.5' do
-      @s[0.5].should == "Fri Jun 13 "
-    end
+    @s[0.5].should == "Fri Jun 13 "
   end
 
   it "raises a TypeError if the given index is nil" do
@@ -46,23 +44,17 @@ describe "StringScanner#[]" do
 
   it "raises a IndexError when there's no named capture" do
     @s.scan(/(\w+) (\w+) (\d+) /)
-    NATFIXME 'Raise IndexError instead of returning nil', exception: SpecFailedException do
-      -> { @s["wday"]}.should raise_error(IndexError)
-    end
-    NATFIXME 'Raise IndexError instead of TypeError', exception: SpecFailedException do
-      -> { @s[:wday]}.should raise_error(IndexError)
-    end
+    -> { @s["wday"]}.should raise_error(IndexError)
+    -> { @s[:wday]}.should raise_error(IndexError)
   end
 
   it "returns named capture" do
     @s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+) /)
-    NATFIXME 'Support named captures', exception: SpecFailedException do
-      @s["wday"].should == "Fri"
-      @s["month"].should == "Jun"
-      @s["day"].should == "13"
-      @s[:wday].should == "Fri"
-      @s[:month].should == "Jun"
-      @s[:day].should == "13"
-    end
+    @s["wday"].should == "Fri"
+    @s["month"].should == "Jun"
+    @s["day"].should == "13"
+    @s[:wday].should == "Fri"
+    @s[:month].should == "Jun"
+    @s[:day].should == "13"
   end
 end

--- a/spec/library/stringscanner/scan_spec.rb
+++ b/spec/library/stringscanner/scan_spec.rb
@@ -51,18 +51,14 @@ describe "StringScanner#scan" do
   end
 
   it "treats String as the pattern itself" do
-    NATFIXME 'Support String pattern', exception: NoMethodError, message: "undefined method `source'" do
-      @s.scan("this").should be_nil
-      @s.scan("This").should == "This"
-    end
+    @s.scan("this").should be_nil
+    @s.scan("This").should == "This"
   end
 
   it "raises a TypeError if pattern isn't a Regexp nor String" do
-    NATFIXME 'validate pattern type', exception: SpecFailedException do
-      -> { @s.scan(5)         }.should raise_error(TypeError)
-      -> { @s.scan(:test)     }.should raise_error(TypeError)
-      -> { @s.scan(mock('x')) }.should raise_error(TypeError)
-    end
+    -> { @s.scan(5)         }.should raise_error(TypeError)
+    -> { @s.scan(:test)     }.should raise_error(TypeError)
+    -> { @s.scan(mock('x')) }.should raise_error(TypeError)
   end
 end
 


### PR DESCRIPTION
* `StringScanner#[]` can simply forward its arguments to `Matchdata#[]`
* Coerce string argument in `StringScanner#scan` into `Regexp`