### PR TITLE
Set $_ to nil once IO#gets returns nil

### DIFF
--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -624,8 +624,10 @@ Value IoObject::gets(Env *env, Value chomp) {
     char buffer[NAT_READ_BYTES + 1];
     size_t index;
     for (index = 0; index < NAT_READ_BYTES; ++index) {
-        if (::read(m_fileno, &buffer[index], 1) == 0)
+        if (::read(m_fileno, &buffer[index], 1) == 0) {
+            env->set_last_line(NilObject::the());
             return NilObject::the();
+        }
 
         if (buffer[index] == '\n')
             break;

--- a/test/natalie/io_test.rb
+++ b/test/natalie/io_test.rb
@@ -48,3 +48,14 @@ describe "IO#autoclose" do
     -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
   end
 end
+
+describe "IO#gets" do
+  it "sets $_ to nil afthe the last line has been read" do
+    File.open(__dir__ + '/../../spec/core/io/fixtures/lines.txt') do |f|
+      while line = f.gets
+        $_.should == line
+      end
+      $_.should be_nil
+    end
+  end
+end


### PR DESCRIPTION
This appears to not be covered in the Ruby specs, I'll try to push that to the upstream specs soon.