### PR TITLE
Implement Kernel.system (it's complicated)

### DIFF
--- a/spec/command_line/dash_e_spec.rb
+++ b/spec/command_line/dash_e_spec.rb
@@ -18,9 +18,7 @@ describe "The -e command line option" do
   end
 
   it "uses '-e' in $0" do
-    NATFIXME 'Implement Kernel.system', exception: NoMethodError, message: /undefined method `system'/ do
-      system(*ruby_exe, '-e', 'exit $0 == "-e"').should == true
-    end
+    system(*ruby_exe, '-e', 'exit $0 == "-e"').should == true
   end
 
   #needs to test return => LocalJumpError

--- a/spec/core/file/setuid_spec.rb
+++ b/spec/core/file/setuid_spec.rb
@@ -28,15 +28,15 @@ describe "File.setuid?" do
     it "returns true when the gid bit is set" do
       platform_is :solaris do
         # Solaris requires execute bit before setting suid
-        NATFIXME 'Implement Kernel#system', exception: NoMethodError, message: "undefined method `system'" do
-          system "chmod u+x #{@name}"
-        end
-        `chmod u+x #{@name}`
+        system "chmod u+x #{@name}"
+        # NATFIXME: Fix arguments for Kernel#system
+        system "chmod", "u+x", @name
       end
-      NATFIXME 'Implement Kernel#system', exception: NoMethodError, message: "undefined method `system'" do
+      NATFIXME 'Fix arguments for Kernel#system', exception: SpecFailedException do
         system "chmod u+s #{@name}"
+        File.setuid?(@name).should == true
       end
-      `chmod u+s #{@name}`
+      system "chmod", "u+s", @name
 
       File.setuid?(@name).should == true
     end

--- a/spec/core/kernel/fixtures/classes.rb
+++ b/spec/core/kernel/fixtures/classes.rb
@@ -89,10 +89,7 @@ module KernelSpecs
   end
 
   class Method
-    public :abort, :exit, :exit!, :fork
-
-    # NATFIXME: the rest of these aren't implemented yet
-    #public :system
+    public :abort, :exit, :exit!, :fork, :system
   end
 
   class Methods

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -836,4 +836,11 @@ module Kernel
       args[0].write(sprintf(*args[1..]))
     end
   end
+
+  def system(...)
+    Process.wait(spawn(...))
+    $?.exitstatus.zero?
+  rescue
+    nil
+  end
 end


### PR DESCRIPTION
This is simply a proxy into chaining `Kernel.spawn` and `Process.wait` with the arguments forwarded. This means this version has the same limitations as `Kernel.spawn`, most notably it only supports arguments to the executable as separate arguments to the method, which means `system("echo foo")` fails. For this reason, the specs have not been included.

Main rationale for adding this is the nightly spec runner. Currently pretty much every spec in `core/kernel` fails because `Kernel.system` does not exist, even though these specs don't need that one. Adding this method will fix most (or maybe all) of these crashes (currently 96), so we can see how well we actually do for the Kernel module.