### PR TITLE
Run subfolders of test/natalie/ too

### DIFF
--- a/test/ruby/natalie_test.rb
+++ b/test/ruby/natalie_test.rb
@@ -10,7 +10,7 @@ describe 'Natalie tests' do
   parallelize_me!
 
   Dir.chdir File.expand_path('../..', __dir__)
-  Dir['test/natalie/*_test.rb'].each do |path|
+  Dir['test/natalie/**/*_test.rb'].each do |path|
     code = File.read(path, encoding: 'utf-8')
     describe path do
       if code =~ /# skip-ruby/


### PR DESCRIPTION
I was surprised to see the CI of #1287 passing, turns out we don't run tests in subfolders. So all those shiny new tests for OpenSSL::Digest are skipped now.