### PR TITLE
Import specs for IO#write and IO.write and allow non-ascii variable names

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -197,7 +197,7 @@ module Natalie
       end
 
       def variable_set(name)
-        raise "bad var name: #{name.inspect}" unless name =~ /^[a-z_][a-z0-9_]*/
+        raise "bad var name: #{name.inspect}" unless name =~ /^(?:[[:alpha:]]|_)[[:alnum:]]*/
         VariableSetInstruction.new(name, local_only: @local_only)
       end
 

--- a/lib/natalie/compiler/multiple_assignment.rb
+++ b/lib/natalie/compiler/multiple_assignment.rb
@@ -161,7 +161,7 @@ module Natalie
       end
 
       def variable_set(name)
-        raise "bad var name: #{name.inspect}" unless name =~ /^[a-z_][a-z0-9_]*/
+        raise "bad var name: #{name.inspect}" unless name =~ /^(?:[[:alpha:]]|_)[[:alnum:]]*/
         VariableSetInstruction.new(name, local_only: false)
       end
 

--- a/lib/natalie/compiler/pass2.rb
+++ b/lib/natalie/compiler/pass2.rb
@@ -50,7 +50,7 @@ module Natalie
       end
 
       def find_or_create_var(env, name, local_only: false)
-        raise "bad var name: #{name.inspect}" unless name =~ /^[a-z_][a-z0-9_]*/
+        raise "bad var name: #{name.inspect}" unless name =~ /^(?:[[:alpha:]]|_)[[:alnum:]]*/
 
         owning_env = env
 

--- a/spec/core/io/shared/binwrite.rb
+++ b/spec/core/io/shared/binwrite.rb
@@ -22,13 +22,13 @@ describe :io_binwrite, shared: true do
   end
 
   it "accepts options as a keyword argument" do
-    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 2..3)' do
+    NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments' do
       IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
 
+      -> {
+        IO.send(@method, @filename, "hi", 0, {flags: File::CREAT})
+      }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 2..3)")
     end
-    -> {
-      IO.send(@method, @filename, "hi", 0, {flags: File::CREAT})
-    }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 2..3)")
   end
 
   it "creates a file if missing" do
@@ -46,8 +46,15 @@ describe :io_binwrite, shared: true do
     fn = @filename + "xxx"
     begin
       File.should_not.exist?(fn)
-      IO.send(@method, fn, "test", 0)
-      File.should.exist?(fn)
+      if @method == :write
+        NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+          IO.send(@method, fn, "test", 0)
+          File.should.exist?(fn)
+        end
+      else
+        IO.send(@method, fn, "test", 0)
+        File.should.exist?(fn)
+      end
     ensure
       rm_r fn
     end
@@ -59,19 +66,35 @@ describe :io_binwrite, shared: true do
   end
 
   it "doesn't truncate the file and writes the given string if an offset is given" do
-    IO.send(@method, @filename, "hello, world!", 0)
-    File.read(@filename).should == "hello, world!34567890123456789"
-    IO.send(@method, @filename, "hello, world!", 20)
-    File.read(@filename).should == "hello, world!3456789hello, world!"
+    if @method == :write
+      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+        IO.send(@method, @filename, "hello, world!", 0)
+        File.read(@filename).should == "hello, world!34567890123456789"
+        IO.send(@method, @filename, "hello, world!", 20)
+        File.read(@filename).should == "hello, world!3456789hello, world!"
+      end
+    else
+      IO.send(@method, @filename, "hello, world!", 0)
+      File.read(@filename).should == "hello, world!34567890123456789"
+      IO.send(@method, @filename, "hello, world!", 20)
+      File.read(@filename).should == "hello, world!3456789hello, world!"
+    end
   end
 
   it "doesn't truncate and writes at the given offset after passing empty opts" do
-    IO.send(@method, @filename, "hello world!", 1, **{})
-    File.read(@filename).should == "0hello world!34567890123456789"
+    if @method == :write
+      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+        IO.send(@method, @filename, "hello world!", 1, **{})
+        File.read(@filename).should == "0hello world!34567890123456789"
+      end
+    else
+      IO.send(@method, @filename, "hello world!", 1, **{})
+      File.read(@filename).should == "0hello world!34567890123456789"
+    end
   end
 
   it "accepts a :mode option" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'Keyword arguments (exact exception differs between callers)' do
       IO.send(@method, @filename, "hello, world!", mode: 'a')
       File.read(@filename).should == "012345678901234567890123456789hello, world!"
       IO.send(@method, @filename, "foo", 2, mode: 'w')
@@ -80,7 +103,7 @@ describe :io_binwrite, shared: true do
   end
 
   it "accepts a :flags option without :mode one" do
-    NATFIXME 'Keyword arguments', exception: TypeError, message: 'no implicit conversion of Hash into Integer' do
+    NATFIXME 'Keyword arguments (exact exception differs between callers)' do
       IO.send(@method, @filename, "hello, world!", flags: File::CREAT)
       File.read(@filename).should == "hello, world!"
     end

--- a/spec/core/io/shared/write.rb
+++ b/spec/core/io/shared/write.rb
@@ -1,0 +1,154 @@
+# encoding: utf-8
+require_relative '../fixtures/classes'
+
+describe :io_write, shared: true do
+  before :each do
+    @filename = tmp("IO_syswrite_file") + $$.to_s
+    File.open(@filename, "w") do |file|
+      file.send(@method, "012345678901234567890123456789")
+    end
+    @file = File.open(@filename, "r+")
+    @readonly_file = File.open(@filename)
+  end
+
+  after :each do
+    @readonly_file.close if @readonly_file
+    @file.close if @file
+    rm_r @filename
+  end
+
+  it "coerces the argument to a string using to_s" do
+    (obj = mock('test')).should_receive(:to_s).and_return('a string')
+    @file.send(@method, obj)
+  end
+
+  it "checks if the file is writable if writing more than zero bytes" do
+    -> { @readonly_file.send(@method, "abcde") }.should raise_error(IOError)
+  end
+
+  it "returns the number of bytes written" do
+    written = @file.send(@method, "abcde")
+    written.should == 5
+  end
+
+  it "invokes to_s on non-String argument" do
+    data = "abcdefgh9876"
+    (obj = mock(data)).should_receive(:to_s).and_return(data)
+    @file.send(@method, obj)
+    @file.seek(0)
+    @file.read(data.size).should == data
+  end
+
+  it "writes all of the string's bytes without buffering if mode is sync" do
+    @file.sync = true
+    written = @file.send(@method, "abcde")
+    written.should == 5
+    File.open(@filename) do |file|
+      file.read(10).should == "abcde56789"
+    end
+  end
+
+  it "does not warn if called after IO#read" do
+    @file.read(5)
+    -> { @file.send(@method, "fghij") }.should_not complain
+  end
+
+  it "writes to the current position after IO#read" do
+    @file.read(5)
+    @file.send(@method, "abcd")
+    @file.rewind
+    @file.read.should == "01234abcd901234567890123456789"
+  end
+
+  it "advances the file position by the count of given bytes" do
+    @file.send(@method, "abcde")
+    @file.read(10).should == "5678901234"
+  end
+
+  it "raises IOError on closed stream" do
+    -> { IOSpecs.closed_io.send(@method, "hello") }.should raise_error(IOError)
+  end
+
+  describe "on a pipe" do
+    before :each do
+      @r, @w = IO.pipe
+    end
+
+    after :each do
+      @r.close
+      @w.close
+    end
+
+    it "writes the given String to the pipe" do
+      @w.send(@method, "foo")
+      @w.close
+      @r.read.should == "foo"
+    end
+
+    # [ruby-core:90895] RJIT worker may leave fd open in a forked child.
+    # For instance, RJIT creates a worker before @r.close with fork(), @r.close happens,
+    # and the RJIT worker keeps the pipe open until the worker execve().
+    # TODO: consider acquiring GVL from RJIT worker.
+    guard_not -> { defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? } do
+      it "raises Errno::EPIPE if the read end is closed and does not die from SIGPIPE" do
+        @r.close
+        -> { @w.send(@method, "foo") }.should raise_error(Errno::EPIPE, /Broken pipe/)
+      end
+    end
+  end
+end
+
+describe :io_write_transcode, shared: true do
+  before :each do
+    @transcode_filename = tmp("io_write_transcode")
+  end
+
+  after :each do
+    rm_r @transcode_filename
+  end
+
+  it "transcodes the given string when the external encoding is set and neither is BINARY" do
+    utf8_str = "hello"
+
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      file.send(@method, utf8_str)
+    end
+
+    result = File.binread(@transcode_filename)
+    expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+
+    result.bytes.should == expected
+  end
+
+  it "transcodes the given string when the external encoding is set and the string encoding is BINARY" do
+    str = "été".b
+
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      -> { file.send(@method, str) }.should raise_error(Encoding::UndefinedConversionError)
+    end
+  end
+end
+
+describe :io_write_no_transcode, shared: true do
+  before :each do
+    @transcode_filename = tmp("io_write_no_transcode")
+  end
+
+  after :each do
+    rm_r @transcode_filename
+  end
+
+  it "does not transcode the given string even when the external encoding is set" do
+    utf8_str = "hello"
+
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      file.send(@method, utf8_str)
+    end
+
+    result = File.binread(@transcode_filename)
+    result.bytes.should == utf8_str.bytes
+  end
+end

--- a/spec/core/io/shared/write.rb
+++ b/spec/core/io/shared/write.rb
@@ -90,7 +90,8 @@ describe :io_write, shared: true do
     # and the RJIT worker keeps the pipe open until the worker execve().
     # TODO: consider acquiring GVL from RJIT worker.
     guard_not -> { defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? } do
-      it "raises Errno::EPIPE if the read end is closed and does not die from SIGPIPE" do
+      # NATFIXME: This crashes Natalie
+      xit "raises Errno::EPIPE if the read end is closed and does not die from SIGPIPE" do
         @r.close
         -> { @w.send(@method, "foo") }.should raise_error(Errno::EPIPE, /Broken pipe/)
       end

--- a/spec/core/io/shared/write.rb
+++ b/spec/core/io/shared/write.rb
@@ -119,7 +119,9 @@ describe :io_write_transcode, shared: true do
     result = File.binread(@transcode_filename)
     expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
 
-    result.bytes.should == expected
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      result.bytes.should == expected
+    end
   end
 
   it "transcodes the given string when the external encoding is set and the string encoding is BINARY" do
@@ -127,7 +129,9 @@ describe :io_write_transcode, shared: true do
 
     File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
       file.external_encoding.should == Encoding::UTF_16BE
-      -> { file.send(@method, str) }.should raise_error(Encoding::UndefinedConversionError)
+      NATFIXME 'Encodings', exception: SpecFailedException do
+        -> { file.send(@method, str) }.should raise_error(Encoding::UndefinedConversionError)
+      end
     end
   end
 end

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -1,0 +1,298 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/write'
+require_relative 'shared/binwrite'
+
+describe "IO#write on a file" do
+  before :each do
+    @filename = tmp("IO_syswrite_file") + $$.to_s
+    File.open(@filename, "w") do |file|
+      file.write("012345678901234567890123456789")
+    end
+    @file = File.open(@filename, "r+")
+    @readonly_file = File.open(@filename)
+  end
+
+  after :each do
+    @file.close
+    @readonly_file.close
+    rm_r @filename
+  end
+
+  it "does not check if the file is writable if writing zero bytes" do
+    -> { @readonly_file.write("") }.should_not raise_error
+  end
+
+  before :each do
+    @external = Encoding.default_external
+    @internal = Encoding.default_internal
+
+    Encoding.default_external = Encoding::UTF_8
+  end
+
+  after :each do
+    Encoding.default_external = @external
+    Encoding.default_internal = @internal
+  end
+
+  it "returns a length of 0 when writing a blank string" do
+    @file.write('').should == 0
+  end
+
+  it "returns a length of 0 when writing blank strings" do
+    @file.write('', '', '').should == 0
+  end
+
+  it "returns a length of 0 when passed no arguments" do
+    @file.write().should == 0
+  end
+
+  it "returns the number of bytes written" do
+    @file.write("hellø").should == 6
+  end
+
+  it "does not modify the passed argument" do
+    File.open(@filename, "w") do |f|
+      f.set_encoding(Encoding::IBM437)
+      # A character whose codepoint differs between UTF-8 and IBM437
+      f.write("ƒ".freeze)
+    end
+
+    File.binread(@filename).bytes.should == [159]
+  end
+
+  it "does not modify arguments when passed multiple arguments and external encoding not set" do
+    a, b = "a".freeze, "b".freeze
+
+    File.open(@filename, "w") do |f|
+      f.write(a, b)
+    end
+
+    File.binread(@filename).bytes.should == [97, 98]
+    a.encoding.should == Encoding::UTF_8
+    b.encoding.should == Encoding::UTF_8
+  end
+
+  it "uses the encoding from the given option for non-ascii encoding" do
+    File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
+      file.write("hi").should == 8
+    end
+    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
+  end
+
+  it "uses the encoding from the given option for non-ascii encoding even if in binary mode" do
+    File.open(@filename, "w", encoding: Encoding::UTF_32LE, binmode: true) do |file|
+      file.should.binmode?
+      file.write("hi").should == 8
+    end
+    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
+
+    File.open(@filename, "wb", encoding: Encoding::UTF_32LE) do |file|
+      file.should.binmode?
+      file.write("hi").should == 8
+    end
+    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
+  end
+
+  it "uses the encoding from the given option for non-ascii encoding when multiple arguments passes" do
+    File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
+      file.write("h", "i").should == 8
+    end
+    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
+  end
+
+  it "raises a invalid byte sequence error if invalid bytes are being written" do
+    # pack "\xFEhi" to avoid utf-8 conflict
+    xFEhi = ([254].pack('C*') + 'hi').force_encoding('utf-8')
+    File.open(@filename, "w", encoding: Encoding::US_ASCII) do |file|
+      -> { file.write(xFEhi) }.should raise_error(Encoding::InvalidByteSequenceError)
+    end
+  end
+
+  # NATFIXME: Compile error: bad var name
+  # it "writes binary data if no encoding is given" do
+    # File.open(@filename, "w") do |file|
+      # file.write('Hëllö'.encode('ISO-8859-1'))
+    # end
+    # ë = ([235].pack('U')).encode('ISO-8859-1')
+    # ö = ([246].pack('U')).encode('ISO-8859-1')
+    # res = "H#{ë}ll#{ö}"
+    # File.binread(@filename).should == res.force_encoding(Encoding::BINARY)
+  # end
+
+  platform_is_not :windows do
+    it "writes binary data if no encoding is given and multiple arguments passed" do
+      File.open(@filename, "w") do |file|
+        file.write("\x87".b, "ą") # 0x87 isn't a valid UTF-8 binary representation of a character
+      end
+      File.binread(@filename).bytes.should == [0x87, 0xC4, 0x85]
+
+      File.open(@filename, "w") do |file|
+        file.write("\x61".encode("utf-32le"), "ą")
+      end
+      File.binread(@filename).bytes.should == [0x61, 0x00, 0x00, 0x00, 0xC4, 0x85]
+    end
+  end
+end
+
+describe "IO.write" do
+  it_behaves_like :io_binwrite, :write
+
+  it "uses an :open_args option" do
+    IO.write(@filename, 'hi', open_args: ["w", nil, {encoding: Encoding::UTF_32LE}]).should == 8
+  end
+
+  it "disregards other options if :open_args is given" do
+    IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
+    File.read(@filename).should == "\0\0hi"
+  end
+
+  it "requires mode to be specified in :open_args" do
+    -> {
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true}])
+    }.should raise_error(IOError, "not opened for writing")
+
+    IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true}]).should == 8
+    IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, mode: "w"}]).should == 8
+  end
+
+  it "requires mode to be specified in :open_args even if flags option passed" do
+    -> {
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}])
+    }.should raise_error(IOError, "not opened for writing")
+
+    IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}]).should == 8
+    IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT, mode: "w"}]).should == 8
+  end
+
+  it "uses the given encoding and returns the number of bytes written" do
+    IO.write(@filename, 'hi', mode: "w", encoding: Encoding::UTF_32LE).should == 8
+  end
+
+  it "raises ArgumentError if encoding is specified in mode parameter and is given as :encoding option" do
+    -> {
+      IO.write(@filename, 'hi', mode: "w:UTF-16LE:UTF-16BE", encoding: Encoding::UTF_32LE)
+    }.should raise_error(ArgumentError, "encoding specified twice")
+
+    -> {
+      IO.write(@filename, 'hi', mode: "w:UTF-16BE", encoding: Encoding::UTF_32LE)
+    }.should raise_error(ArgumentError, "encoding specified twice")
+  end
+
+  it "writes the file with the permissions in the :perm parameter" do
+    rm_r @filename
+    IO.write(@filename, 'write :perm spec', mode: "w", perm: 0o755).should == 16
+    (File.stat(@filename).mode & 0o777) == 0o755
+  end
+
+  it "writes binary data if no encoding is given" do
+    IO.write(@filename, 'Hëllö'.encode('ISO-8859-1'))
+    xEB = [235].pack('C*')
+    xF6 = [246].pack('C*')
+    File.binread(@filename).should == ("H" + xEB + "ll" + xF6).force_encoding(Encoding::BINARY)
+  end
+
+  platform_is_not :windows do
+    describe "on a FIFO" do
+      before :each do
+        @fifo = tmp("File_open_fifo")
+        File.mkfifo(@fifo)
+      end
+
+      after :each do
+        rm_r @fifo
+      end
+
+      # rb_cloexec_open() is currently missing a retry on EINTR.
+      # @ioquatix is looking into fixing it. Quarantined until it's done.
+      quarantine! do
+        it "writes correctly" do
+          thr = Thread.new do
+            IO.read(@fifo)
+          end
+          begin
+            string = "hi"
+            IO.write(@fifo, string).should == string.length
+          ensure
+            thr.join
+          end
+        end
+      end
+    end
+
+    ruby_version_is "3.3" do
+      # https://bugs.ruby-lang.org/issues/19630
+      it "warns about deprecation given a path with a pipe" do
+        -> {
+          -> {
+            IO.write("|cat", "xxx")
+          }.should output_to_fd("xxx")
+        }.should complain(/IO process creation with a leading '\|'/)
+      end
+    end
+  end
+end
+
+describe "IO#write" do
+  it_behaves_like :io_write, :write
+  it_behaves_like :io_write_transcode, :write
+
+  it "accepts multiple arguments" do
+    IO.pipe do |r, w|
+      w.write("foo", "bar")
+      w.close
+
+      r.read.should == "foobar"
+    end
+  end
+end
+
+platform_is :windows do
+  describe "IO#write on Windows" do
+    before :each do
+      @fname = tmp("io_write.txt")
+    end
+
+    after :each do
+      rm_r @fname
+      @io.close if @io and !@io.closed?
+    end
+
+    it "normalizes line endings in text mode" do
+      @io = new_io(@fname, "wt")
+      @io.write "a\nb\nc"
+      @io.close
+      File.binread(@fname).should == "a\r\nb\r\nc"
+    end
+
+    it "does not normalize line endings in binary mode" do
+      @io = new_io(@fname, "wb")
+      @io.write "a\r\nb\r\nc"
+      @io.close
+      File.binread(@fname).should == "a\r\nb\r\nc"
+    end
+  end
+end
+
+describe "IO#write on STDOUT" do
+  # https://bugs.ruby-lang.org/issues/14413
+  platform_is_not :windows do
+    it "raises SignalException SIGPIPE if the stream is closed instead of Errno::EPIPE like other IOs" do
+      stderr_file = tmp("stderr")
+      begin
+        IO.popen([*ruby_exe, "-e", "loop { puts :ok }"], "r", err: stderr_file) do |io|
+          io.gets.should == "ok\n"
+          io.close
+        end
+        status = $?
+        status.should_not.success?
+        status.should.signaled?
+        Signal.signame(status.termsig).should == 'PIPE'
+        File.read(stderr_file).should.empty?
+      ensure
+        rm_r stderr_file
+      end
+    end
+  end
+end

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -110,7 +110,8 @@ describe "IO#write on a file" do
     end
   end
 
-  it "writes binary data if no encoding is given" do
+  # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
+  xit "writes binary data if no encoding is given" do
     File.open(@filename, "w") do |file|
       file.write('Hëllö'.encode('ISO-8859-1'))
     end
@@ -185,7 +186,8 @@ describe "IO.write" do
     (File.stat(@filename).mode & 0o777) == 0o755
   end
 
-  it "writes binary data if no encoding is given" do
+  # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
+  xit "writes binary data if no encoding is given" do
     IO.write(@filename, 'Hëllö'.encode('ISO-8859-1'))
     xEB = [235].pack('C*')
     xF6 = [246].pack('C*')

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -110,16 +110,15 @@ describe "IO#write on a file" do
     end
   end
 
-  # NATFIXME: Compile error: bad var name
-  # it "writes binary data if no encoding is given" do
-    # File.open(@filename, "w") do |file|
-      # file.write('Hëllö'.encode('ISO-8859-1'))
-    # end
-    # ë = ([235].pack('U')).encode('ISO-8859-1')
-    # ö = ([246].pack('U')).encode('ISO-8859-1')
-    # res = "H#{ë}ll#{ö}"
-    # File.binread(@filename).should == res.force_encoding(Encoding::BINARY)
-  # end
+  it "writes binary data if no encoding is given" do
+    File.open(@filename, "w") do |file|
+      file.write('Hëllö'.encode('ISO-8859-1'))
+    end
+    ë = ([235].pack('U')).encode('ISO-8859-1')
+    ö = ([246].pack('U')).encode('ISO-8859-1')
+    res = "H#{ë}ll#{ö}"
+    File.binread(@filename).should == res.force_encoding(Encoding::BINARY)
+  end
 
   platform_is_not :windows do
     it "writes binary data if no encoding is given and multiple arguments passed" do

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -21,7 +21,9 @@ describe "IO#write on a file" do
   end
 
   it "does not check if the file is writable if writing zero bytes" do
-    -> { @readonly_file.write("") }.should_not raise_error
+    NATFIXME 'does not check if the file is writable if writing zero bytes', exception: SpecFailedException do
+      -> { @readonly_file.write("") }.should_not raise_error
+    end
   end
 
   before :each do
@@ -45,7 +47,9 @@ describe "IO#write on a file" do
   end
 
   it "returns a length of 0 when passed no arguments" do
-    @file.write().should == 0
+    NATFIXME 'Support zero arguments', exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1+)' do
+      @file.write().should == 0
+    end
   end
 
   it "returns the number of bytes written" do
@@ -59,7 +63,9 @@ describe "IO#write on a file" do
       f.write("ƒ".freeze)
     end
 
-    File.binread(@filename).bytes.should == [159]
+    NATFIXME 'Encoding', exception: SpecFailedException do
+      File.binread(@filename).bytes.should == [159]
+    end
   end
 
   it "does not modify arguments when passed multiple arguments and external encoding not set" do
@@ -75,38 +81,46 @@ describe "IO#write on a file" do
   end
 
   it "uses the encoding from the given option for non-ascii encoding" do
-    File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
-      file.write("hi").should == 8
+    NATFIXME 'Encoding', exception: SpecFailedException do
+      File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
+        file.write("hi").should == 8
+      end
+      File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
     end
-    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
   end
 
   it "uses the encoding from the given option for non-ascii encoding even if in binary mode" do
-    File.open(@filename, "w", encoding: Encoding::UTF_32LE, binmode: true) do |file|
-      file.should.binmode?
-      file.write("hi").should == 8
-    end
-    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
+    NATFIXME 'Encoding', exception: SpecFailedException do
+      File.open(@filename, "w", encoding: Encoding::UTF_32LE, binmode: true) do |file|
+        file.should.binmode?
+        file.write("hi").should == 8
+      end
+      File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
 
-    File.open(@filename, "wb", encoding: Encoding::UTF_32LE) do |file|
-      file.should.binmode?
-      file.write("hi").should == 8
+      File.open(@filename, "wb", encoding: Encoding::UTF_32LE) do |file|
+        file.should.binmode?
+        file.write("hi").should == 8
+      end
+      File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
     end
-    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
   end
 
   it "uses the encoding from the given option for non-ascii encoding when multiple arguments passes" do
-    File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
-      file.write("h", "i").should == 8
+    NATFIXME 'Encoding', exception: SpecFailedException do
+      File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
+        file.write("h", "i").should == 8
+      end
+      File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
     end
-    File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
   end
 
   it "raises a invalid byte sequence error if invalid bytes are being written" do
     # pack "\xFEhi" to avoid utf-8 conflict
     xFEhi = ([254].pack('C*') + 'hi').force_encoding('utf-8')
     File.open(@filename, "w", encoding: Encoding::US_ASCII) do |file|
-      -> { file.write(xFEhi) }.should raise_error(Encoding::InvalidByteSequenceError)
+      NATFIXME 'Encoding', exception: SpecFailedException do
+        -> { file.write(xFEhi) }.should raise_error(Encoding::InvalidByteSequenceError)
+      end
     end
   end
 
@@ -140,50 +154,66 @@ describe "IO.write" do
   it_behaves_like :io_binwrite, :write
 
   it "uses an :open_args option" do
-    IO.write(@filename, 'hi', open_args: ["w", nil, {encoding: Encoding::UTF_32LE}]).should == 8
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+      IO.write(@filename, 'hi', open_args: ["w", nil, {encoding: Encoding::UTF_32LE}]).should == 8
+    end
   end
 
   it "disregards other options if :open_args is given" do
-    IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
-    File.read(@filename).should == "\0\0hi"
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 2)' do
+      IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
+      File.read(@filename).should == "\0\0hi"
+    end
   end
 
   it "requires mode to be specified in :open_args" do
-    -> {
-      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true}])
-    }.should raise_error(IOError, "not opened for writing")
+    NATFIXME 'Add keyword arguments to IO.write', exception: SpecFailedException do
+      -> {
+        IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true}])
+      }.should raise_error(IOError, "not opened for writing")
+    end
 
-    IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true}]).should == 8
-    IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, mode: "w"}]).should == 8
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+      IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true}]).should == 8
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, mode: "w"}]).should == 8
+    end
   end
 
   it "requires mode to be specified in :open_args even if flags option passed" do
-    -> {
-      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}])
-    }.should raise_error(IOError, "not opened for writing")
+    NATFIXME 'Add keyword arguments to IO.write', exception: SpecFailedException do
+      -> {
+        IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}])
+      }.should raise_error(IOError, "not opened for writing")
 
-    IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}]).should == 8
-    IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT, mode: "w"}]).should == 8
+      IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}]).should == 8
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT, mode: "w"}]).should == 8
+    end
   end
 
   it "uses the given encoding and returns the number of bytes written" do
-    IO.write(@filename, 'hi', mode: "w", encoding: Encoding::UTF_32LE).should == 8
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+      IO.write(@filename, 'hi', mode: "w", encoding: Encoding::UTF_32LE).should == 8
+    end
   end
 
   it "raises ArgumentError if encoding is specified in mode parameter and is given as :encoding option" do
-    -> {
-      IO.write(@filename, 'hi', mode: "w:UTF-16LE:UTF-16BE", encoding: Encoding::UTF_32LE)
-    }.should raise_error(ArgumentError, "encoding specified twice")
+    NATFIXME 'Keyword arguments', exception: SpecFailedException do
+      -> {
+        IO.write(@filename, 'hi', mode: "w:UTF-16LE:UTF-16BE", encoding: Encoding::UTF_32LE)
+      }.should raise_error(ArgumentError, "encoding specified twice")
 
-    -> {
-      IO.write(@filename, 'hi', mode: "w:UTF-16BE", encoding: Encoding::UTF_32LE)
-    }.should raise_error(ArgumentError, "encoding specified twice")
+      -> {
+        IO.write(@filename, 'hi', mode: "w:UTF-16BE", encoding: Encoding::UTF_32LE)
+      }.should raise_error(ArgumentError, "encoding specified twice")
+    end
   end
 
   it "writes the file with the permissions in the :perm parameter" do
     rm_r @filename
-    IO.write(@filename, 'write :perm spec', mode: "w", perm: 0o755).should == 16
-    (File.stat(@filename).mode & 0o777) == 0o755
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+      IO.write(@filename, 'write :perm spec', mode: "w", perm: 0o755).should == 16
+      (File.stat(@filename).mode & 0o777) == 0o755
+    end
   end
 
   # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
@@ -282,15 +312,17 @@ describe "IO#write on STDOUT" do
     it "raises SignalException SIGPIPE if the stream is closed instead of Errno::EPIPE like other IOs" do
       stderr_file = tmp("stderr")
       begin
-        IO.popen([*ruby_exe, "-e", "loop { puts :ok }"], "r", err: stderr_file) do |io|
-          io.gets.should == "ok\n"
-          io.close
+        NATFIXME 'Implement IO.popen', exception: NoMethodError, message: "undefined method `popen' for IO:Class" do
+          IO.popen([*ruby_exe, "-e", "loop { puts :ok }"], "r", err: stderr_file) do |io|
+            io.gets.should == "ok\n"
+            io.close
+          end
+          status = $?
+          status.should_not.success?
+          status.should.signaled?
+          Signal.signame(status.termsig).should == 'PIPE'
+          File.read(stderr_file).should.empty?
         end
-        status = $?
-        status.should_not.success?
-        status.should.signaled?
-        Signal.signame(status.termsig).should == 'PIPE'
-        File.read(stderr_file).should.empty?
       ensure
         rm_r stderr_file
       end


### PR DESCRIPTION
The current version of Natalie is unable to compile this file: `bad var name: :ë`. This pull request does include a change to accept non-ascii variable names. I have no idea how well this works with the self hosted compiler mentioned in #1315, so this commit might have to be excluded