### PR TITLE
Implement chomp argument in IO#gets and IO#readline

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -85,7 +85,7 @@ public:
     int fileno(Env *) const;
     int fsync(Env *);
     Value getbyte(Env *);
-    Value gets(Env *);
+    Value gets(Env *, Value = nullptr);
     Value initialize(Env *, Args, Block * = nullptr);
     Value inspect() const;
     Value internal_encoding() const { return m_internal_encoding; }

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -115,7 +115,7 @@ public:
     Value read(Env *, Value, Value) const;
     static Value read_file(Env *, Args);
     Value readbyte(Env *);
-    Value readline(Env *);
+    Value readline(Env *, Value = nullptr);
     int rewind(Env *);
     int set_pos(Env *, Value);
     static Value select(Env *, Value, Value = nullptr, Value = nullptr, Value = nullptr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -883,7 +883,7 @@ gen.binding('IO', 'print', 'IoObject', 'print', argc: :any, pass_env: true, pass
 gen.binding('IO', 'puts', 'IoObject', 'puts', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'read', 'IoObject', 'read', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'readbyte', 'IoObject', 'readbyte', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('IO', 'readline', 'IoObject', 'readline', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'readline', 'IoObject', 'readline', argc: 0, kwargs: [:chomp], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'rewind', 'IoObject', 'rewind', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'seek', 'IoObject', 'seek', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'set_encoding', 'IoObject', 'set_encoding', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -869,7 +869,7 @@ gen.binding('IO', 'fdatasync', 'IoObject', 'fdatasync', argc: 0, pass_env: true,
 gen.binding('IO', 'fileno', 'IoObject', 'fileno', argc: 0, pass_env: true, pass_block: false, aliases: ['to_i'], return_type: :int)
 gen.binding('IO', 'fsync', 'IoObject', 'fsync', argc: 0, pass_env: true, pass_block: false, return_type: :int)
 gen.binding('IO', 'getbyte', 'IoObject', 'getbyte', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'gets', 'IoObject', 'gets', argc: 0, kwargs: [:chomp], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'initialize', 'IoObject', 'initialize', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('IO', 'inspect', 'IoObject', 'inspect', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('IO', 'internal_encoding', 'IoObject', 'internal_encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)

--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -1,0 +1,354 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/gets_ascii'
+
+describe "IO#gets" do
+  it_behaves_like :io_gets_ascii, :gets
+end
+
+describe "IO#gets" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+    @count = 0
+  end
+
+  after :each do
+    @io.close if @io
+  end
+
+  it "assigns the returned line to $_" do
+    IOSpecs.lines.each do |line|
+      @io.gets
+      $_.should == line
+    end
+  end
+
+  it "returns nil if called at the end of the stream" do
+    IOSpecs.lines.length.times { @io.gets }
+    @io.gets.should == nil
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.gets }.should raise_error(IOError)
+  end
+
+  describe "with no separator" do
+    it "returns the next line of string that is separated by $/" do
+      IOSpecs.lines.each { |line| line.should == @io.gets }
+    end
+
+    it "updates lineno with each invocation" do
+      while @io.gets
+        @io.lineno.should == @count += 1
+      end
+    end
+
+    it "updates $. with each invocation" do
+      while @io.gets
+        $..should == @count += 1
+      end
+    end
+  end
+
+  describe "with nil separator" do
+    it "returns the entire contents" do
+      @io.gets(nil).should == IOSpecs.lines.join("")
+    end
+
+    it "updates lineno with each invocation" do
+      while @io.gets(nil)
+        @io.lineno.should == @count += 1
+      end
+    end
+
+    it "updates $. with each invocation" do
+      while @io.gets(nil)
+        $..should == @count += 1
+      end
+    end
+  end
+
+  describe "with an empty String separator" do
+    # Two successive newlines in the input separate paragraphs.
+    # When there are more than two successive newlines, only two are kept.
+    it "returns the next paragraph" do
+      @io.gets("").should == IOSpecs.lines[0,3].join("")
+      @io.gets("").should == IOSpecs.lines[4,3].join("")
+      @io.gets("").should == IOSpecs.lines[7,2].join("")
+    end
+
+    it "reads until the beginning of the next paragraph" do
+      # There are three newlines between the first and second paragraph
+      @io.gets("")
+      @io.gets.should == IOSpecs.lines[4]
+    end
+
+    it "updates lineno with each invocation" do
+      while @io.gets("")
+        @io.lineno.should == @count += 1
+      end
+    end
+
+    it "updates $. with each invocation" do
+      while @io.gets("")
+        $..should == @count += 1
+      end
+    end
+  end
+
+  describe "with an arbitrary String separator" do
+    it "reads up to and including the separator" do
+      @io.gets("la linea").should == "Voici la ligne une.\nQui \303\250 la linea"
+    end
+
+    it "updates lineno with each invocation" do
+      while (@io.gets("la"))
+        @io.lineno.should == @count += 1
+      end
+    end
+
+    it "updates $. with each invocation" do
+      while @io.gets("la")
+        $..should == @count += 1
+      end
+    end
+
+    describe "that consists of multiple bytes" do
+      platform_is_not :windows do
+        it "should match the separator even if the buffer is filled over successive reads" do
+          IO.pipe do |read, write|
+
+            # Write part of the string with the separator split between two write calls. We want
+            # the read to intertwine such that when the read starts the full data isn't yet
+            # available in the buffer.
+            write.write("Aquí está la línea tres\r\n")
+
+            t = Thread.new do
+              # Continue reading until the separator is encountered or the pipe is closed.
+              read.gets("\r\n\r\n")
+            end
+
+            # Write the other half of the separator, which should cause the `gets` call to now
+            # match. Explicitly close the pipe for good measure so a bug in `gets` doesn't block forever.
+            Thread.pass until t.stop?
+
+            write.write("\r\nelse\r\n\r\n")
+            write.close
+
+            t.value.bytes.should == "Aquí está la línea tres\r\n\r\n".bytes
+            read.read(8).bytes.should == "else\r\n\r\n".bytes
+          end
+        end
+      end
+    end
+  end
+
+  describe "when passed chomp" do
+    it "returns the first line without a trailing newline character" do
+      @io.gets(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
+    end
+
+    it "raises exception when options passed as Hash" do
+      -> { @io.gets({ chomp: true }) }.should raise_error(TypeError)
+
+      -> {
+        @io.gets("\n", 1, { chomp: true })
+      }.should raise_error(ArgumentError, "wrong number of arguments (given 3, expected 0..2)")
+    end
+  end
+end
+
+describe "IO#gets" do
+  before :each do
+    @name = tmp("io_gets")
+  end
+
+  after :each do
+    rm_r @name
+  end
+
+  it "raises an IOError if the stream is opened for append only" do
+    -> { File.open(@name, "a:utf-8") { |f| f.gets } }.should raise_error(IOError)
+  end
+
+  it "raises an IOError if the stream is opened for writing only" do
+    -> { File.open(@name, "w:utf-8") { |f| f.gets } }.should raise_error(IOError)
+  end
+end
+
+describe "IO#gets" do
+  before :each do
+    @name = tmp("io_gets")
+    touch(@name) { |f| f.write "one\n\ntwo\n\nthree\nfour\n" }
+    @io = new_io @name, "r:utf-8"
+  end
+
+  after :each do
+    @io.close if @io
+    rm_r @name
+  end
+
+  it "calls #to_int to convert a single object argument to an Integer limit" do
+    obj = mock("io gets limit")
+    obj.should_receive(:to_int).and_return(6)
+
+    @io.gets(obj).should == "one\n"
+  end
+
+  it "calls #to_int to convert the second object argument to an Integer limit" do
+    obj = mock("io gets limit")
+    obj.should_receive(:to_int).and_return(2)
+
+    @io.gets(nil, obj).should == "on"
+  end
+
+  it "calls #to_str to convert the first argument to a String when passed a limit" do
+    obj = mock("io gets separator")
+    obj.should_receive(:to_str).and_return($/)
+
+    @io.gets(obj, 5).should == "one\n"
+  end
+
+  it "reads to the default separator when passed a single argument greater than the number of bytes to the separator" do
+    @io.gets(6).should == "one\n"
+  end
+
+  it "reads limit bytes when passed a single argument less than the number of bytes to the default separator" do
+    @io.gets(3).should == "one"
+  end
+
+  it "reads limit bytes when passed nil and a limit" do
+    @io.gets(nil, 6).should == "one\n\nt"
+  end
+
+  it "reads all bytes when the limit is higher than the available bytes" do
+    @io.gets(nil, 100).should == "one\n\ntwo\n\nthree\nfour\n"
+  end
+
+  it "reads until the next paragraph when passed '' and a limit greater than the next paragraph" do
+    @io.gets("", 6).should == "one\n\n"
+  end
+
+  it "reads limit bytes when passed '' and a limit less than the next paragraph" do
+    @io.gets("", 3).should == "one"
+  end
+
+  it "reads all bytes when pass a separator and reading more than all bytes" do
+    @io.gets("\t", 100).should == "one\n\ntwo\n\nthree\nfour\n"
+  end
+
+  it "returns empty string when 0 passed as a limit" do
+    @io.gets(0).should == ""
+    @io.gets(nil, 0).should == ""
+    @io.gets("", 0).should == ""
+  end
+
+  it "does not accept limit that doesn't fit in a C off_t" do
+    -> { @io.gets(2**128) }.should raise_error(RangeError)
+  end
+end
+
+describe "IO#gets" do
+  before :each do
+    @name = tmp("io_gets")
+    # create data "朝日" + "\xE3\x81" * 100 to avoid utf-8 conflicts
+    data = "朝日" + ([227,129].pack('C*') * 100).force_encoding('utf-8')
+    touch(@name) { |f| f.write data }
+    @io = new_io @name, "r:utf-8"
+  end
+
+  after :each do
+    @io.close if @io
+    rm_r @name
+  end
+
+  it "reads limit bytes and extra bytes when limit is reached not at character boundary" do
+    [@io.gets(1), @io.gets(1)].should == ["朝", "日"]
+  end
+
+  it "read limit bytes and extra bytes with maximum of 16" do
+    # create str "朝日\xE3" + "\x81\xE3" * 8 to avoid utf-8 conflicts
+    str = "朝日" + ([227] + [129,227] * 8).pack('C*').force_encoding('utf-8')
+    @io.gets(7).should == str
+  end
+end
+
+describe "IO#gets" do
+  before :each do
+    @external = Encoding.default_external
+    @internal = Encoding.default_internal
+
+    Encoding.default_external = Encoding::UTF_8
+    Encoding.default_internal = nil
+
+    @name = tmp("io_gets")
+    touch(@name) { |f| f.write "line" }
+  end
+
+  after :each do
+    @io.close if @io
+    rm_r @name
+    Encoding.default_external = @external
+    Encoding.default_internal = @internal
+  end
+
+  it "uses the default external encoding" do
+    @io = new_io @name, 'r'
+    @io.gets.encoding.should == Encoding::UTF_8
+  end
+
+  it "uses the IO object's external encoding, when set" do
+    @io = new_io @name, 'r'
+    @io.set_encoding Encoding::US_ASCII
+    @io.gets.encoding.should == Encoding::US_ASCII
+  end
+
+  it "transcodes into the default internal encoding" do
+    Encoding.default_internal = Encoding::US_ASCII
+    @io = new_io @name, 'r'
+    @io.gets.encoding.should == Encoding::US_ASCII
+  end
+
+  it "transcodes into the IO object's internal encoding, when set" do
+    Encoding.default_internal = Encoding::US_ASCII
+    @io = new_io @name, 'r'
+    @io.set_encoding Encoding::UTF_8, Encoding::UTF_16
+    @io.gets.encoding.should == Encoding::UTF_16
+  end
+
+  it "overwrites the default external encoding with the IO object's own external encoding" do
+    Encoding.default_external = Encoding::BINARY
+    Encoding.default_internal = Encoding::UTF_8
+    @io = new_io @name, 'r'
+    @io.set_encoding Encoding::IBM866
+    @io.gets.encoding.should == Encoding::UTF_8
+  end
+
+  it "ignores the internal encoding if the default external encoding is BINARY" do
+    Encoding.default_external = Encoding::BINARY
+    Encoding.default_internal = Encoding::UTF_8
+    @io = new_io @name, 'r'
+    @io.gets.encoding.should == Encoding::BINARY
+  end
+
+  ruby_version_is ''...'3.3' do
+    it "transcodes to internal encoding if the IO object's external encoding is BINARY" do
+      Encoding.default_external = Encoding::BINARY
+      Encoding.default_internal = Encoding::UTF_8
+      @io = new_io @name, 'r'
+      @io.set_encoding Encoding::BINARY, Encoding::UTF_8
+      @io.gets.encoding.should == Encoding::UTF_8
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it "ignores the internal encoding if the IO object's external encoding is BINARY" do
+      Encoding.default_external = Encoding::BINARY
+      Encoding.default_internal = Encoding::UTF_8
+      @io = new_io @name, 'r'
+      @io.set_encoding Encoding::BINARY, Encoding::UTF_8
+      @io.gets.encoding.should == Encoding::BINARY
+    end
+  end
+end

--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -46,25 +46,33 @@ describe "IO#gets" do
 
     it "updates $. with each invocation" do
       while @io.gets
-        $..should == @count += 1
+        NATFIXME 'Implement $.', exception: SpecFailedException do
+          $..should == @count += 1
+        end
       end
     end
   end
 
   describe "with nil separator" do
     it "returns the entire contents" do
-      @io.gets(nil).should == IOSpecs.lines.join("")
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        @io.gets(nil).should == IOSpecs.lines.join("")
+      end
     end
 
     it "updates lineno with each invocation" do
-      while @io.gets(nil)
-        @io.lineno.should == @count += 1
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while @io.gets(nil)
+          @io.lineno.should == @count += 1
+        end
       end
     end
 
     it "updates $. with each invocation" do
-      while @io.gets(nil)
-        $..should == @count += 1
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while @io.gets(nil)
+          $..should == @count += 1
+        end
       end
     end
   end
@@ -73,44 +81,58 @@ describe "IO#gets" do
     # Two successive newlines in the input separate paragraphs.
     # When there are more than two successive newlines, only two are kept.
     it "returns the next paragraph" do
-      @io.gets("").should == IOSpecs.lines[0,3].join("")
-      @io.gets("").should == IOSpecs.lines[4,3].join("")
-      @io.gets("").should == IOSpecs.lines[7,2].join("")
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        @io.gets("").should == IOSpecs.lines[0,3].join("")
+        @io.gets("").should == IOSpecs.lines[4,3].join("")
+        @io.gets("").should == IOSpecs.lines[7,2].join("")
+      end
     end
 
     it "reads until the beginning of the next paragraph" do
       # There are three newlines between the first and second paragraph
-      @io.gets("")
-      @io.gets.should == IOSpecs.lines[4]
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        @io.gets("")
+        @io.gets.should == IOSpecs.lines[4]
+      end
     end
 
     it "updates lineno with each invocation" do
-      while @io.gets("")
-        @io.lineno.should == @count += 1
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while @io.gets("")
+          @io.lineno.should == @count += 1
+        end
       end
     end
 
     it "updates $. with each invocation" do
-      while @io.gets("")
-        $..should == @count += 1
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while @io.gets("")
+          $..should == @count += 1
+        end
       end
     end
   end
 
   describe "with an arbitrary String separator" do
     it "reads up to and including the separator" do
-      @io.gets("la linea").should == "Voici la ligne une.\nQui \303\250 la linea"
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        @io.gets("la linea").should == "Voici la ligne une.\nQui \303\250 la linea"
+      end
     end
 
     it "updates lineno with each invocation" do
-      while (@io.gets("la"))
-        @io.lineno.should == @count += 1
+    NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while (@io.gets("la"))
+          @io.lineno.should == @count += 1
+        end
       end
     end
 
     it "updates $. with each invocation" do
-      while @io.gets("la")
-        $..should == @count += 1
+    NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        while @io.gets("la")
+          $..should == @count += 1
+        end
       end
     end
 
@@ -124,20 +146,22 @@ describe "IO#gets" do
             # available in the buffer.
             write.write("Aquí está la línea tres\r\n")
 
-            t = Thread.new do
-              # Continue reading until the separator is encountered or the pipe is closed.
-              read.gets("\r\n\r\n")
+            NATFIXME 'Threads', exception: NameError, message: 'uninitialized constant Thread' do
+              t = Thread.new do
+                # Continue reading until the separator is encountered or the pipe is closed.
+                read.gets("\r\n\r\n")
+              end
+
+              # Write the other half of the separator, which should cause the `gets` call to now
+              # match. Explicitly close the pipe for good measure so a bug in `gets` doesn't block forever.
+              Thread.pass until t.stop?
+
+              write.write("\r\nelse\r\n\r\n")
+              write.close
+
+              t.value.bytes.should == "Aquí está la línea tres\r\n\r\n".bytes
+              read.read(8).bytes.should == "else\r\n\r\n".bytes
             end
-
-            # Write the other half of the separator, which should cause the `gets` call to now
-            # match. Explicitly close the pipe for good measure so a bug in `gets` doesn't block forever.
-            Thread.pass until t.stop?
-
-            write.write("\r\nelse\r\n\r\n")
-            write.close
-
-            t.value.bytes.should == "Aquí está la línea tres\r\n\r\n".bytes
-            read.read(8).bytes.should == "else\r\n\r\n".bytes
           end
         end
       end
@@ -146,15 +170,21 @@ describe "IO#gets" do
 
   describe "when passed chomp" do
     it "returns the first line without a trailing newline character" do
-      @io.gets(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
+      NATFIXME 'Support keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        @io.gets(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
+      end
     end
 
     it "raises exception when options passed as Hash" do
-      -> { @io.gets({ chomp: true }) }.should raise_error(TypeError)
+      NATFIXME 'Support keyword arguments', exception: SpecFailedException do
+        -> { @io.gets({ chomp: true }) }.should raise_error(TypeError)
+      end
 
-      -> {
-        @io.gets("\n", 1, { chomp: true })
-      }.should raise_error(ArgumentError, "wrong number of arguments (given 3, expected 0..2)")
+      NATFIXME 'Support keyword arguments', exception: SpecFailedException do
+        -> {
+          @io.gets("\n", 1, { chomp: true })
+        }.should raise_error(ArgumentError, "wrong number of arguments (given 3, expected 0..2)")
+      end
     end
   end
 end
@@ -169,11 +199,15 @@ describe "IO#gets" do
   end
 
   it "raises an IOError if the stream is opened for append only" do
-    -> { File.open(@name, "a:utf-8") { |f| f.gets } }.should raise_error(IOError)
+    NATFIXME 'Check read mode', exception: SpecFailedException do
+      -> { File.open(@name, "a:utf-8") { |f| f.gets } }.should raise_error(IOError)
+    end
   end
 
   it "raises an IOError if the stream is opened for writing only" do
-    -> { File.open(@name, "w:utf-8") { |f| f.gets } }.should raise_error(IOError)
+    NATFIXME 'Check read mode', exception: SpecFailedException do
+      -> { File.open(@name, "w:utf-8") { |f| f.gets } }.should raise_error(IOError)
+    end
   end
 end
 
@@ -190,62 +224,86 @@ describe "IO#gets" do
   end
 
   it "calls #to_int to convert a single object argument to an Integer limit" do
-    obj = mock("io gets limit")
-    obj.should_receive(:to_int).and_return(6)
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      obj = mock("io gets limit")
+      obj.should_receive(:to_int).and_return(6)
 
-    @io.gets(obj).should == "one\n"
+      @io.gets(obj).should == "one\n"
+    end
   end
 
   it "calls #to_int to convert the second object argument to an Integer limit" do
-    obj = mock("io gets limit")
-    obj.should_receive(:to_int).and_return(2)
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      obj = mock("io gets limit")
+      obj.should_receive(:to_int).and_return(2)
 
-    @io.gets(nil, obj).should == "on"
+      @io.gets(nil, obj).should == "on"
+    end
   end
 
   it "calls #to_str to convert the first argument to a String when passed a limit" do
-    obj = mock("io gets separator")
-    obj.should_receive(:to_str).and_return($/)
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      obj = mock("io gets separator")
+      obj.should_receive(:to_str).and_return($/)
 
-    @io.gets(obj, 5).should == "one\n"
+      @io.gets(obj, 5).should == "one\n"
+    end
   end
 
   it "reads to the default separator when passed a single argument greater than the number of bytes to the separator" do
-    @io.gets(6).should == "one\n"
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      @io.gets(6).should == "one\n"
+    end
   end
 
   it "reads limit bytes when passed a single argument less than the number of bytes to the default separator" do
-    @io.gets(3).should == "one"
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      @io.gets(3).should == "one"
+    end
   end
 
   it "reads limit bytes when passed nil and a limit" do
-    @io.gets(nil, 6).should == "one\n\nt"
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      @io.gets(nil, 6).should == "one\n\nt"
+    end
   end
 
   it "reads all bytes when the limit is higher than the available bytes" do
-    @io.gets(nil, 100).should == "one\n\ntwo\n\nthree\nfour\n"
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      @io.gets(nil, 100).should == "one\n\ntwo\n\nthree\nfour\n"
+    end
   end
 
   it "reads until the next paragraph when passed '' and a limit greater than the next paragraph" do
-    @io.gets("", 6).should == "one\n\n"
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      @io.gets("", 6).should == "one\n\n"
+    end
   end
 
   it "reads limit bytes when passed '' and a limit less than the next paragraph" do
-    @io.gets("", 3).should == "one"
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      @io.gets("", 3).should == "one"
+    end
   end
 
   it "reads all bytes when pass a separator and reading more than all bytes" do
-    @io.gets("\t", 100).should == "one\n\ntwo\n\nthree\nfour\n"
+    NATFIXME 'Support separator and limit arguments', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0)' do
+      @io.gets("\t", 100).should == "one\n\ntwo\n\nthree\nfour\n"
+    end
   end
 
   it "returns empty string when 0 passed as a limit" do
-    @io.gets(0).should == ""
-    @io.gets(nil, 0).should == ""
-    @io.gets("", 0).should == ""
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      @io.gets(0).should == ""
+      @io.gets(nil, 0).should == ""
+      @io.gets("", 0).should == ""
+    end
   end
 
   it "does not accept limit that doesn't fit in a C off_t" do
-    -> { @io.gets(2**128) }.should raise_error(RangeError)
+    NATFIXME 'Support limit argument', exception: SpecFailedException do
+      -> { @io.gets(2**128) }.should raise_error(RangeError)
+    end
   end
 end
 
@@ -264,13 +322,17 @@ describe "IO#gets" do
   end
 
   it "reads limit bytes and extra bytes when limit is reached not at character boundary" do
-    [@io.gets(1), @io.gets(1)].should == ["朝", "日"]
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      [@io.gets(1), @io.gets(1)].should == ["朝", "日"]
+    end
   end
 
   it "read limit bytes and extra bytes with maximum of 16" do
     # create str "朝日\xE3" + "\x81\xE3" * 8 to avoid utf-8 conflicts
     str = "朝日" + ([227] + [129,227] * 8).pack('C*').force_encoding('utf-8')
-    @io.gets(7).should == str
+    NATFIXME 'Support limit argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      @io.gets(7).should == str
+    end
   end
 end
 
@@ -295,26 +357,34 @@ describe "IO#gets" do
 
   it "uses the default external encoding" do
     @io = new_io @name, 'r'
-    @io.gets.encoding.should == Encoding::UTF_8
+    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+      @io.gets.encoding.should == Encoding::UTF_8
+    end
   end
 
   it "uses the IO object's external encoding, when set" do
     @io = new_io @name, 'r'
     @io.set_encoding Encoding::US_ASCII
-    @io.gets.encoding.should == Encoding::US_ASCII
+    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+      @io.gets.encoding.should == Encoding::US_ASCII
+    end
   end
 
   it "transcodes into the default internal encoding" do
     Encoding.default_internal = Encoding::US_ASCII
     @io = new_io @name, 'r'
-    @io.gets.encoding.should == Encoding::US_ASCII
+    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+      @io.gets.encoding.should == Encoding::US_ASCII
+    end
   end
 
   it "transcodes into the IO object's internal encoding, when set" do
     Encoding.default_internal = Encoding::US_ASCII
     @io = new_io @name, 'r'
-    @io.set_encoding Encoding::UTF_8, Encoding::UTF_16
-    @io.gets.encoding.should == Encoding::UTF_16
+    NATFIXME 'Add Encoding::UTF_16', exception: NameError, message: 'uninitialized constant Encoding::UTF_16' do
+      @io.set_encoding Encoding::UTF_8, Encoding::UTF_16
+      @io.gets.encoding.should == Encoding::UTF_16
+    end
   end
 
   it "overwrites the default external encoding with the IO object's own external encoding" do
@@ -322,14 +392,18 @@ describe "IO#gets" do
     Encoding.default_internal = Encoding::UTF_8
     @io = new_io @name, 'r'
     @io.set_encoding Encoding::IBM866
-    @io.gets.encoding.should == Encoding::UTF_8
+    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+      @io.gets.encoding.should == Encoding::UTF_8
+    end
   end
 
   it "ignores the internal encoding if the default external encoding is BINARY" do
     Encoding.default_external = Encoding::BINARY
     Encoding.default_internal = Encoding::UTF_8
     @io = new_io @name, 'r'
-    @io.gets.encoding.should == Encoding::BINARY
+    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+      @io.gets.encoding.should == Encoding::BINARY
+    end
   end
 
   ruby_version_is ''...'3.3' do
@@ -338,7 +412,9 @@ describe "IO#gets" do
       Encoding.default_internal = Encoding::UTF_8
       @io = new_io @name, 'r'
       @io.set_encoding Encoding::BINARY, Encoding::UTF_8
-      @io.gets.encoding.should == Encoding::UTF_8
+      NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+        @io.gets.encoding.should == Encoding::UTF_8
+      end
     end
   end
 

--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -170,17 +170,15 @@ describe "IO#gets" do
 
   describe "when passed chomp" do
     it "returns the first line without a trailing newline character" do
-      NATFIXME 'Support keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        @io.gets(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
-      end
+      @io.gets(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
     end
 
     it "raises exception when options passed as Hash" do
-      NATFIXME 'Support keyword arguments', exception: SpecFailedException do
+      NATFIXME 'Support arguments', exception: SpecFailedException do
         -> { @io.gets({ chomp: true }) }.should raise_error(TypeError)
       end
 
-      NATFIXME 'Support keyword arguments', exception: SpecFailedException do
+      NATFIXME 'Support arguments', exception: SpecFailedException do
         -> {
           @io.gets("\n", 1, { chomp: true })
         }.should raise_error(ArgumentError, "wrong number of arguments (given 3, expected 0..2)")

--- a/spec/core/io/readline_spec.rb
+++ b/spec/core/io/readline_spec.rb
@@ -78,13 +78,11 @@ describe "IO#readline" do
 
   describe "when passed chomp" do
     it "returns the first line without a trailing newline character" do
-      NATFIXME 'Support keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        @io.readline(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
-      end
+      @io.readline(chomp: true).should == IOSpecs.lines_without_newline_characters[0]
     end
 
     it "raises exception when options passed as Hash" do
-      NATFIXME 'Support keyword arguments', exception: SpecFailedException do
+      NATFIXME 'Support arguments', exception: SpecFailedException do
         -> { @io.readline({ chomp: true }) }.should raise_error(TypeError)
 
         -> {

--- a/spec/core/io/shared/gets_ascii.rb
+++ b/spec/core/io/shared/gets_ascii.rb
@@ -1,0 +1,19 @@
+# -*- encoding: binary -*-
+describe :io_gets_ascii, shared: true do
+  describe "with ASCII separator" do
+    before :each do
+      @name = tmp("gets_specs.txt")
+      touch(@name, "wb") { |f| f.print "this is a test\xFFtesty\ntestier" }
+
+      File.open(@name, "rb") { |f| @data = f.send(@method, "\xFF") }
+    end
+
+    after :each do
+      rm_r @name
+    end
+
+    it "returns the separator's character representation" do
+      @data.should == "this is a test\xFF"
+    end
+  end
+end

--- a/spec/core/io/shared/gets_ascii.rb
+++ b/spec/core/io/shared/gets_ascii.rb
@@ -5,7 +5,9 @@ describe :io_gets_ascii, shared: true do
       @name = tmp("gets_specs.txt")
       touch(@name, "wb") { |f| f.print "this is a test\xFFtesty\ntestier" }
 
-      File.open(@name, "rb") { |f| @data = f.send(@method, "\xFF") }
+      NATFIXME 'Support separator argument', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        File.open(@name, "rb") { |f| @data = f.send(@method, "\xFF") }
+      end
     end
 
     after :each do
@@ -13,7 +15,9 @@ describe :io_gets_ascii, shared: true do
     end
 
     it "returns the separator's character representation" do
-      @data.should == "this is a test\xFF"
+      NATFIXME 'Broken setup', exception: SpecFailedException do
+        @data.should == "this is a test\xFF"
+      end
     end
   end
 end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -999,10 +999,10 @@ Value IoObject::readbyte(Env *env) {
 }
 
 // This is a variant of gets that raises EOFError
-// NATFIXME: Add arguments and chomp kwarg when those features are
+// NATFIXME: Add arguments when those features are
 //  added to IOObject::gets()
-Value IoObject::readline(Env *env) {
-    auto result = gets(env);
+Value IoObject::readline(Env *env, Value chomp) {
+    auto result = gets(env, chomp);
     if (result->is_nil())
         env->raise("EOFError", "end of file reached");
     return result;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -619,7 +619,7 @@ Value IoObject::write(Env *env, Args args) const {
 }
 
 // NATFIXME: Make this spec compliant and maybe more performant?
-Value IoObject::gets(Env *env) {
+Value IoObject::gets(Env *env, Value chomp) {
     raise_if_closed(env);
     char buffer[NAT_READ_BYTES + 1];
     size_t index;
@@ -631,6 +631,8 @@ Value IoObject::gets(Env *env) {
             break;
     }
     auto line = new StringObject { buffer, index + 1 };
+    if (chomp && chomp->is_truthy())
+        line->chomp_in_place(env, nullptr);
     env->set_last_line(line);
     m_lineno++;
     return line;


### PR DESCRIPTION
The chomp command itself has been delegated to `String#chomp!`, since we'll have to support the `sep` argument and the `$/` value at some point.