### PR TITLE
Sync specs for bitwise operators of Integer

### DIFF
--- a/spec/core/integer/bit_and_spec.rb
+++ b/spec/core/integer/bit_and_spec.rb
@@ -28,7 +28,6 @@ describe "Integer#&" do
       (-1 & 2**64).should == 18446744073709551616
     end
 
-    # NATFIXME: Upstream bug (https://github.com/ruby/spec/pull/1011)
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit and")
       obj.should_receive(:coerce).with(6).and_return([6, 3])

--- a/spec/core/integer/bit_or_spec.rb
+++ b/spec/core/integer/bit_or_spec.rb
@@ -29,7 +29,6 @@ describe "Integer#|" do
       (-1 | 2**64).should == -1
     end
 
-    # NATFIXME: Upstream bug (https://github.com/ruby/spec/pull/1011)
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit or")
       obj.should_receive(:coerce).with(6).and_return([6, 3])

--- a/spec/core/integer/bit_xor_spec.rb
+++ b/spec/core/integer/bit_xor_spec.rb
@@ -27,7 +27,6 @@ describe "Integer#^" do
       (-1 ^ 2**64).should == -18446744073709551617
     end
 
-    # NATFIXME: Upstream bug (https://github.com/ruby/spec/pull/1011)
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit xor")
       obj.should_receive(:coerce).with(6).and_return([6, 3])


### PR DESCRIPTION
The upstream bugs are fixed, no need to keep references to those.