### PR TITLE
Remove guards for Ruby version <= 3.0

### DIFF
--- a/spec/core/warning/element_reference_spec.rb
+++ b/spec/core/warning/element_reference_spec.rb
@@ -1,11 +1,9 @@
 require_relative '../../spec_helper'
 
 describe "Warning.[]" do
-  ruby_version_is '2.7.2' do
-    it "returns default values for categories :deprecated and :experimental" do
-      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
-      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
-    end
+  it "returns default values for categories :deprecated and :experimental" do
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
   end
 
   ruby_version_is '3.3' do

--- a/spec/language/block_spec.rb
+++ b/spec/language/block_spec.rb
@@ -234,10 +234,8 @@ describe "A block" do
       @y.s(0) { 1 }.should == 1
     end
 
-    ruby_version_is "2.5" do
-      it "may include a rescue clause" do
-        eval("@y.z do raise ArgumentError; rescue ArgumentError; 7; end").should == 7
-      end
+    it "may include a rescue clause" do
+      eval("@y.z do raise ArgumentError; rescue ArgumentError; 7; end").should == 7
     end
   end
 
@@ -250,10 +248,8 @@ describe "A block" do
       @y.s(0) { || 1 }.should == 1
     end
 
-    ruby_version_is "2.5" do
-      it "may include a rescue clause" do
-        eval('@y.z do || raise ArgumentError; rescue ArgumentError; 7; end').should == 7
-      end
+    it "may include a rescue clause" do
+      eval('@y.z do || raise ArgumentError; rescue ArgumentError; 7; end').should == 7
     end
   end
 
@@ -281,10 +277,8 @@ describe "A block" do
       @y.s([1, 2]) { |a| a }.should == [1, 2]
     end
 
-    ruby_version_is "2.5" do
-      it "may include a rescue clause" do
-        eval('@y.s(1) do |x| raise ArgumentError; rescue ArgumentError; 7; end').should == 7
-      end
+    it "may include a rescue clause" do
+      eval('@y.s(1) do |x| raise ArgumentError; rescue ArgumentError; 7; end').should == 7
     end
   end
 

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -5,20 +5,10 @@ def argument_proxy(*args, **kwargs)
 end
 
 describe 'splat operators' do
-  ruby_version_is ''...'3.0' do
-    it 'should work with literal arguments' do
-      argument_proxy(1).should == [[1], {}]
-      argument_proxy(1, 2).should == [[1, 2], {}]
-      argument_proxy(1, 2, {}).should == [[1, 2], {}]
-    end
-  end
-
-  ruby_version_is '3.0' do
-    it 'should work with literal arguments' do
-      argument_proxy(1).should == [[1], {}]
-      argument_proxy(1, 2).should == [[1, 2], {}]
-      argument_proxy(1, 2, {}).should == [[1, 2, {}], {}]
-    end
+  it 'should work with literal arguments' do
+    argument_proxy(1).should == [[1], {}]
+    argument_proxy(1, 2).should == [[1, 2], {}]
+    argument_proxy(1, 2, {}).should == [[1, 2, {}], {}]
   end
 
   it 'should work with literal keyword arguments' do
@@ -31,26 +21,13 @@ describe 'splat operators' do
     argument_proxy(1, 2, foo: 'a', bar: 'b').should == [[1, 2], { foo: 'a', bar: 'b' }]
   end
 
-  ruby_version_is ''...'3.0' do
-    it 'should work with splat operators' do
-      args = [1, 2]
-      argument_proxy(*args).should == [[1, 2], {}]
-      argument_proxy(*[1, 2]).should == [[1, 2], {}]
-      args << {}
-      argument_proxy(*args).should == [[1, 2], {}]
-      argument_proxy(*[1, 2, {}]).should == [[1, 2], {}]
-    end
-  end
-
-  ruby_version_is '3.0' do
-    it 'should work with splat operators' do
-      args = [1, 2]
-      argument_proxy(*args).should == [[1, 2], {}]
-      argument_proxy(*[1, 2]).should == [[1, 2], {}]
-      args << {}
-      argument_proxy(*args).should == [[1, 2, {}], {}]
-      argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
-    end
+  it 'should work with splat operators' do
+    args = [1, 2]
+    argument_proxy(*args).should == [[1, 2], {}]
+    argument_proxy(*[1, 2]).should == [[1, 2], {}]
+    args << {}
+    argument_proxy(*args).should == [[1, 2, {}], {}]
+    argument_proxy(*[1, 2, {}]).should == [[1, 2, {}], {}]
   end
 
   it 'should work with splat operator and literal keywords' do

--- a/test/natalie/class_test.rb
+++ b/test/natalie/class_test.rb
@@ -53,14 +53,12 @@ describe 'class' do
     end
 
     it 'raises an error if the superclass is not a class' do
-      ruby_version_is '3.0' do # the message changed in 3.0
-        -> {
-          class WatClass < WAT; end
-        }.should raise_error(TypeError, "superclass must be an instance of Class (given an instance of Integer)")
-        -> {
-          Class.new(WAT)
-        }.should raise_error(TypeError, "superclass must be an instance of Class (given an instance of Integer)")
-      end
+      -> {
+        class WatClass < WAT; end
+      }.should raise_error(TypeError, "superclass must be an instance of Class (given an instance of Integer)")
+      -> {
+        Class.new(WAT)
+      }.should raise_error(TypeError, "superclass must be an instance of Class (given an instance of Integer)")
     end
 
     it 'raises an error if the superclass is Class' do


### PR DESCRIPTION
Since Ruby 3.0 is the lowest version to be supported. These changes are in sync with the upstream version of the specs.