### PR TITLE
Use prism nodes directly for pass1

### DIFF
--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -216,9 +216,9 @@ module Natalie
 
         if @loaded_paths[path]
           if require_once
-            s(:false)
+            ::Prism::FalseNode.new(nil)
           else
-            s(:true)
+            ::Prism::TrueNode.new(nil)
           end
         else
           @loaded_paths[path] = true
@@ -227,7 +227,7 @@ module Natalie
           s(:block,
             s(:with_main,
               expand_macros(file_ast, path)),
-            s(:true))
+            ::Prism::TrueNode.new(nil))
         end
       end
 
@@ -247,7 +247,7 @@ module Natalie
         end
         s(:block,
           s(:require_cpp_file, nil, :__inline__, s(:str, cpp_source)),
-          s(:true))
+          ::Prism::TrueNode.new(nil))
       end
 
       def drop_load_error(msg)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -113,6 +113,11 @@ module Natalie
       # INDIVIDUAL PRISM NODES = = = = =
       # (in alphabetical order)
 
+      def transform_float_node(node, used:)
+        return [] unless used
+        [PushFloatInstruction.new(node.value)]
+      end
+
       def transform_imaginary_node(node, used:)
         return [] unless used
 

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -5,43 +5,6 @@ require_relative './const_prepper'
 require_relative './multiple_assignment'
 require_relative './rescue'
 
-module Prism
-  class Node
-    # This is to maintain the same interface as Sexp instances. It doesn't
-    # provide the exact same thing, so as we migrate we'll need to update call
-    # sites to handle the "correct" type. The list of types that we need to
-    # handle are:
-    #
-    # * args
-    # * attrasgn
-    # * bare_hash
-    # * block
-    # * block_pass
-    # * cdecl
-    # * colon2
-    # * colon3
-    # * cvar
-    # * evstr
-    # * forward_args
-    # * gasgn
-    # * iasgn
-    # * kwarg
-    # * kwsplat
-    # * lasgn
-    # * lvar
-    # * masgn
-    # * resbody
-    # * safe_call
-    # * str
-    # * to_ary
-    # * zsuper
-    #
-    def sexp_type
-      type
-    end
-  end
-end
-
 module Natalie
   class Compiler
     # This compiler pass transforms AST from the Parser into Intermediate

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -113,6 +113,29 @@ module Natalie
       # INDIVIDUAL PRISM NODES = = = = =
       # (in alphabetical order)
 
+      def transform_imaginary_node(node, used:)
+        return [] unless used
+
+        value = node.value.imaginary
+        instruction =
+          case value
+          when Integer
+            PushIntInstruction.new(value)
+          when Float
+            PushFloatInstruction.new(value)
+          when Rational
+            PushRationalInstruction.new(value)
+          else
+            raise "Unexpected imaginary value: \"#{value.inspect}\""
+          end
+
+        [
+          PushIntInstruction.new(0),
+          instruction,
+          PushComplexInstruction.new,
+        ]
+      end
+
       def transform_integer_node(node, used:)
         return [] unless used
         [PushIntInstruction.new(node.value)]
@@ -121,9 +144,10 @@ module Natalie
       def transform_rational_node(node, used:)
         return [] unless used
 
+        value = node.value
         [
-          PushIntInstruction.new(node.value.numerator),
-          PushIntInstruction.new(node.value.denominator),
+          PushIntInstruction.new(value.numerator),
+          PushIntInstruction.new(value.denominator),
           PushRationalInstruction.new,
         ]
       end

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -114,7 +114,18 @@ module Natalie
       # (in alphabetical order)
 
       def transform_integer_node(node, used:)
-        used ? [PushIntInstruction.new(node.value)] : []
+        return [] unless used
+        [PushIntInstruction.new(node.value)]
+      end
+
+      def transform_rational_node(node, used:)
+        return [] unless used
+
+        [
+          PushIntInstruction.new(node.value.numerator),
+          PushIntInstruction.new(node.value.denominator),
+          PushRationalInstruction.new,
+        ]
       end
 
       # INDIVIDUAL EXPRESSIONS = = = = =

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -113,6 +113,20 @@ module Natalie
       # INDIVIDUAL PRISM NODES = = = = =
       # (in alphabetical order)
 
+      def transform_and_node(node, used:)
+        instructions = [
+          *transform_expression(node.left, used: true),
+          DupInstruction.new,
+          IfInstruction.new,
+          PopInstruction.new,
+          *transform_expression(node.right, used: true),
+          ElseInstruction.new(:if),
+          EndInstruction.new(:if),
+        ]
+        instructions << PopInstruction.new unless used
+        instructions
+      end
+
       def transform_false_node(_, used:)
         return [] unless used
         [PushFalseInstruction.new]
@@ -186,23 +200,6 @@ module Natalie
         instructions << DupInstruction.new if used
         instructions << transform_expression(old_name, used: true)
         instructions << AliasInstruction.new
-      end
-
-      def transform_and(exp, used:)
-        _, lhs, rhs = exp
-        lhs_instructions = transform_expression(lhs, used: true)
-        rhs_instructions = transform_expression(rhs, used: true)
-        instructions = [
-          lhs_instructions,
-          DupInstruction.new,
-          IfInstruction.new,
-          PopInstruction.new,
-          rhs_instructions,
-          ElseInstruction.new(:if),
-          EndInstruction.new(:if),
-        ]
-        instructions << PopInstruction.new unless used
-        instructions
       end
 
       def transform_array(exp, used:)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -5,6 +5,43 @@ require_relative './const_prepper'
 require_relative './multiple_assignment'
 require_relative './rescue'
 
+module Prism
+  class Node
+    # This is to maintain the same interface as Sexp instances. It doesn't
+    # provide the exact same thing, so as we migrate we'll need to update call
+    # sites to handle the "correct" type. The list of types that we need to
+    # handle are:
+    #
+    # * args
+    # * attrasgn
+    # * bare_hash
+    # * block
+    # * block_pass
+    # * cdecl
+    # * colon2
+    # * colon3
+    # * cvar
+    # * evstr
+    # * forward_args
+    # * gasgn
+    # * iasgn
+    # * kwarg
+    # * kwsplat
+    # * lasgn
+    # * lvar
+    # * masgn
+    # * resbody
+    # * safe_call
+    # * str
+    # * to_ary
+    # * zsuper
+    #
+    def sexp_type
+      type
+    end
+  end
+end
+
 module Natalie
   class Compiler
     # This compiler pass transforms AST from the Parser into Intermediate
@@ -49,6 +86,9 @@ module Natalie
         when Sexp
           method = "transform_#{exp.sexp_type}"
           Array(send(method, exp, used: used)).flatten
+        when ::Prism::Node
+          method = "transform_#{exp.type}"
+          Array(send(method, exp, used: used)).flatten
         else
           raise "Unknown expression type: #{exp.inspect}"
         end
@@ -69,6 +109,13 @@ module Natalie
       end
 
       private
+
+      # INDIVIDUAL PRISM NODES = = = = =
+      # (in alphabetical order)
+
+      def transform_integer_node(node, used:)
+        used ? [PushIntInstruction.new(node.value)] : []
+      end
 
       # INDIVIDUAL EXPRESSIONS = = = = =
       # (in alphabetical order)

--- a/lib/natalie/compiler/rescue.rb
+++ b/lib/natalie/compiler/rescue.rb
@@ -24,7 +24,7 @@ module Natalie
 
         [
           try_instruction,
-          transform_body(body || exp.new(:nil)),
+          transform_body(body || ::Prism::NilNode.new(nil)),
           CatchInstruction.new,
           transform_catch_body(rescue_exprs, retry_id: retry_id),
           EndInstruction.new(:try),

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -390,9 +390,7 @@ module Natalie
           location: node.location)
       end
 
-      def visit_imaginary_node(node)
-        s(:lit, node.value, location: node.location)
-      end
+      alias visit_imaginary_node visit_passthrough
 
       def visit_interpolated_regular_expression_node(node)
         dregx = visit_interpolated_stringish_node(node, sexp_type: :dregx, unescaped: false)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -623,7 +623,7 @@ module Natalie
       end
 
       def visit_or_node(node)
-        s(:or, visit(node.left), visit(node.right), location: node.location)
+        node.copy(left: visit(node.left), right: visit(node.right))
       end
 
       def visit_parameters_node(node)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -673,9 +673,7 @@ module Natalie
         end
       end
 
-      def visit_rational_node(node)
-        s(:lit, node.value, location: node.location)
-      end
+      alias visit_rational_node visit_passthrough
 
       def visit_redo_node(node)
         s(:redo, location: node.location)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -2,6 +2,53 @@ $LOAD_PATH << File.expand_path('../../build/prism/lib', __dir__)
 $LOAD_PATH << File.expand_path('../../build/prism/ext', __dir__)
 require 'prism'
 
+module Prism
+  class Node
+    # This is to maintain the same interface as Sexp instances. It doesn't
+    # provide the exact same thing, so as we migrate we'll need to update call
+    # sites to handle the "correct" type. The list of types that we need to
+    # handle are:
+    #
+    # * args
+    # * attrasgn
+    # * bare_hash
+    # * block
+    # * block_pass
+    # * cdecl
+    # * colon2
+    # * colon3
+    # * cvar
+    # * evstr
+    # * forward_args
+    # * gasgn
+    # * iasgn
+    # * kwarg
+    # * kwsplat
+    # * lasgn
+    # * lvar
+    # * masgn
+    # * resbody
+    # * safe_call
+    # * str
+    # * to_ary
+    # * zsuper
+    #
+    def sexp_type
+      type
+    end
+
+    # We need this to maintain the same interface as Sexp instances in the case
+    # of the repl.
+    def new(*parts)
+      Natalie::Parser::Sexp.new(*parts).tap do |sexp|
+        sexp.file = "<compiled>"
+        sexp.line = location.start_line
+        sexp.column = location.start_column
+      end
+    end
+  end
+end
+
 module Natalie
   class Parser
     class IncompleteExpression < StandardError

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -306,7 +306,7 @@ module Natalie
       end
 
       def visit_defined_node(node)
-        s(:defined, visit(node.value), location: node.location)
+        node.copy(value: visit(node.value))
       end
 
       def visit_else_node(node)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -24,7 +24,7 @@ module Natalie
       end
 
       def visit_and_node(node)
-        s(:and, visit(node.left), visit(node.right), location: node.location)
+        node.copy(left: visit(node.left), right: visit(node.right))
       end
 
       def visit_array_node(node)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -294,13 +294,13 @@ module Natalie
             receiver,
             node.name.to_sym,
             visit(node.parameters) || s(:args, location: node.location),
-            visit(node.body) || s(:nil, location: node.location),
+            visit(node.body) || nil_node(node.location),
             location: node.location)
         else
           s(:defn,
             node.name.to_sym,
             visit(node.parameters) || s(:args, location: node.location),
-            visit(node.body) || s(:nil, location: node.location),
+            visit(node.body) || nil_node(node.location),
             location: node.location)
         end
       end
@@ -313,9 +313,7 @@ module Natalie
         visit(node.child_nodes.first)
       end
 
-      def visit_false_node(node)
-        s(:false, location: node.location)
-      end
+      alias visit_false_node visit_passthrough
 
       alias visit_float_node visit_passthrough
 
@@ -603,9 +601,7 @@ module Natalie
         visit_return_or_next_or_break_node(node, sexp_type: :next)
       end
 
-      def visit_nil_node(node)
-        s(:nil, location: node.location)
-      end
+      alias visit_nil_node visit_passthrough
 
       def visit_numbered_reference_read_node(node)
         s(:nth_ref, node.number, location: node.location)
@@ -645,7 +641,7 @@ module Natalie
         if node.body
           visit(node.body)
         else
-          s(:nil, location: node.location)
+          nil_node(node.location)
         end
       end
 
@@ -741,9 +737,7 @@ module Natalie
         end
       end
 
-      def visit_self_node(node)
-        s(:self, location: node.location)
-      end
+      alias visit_self_node visit_passthrough
 
       def visit_singleton_class_node(node)
         s(:sclass, visit(node.expression), visit(node.body), location: node.location)
@@ -810,9 +804,7 @@ module Natalie
         s(:lit, node.unescaped.to_sym, location: node.location)
       end
 
-      def visit_true_node(node)
-        s(:true, location: node.location)
-      end
+      alias visit_true_node visit_passthrough
 
       def visit_undef_node(node)
         if node.names.size == 1
@@ -870,6 +862,10 @@ module Natalie
 
       def s(*items, location:)
         Sexp.new(*items, location: location, file: @path)
+      end
+
+      def nil_node(location)
+        ::Prism::NilNode.new(location)
       end
 
       def flatten(ary)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -15,6 +15,10 @@ module Natalie
         @path = path
       end
 
+      def visit_passthrough(node)
+        node
+      end
+
       def visit_alias_method_node(node)
         s(:alias, visit(node.new_name), visit(node.old_name), location: node.location)
       end
@@ -426,9 +430,7 @@ module Natalie
         s(:iasgn, node.name, visit(node.value), location: node.location)
       end
 
-      def visit_integer_node(node)
-        s(:lit, node.value, location: node.location)
-      end
+      alias visit_integer_node visit_passthrough
 
       def visit_interpolated_string_node(node)
         visit_interpolated_stringish_node(node, sexp_type: :dstr)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -317,9 +317,7 @@ module Natalie
         s(:false, location: node.location)
       end
 
-      def visit_float_node(node)
-        s(:lit, node.value, location: node.location)
-      end
+      alias visit_float_node visit_passthrough
 
       def visit_for_node(node)
         s(:for,


### PR DESCRIPTION
This pull request is the beginning of work to have pass1 use prism nodes directly instead of going through a sexp translation layer. It purposefully does _not_ do every node, in an effort to make this easier to review, and to make it so that other contributors can do this incrementally. This pull request migrates 11 node types.

The first four are integer, rational, imaginary, and float. In the old AST these are all `:lit` nodes. In prism's AST they are all their own node types. For the parser we alias all their visit methods to `visit_passthrough` since they are all leaves in the old AST so that they get returned directly. For pass1 we implement our new `transform_` methods for each of the node types that is effectively a copy of one of the branches in `transform_lit`.

The next commit is false, true, nil, and self. These are also leaves and can be done the same as the previous examples. The only other issue is that some places explicitly create false, true, and nil nodes to use in place of missing nodes or as return values for macros. For these we manually create prism nodes. I don't love the interface to create these nodes (it seems really verbose to say `::Prism::NilNode.new(nil)` but that's probably something that can be addressed later.

Then we do 3 commits with and, or, and defined nodes. It's important to note that these nodes are inner nodes and not leaves. So we cannot just alias them to `visit_passthrough` in the parser because that would leave all of their children in place as well. Fortunately prism has a `copy` API we can use, that will reuse all of the attributes of a node that _aren't_ given to the copy method. So when we're parsing those nodes, we use the copy method with the visited output. So these now become prism nodes holding onto sexp instances. It's a little weird, but it works.

Hopefully this enables the rest of the tree to be migrated as well without too much pain. If this is a good direction after review, we can set up a tracking issue or something to make sure we don't step on each others toes when working on different nodes.