### PR TITLE
Rework IO#gets

### DIFF
--- a/spec/core/io/gets_spec.rb
+++ b/spec/core/io/gets_spec.rb
@@ -359,15 +359,13 @@ describe "IO#gets" do
 
   it "uses the default external encoding" do
     @io = new_io @name, 'r'
-    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
-      @io.gets.encoding.should == Encoding::UTF_8
-    end
+    @io.gets.encoding.should == Encoding::UTF_8
   end
 
   it "uses the IO object's external encoding, when set" do
     @io = new_io @name, 'r'
     @io.set_encoding Encoding::US_ASCII
-    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+    NATFIXME 'Transcoding', exception: SpecFailedException do
       @io.gets.encoding.should == Encoding::US_ASCII
     end
   end
@@ -375,7 +373,7 @@ describe "IO#gets" do
   it "transcodes into the default internal encoding" do
     Encoding.default_internal = Encoding::US_ASCII
     @io = new_io @name, 'r'
-    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+    NATFIXME 'Transcoding', exception: SpecFailedException do
       @io.gets.encoding.should == Encoding::US_ASCII
     end
   end
@@ -394,16 +392,14 @@ describe "IO#gets" do
     Encoding.default_internal = Encoding::UTF_8
     @io = new_io @name, 'r'
     @io.set_encoding Encoding::IBM866
-    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
-      @io.gets.encoding.should == Encoding::UTF_8
-    end
+    @io.gets.encoding.should == Encoding::UTF_8
   end
 
   it "ignores the internal encoding if the default external encoding is BINARY" do
     Encoding.default_external = Encoding::BINARY
     Encoding.default_internal = Encoding::UTF_8
     @io = new_io @name, 'r'
-    NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
+    NATFIXME 'Transcoding', exception: SpecFailedException do
       @io.gets.encoding.should == Encoding::BINARY
     end
   end
@@ -414,9 +410,7 @@ describe "IO#gets" do
       Encoding.default_internal = Encoding::UTF_8
       @io = new_io @name, 'r'
       @io.set_encoding Encoding::BINARY, Encoding::UTF_8
-      NATFIXME 'Transcoding', exception: NoMethodError, message: "undefined method `encoding' for nil:NilClass" do
-        @io.gets.encoding.should == Encoding::UTF_8
-      end
+      @io.gets.encoding.should == Encoding::UTF_8
     end
   end
 

--- a/spec/core/kernel/open_spec.rb
+++ b/spec/core/kernel/open_spec.rb
@@ -26,9 +26,7 @@ describe "Kernel#open" do
   end
 
   it "opens a file when called with a block" do
-    NATFIXME 'opens a file when called with a block', exception: SpecFailedException do
-      open(@name, "r") { |f| f.gets }.should == @content
-    end
+    open(@name, "r") { |f| f.gets }.should == @content
   end
 
   platform_is_not :windows, :wasi do
@@ -121,18 +119,14 @@ describe "Kernel#open" do
       obj.should_receive(:to_path).at_least(1).times.and_return(@name)
       obj.should_not_receive(:to_str)
 
-      NATFIXME 'calls #to_path to covert the argument to a String before calling #to_str', exception: SpecFailedException do
-        open(obj, "r") { |f| f.gets }.should == @content
-      end
+      open(obj, "r") { |f| f.gets }.should == @content
     end
 
     it "calls #to_str to convert the argument to a String" do
       obj = mock("open to_str")
       obj.should_receive(:to_str).at_least(1).times.and_return(@name)
 
-      NATFIXME 'calls #to_str to convert the argument to a String', exception: SpecFailedException do
-        open(obj, "r") { |f| f.gets }.should == @content
-      end
+      open(obj, "r") { |f| f.gets }.should == @content
     end
 
     it "calls #to_open on argument" do
@@ -202,9 +196,7 @@ describe "Kernel#open" do
   end
 
   it "accepts nil for mode and permission" do
-    NATFIXME 'accepts nil for mode and permission', exception: SpecFailedException do
-      open(@name, nil, nil) { |f| f.gets }.should == @content
-    end
+    open(@name, nil, nil) { |f| f.gets }.should == @content
   end
 
   it "is not redefined by open-uri" do

--- a/test/natalie/io_test.rb
+++ b/test/natalie/io_test.rb
@@ -48,3 +48,24 @@ describe "IO#autoclose" do
     -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
   end
 end
+
+describe "IO#gets" do
+  before :each do
+    @name = tmp("io_gets")
+    File.open(@name, 'w') do |fh|
+      fh.write('.' * 2050 + "\n")
+      fh.write(':' * 2500 + "\n")
+    end
+    @io = File.open(@name)
+  end
+
+  after :each do
+    rm_r @name
+  end
+
+  it "can read lines larger than our block size (1024)" do
+    @io.gets.should == '.' * 2050 + "\n"
+    @io.gets.should == ':' * 2500 + "\n"
+    @io.gets.should be_nil
+  end
+end


### PR DESCRIPTION
This fixes the following issues:
* Accept lines of more than 1024 bytes
* Accept files not ending with a newline
* Improve performance by reading chunks instead of separate bytes

My long term plan was to fix the remaining spec incompatibilities of `IO#gets`, then implement `IO#readline` and `IO#readlines` using `IO#gets`. I may have gotten sniped by #1314 for that one. I will still try to finish this method and have another look at all the duplication we have now.