### PR TITLE
Implement $. (last line number)

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -159,6 +159,7 @@ public:
     Value output_record_separator();
     Value last_line();
     Value set_last_line(Value);
+    Value set_last_lineno(Value);
 
 private:
     ManagedVector<Value> *m_vars { nullptr };

--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -46,9 +46,7 @@ describe "IO#gets" do
 
     it "updates $. with each invocation" do
       while @io.gets
-        NATFIXME 'Implement $.', exception: SpecFailedException do
-          $..should == @count += 1
-        end
+        $..should == @count += 1
       end
     end
   end

--- a/spec/core/io/lineno_spec.rb
+++ b/spec/core/io/lineno_spec.rb
@@ -133,10 +133,8 @@ describe "IO#lineno=" do
     @io.lineno = count = 500
     $..should == 0
 
-    NATFIXME 'Implement $.', exception: SpecFailedException do
-      while @io.gets
-        $..should == count += 1
-      end
+    while @io.gets
+      $..should == count += 1
     end
   end
 end

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -48,6 +48,10 @@ Value Env::set_last_line(Value val) {
     return global_set("$_"_s, val);
 }
 
+Value Env::set_last_lineno(Value val) {
+    return global_set("$."_s, val);
+}
+
 const Method *Env::current_method() {
     Env *env = this;
     while (!env->method() && env->outer()) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -39,8 +39,8 @@ Value Env::output_record_separator() {
 
 // Return the last line `$_` or nil
 Value Env::last_line() {
-    Value fsep = global_get("$_"_s);
-    if (fsep) return fsep;
+    Value last_line = global_get("$_"_s);
+    if (last_line) return last_line;
     return NilObject::the();
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -633,8 +633,9 @@ Value IoObject::gets(Env *env, Value chomp) {
     auto line = new StringObject { buffer, index + 1 };
     if (chomp && chomp->is_truthy())
         line->chomp_in_place(env, nullptr);
-    env->set_last_line(line);
     m_lineno++;
+    env->set_last_line(line);
+    env->set_last_lineno(IntegerObject::create(m_lineno));
     return line;
 }
 


### PR DESCRIPTION
Another one of those Ruby features I never knew, although I'm kind of puzzled for a use case for this one (possibly for using `ruby -p`?)

As a bonus, a bit of a rename cleanup in `Env::last_line` which didn't really deserve its own commit.