### PR TITLE
Implement IO#lineno and IO#lineno=

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -95,6 +95,7 @@ public:
     bool is_close_on_exec(Env *) const;
     bool is_eof(Env *);
     bool isatty(Env *) const;
+    int lineno(Env *) const;
     static Value pipe(Env *, Value, Value, Block *, ClassObject *);
     int pos(Env *);
     Value pread(Env *, Value, Value, Value = nullptr);
@@ -107,6 +108,7 @@ public:
     Value set_close_on_exec(Env *, Value);
     Value set_encoding(Env *, Value, Value = nullptr);
     void set_fileno(int fileno) { m_fileno = fileno; }
+    Value set_lineno(Env *, Value);
     Value set_sync(Env *, Value);
     Value stat(Env *) const;
     static Value sysopen(Env *, Value, Value = nullptr, Value = nullptr);
@@ -136,6 +138,7 @@ private:
     EncodingObject *m_external_encoding { nullptr };
     EncodingObject *m_internal_encoding { nullptr };
     int m_fileno { -1 };
+    int m_lineno { 0 };
     bool m_closed { false };
     bool m_autoclose { false };
     bool m_sync { false };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -85,7 +85,7 @@ public:
     int fileno(Env *) const;
     int fsync(Env *);
     Value getbyte(Env *);
-    Value gets(Env *) const;
+    Value gets(Env *);
     Value initialize(Env *, Args, Block * = nullptr);
     Value inspect() const;
     Value internal_encoding() const { return m_internal_encoding; }
@@ -115,7 +115,7 @@ public:
     Value read(Env *, Value, Value) const;
     static Value read_file(Env *, Args);
     Value readbyte(Env *);
-    Value readline(Env *) const;
+    Value readline(Env *);
     int rewind(Env *);
     int set_pos(Env *, Value);
     static Value select(Env *, Value, Value = nullptr, Value = nullptr, Value = nullptr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -874,6 +874,8 @@ gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: :any, pass_env: 
 gen.binding('IO', 'inspect', 'IoObject', 'inspect', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'internal_encoding', 'IoObject', 'internal_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'isatty', 'IoObject', 'isatty', argc: 0, pass_env: true, pass_block: false, aliases: ['tty?'], return_type: :bool)
+gen.binding('IO', 'lineno', 'IoObject', 'lineno', argc: 0, pass_env: true, pass_block: false, return_type: :int)
+gen.binding('IO', 'lineno=', 'IoObject', 'set_lineno', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'path', 'IoObject', 'get_path', argc: 0, pass_env: false, pass_block: false, aliases: ['to_path'], return_type: :Object)
 gen.binding('IO', 'pos=', 'IoObject', 'set_pos', argc: 1, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'pread', 'IoObject', 'pread', argc: 2..3, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/lineno_spec.rb
+++ b/spec/core/io/lineno_spec.rb
@@ -1,0 +1,136 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#lineno" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.close if @io
+  end
+
+  it "raises an IOError on a closed stream" do
+    -> { IOSpecs.closed_io.lineno }.should raise_error(IOError)
+  end
+
+  it "raises an IOError on a write-only stream" do
+    name = tmp("io_lineno.txt")
+    begin
+      File.open(name, 'w') do |f|
+        -> { f.lineno }.should raise_error(IOError)
+      end
+    ensure
+      rm_r name
+    end
+  end
+
+  it "raises an IOError on a duplexed stream with the read side closed" do
+    IO.popen('cat', 'r+') do |p|
+      p.close_read
+      -> { p.lineno }.should raise_error(IOError)
+    end
+  end
+
+  it "returns the current line number" do
+    @io.lineno.should == 0
+
+    count = 0
+    while @io.gets
+      @io.lineno.should == count += 1
+    end
+
+    @io.rewind
+    @io.lineno.should == 0
+  end
+end
+
+describe "IO#lineno=" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.close if @io
+  end
+
+  it "raises an IOError on a closed stream" do
+    -> { IOSpecs.closed_io.lineno = 5 }.should raise_error(IOError)
+  end
+
+  it "raises an IOError on a write-only stream" do
+    name = tmp("io_lineno.txt")
+    begin
+      File.open(name, 'w') do |f|
+        -> { f.lineno = 0 }.should raise_error(IOError)
+      end
+    ensure
+      rm_r name
+    end
+  end
+
+  it "raises an IOError on a duplexed stream with the read side closed" do
+    IO.popen('cat', 'r+') do |p|
+      p.close_read
+      -> { p.lineno = 0 }.should raise_error(IOError)
+    end
+  end
+
+  it "calls #to_int on a non-numeric argument" do
+    obj = mock('123')
+    obj.should_receive(:to_int).and_return(123)
+
+    @io.lineno = obj
+    @io.lineno.should == 123
+  end
+
+  it "truncates a Float argument" do
+    @io.lineno = 1.5
+    @io.lineno.should == 1
+
+    @io.lineno = 92233.72036854775808
+    @io.lineno.should == 92233
+  end
+
+  it "raises TypeError if cannot convert argument to Integer implicitly" do
+    -> { @io.lineno = "1" }.should raise_error(TypeError, 'no implicit conversion of String into Integer')
+    -> { @io.lineno = nil }.should raise_error(TypeError, 'no implicit conversion from nil to integer')
+  end
+
+  it "does not accept Integers that don't fit in a C int" do
+    -> { @io.lineno = 2**32 }.should raise_error(RangeError)
+  end
+
+  it "sets the current line number to the given value" do
+    @io.lineno = count = 500
+
+    while @io.gets
+      @io.lineno.should == count += 1
+    end
+
+    @io.rewind
+    @io.lineno.should == 0
+  end
+
+  it "does not change $." do
+    original_line = $.
+    numbers = [-2**30, -2**16, -2**8, -100, -10, -1, 0, 1, 10, 2**8, 2**16, 2**30]
+    numbers.each do |num|
+      @io.lineno = num
+      @io.lineno.should == num
+      $..should == original_line
+    end
+  end
+
+  it "does not change $. until next read" do
+    $. = 0
+    $..should == 0
+
+    @io.lineno = count = 500
+    $..should == 0
+
+    while @io.gets
+      $..should == count += 1
+    end
+  end
+end

--- a/spec/core/io/lineno_spec.rb
+++ b/spec/core/io/lineno_spec.rb
@@ -26,9 +26,11 @@ describe "IO#lineno" do
   end
 
   it "raises an IOError on a duplexed stream with the read side closed" do
-    IO.popen('cat', 'r+') do |p|
-      p.close_read
-      -> { p.lineno }.should raise_error(IOError)
+    NATFIXME 'Implement IO.popen', exception: NoMethodError, message: "undefined method `popen' for IO:Class" do
+      IO.popen('cat', 'r+') do |p|
+        p.close_read
+        -> { p.lineno }.should raise_error(IOError)
+      end
     end
   end
 
@@ -70,9 +72,11 @@ describe "IO#lineno=" do
   end
 
   it "raises an IOError on a duplexed stream with the read side closed" do
-    IO.popen('cat', 'r+') do |p|
-      p.close_read
-      -> { p.lineno = 0 }.should raise_error(IOError)
+    NATFIXME 'Implement IO.popen', exception: NoMethodError, message: "undefined method `popen' for IO:Class" do
+      IO.popen('cat', 'r+') do |p|
+        p.close_read
+        -> { p.lineno = 0 }.should raise_error(IOError)
+      end
     end
   end
 
@@ -129,8 +133,10 @@ describe "IO#lineno=" do
     @io.lineno = count = 500
     $..should == 0
 
-    while @io.gets
-      $..should == count += 1
+    NATFIXME 'Implement $.', exception: SpecFailedException do
+      while @io.gets
+        $..should == count += 1
+      end
     end
   end
 end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -475,6 +475,10 @@ bool IoObject::isatty(Env *env) const {
     return ::isatty(m_fileno) == 1;
 }
 
+int IoObject::lineno(Env *env) const {
+    return m_lineno;
+}
+
 Value IoObject::read_file(Env *env, Args args) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 1, 3);
@@ -808,6 +812,11 @@ Value IoObject::set_encoding(Env *env, Value ext_enc, Value int_enc) {
     }
 
     return this;
+}
+
+Value IoObject::set_lineno(Env *env, Value lineno) {
+    m_lineno = lineno->to_int(env)->to_nat_int_t();
+    return lineno;
 }
 
 Value IoObject::set_sync(Env *env, Value value) {


### PR DESCRIPTION
Which is a brittle interface by design: It gets updated with `IO#gets` and `IO#readline`, but not with `IO#read`. So `f.readline; f.lineno == 1`, but `f.read; f.lineno == 0`.