### PR TITLE
Add Date class

### DIFF
--- a/lib/date.rb
+++ b/lib/date.rb
@@ -1,0 +1,352 @@
+require 'natalie/inline'
+
+class Date
+  include Comparable
+
+  ITALY = 2299161 # 1582-10-15
+  ENGLAND = 2361222 # 1752-09-14
+
+  freeze = ->(values) { values.map { |value| value.nil? ? nil : value.freeze }.freeze }
+
+  ABBR_DAYNAMES = freeze[['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']]
+  ABBR_MONTHNAMES = freeze[[nil, 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']]
+  DAYNAMES = freeze[['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']]
+  MONTHNAMES = freeze[[nil, 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']]
+
+  Error = Class.new(ArgumentError)
+
+  class << self
+    def civil_to_jd(y, m, d, start)
+      if m <= 2
+        y -= 1
+        m += 12
+      end
+      a = (y / 100.0).floor
+      b = 2 - a + (a / 4.0).floor
+      n = (365.25 * (y + 4716)).floor + (30.6001 * (m + 1)).floor + d + b - 1524
+      n < start ? n - b : n
+    end
+
+    def gregorian_leap?(year)
+      (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    end
+
+    def jd(number = 0, start = Date::ITALY)
+      year, month, mday = jd_to_civil(number, start)
+      date = allocate
+      date.instance_variable_set(:@year, year)
+      date.instance_variable_set(:@month, month)
+      date.instance_variable_set(:@mday, mday)
+      date.instance_variable_set(:@start, start)
+      date.instance_variable_set(:@jd, number)
+      date
+    end
+
+    def jd_to_civil(number = 0, start = Date::ITALY)
+      if number < start
+        a = number
+      else
+        x = ((number - 1867216.25) / 36524.25).floor
+        a = number + 1 + x - (x / 4.0).floor
+      end
+      b = a + 1524
+      c = ((b - 122.1) / 365.25).floor
+      d = (365.25 * c).floor
+      e = ((b - d) / 30.6001).floor
+      mday = b - d - (30.6001 * e).floor
+      if e <= 13
+        month = e - 1
+        year = c - 4716
+      else
+        month = e - 13
+        year = c - 4715
+      end
+      [year, month, mday]
+    end
+
+    def julian_leap?(year)
+      year % 4 == 0
+    end
+
+    def today(start = Date::ITALY)
+      time = Time.now
+      new(time.year, time.month, time.mday, start)
+    end
+
+    alias civil new
+    alias leap? gregorian_leap?
+  end
+
+  def initialize(year = -4712, month = 1, mday = 1, start = Date::ITALY)
+    if month < 0
+      month += 13
+    end
+    unless month.between?(1, 12)
+      raise Date::Error, 'invalid date'
+    end
+    last = last_mday(year, month)
+    if mday < 0
+      mday = last + mday + 1
+    end
+    if mday < 1 || mday > last
+      raise Date::Error, 'invalid date'
+    end
+    @year = year
+    @month = month
+    @mday = mday
+    @start = start
+    @jd = self.class.civil_to_jd(year, month, mday, start)
+    if @jd >= start
+      y, m, d = self.class.jd_to_civil(@jd)
+      unless m == @month && d == @mday
+        raise Date::Error, 'invalid date'
+      end
+    end
+  end
+
+  def +(other)
+    if other.is_a?(Numeric)
+      self.class.jd(@jd + other, @start)
+    else
+      raise TypeError, 'expected numeric'
+    end
+  end
+
+  def -(other)
+    if other.is_a?(self.class)
+      Rational(@jd - other.jd)
+    elsif other.is_a?(Numeric)
+      self.class.jd(@jd - other, @start)
+    else
+      raise TypeError, 'expected numeric'
+    end
+  end
+
+  def <<(n)
+    unless n.is_a?(Numeric)
+      raise TypeError, 'expected numeric'
+    end
+    self >> (-n)
+  end
+
+  def <=>(other)
+    if other.is_a?(self.class)
+      @jd <=> other.jd
+    elsif other.is_a?(Numeric)
+      @jd <=> other
+    end
+  end
+
+  def >>(n)
+    unless n.is_a?(Numeric)
+      raise TypeError, "#{n.class} can't be coerced into Integer"
+    end
+    n = n.to_int
+    i = (@year * 12) + (@month - 1) + n
+    year = i.div(12)
+    month = (i % 12) + 1
+    mday = @mday
+    last = last_mday(year, month)
+    if mday > last
+      mday = last
+    end
+    self.class.new(year, month, mday)
+  rescue Date::Error
+    self.class.jd(@start - 1)
+  end
+
+  def asctime
+    strftime('%a %b %e %H:%M:%S %Y')
+  end
+
+  def downto(min)
+    return to_enum(:downto, max) unless block_given?
+    date = self
+    while date >= min
+      yield date
+      date -= 1
+    end
+  end
+
+  def eql?(other)
+    unless other.is_a?(self.class)
+      return false
+    end
+    (self <=> other).zero?
+  end
+
+  def friday?
+    wday == 5
+  end
+
+  def gregorian?
+    @jd >= @start
+  end
+
+  def inspect
+    "#<Date: #{self} ((#{@jd}j),#{@start}j)>"
+  end
+
+  attr_reader :jd
+
+  def julian?
+    @jd < @start
+  end
+
+  def leap?
+    self.class.gregorian_leap?(@year)
+  end
+
+  attr_reader :mday
+
+  def monday?
+    wday == 1
+  end
+
+  attr_reader :month
+
+  def next
+    self.class.jd(@jd + 1, @start)
+  end
+
+  def next_day(n = 1)
+    self + n
+  end
+
+  def next_month(n = 1)
+    self >> n
+  end
+
+  def next_year(n = 1)
+    self >> (n * 12)
+  end
+
+  def prev_day(n = 1)
+    self - n
+  end
+
+  def prev_month(n = 1)
+    self << n
+  end
+
+  def prev_year(n = 1)
+    self << (n * 12)
+  end
+
+  def rfc2822
+    strftime('%a, %-d %b %Y %T %z')
+  end
+
+  def rfc3339
+    strftime('%Y-%m-%dT%H:%M:%S+00:00')
+  end
+
+  def saturday?
+    wday == 6
+  end
+
+  def start
+    @start.to_f
+  end
+
+  def step(limit, step = 1)
+    return to_enum(:step, limit, step) unless block_given?
+    date = self
+    if step < 0
+      while date >= limit
+        yield date
+        date += step
+      end
+    elsif step > 0
+      while date <= limit
+        yield date
+        date += step
+      end
+    end
+  end
+
+  def strftime(format = '%F')
+    __inline__ <<-END
+      format_var->assert_type(env, Object::Type::String, "String");
+      struct tm time = { 0 };
+      time.tm_year = IntegerObject::convert_to_int(env, self->ivar_get(env, "@year"_s)) - 1900;
+      time.tm_mon = IntegerObject::convert_to_int(env, self->ivar_get(env, "@month"_s)) - 1;
+      time.tm_mday = IntegerObject::convert_to_int(env, self->ivar_get(env, "@mday"_s));
+      time.tm_gmtoff = 0;
+      time.tm_isdst = 0;
+      int maxsize = 32;
+      char buffer[maxsize];
+      auto length = ::strftime(buffer, maxsize, format_var->as_string()->c_str(), &time);
+      return new StringObject { buffer, length, EncodingObject::get(Encoding::US_ASCII) };
+    END
+  end
+
+  def sunday?
+    wday == 0
+  end
+
+  def thursday?
+    wday == 4
+  end
+
+  def to_date
+    self
+  end
+
+  def to_s
+    strftime('%Y-%m-%d')
+  end
+
+  def to_time
+    Time.new(@year, @month, @mday)
+  end
+
+  def tuesday?
+    wday == 2
+  end
+
+  def upto(max)
+    return to_enum(:upto, max) unless block_given?
+    date = self
+    while date <= max
+      yield date
+      date += 1
+    end
+  end
+
+  def wday
+    (@jd + 1) % 7
+  end
+
+  def wednesday?
+    wday == 3
+  end
+
+  attr_reader :year
+
+  alias ctime asctime
+  alias day mday
+  alias iso8601 to_s
+  alias mon month
+  alias rfc822 rfc2822
+  alias succ next
+  alias xmlschema to_s
+
+  private
+
+  MONTHDAYS = [nil, 31, nil, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31].freeze
+
+  def last_mday(year, month)
+    if month == 2
+      self.class.leap?(year) ? 29 : 28
+    else
+      MONTHDAYS[month]
+    end
+  end
+end
+
+class Time
+  def to_date
+    Date.new(year, month, mday)
+  end
+end

--- a/spec/library/date/add_month_spec.rb
+++ b/spec/library/date/add_month_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#>>" do
+  it "adds the number of months to a Date" do
+    d = Date.civil(2007,2,27) >> 10
+    d.should == Date.civil(2007, 12, 27)
+  end
+
+  it "sets the day to the last day of a month if the day doesn't exist" do
+    d = Date.civil(2008,3,31) >> 1
+    d.should == Date.civil(2008, 4, 30)
+  end
+
+  it "returns the day of the reform if date falls within calendar reform" do
+    calendar_reform_italy = Date.new(1582, 10, 4)
+    d1 = Date.new(1582, 9, 9) >> 1
+    d2 = Date.new(1582, 9, 10) >> 1
+    d1.should == calendar_reform_italy
+    d2.should == calendar_reform_italy
+  end
+
+  it "raise a TypeError when passed a Symbol" do
+    -> { Date.civil(2007,2,27) >> :hello }.should raise_error(TypeError)
+  end
+
+  it "raise a TypeError when passed a String" do
+    -> { Date.civil(2007,2,27) >> "hello" }.should raise_error(TypeError)
+  end
+
+  it "raise a TypeError when passed a Date" do
+    -> { Date.civil(2007,2,27) >> Date.new }.should raise_error(TypeError)
+  end
+
+  it "raise a TypeError when passed an Object" do
+    -> { Date.civil(2007,2,27) >> Object.new }.should raise_error(TypeError)
+  end
+end

--- a/spec/library/date/boat_spec.rb
+++ b/spec/library/date/boat_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#<=>" do
+  it "returns 0 when two dates are equal" do
+    (Date.civil(2000, 04, 06) <=> Date.civil(2000, 04, 06)).should == 0
+  end
+
+  it "returns -1 when self is less than another date" do
+    (Date.civil(2000, 04, 05) <=> Date.civil(2000, 04, 06)).should == -1
+  end
+
+  it "returns -1 when self is less than a Numeric" do
+    (Date.civil(2000, 04, 05) <=> Date.civil(2000, 04, 06).jd).should == -1
+  end
+
+  it "returns 1 when self is greater than another date" do
+    (Date.civil(2001, 04, 05) <=> Date.civil(2000, 04, 06)).should == 1
+  end
+
+  it "returns 1 when self is greater than a Numeric" do
+    (Date.civil(2001, 04, 05) <=> Date.civil(2000, 04, 06).jd).should == 1
+  end
+end

--- a/spec/library/date/civil_spec.rb
+++ b/spec/library/date/civil_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'shared/civil'
+require 'date'
+
+describe "Date.civil" do
+  it_behaves_like :date_civil, :civil
+end

--- a/spec/library/date/constants_spec.rb
+++ b/spec/library/date/constants_spec.rb
@@ -1,0 +1,52 @@
+require 'date'
+require_relative '../../spec_helper'
+
+describe "Date constants" do
+
+  it "defines JULIAN" do
+    NATFIXME 'Implement Date::Infinity and Date::JULIAN', exception: NameError do
+      (Date::JULIAN <=> Date::Infinity.new).should == 0
+    end
+  end
+
+  it "defines GREGORIAN" do
+    NATFIXME 'Implement Date::Infinity and Date::GREGORIAN', exception: NameError do
+      (Date::GREGORIAN <=> -Date::Infinity.new).should == 0
+    end
+  end
+
+  it "defines ITALY" do
+    Date::ITALY.should == 2299161 # 1582-10-15
+  end
+
+  it "defines ENGLAND" do
+    Date::ENGLAND.should == 2361222 # 1752-09-14
+  end
+
+  it "defines MONTHNAMES" do
+    Date::MONTHNAMES.should == [nil] + %w(January February March April May June July
+                                          August September October November December)
+  end
+
+  it "defines DAYNAMES" do
+    Date::DAYNAMES.should == %w(Sunday Monday Tuesday Wednesday Thursday Friday Saturday)
+  end
+
+  it "defines ABBR_MONTHNAMES" do
+    Date::ABBR_DAYNAMES.should == %w(Sun Mon Tue Wed Thu Fri Sat)
+  end
+
+  it "freezes MONTHNAMES, DAYNAMES, ABBR_MONTHNAMES, ABBR_DAYSNAMES" do
+    [Date::MONTHNAMES, Date::DAYNAMES, Date::ABBR_MONTHNAMES, Date::ABBR_DAYNAMES].each do |ary|
+      -> {
+        ary << "Unknown"
+      }.should raise_error(FrozenError, /frozen/)
+      ary.compact.each do |name|
+        -> {
+          name << "modified"
+        }.should raise_error(FrozenError, /frozen/)
+      end
+    end
+  end
+
+end

--- a/spec/library/date/day_spec.rb
+++ b/spec/library/date/day_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#day" do
+  it "returns the day" do
+    d = Date.new(2000, 7, 1).day
+    d.should == 1
+  end
+end

--- a/spec/library/date/downto_spec.rb
+++ b/spec/library/date/downto_spec.rb
@@ -1,0 +1,18 @@
+require 'date'
+require_relative '../../spec_helper'
+
+describe "Date#downto" do
+
+  it "creates earlier dates when passed a negative step" do
+    ds    = Date.civil(2000, 4, 14)
+    de    = Date.civil(2000, 3, 29)
+    count = 0
+    ds.step(de, -1) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 17
+  end
+
+end

--- a/spec/library/date/eql_spec.rb
+++ b/spec/library/date/eql_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#eql?" do
+  it "returns true if self is equal to another date" do
+    Date.civil(2007, 10, 11).eql?(Date.civil(2007, 10, 11)).should be_true
+  end
+
+  it "returns false if self is not equal to another date" do
+    Date.civil(2007, 10, 11).eql?(Date.civil(2007, 10, 12)).should be_false
+  end
+end

--- a/spec/library/date/friday_spec.rb
+++ b/spec/library/date/friday_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#friday?" do
+  it "should be friday" do
+    Date.new(2000, 1, 7).friday?.should be_true
+  end
+
+  it "should not be friday" do
+    Date.new(2000, 1, 8).friday?.should be_false
+  end
+end

--- a/spec/library/date/gregorian_leap_spec.rb
+++ b/spec/library/date/gregorian_leap_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#gregorian_leap?" do
+  it "returns true if a year is a leap year in the Gregorian calendar" do
+    Date.gregorian_leap?(2000).should be_true
+    Date.gregorian_leap?(2004).should be_true
+  end
+
+  it "returns false if a year is not a leap year in the Gregorian calendar" do
+    Date.gregorian_leap?(1900).should be_false
+    Date.gregorian_leap?(1999).should be_false
+    Date.gregorian_leap?(2002).should be_false
+  end
+end

--- a/spec/library/date/gregorian_spec.rb
+++ b/spec/library/date/gregorian_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#gregorian?" do
+
+  it "marks a day before the calendar reform as Julian" do
+    Date.civil(1007, 2, 27).gregorian?.should be_false
+    Date.civil(1907, 2, 27, Date.civil(1930, 1, 1).jd).gregorian?.should be_false
+  end
+
+  it "marks a day after the calendar reform as Julian" do
+    Date.civil(2007, 2, 27).should.gregorian?
+    Date.civil(1607, 2, 27, Date.civil(1582, 1, 1).jd).gregorian?.should be_true
+  end
+
+end

--- a/spec/library/date/jd_spec.rb
+++ b/spec/library/date/jd_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'shared/jd'
+require 'date'
+
+describe "Date#jd" do
+
+  it "determines the Julian day for a Date object" do
+    Date.civil(2008, 1, 16).jd.should == 2454482
+  end
+
+end
+
+describe "Date.jd" do
+  it_behaves_like :date_jd, :jd
+end

--- a/spec/library/date/julian_leap_spec.rb
+++ b/spec/library/date/julian_leap_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date.julian_leap?" do
+  it "determines whether a year is a leap year in the Julian calendar" do
+    Date.julian_leap?(1900).should be_true
+    Date.julian_leap?(2000).should be_true
+    Date.julian_leap?(2004).should be_true
+  end
+
+  it "determines whether a year is not a leap year in the Julian calendar" do
+    Date.julian_leap?(1999).should be_false
+    Date.julian_leap?(2002).should be_false
+  end
+end

--- a/spec/library/date/julian_spec.rb
+++ b/spec/library/date/julian_spec.rb
@@ -1,0 +1,16 @@
+require 'date'
+require_relative '../../spec_helper'
+
+describe "Date#julian?" do
+
+  it "marks a day before the calendar reform as Julian" do
+    Date.civil(1007, 2, 27).should.julian?
+    Date.civil(1907, 2, 27, Date.civil(1930, 1, 1).jd).julian?.should be_true
+  end
+
+  it "marks a day after the calendar reform as Julian" do
+    Date.civil(2007, 2, 27).should_not.julian?
+    Date.civil(1607, 2, 27, Date.civil(1582, 1, 1).jd).julian?.should be_false
+  end
+
+end

--- a/spec/library/date/minus_month_spec.rb
+++ b/spec/library/date/minus_month_spec.rb
@@ -1,0 +1,23 @@
+require 'date'
+require_relative '../../spec_helper'
+
+describe "Date#<<" do
+
+  it "subtracts a number of months from a date" do
+    d = Date.civil(2007,2,27) << 10
+    d.should == Date.civil(2006, 4, 27)
+  end
+
+  it "returns the last day of a month if the day doesn't exist" do
+    d = Date.civil(2008,3,31) << 1
+    d.should == Date.civil(2008, 2, 29)
+  end
+
+  it "raises an error on non numeric parameters" do
+    -> { Date.civil(2007,2,27) << :hello }.should raise_error(TypeError)
+    -> { Date.civil(2007,2,27) << "hello" }.should raise_error(TypeError)
+    -> { Date.civil(2007,2,27) << Date.new }.should raise_error(TypeError)
+    -> { Date.civil(2007,2,27) << Object.new }.should raise_error(TypeError)
+  end
+
+end

--- a/spec/library/date/monday_spec.rb
+++ b/spec/library/date/monday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#monday?" do
+  it "should be monday" do
+    Date.new(2000, 1, 3).monday?.should be_true
+  end
+end

--- a/spec/library/date/month_spec.rb
+++ b/spec/library/date/month_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#month" do
+  it "returns the month" do
+    m = Date.new(2000, 7, 1).month
+    m.should == 7
+  end
+end

--- a/spec/library/date/new_spec.rb
+++ b/spec/library/date/new_spec.rb
@@ -1,0 +1,8 @@
+require 'date'
+require_relative '../../spec_helper'
+require_relative 'shared/civil'
+require_relative 'shared/new_bang'
+
+describe "Date.new" do
+  it_behaves_like :date_civil, :new
+end

--- a/spec/library/date/next_day_spec.rb
+++ b/spec/library/date/next_day_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#next_day" do
+  it "returns the next day" do
+    d = Date.new(2000, 1, 4).next_day
+    d.should == Date.new(2000, 1, 5)
+  end
+
+  it "returns three days later across months" do
+    d = Date.new(2000, 1, 30).next_day(3)
+    d.should == Date.new(2000, 2, 2)
+  end
+end

--- a/spec/library/date/next_month_spec.rb
+++ b/spec/library/date/next_month_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#next_month" do
+  it "returns the next month" do
+    d = Date.new(2000, 7, 1).next_month
+    d.should == Date.new(2000, 8, 1)
+  end
+
+  it "returns three months later" do
+    d = Date.new(2000, 7, 1).next_month(3)
+    d.should == Date.new(2000, 10, 1)
+  end
+
+  it "returns three months later across years" do
+    d = Date.new(2000, 12, 1).next_month(3)
+    d.should == Date.new(2001, 3, 1)
+  end
+
+  it "returns last day of month two months later" do
+    d = Date.new(2000, 1, 31).next_month(2)
+    d.should == Date.new(2000, 3, 31)
+  end
+
+  it "returns last day of next month when same day does not exist" do
+    d = Date.new(2001, 1, 30).next_month
+    d.should == Date.new(2001, 2, 28)
+  end
+end

--- a/spec/library/date/next_year_spec.rb
+++ b/spec/library/date/next_year_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#next_year" do
+  it "returns the day of the reform if date falls within calendar reform" do
+    calendar_reform_italy = Date.new(1582, 10, 4)
+    d1 = Date.new(1581, 10, 9).next_year
+    d2 = Date.new(1581, 10, 10).next_year
+    d1.should == calendar_reform_italy
+    d2.should == calendar_reform_italy
+  end
+end

--- a/spec/library/date/plus_spec.rb
+++ b/spec/library/date/plus_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#+" do
+  before :all do
+    @date = Date.civil(2000, 1, 1)
+  end
+
+  it "returns a new Date object that is n days later than the current one" do
+    (@date + 31).should == Date.civil(2000, 2, 1)
+  end
+
+  it "accepts a negative argument and returns a new Date that is earlier than the current one" do
+    (@date + -1).should == Date.civil(1999, 12, 31)
+  end
+
+  it "raises TypeError if argument is not Numeric" do
+    -> { Date.today + Date.today }.should raise_error(TypeError)
+  end
+end

--- a/spec/library/date/prev_day_spec.rb
+++ b/spec/library/date/prev_day_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#prev_day" do
+  it "returns previous day" do
+    d = Date.new(2000, 7, 2).prev_day
+    d.should == Date.new(2000, 7, 1)
+  end
+
+  it "returns three days ago across months" do
+    d = Date.new(2000, 7, 2).prev_day(3)
+    d.should == Date.new(2000, 6, 29)
+  end
+end

--- a/spec/library/date/prev_month_spec.rb
+++ b/spec/library/date/prev_month_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#prev_month" do
+  it "returns previous month" do
+    d = Date.new(2000, 9, 1).prev_month
+    d.should == Date.new(2000, 8, 1)
+  end
+
+  it "returns three months ago" do
+    d = Date.new(2000, 10, 1).prev_month(3)
+    d.should == Date.new(2000, 7, 1)
+  end
+
+  it "returns three months ago across years" do
+    d = Date.new(2000, 1, 1).prev_month(3)
+    d.should == Date.new(1999, 10, 1)
+  end
+
+  it "returns last day of month two months ago" do
+    d = Date.new(2000, 3, 31).prev_month(2)
+    d.should == Date.new(2000, 1, 31)
+  end
+
+  it "returns last day of previous month when same day does not exist" do
+    d = Date.new(2001, 3, 30).prev_month
+    d.should == Date.new(2001, 2, 28)
+  end
+end

--- a/spec/library/date/prev_year_spec.rb
+++ b/spec/library/date/prev_year_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#prev_year" do
+  it "returns the day of the reform if date falls within calendar reform" do
+    calendar_reform_italy = Date.new(1582, 10, 4)
+    d1 = Date.new(1583, 10, 9).prev_year
+    d2 = Date.new(1583, 10, 10).prev_year
+    d1.should == calendar_reform_italy
+    d2.should == calendar_reform_italy
+  end
+end

--- a/spec/library/date/saturday_spec.rb
+++ b/spec/library/date/saturday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#saturday?" do
+  it "should be saturday" do
+    Date.new(2000, 1, 1).saturday?.should be_true
+  end
+end

--- a/spec/library/date/shared/civil.rb
+++ b/spec/library/date/shared/civil.rb
@@ -1,0 +1,57 @@
+describe :date_civil, shared: true do
+  it "creates a Date for -4712 by default" do
+    # the #chomp calls are necessary because of RSpec
+    d = Date.send(@method)
+    d.year.should == -4712
+    d.month.should == 1
+    d.day.should == 1
+    d.should.julian?
+    d.jd.should == 0
+  end
+
+  it "creates a date with arguments" do
+    d = Date.send(@method, 2000, 3, 5)
+    d.year.should == 2000
+    d.month.should == 3
+    d.day.should == 5
+    d.should_not.julian?
+    d.jd.should == 2451609
+
+    # Should also work with years far in the past and future
+
+    d = Date.send(@method, -9000, 7, 5)
+    d.year.should == -9000
+    d.month.should == 7
+    d.day.should == 5
+    d.should.julian?
+    d.jd.should == -1566006
+
+    d = Date.send(@method, 9000, 10, 14)
+    d.year.should == 9000
+    d.month.should == 10
+    d.day.should == 14
+    d.should_not.julian?
+    d.jd.should == 5008529
+
+  end
+
+  it "doesn't create dates for invalid arguments" do
+    -> { Date.send(@method, 2000, 13, 31) }.should raise_error(ArgumentError)
+    -> { Date.send(@method, 2000, 12, 32) }.should raise_error(ArgumentError)
+    -> { Date.send(@method, 2000,  2, 30) }.should raise_error(ArgumentError)
+    -> { Date.send(@method, 1900,  2, 29) }.should raise_error(ArgumentError)
+    -> { Date.send(@method, 2000,  2, 29) }.should_not raise_error(ArgumentError)
+
+    -> { Date.send(@method, 1582, 10, 14) }.should raise_error(ArgumentError)
+    -> { Date.send(@method, 1582, 10, 15) }.should_not raise_error(ArgumentError)
+
+  end
+
+  it "creates a Date for different calendar reform dates" do
+    d1 = Date.send(@method, 1582, 10, 4)
+    d1.succ.day.should == 15
+
+    d2 = Date.send(@method, 1582, 10, 4, Date::ENGLAND)
+    d2.succ.day.should == 5
+  end
+end

--- a/spec/library/date/shared/jd.rb
+++ b/spec/library/date/shared/jd.rb
@@ -1,0 +1,14 @@
+describe :date_jd, shared: true do
+  it "constructs a Date object if passed a Julian day" do
+    Date.send(@method, 2454482).should == Date.civil(2008, 1, 16)
+  end
+
+  it "returns a Date object representing Julian day 0 (-4712-01-01) if no arguments passed" do
+    Date.send(@method).should == Date.civil(-4712, 1, 1)
+  end
+
+  it "constructs a Date object if passed a negative number" do
+    Date.send(@method, -1).should == Date.civil(-4713, 12, 31)
+  end
+
+end

--- a/spec/library/date/shared/new_bang.rb
+++ b/spec/library/date/shared/new_bang.rb
@@ -1,0 +1,14 @@
+describe :date_new_bang, shared: true do
+
+  it "returns a new Date object set to Astronomical Julian Day 0 if no arguments passed" do
+    d = Date.send(@method)
+    d.ajd.should == 0
+  end
+
+  it "accepts astronomical julian day number, offset as a fraction of a day and returns a new Date object" do
+    d = Date.send(@method, 10, 0.5)
+    d.ajd.should == 10
+    d.jd.should == 11
+  end
+
+end

--- a/spec/library/date/step_spec.rb
+++ b/spec/library/date/step_spec.rb
@@ -1,0 +1,56 @@
+require 'date'
+require_relative '../../spec_helper'
+
+describe "Date#step" do
+
+  it "steps forward in time" do
+    ds    = Date.civil(2008, 10, 11)
+    de    = Date.civil(2008,  9, 29)
+    count = 0
+    de.step(ds) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 13
+
+    count = 0
+    de.step(ds, 5) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 3
+
+    count = 0
+    ds.step(de) do |d|; count += 1; end
+    count.should == 0
+
+  end
+
+  it "steps backward in time" do
+    ds    = Date.civil(2000, 4, 14)
+    de    = Date.civil(2000, 3, 29)
+    count = 0
+    ds.step(de, -1) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 17
+
+    count = 0
+    ds.step(de, -5) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 4
+
+    count = 0
+    de.step(ds, -1) do |d|; count += 1; end
+    count.should == 0
+
+  end
+
+end

--- a/spec/library/date/sunday_spec.rb
+++ b/spec/library/date/sunday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#sunday?" do
+  it "should be sunday" do
+    Date.new(2000, 1, 2).sunday?.should be_true
+  end
+end

--- a/spec/library/date/thursday_spec.rb
+++ b/spec/library/date/thursday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#thursday?" do
+  it "should be thursday" do
+    Date.new(2000, 1, 6).thursday?.should be_true
+  end
+end

--- a/spec/library/date/tuesday_spec.rb
+++ b/spec/library/date/tuesday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#tuesday?" do
+  it "should be tuesday" do
+    Date.new(2000, 1, 4).tuesday?.should be_true
+  end
+end

--- a/spec/library/date/upto_spec.rb
+++ b/spec/library/date/upto_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#upto" do
+  it "returns future dates for the default step value" do
+    ds    = Date.civil(2008, 10, 11)
+    de    = Date.civil(2008,  9, 29)
+    count = 0
+    de.upto(ds) do |d|
+      d.should <= ds
+      d.should >= de
+      count += 1
+    end
+    count.should == 13
+  end
+end

--- a/spec/library/date/wday_spec.rb
+++ b/spec/library/date/wday_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#wday" do
+  it "returns the week day as a number starting with Sunday as 0" do
+    w = Date.new(2000, 1, 1).wday
+    w.should == 6
+  end
+end

--- a/spec/library/date/wednesday_spec.rb
+++ b/spec/library/date/wednesday_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#wednesday?" do
+  it "should be wednesday" do
+    Date.new(2000, 1, 5).wednesday?.should be_true
+  end
+end

--- a/spec/library/date/year_spec.rb
+++ b/spec/library/date/year_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "Date#year" do
+  it "returns the year" do
+    y = Date.new(2000, 7, 1).year
+    y.should == 2000
+  end
+end


### PR DESCRIPTION
Adds another 80 passing specs to the total:

    $ bin/natalie test/runner.rb --run-grouped spec/library/date/*_spec.rb
    ................*.*...............................................................

    80 spec(s) passed.
    2 spec(s) skipped.

Couple of NATFIXME for `Date::Infinity` which isn't implemented yet.