### PR TITLE
Refresh specs for IO#gets

### DIFF
--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -24,6 +24,12 @@ describe "IO#gets" do
     end
   end
 
+  it "sets $_ to nil after the last line has been read" do
+    while @io.gets
+    end
+    $_.should be_nil
+  end
+
   it "returns nil if called at the end of the stream" do
     IOSpecs.lines.length.times { @io.gets }
     @io.gets.should == nil

--- a/test/natalie/io_test.rb
+++ b/test/natalie/io_test.rb
@@ -48,14 +48,3 @@ describe "IO#autoclose" do
     -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
   end
 end
-
-describe "IO#gets" do
-  it "sets $_ to nil afthe the last line has been read" do
-    File.open(__dir__ + '/../../spec/core/io/fixtures/lines.txt') do |f|
-      while line = f.gets
-        $_.should == line
-      end
-      $_.should be_nil
-    end
-  end
-end


### PR DESCRIPTION
This adds the test for setting $_ to nil after the last line has been read, so this test can be removed from our natalie test suite.