### PR TITLE
Implement Module#autoload?

### DIFF
--- a/include/natalie/constant.hpp
+++ b/include/natalie/constant.hpp
@@ -9,9 +9,10 @@ public:
         : m_name(name)
         , m_value(value) {};
 
-    Constant(SymbolObject *name, MethodFnPtr autoload_fn)
+    Constant(SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path)
         : m_name(name)
-        , m_autoload_fn(autoload_fn) {};
+        , m_autoload_fn(autoload_fn)
+        , m_autoload_path(autoload_path) {};
 
     SymbolObject *name() const { return m_name; }
 
@@ -30,6 +31,7 @@ public:
     void set_autoload_fn(MethodFnPtr fn) { m_autoload_fn = fn; }
 
     bool needs_load() const { return !m_value && m_autoload_fn; }
+    StringObject *autoload_path() const { return m_autoload_path; }
     void autoload(Env *, Value);
 
     void visit_children(Visitor &visitor);
@@ -40,5 +42,6 @@ private:
     bool m_private { false };
     bool m_deprecated { false };
     MethodFnPtr m_autoload_fn { nullptr };
+    StringObject *m_autoload_path { nullptr };
 };
 }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -46,12 +46,14 @@ public:
     Value prepend(Env *, Args args);
     void prepend_once(Env *, ModuleObject *);
 
+    Value is_autoload(Env *, Value) const;
+
     virtual Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise) override;
     virtual Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise) override;
     virtual Value const_get(SymbolObject *) const override;
     virtual Value const_fetch(SymbolObject *) override;
     virtual Value const_set(SymbolObject *, Value) override;
-    virtual Value const_set(SymbolObject *, MethodFnPtr) override;
+    virtual Value const_set(SymbolObject *, MethodFnPtr, StringObject *) override;
 
     Value const_get(Env *, Value);
     Value const_set(Env *, Value, Value);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -236,7 +236,7 @@ public:
     virtual Value const_get(SymbolObject *) const;
     virtual Value const_fetch(SymbolObject *);
     virtual Value const_set(SymbolObject *, Value);
-    virtual Value const_set(SymbolObject *, MethodFnPtr);
+    virtual Value const_set(SymbolObject *, MethodFnPtr, StringObject *);
 
     bool ivar_defined(Env *, SymbolObject *);
     Value ivar_get(Env *, SymbolObject *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -990,6 +990,7 @@ gen.binding('Module', 'attr', 'ModuleObject', 'attr', argc: 1.., pass_env: true,
 gen.binding('Module', 'attr_accessor', 'ModuleObject', 'attr_accessor', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'attr_reader', 'ModuleObject', 'attr_reader', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'attr_writer', 'ModuleObject', 'attr_writer', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Module', 'autoload?', 'ModuleObject', 'is_autoload', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'const_defined?', 'ModuleObject', 'const_defined', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Module', 'const_get', 'ModuleObject', 'const_get', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'const_missing', 'ModuleObject', 'const_missing', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/instructions/autoload_const_instruction.rb
+++ b/lib/natalie/compiler/instructions/autoload_const_instruction.rb
@@ -3,8 +3,9 @@ require_relative './base_instruction'
 module Natalie
   class Compiler
     class AutoloadConstInstruction < BaseInstruction
-      def initialize(name)
+      def initialize(name:, path:)
         @name = name
+        @path = path
       end
 
       def has_body?
@@ -12,7 +13,7 @@ module Natalie
       end
 
       def to_s
-        "autoload_const #{@name}"
+        "autoload_const #{@name}, #{@path.inspect}"
       end
 
       def generate(transform)
@@ -25,7 +26,7 @@ module Natalie
           fn_code << '}'
           transform.top(fn_code)
         end
-        transform.exec("self->const_set(#{transform.intern(@name)}, #{fn})")
+        transform.exec("self->const_set(#{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))")
         transform.push_nil
       end
 

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -120,7 +120,7 @@ module Natalie
         end
 
         body = load_file(full_path, require_once: true)
-        expr.new(:autoload_const, const, full_path, body)
+        expr.new(:autoload_const, const, path, body)
       end
 
       def macro_require(expr:, current_path:, depth:)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -280,7 +280,7 @@ module Natalie
       def transform_autoload_const(exp, used:)
         _, name, path, *body = exp
         instructions = [
-          AutoloadConstInstruction.new(name),
+          AutoloadConstInstruction.new(name: name, path: path),
           transform_body(body, used: true),
           EndInstruction.new(:autoload_const),
         ]

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -12,6 +12,7 @@ void Constant::autoload(Env *env, Value self) {
 void Constant::visit_children(Visitor &visitor) {
     visitor.visit(m_name);
     visitor.visit(m_value);
+    visitor.visit(m_autoload_path);
 }
 
 }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -182,6 +182,17 @@ Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject
     return constant;
 }
 
+Value ModuleObject::is_autoload(Env *env, Value name) const {
+    auto name_sym = name->to_symbol(env, Conversion::Strict);
+    auto constant = m_constants.get(name_sym);
+    if (constant && constant->needs_load()) {
+        auto path = constant->autoload_path();
+        assert(path);
+        return path;
+    }
+    return NilObject::the();
+}
+
 Value ModuleObject::const_find_with_autoload(Env *env, Value self, SymbolObject *name, ConstLookupSearchMode search_mode, ConstLookupFailureMode failure_mode) {
     ModuleObject *module = nullptr;
     auto constant = find_constant(env, name, &module, search_mode);
@@ -236,8 +247,8 @@ Value ModuleObject::const_set(SymbolObject *name, Value val) {
     return val;
 }
 
-Value ModuleObject::const_set(SymbolObject *name, MethodFnPtr autoload_fn) {
-    m_constants.put(name, new Constant { name, autoload_fn });
+Value ModuleObject::const_set(SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
+    m_constants.put(name, new Constant { name, autoload_fn, autoload_path });
     return NilObject::the();
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -626,8 +626,8 @@ Value Object::const_set(SymbolObject *name, Value val) {
     return m_klass->const_set(name, val);
 }
 
-Value Object::const_set(SymbolObject *name, MethodFnPtr autoload_fn) {
-    return m_klass->const_set(name, autoload_fn);
+Value Object::const_set(SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
+    return m_klass->const_set(name, autoload_fn, autoload_path);
 }
 
 bool Object::ivar_defined(Env *env, SymbolObject *name) {

--- a/test/natalie/autoload_test.rb
+++ b/test/natalie/autoload_test.rb
@@ -7,6 +7,7 @@ module Foo
   autoload :UpALevel, 'autoload/up_a_level'
   autoload :Nested, 'autoload/nested'
   autoload :Missing, 'autoload/missing'
+  autoload :Query, 'autoload/query'
 end
 
 describe 'autoload' do
@@ -28,5 +29,22 @@ describe 'autoload' do
     $missing_loaded.should == nil
     -> { Foo::Missing }.should raise_error(NameError, /uninitialized constant Foo::Missing/)
     $missing_loaded.should == true
+  end
+end
+
+describe 'Module#autoload?' do
+  it 'returns the path when the constant name is yet to be autoload' do
+    Foo.autoload?(:Query).should == 'autoload/query'
+    Foo.autoload?('Query').should == 'autoload/query'
+    Foo::Query.should be_an_instance_of(Class)
+  end
+
+  it 'returns nil once the constant is loaded' do
+    Foo.autoload?(:Query).should == nil
+  end
+
+  it 'raises a TypeError for other kinds of arguments' do
+    -> { Foo.autoload?(1) }.should raise_error(TypeError, '1 is not a symbol nor a string')
+    -> { Foo.autoload?(nil) }.should raise_error(TypeError, 'nil is not a symbol nor a string')
   end
 end

--- a/test/support/autoload/query.rb
+++ b/test/support/autoload/query.rb
@@ -1,0 +1,5 @@
+module Foo
+  class Query
+  end
+end
+


### PR DESCRIPTION
I was debugging something earlier and it would have been nice to have `Module#autoload?` so I added it!

Unfortunately, the `autoload_spec.rb` from ruby/spec isn't going to be useful for us because our `autoload` is a macro and cannot be called like they do here:

```ruby
# won't work with Natalie because we can't know which module that is at compile-time
ModuleSpecs::Autoload.autoload :Autoload, "autoload.rb"

# won't work with Natalie because calling `fixture` needs code not defined at compile-time
autoload :X, fixture(__FILE__, "autoload_x.rb")
```

...so I opted to make our own set of tests.