### PR TITLE
Build exception backtrace including module/class locations

### DIFF
--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -59,6 +59,8 @@ public:
     bool is_singleton() const { return m_is_singleton; }
     void set_is_singleton(bool is_singleton) { m_is_singleton = is_singleton; }
 
+    virtual String backtrace_name() const override final;
+
     virtual void gc_inspect(char *buf, size_t len) const override {
         if (m_class_name)
             snprintf(buf, len, "<ClassObject %p name=%s>", this, m_class_name.value().c_str());

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -29,7 +29,8 @@ public:
         , m_caller { nullptr }
         , m_file { other.m_file }
         , m_line { other.m_line }
-        , m_method { other.m_method } { }
+        , m_method { other.m_method }
+        , m_module { other.m_module } { }
 
     Env &operator=(Env &other) = delete;
 
@@ -136,6 +137,9 @@ public:
     const Method *method() { return m_method; }
     void set_method(const Method *method) { m_method = method; }
 
+    const ModuleObject *module() { return m_module; }
+    void set_module(const ModuleObject *module) { m_module = module; }
+
     Value match() { return m_match; }
     void set_match(Value match) { m_match = match; }
     void clear_match() { m_match = nullptr; }
@@ -170,6 +174,7 @@ private:
     const char *m_file { nullptr };
     size_t m_line { 0 };
     const Method *m_method { nullptr };
+    const ModuleObject *m_module { nullptr };
     Value m_match { nullptr };
     ExceptionObject *m_exception { nullptr };
 };

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -118,6 +118,8 @@ public:
     String dbg_inspect() const override;
     Value name(Env *) const;
     Optional<String> name() { return m_class_name; }
+    virtual String backtrace_name() const;
+
     ArrayObject *attr(Env *, Args);
     ArrayObject *attr_reader(Env *, Args);
     SymbolObject *attr_reader(Env *, Value);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -114,7 +114,7 @@ public:
     bool is_method_defined(Env *, Value) const;
 
     String inspect_str() const;
-    Value inspect(Env *);
+    Value inspect(Env *) const;
     String dbg_inspect() const override;
     Value name(Env *) const;
     Optional<String> name() { return m_class_name; }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -64,7 +64,7 @@ public:
 
     Value eval_body(Env *, Value (*)(Env *, Value));
 
-    Optional<String> class_name() {
+    Optional<String> class_name() const {
         return m_class_name;
     }
 
@@ -113,10 +113,10 @@ public:
 
     bool is_method_defined(Env *, Value) const;
 
-    String inspect_str();
+    String inspect_str() const;
     Value inspect(Env *);
     String dbg_inspect() const override;
-    Value name(Env *);
+    Value name(Env *) const;
     Optional<String> name() { return m_class_name; }
     ArrayObject *attr(Env *, Args);
     ArrayObject *attr_reader(Env *, Args);

--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -3,17 +3,21 @@ require_relative './base_instruction'
 module Natalie
   class Compiler
     class DefineClassInstruction < BaseInstruction
-      def initialize(name:, is_private:)
+      def initialize(name:, is_private:, file:, line:)
         super()
         @name = name.to_sym
         @is_private = is_private
+
+        # source location info
+        @file = file
+        @line = line
       end
 
       def has_body?
         true
       end
 
-      attr_reader :name
+      attr_reader :name, :file, :line
 
       def private?
         @is_private
@@ -26,7 +30,11 @@ module Natalie
       end
 
       def generate(transform)
+        transform.set_file(@file)
+        transform.set_line(@line)
+
         body = transform.fetch_block_of_instructions(expected_label: :define_class)
+
         fn = transform.temp("class_#{@name}")
         transform.with_new_scope(body) do |t|
           fn_code = []
@@ -35,11 +43,13 @@ module Natalie
           fn_code << '}'
           transform.top(fn_code)
         end
+
         klass = transform.temp('class')
         namespace = transform.pop
         superclass = transform.pop
-        code = []
         search_mode = private? ? 'StrictPrivate' : 'Strict'
+
+        code = []
         code << "auto #{klass} = #{namespace}->const_find_with_autoload(env, self, " \
                 "#{transform.intern(@name)}, Object::ConstLookupSearchMode::#{search_mode}, " \
                 'Object::ConstLookupFailureMode::Null)'
@@ -48,6 +58,7 @@ module Natalie
         code << "  #{namespace}->const_set(#{transform.intern(@name)}, #{klass})"
         code << '}'
         code << "#{klass}->as_class()->eval_body(env, #{fn})"
+
         transform.exec_and_push(:result_of_define_class, code)
       end
 

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -428,7 +428,12 @@ module Natalie
         end
         name, is_private, prep_instruction = constant_name(name)
         instructions << prep_instruction
-        instructions << DefineClassInstruction.new(name: name, is_private: is_private)
+        instructions << DefineClassInstruction.new(
+          name: name,
+          is_private: is_private,
+          file: exp.file,
+          line: exp.line,
+        )
         instructions += transform_body(body, used: true)
         instructions << EndInstruction.new(:define_class)
         instructions << PopInstruction.new unless used
@@ -1011,7 +1016,12 @@ module Natalie
         instructions = []
         name, is_private, prep_instruction = constant_name(name)
         instructions << prep_instruction
-        instructions << DefineModuleInstruction.new(name: name, is_private: is_private)
+        instructions << DefineModuleInstruction.new(
+          name: name,
+          is_private: is_private,
+          file: exp.file,
+          line: exp.line,
+        )
         instructions += transform_body(body, used: true)
         instructions << EndInstruction.new(:define_module)
         instructions << PopInstruction.new unless used

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -71,4 +71,10 @@ ClassObject *ClassObject::bootstrap_basic_object(Env *env, ClassObject *Class) {
     return BasicObject;
 }
 
+String ClassObject::backtrace_name() const {
+    if (!m_class_name)
+        return inspect_str();
+    return String::format("<class:{}>", m_class_name.value());
+}
+
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -339,6 +339,7 @@ void Env::visit_children(Visitor &visitor) {
     visitor.visit(m_this_block);
     visitor.visit(m_caller);
     visitor.visit(m_method);
+    visitor.visit(m_module);
     visitor.visit(m_match);
     visitor.visit(m_exception);
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -63,8 +63,12 @@ const Method *Env::current_method() {
 String Env::build_code_location_name() {
     if (is_main())
         return "<main>";
+
     if (method())
         return method()->name();
+
+    if (module())
+        return module()->backtrace_name();
 
     // we're in a block, so try to build a string like "block in foo", "block in block in foo", etc.
     if (outer()) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -548,7 +548,7 @@ bool ModuleObject::is_method_defined(Env *env, Value name_value) const {
     return !!find_method(env, name);
 }
 
-String ModuleObject::inspect_str() {
+String ModuleObject::inspect_str() const {
     if (m_class_name) {
         if (owner() && owner() != GlobalEnv::the()->Object()) {
             return String::format("{}::{}", owner()->inspect_str(), m_class_name.value());
@@ -574,7 +574,7 @@ String ModuleObject::dbg_inspect() const {
     return Object::dbg_inspect();
 }
 
-Value ModuleObject::name(Env *env) {
+Value ModuleObject::name(Env *env) const {
     if (m_class_name) {
         String name = m_class_name.value();
         auto the_owner = owner();

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -290,6 +290,7 @@ void ModuleObject::alias(Env *env, SymbolObject *new_name, SymbolObject *old_nam
 Value ModuleObject::eval_body(Env *env, Value (*fn)(Env *, Value)) {
     Env body_env { m_env };
     body_env.set_caller(env);
+    body_env.set_module(this);
     Value result = fn(&body_env, this);
     m_method_visibility = MethodVisibility::Public;
     m_module_function = false;
@@ -589,6 +590,12 @@ Value ModuleObject::name(Env *env) const {
     } else {
         return NilObject::the();
     }
+}
+
+String ModuleObject::backtrace_name() const {
+    if (!m_class_name)
+        return inspect_str();
+    return String::format("<module:{}>", m_class_name.value());
 }
 
 ArrayObject *ModuleObject::attr(Env *env, Args args) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -565,7 +565,7 @@ String ModuleObject::inspect_str() const {
     }
 }
 
-Value ModuleObject::inspect(Env *env) {
+Value ModuleObject::inspect(Env *env) const {
     return new StringObject { inspect_str() };
 }
 

--- a/test/natalie/backtrace_test.rb
+++ b/test/natalie/backtrace_test.rb
@@ -1,0 +1,20 @@
+require_relative '../spec_helper'
+
+describe 'backtrace' do
+  it 'records code locations in modules and classes' do
+    bt = nil
+    lambda {
+      module Foo
+        class Bar
+          class Baz < Buz # Baz is undefined
+          end
+        end
+      end
+    }.should raise_error(NameError) { |e| bt = e.backtrace }
+    bt.filter_map { |l| l.match(/<[^>]+>/)&.to_s }.grep_v(/<top \(required\)>/).uniq.should == %w[
+      <class:Bar>
+      <module:Foo>
+      <main>
+    ]
+  end
+end


### PR DESCRIPTION
Given:

```ruby
module A
  class B
    class C < D # D is undefined, causing an exception
    end
  end
end
```

**Before:**

```
Traceback (most recent call last):
src/errno.rb:398:in `<main>': uninitialized constant A::B::D (NameError)
```

Funny that `src/errno.rb` was the reported file location. 😬 

**After:**

```
Traceback (most recent call last):
        3: from bt.rb:1:in `<main>'
        2: from bt.rb:2:in `<module:A>'
        1: from bt.rb:3:in `<class:B>'
bt.rb:3:in `const_missing': uninitialized constant A::B::D (NameError)
```