### PR TITLE
Improve layout for compile errors and crashes on nightly tests

### DIFF
--- a/spec/support/nightly_ruby_spec_runner.rb
+++ b/spec/support/nightly_ruby_spec_runner.rb
@@ -64,7 +64,9 @@ Dir[specs].each do |path|
 
     unless system("bin/natalie -c #{binary_name} #{path} 2> #{stderr.path}")
       compile_errors += 1
-      current[:error_messages] = File.readlines(stderr.path)
+      lines = File.readlines(stderr.path).map(&:chomp)
+      error_message = lines.reject(&:empty?).first.split(':', 4).last.strip
+      current[:error_messages] = ["#{error_message}\n" + lines.inspect]
       puts "Spec #{path} could not be compiled"
       return
     end

--- a/spec/support/nightly_ruby_spec_runner.rb
+++ b/spec/support/nightly_ruby_spec_runner.rb
@@ -107,7 +107,9 @@ Dir[specs].each do |path|
     if !status.success? && !current[:timeouted]
       puts "Spec #{path} crashed"
       current[:crashed] = true
-      current[:error_messages] = File.readlines(stderr.path)
+      lines = File.readlines(stderr.path).map(&:chomp)
+      error_message = lines.last.split(':', 4).last
+      current[:error_messages] = ["#{error_message}\n" + lines.inspect]
       crashed_count += 1
     end
 


### PR DESCRIPTION
The changes of #1263 showed the new information in a way that didn't really work well with the layout of the page. This change alters the output to fit this mold as best as it can. It's still not perfect, but this felt like the best we can do for now.
I did run a local webserver with the new stats file to actually watch the output this time :wink: 
