### PR TITLE
Leave in place class variable nodes

### DIFF
--- a/lib/natalie/compiler/multiple_assignment.rb
+++ b/lib/natalie/compiler/multiple_assignment.rb
@@ -26,6 +26,8 @@ module Natalie
           transform_attr_assign_arg(arg.receiver, arg.name, arg.arguments)
         when :constant_target_node, :constant_path_target_node
           transform_constant(arg)
+        when :class_variable_target_node
+          transform_class_variable(arg.name)
         when :global_variable_target_node
           transform_global_variable(arg.name)
         when :instance_variable_target_node
@@ -89,6 +91,9 @@ module Natalie
             file: @file,
             line: @line,
           )
+        when :class_variable_target_node
+          @instructions << ClassVariableSetInstruction.new(arg.name)
+          @instructions << ClassVariableGetInstruction.new(arg.name)
         when :global_variable_target_node
           @instructions << GlobalVariableSetInstruction.new(arg.name)
           @instructions << GlobalVariableGetInstruction.new(arg.name)
@@ -110,6 +115,11 @@ module Natalie
         name, prep_instruction = constant_name(name)
         @instructions << prep_instruction
         @instructions << ConstSetInstruction.new(name)
+      end
+
+      def transform_class_variable(name)
+        shift_or_pop_next_arg
+        @instructions << ClassVariableSetInstruction.new(name)
       end
 
       def transform_global_variable(name)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -135,6 +135,22 @@ module Natalie
         instructions
       end
 
+      def transform_class_variable_and_write_node(node, used:)
+        instructions = [
+          ClassVariableGetInstruction.new(node.name, default_to_nil: true),
+          IfInstruction.new,
+          transform_expression(node.value, used: true),
+          ClassVariableSetInstruction.new(node.name),
+          ClassVariableGetInstruction.new(node.name),
+          ElseInstruction.new(:if),
+          ClassVariableGetInstruction.new(node.name, default_to_nil: true),
+          EndInstruction.new(:if)
+        ]
+
+        instructions << PopInstruction.new unless used
+        instructions
+      end
+
       def transform_class_variable_or_write_node(node, used:)
         instructions = [
           ClassVariableGetInstruction.new(node.name, default_to_nil: true),

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -119,6 +119,11 @@ module Natalie
         instructions
       end
 
+      def transform_class_variable_read_node(node, used:)
+        return [] unless used
+        ClassVariableGetInstruction.new(node.name)
+      end
+
       def transform_constant_path_node(node, used:)
         name, _is_private, prep_instruction = constant_name(node)
         # FIXME: is_private shouldn't be ignored I think
@@ -644,12 +649,6 @@ module Natalie
           PushSelfInstruction.new,
           ConstFindInstruction.new(name, strict: false),
         ]
-      end
-
-      def transform_cvar(exp, used:)
-        return [] unless used
-        _, name = exp
-        ClassVariableGetInstruction.new(name)
       end
 
       def transform_cvdecl(exp, used:)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -124,6 +124,12 @@ module Natalie
         ClassVariableGetInstruction.new(node.name)
       end
 
+      def transform_class_variable_write_node(node, used:)
+        instructions = [transform_expression(node.value, used: true), ClassVariableSetInstruction.new(node.name)]
+        instructions << ClassVariableGetInstruction.new(node.name) if used
+        instructions
+      end
+
       def transform_constant_path_node(node, used:)
         name, _is_private, prep_instruction = constant_name(node)
         # FIXME: is_private shouldn't be ignored I think
@@ -649,13 +655,6 @@ module Natalie
           PushSelfInstruction.new,
           ConstFindInstruction.new(name, strict: false),
         ]
-      end
-
-      def transform_cvdecl(exp, used:)
-        _, name, value = exp
-        instructions = [transform_expression(value, used: true), ClassVariableSetInstruction.new(name)]
-        instructions << ClassVariableGetInstruction.new(name) if used
-        instructions
       end
 
       def transform_def(exp, used:)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -311,6 +311,10 @@ module Natalie
         copy(node, value: visit(node.value))
       end
 
+      def visit_class_variable_and_write_node(node)
+        copy(node, value: visit(node.value))
+      end
+
       def visit_class_variable_or_write_node(node)
         copy(node, value: visit(node.value))
       end

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -299,9 +299,7 @@ module Natalie
           location: node.location)
       end
 
-      def visit_class_variable_read_node(node)
-        s(:cvar, node.name, location: node.location)
-      end
+      alias visit_class_variable_read_node visit_passthrough
 
       def visit_class_variable_or_write_node(node)
         s(:op_asgn_or,

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -309,7 +309,7 @@ module Natalie
       end
 
       def visit_class_variable_write_node(node)
-        s(:cvdecl, node.name, visit(node.value), location: node.location)
+        copy(node, value: visit(node.value))
       end
 
       def visit_class_variable_operator_write_node(node)

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -13,7 +13,6 @@ module Prism
     # * attrasgn
     # * bare_hash
     # * block_pass
-    # * cvar
     # * evstr
     # * gasgn
     # * iasgn
@@ -302,10 +301,7 @@ module Natalie
       alias visit_class_variable_read_node visit_passthrough
 
       def visit_class_variable_or_write_node(node)
-        s(:op_asgn_or,
-          s(:cvar, node.name, location: node.location),
-          s(:cvdecl, node.name, visit(node.value), location: node.location),
-          location: node.location)
+        copy(node, value: visit(node.value))
       end
 
       def visit_class_variable_write_node(node)
@@ -313,7 +309,7 @@ module Natalie
       end
 
       def visit_class_variable_operator_write_node(node)
-        visit_operator_write_node(node, read_sexp_type: :cvar, write_sexp_type: :cvdecl)
+        copy(node, value: visit(node.value))
       end
 
       def visit_constant_path_node(node)


### PR DESCRIPTION
This PR attempts to leave in place all class variable -related nodes. This includes all 6 related nodes including:

* class variable read
* class variable target
* class variable write
* class variable and write
* class variable or write
* class variable operator write

Some logic could probably be shared in the future between the and/or/operator writes, but for now I thought it better to be explicit while in this transitionary period.

The target nodes are really the most difficult, because they appear in 3 places you might not expect. I fixed the first two, but the last one will require a bigger change than I thought made sense for this PR. Besides, it's already broken today, so I figured it probably wasn't as big of a deal. They are:

* `begin; rescue => @@foo; end` - This was working in the previous version, so this works now.
* `@@foo, = 1` - This was working in the previous version, so this works now.
* `for @@foo in bar; end` - This was never working, and it looks like the for loop generally assumes that it only receives local variables, so that will need a larger change.