### PR TITLE
Add frozen check in Kernel#remove_instance_variable

### DIFF
--- a/include/natalie/nil_object.hpp
+++ b/include/natalie/nil_object.hpp
@@ -15,10 +15,11 @@ class NilObject : public Object {
 public:
     static NilObject *the() {
         if (s_instance) {
-            assert(s_instance->flags() == 0);
+            assert(s_instance->flags() == Flag::Frozen);
             return s_instance;
         }
         s_instance = new NilObject();
+        s_instance->freeze();
         return s_instance;
     }
 

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -117,6 +117,7 @@ private:
             }
             if (all_ascii) m_encoding = EncodingObject::get(Encoding::US_ASCII);
         }
+        freeze();
     }
 
     const TM::String m_name {};

--- a/spec/core/kernel/remove_instance_variable_spec.rb
+++ b/spec/core/kernel/remove_instance_variable_spec.rb
@@ -41,6 +41,19 @@ describe "Kernel#remove_instance_variable" do
     end.should raise_error(TypeError)
   end
 
+  it "raises a FrozenError if self is frozen" do
+    o = Object.new
+    o.freeze
+    -> { o.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    -> { o.remove_instance_variable(:foo) }.should raise_error(NameError)
+  end
+
+  it "raises for frozen objects" do
+    -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    -> { nil.remove_instance_variable(:foo) }.should raise_error(NameError)
+    -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+  end
+
   describe "when passed a String" do
     it_behaves_like :kernel_remove_instance_variable, nil, "@greeting"
   end

--- a/spec/core/kernel/remove_instance_variable_spec.rb
+++ b/spec/core/kernel/remove_instance_variable_spec.rb
@@ -51,9 +51,7 @@ describe "Kernel#remove_instance_variable" do
   it "raises for frozen objects" do
     -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
     -> { nil.remove_instance_variable(:foo) }.should raise_error(NameError)
-    NATFIXME 'Symbol should be frozen', exception: SpecFailedException do
-      -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
-    end
+    -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
   end
 
   describe "when passed a String" do

--- a/spec/core/kernel/remove_instance_variable_spec.rb
+++ b/spec/core/kernel/remove_instance_variable_spec.rb
@@ -49,9 +49,7 @@ describe "Kernel#remove_instance_variable" do
   end
 
   it "raises for frozen objects" do
-    NATFIXME 'NilObject should be frozen', exception: SpecFailedException do
-      -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
-    end
+    -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
     -> { nil.remove_instance_variable(:foo) }.should raise_error(NameError)
     NATFIXME 'Symbol should be frozen', exception: SpecFailedException do
       -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)

--- a/spec/core/kernel/remove_instance_variable_spec.rb
+++ b/spec/core/kernel/remove_instance_variable_spec.rb
@@ -49,9 +49,13 @@ describe "Kernel#remove_instance_variable" do
   end
 
   it "raises for frozen objects" do
-    -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    NATFIXME 'NilObject should be frozen', exception: SpecFailedException do
+      -> { nil.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    end
     -> { nil.remove_instance_variable(:foo) }.should raise_error(NameError)
-    -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    NATFIXME 'Symbol should be frozen', exception: SpecFailedException do
+      -> { :foo.remove_instance_variable(:@foo) }.should raise_error(FrozenError)
+    end
   end
 
   describe "when passed a String" do

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -573,6 +573,7 @@ RationalObject *KernelModule::Rational(Env *env, double arg) {
 
 Value KernelModule::remove_instance_variable(Env *env, Value name_val) {
     auto name = name_val->to_instance_variable_name(env);
+    this->assert_not_frozen(env);
     return ivar_remove(env, name);
 }
 


### PR DESCRIPTION
This includes the additional changes of making `nil` and symbols frozen, which was required to make the tests pass. We were deviating from CRuby, but it does not appear in any spec for the classes themself.