### PR TITLE
Add env keyword to ruby_exe test helper

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -232,16 +232,17 @@ def min_long
   -(2**(0.size * 8 - 1))
 end
 
-def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0)
+def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0, env: {})
+  env = env.map { |key, value| "#{key}=#{value} " }.join
   binary = ENV['NAT_BINARY'] || 'bin/natalie'
   if code.nil?
     return binary if args.nil?
 
-    return `#{binary} #{options} #{args}`
+    return `#{env}#{binary} #{options} #{args}`
   end
 
   output = if !escape
-             `#{binary} #{options} -e #{code.inspect} #{args}`
+             `#{env}#{binary} #{options} -e #{code.inspect} #{args}`
            elsif File.readable?(code)
              `#{binary} #{options} #{code} #{args}`
            else
@@ -249,7 +250,7 @@ def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0)
                file.write(code)
                file.rewind
 
-               `#{binary} #{options} #{file.path} #{args}`
+               `#{env}#{binary} #{options} #{file.path} #{args}`
              end
            end
 


### PR DESCRIPTION
https://github.com/ruby/spec/blob/e7c3c5396cbe0b12ce9f66f04287e64fb83fc097/command_line/feature_spec.rb#L53

I just happened to open a random failing test and bumped into this issue. It is used in two other specs as well.