### PR TITLE
Improve Kernel#spawn

### DIFF
--- a/spec/core/file/setuid_spec.rb
+++ b/spec/core/file/setuid_spec.rb
@@ -29,14 +29,8 @@ describe "File.setuid?" do
       platform_is :solaris do
         # Solaris requires execute bit before setting suid
         system "chmod u+x #{@name}"
-        # NATFIXME: Fix arguments for Kernel#system
-        system "chmod", "u+x", @name
       end
-      NATFIXME 'Fix arguments for Kernel#system', exception: SpecFailedException do
-        system "chmod u+s #{@name}"
-        File.setuid?(@name).should == true
-      end
-      system "chmod", "u+s", @name
+      system "chmod u+s #{@name}"
 
       File.setuid?(@name).should == true
     end

--- a/spec/core/kernel/spawn_spec.rb
+++ b/spec/core/kernel/spawn_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+# These specs only run a basic usage of #spawn.
+# Process.spawn has more complete specs and they are not
+# run here as it is redundant and takes too long for little gain.
+describe "Kernel#spawn" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:spawn)
+  end
+
+  it "executes the given command" do
+    -> {
+      Process.wait spawn("echo spawn")
+    }.should output_to_fd("spawn\n")
+  end
+end
+
+describe "Kernel.spawn" do
+  it "executes the given command" do
+    -> {
+      Process.wait Kernel.spawn("echo spawn")
+    }.should output_to_fd("spawn\n")
+  end
+end

--- a/spec/core/kernel/spawn_spec.rb
+++ b/spec/core/kernel/spawn_spec.rb
@@ -10,16 +10,20 @@ describe "Kernel#spawn" do
   end
 
   it "executes the given command" do
-    -> {
-      Process.wait spawn("echo spawn")
-    }.should output_to_fd("spawn\n")
+    NATFIXME 'Capture output in output_to_fd', exception: SpecFailedException do
+      -> {
+        Process.wait spawn("echo spawn")
+      }.should output_to_fd("spawn\n")
+    end
   end
 end
 
 describe "Kernel.spawn" do
   it "executes the given command" do
-    -> {
-      Process.wait Kernel.spawn("echo spawn")
-    }.should output_to_fd("spawn\n")
+    NATFIXME 'Capture output in output_to_fd', exception: SpecFailedException do
+      -> {
+        Process.wait Kernel.spawn("echo spawn")
+      }.should output_to_fd("spawn\n")
+    end
   end
 end


### PR DESCRIPTION
Support the single string argument form, split that into separate arguments.

The specs will still fail, it looks like our output_to_fd capture is broken, since running this spec with MRI using our test library fails too.