### PR TITLE
Add warnings for IO.new (and subclasses) with block

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -86,7 +86,7 @@ public:
     int fsync(Env *);
     Value getbyte(Env *);
     Value gets(Env *) const;
-    Value initialize(Env *, Args);
+    Value initialize(Env *, Args, Block * = nullptr);
     Value inspect() const;
     Value internal_encoding() const { return m_internal_encoding; }
     bool is_autoclose(Env *) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -870,7 +870,7 @@ gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_
 gen.binding('IO', 'fsync', 'IoObject', 'fsync', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'getbyte', 'IoObject', 'getbyte', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('IO', 'inspect', 'IoObject', 'inspect', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'internal_encoding', 'IoObject', 'internal_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'isatty', 'IoObject', 'isatty', argc: 0, pass_env: true, pass_block: false, aliases: ['tty?'], return_type: :bool)

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -284,14 +284,14 @@ Value Addrinfo_to_sockaddr(Env *env, Value self, Args args, Block *block) {
     }
 }
 
-Value BasicSocket_s_for_fd(Env *env, Value self, Args args, Block *) {
+Value BasicSocket_s_for_fd(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_is(env, 1);
     auto fd = args.at(0);
 
     auto BasicSocket = find_top_level_const(env, "BasicSocket"_s);
 
     auto sock = BasicSocket.send(env, "new"_s);
-    sock->as_io()->initialize(env, { fd });
+    sock->as_io()->initialize(env, { fd }, block);
 
     return self;
 }
@@ -563,7 +563,7 @@ Value Socket_initialize(Env *env, Value self, Args args, Block *block) {
     if (fd == -1)
         env->raise_errno();
 
-    self->as_io()->initialize(env, { Value::integer(fd) });
+    self->as_io()->initialize(env, { Value::integer(fd) }, block);
 
     return self;
 }
@@ -995,7 +995,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args args, Block *block) {
     auto fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1)
         env->raise_errno();
-    self->as_io()->initialize(env, { Value::integer(fd) });
+    self->as_io()->initialize(env, { Value::integer(fd) }, block);
     self->as_io()->binmode(env);
 
     auto Socket = find_top_level_const(env, "Socket"_s);
@@ -1020,7 +1020,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args args, Block *block) {
     return self;
 }
 
-Value TCPServer_initialize(Env *env, Value self, Args args, Block *) {
+Value TCPServer_initialize(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_between(env, 1, 2);
     auto hostname = args.at(0);
     auto port = args.at(1, NilObject::the());
@@ -1034,7 +1034,7 @@ Value TCPServer_initialize(Env *env, Value self, Args args, Block *) {
     auto fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (fd == -1)
         env->raise_errno();
-    self->as_io()->initialize(env, { Value::integer(fd) });
+    self->as_io()->initialize(env, { Value::integer(fd) }, block);
 
     self.send(env, "setsockopt"_s, { "SOCKET"_s, "REUSEADDR"_s, TrueObject::the() });
 

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -27,6 +27,8 @@ class StringIO
     if !closed_write? && string.frozen?
       raise Errno::EACCES, 'Permission denied'
     end
+
+    warn('warning: StringIO::new() does not take block; use StringIO::open() instead') if block_given?
   end
 
   def close

--- a/spec/core/file/new_spec.rb
+++ b/spec/core/file/new_spec.rb
@@ -189,6 +189,12 @@ describe "File.new" do
     }.should raise_error(Errno::EEXIST, /File exists/)
   end
 
+  it "does not use the given block and warns to use File::open" do
+    -> {
+      @fh = File.new(@file) { raise }
+    }.should complain(/warning: File::new\(\) does not take block; use File::open\(\) instead/)
+  end
+
   it "raises a TypeError if the first parameter can't be coerced to a string" do
     -> { File.new(true) }.should raise_error(TypeError)
     -> { File.new(false) }.should raise_error(TypeError)

--- a/spec/core/io/new_spec.rb
+++ b/spec/core/io/new_spec.rb
@@ -5,6 +5,12 @@ require_relative 'shared/new'
 
 describe "IO.new" do
   it_behaves_like :io_new, :new
+
+  it "does not use the given block and warns to use IO::open" do
+    -> {
+      @io = IO.send(@method, @fd) { raise }
+    }.should complain(/warning: IO::new\(\) does not take block; use IO::open\(\) instead/)
+  end
 end
 
 describe "IO.new" do

--- a/spec/library/socket/tcpserver/new_spec.rb
+++ b/spec/library/socket/tcpserver/new_spec.rb
@@ -100,6 +100,12 @@ describe "TCPServer.new" do
     addr[1].should be_kind_of(Integer)
   end
 
+  it "does not use the given block and warns to use TCPServer::open" do
+    -> {
+      @server = TCPServer.new(0) { raise }
+    }.should complain(/warning: TCPServer::new\(\) does not take block; use TCPServer::open\(\) instead/)
+  end
+
   it "raises Errno::EADDRNOTAVAIL when the address is unknown" do
     -> { TCPServer.new("1.2.3.4", 0) }.should raise_error(Errno::EADDRNOTAVAIL)
   end

--- a/spec/library/stringio/new_spec.rb
+++ b/spec/library/stringio/new_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require 'stringio'
+
+describe "StringIO.new" do
+  it "does not use the given block and warns to use StringIO::open" do
+    -> {
+      StringIO.new { raise }
+    }.should complain(/warning: StringIO::new\(\) does not take block; use StringIO::open\(\) instead/)
+  end
+end

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -34,7 +34,6 @@ static int effective_uid_access(const char *path_name, int type) {
 #endif
 }
 
-// NATFIXME : block form is not used
 Value FileObject::initialize(Env *env, Args args, Block *block) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 1, 3);
@@ -62,6 +61,8 @@ Value FileObject::initialize(Env *env, Args args, Block *block) {
         set_path(filename->as_string());
     }
     set_encoding(env, flags.external_encoding, flags.internal_encoding);
+    if (block)
+        env->warn("File::new() does not take block; use File::open() instead");
     return this;
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -302,7 +302,7 @@ Value IoObject::initialize(Env *env, Args args, Block *block) {
     set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     m_autoclose = wanted_flags.autoclose;
     if (block)
-        env->warn("IO::new() does not take block; use IO::open() instead");
+        env->warn("{}::new() does not take block; use {}::open() instead", m_klass->inspect_str(), m_klass->inspect_str());
     return this;
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -281,7 +281,7 @@ namespace ioutil {
     }
 }
 
-Value IoObject::initialize(Env *env, Args args) {
+Value IoObject::initialize(Env *env, Args args, Block *block) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 1, 2);
     Value file_number = args.at(0);
@@ -301,6 +301,8 @@ Value IoObject::initialize(Env *env, Args args) {
     set_fileno(fileno);
     set_encoding(env, wanted_flags.external_encoding, wanted_flags.internal_encoding);
     m_autoclose = wanted_flags.autoclose;
+    if (block)
+        env->warn("IO::new() does not take block; use IO::open() instead");
     return this;
 }
 


### PR DESCRIPTION
This resolves the `NATFIXME : block form is not used` comment in `file_object.cpp` by explaining why we don't use the block.