### PR TITLE
Fix argument forwarding ... syntax stack mixup

### DIFF
--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -81,7 +81,11 @@ describe 'forward args' do
   end
 
   def foo(...)
-    bar(...)
+    baz(bar(...))
+  end
+
+  def baz(a)
+    a
   end
 
   it 'passes all arguments as-is' do


### PR DESCRIPTION
I guess we were pushing the args onto the stack more than once. Whoops!

Fixes #1307 