### PR TITLE
Improve IO.write

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -104,7 +104,7 @@ public:
     static Value try_convert(Env *, Value);
 
     Value write(Env *, Args) const;
-    static Value write_file(Env *, Value, Value);
+    static Value write_file(Env *, Args);
 
     Value get_path() const;
     void set_path(StringObject *path) { m_path = path; }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -852,7 +852,7 @@ gen.static_binding('IO', 'read', 'IoObject', 'read_file', argc: :any, pass_env: 
 gen.static_binding('IO', 'select', 'IoObject', 'select', argc: 1..4, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'sysopen', 'IoObject', 'sysopen', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('IO', 'try_convert', 'IoObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
-gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding('IO', 'write', 'IoObject', 'write_file', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', '<<', 'IoObject', 'append', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'advise', 'IoObject', 'advise', argc: 1..3, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'autoclose?', 'IoObject', 'is_autoclose', argc: 0, pass_env: true, pass_block: false, return_type: :bool)

--- a/spec/core/io/shared/binwrite.rb
+++ b/spec/core/io/shared/binwrite.rb
@@ -22,21 +22,11 @@ describe :io_binwrite, shared: true do
   end
 
   it "accepts options as a keyword argument" do
-    if @method == :write
-      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-        IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
+    IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
 
-        -> {
-          IO.send(@method, @filename, "hi", 0, {flags: File::CREAT})
-        }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 2..3)")
-      end
-    else
-      IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
-
-      -> {
-        IO.send(@method, @filename, "hi", 0, {flags: File::CREAT})
-      }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 2..3)")
-    end
+    -> {
+      IO.send(@method, @filename, "hi", 0, {flags: File::CREAT})
+    }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 2..3)")
   end
 
   it "creates a file if missing" do
@@ -54,15 +44,8 @@ describe :io_binwrite, shared: true do
     fn = @filename + "xxx"
     begin
       File.should_not.exist?(fn)
-      if @method == :write
-        NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-          IO.send(@method, fn, "test", 0)
-          File.should.exist?(fn)
-        end
-      else
-        IO.send(@method, fn, "test", 0)
-        File.should.exist?(fn)
-      end
+      IO.send(@method, fn, "test", 0)
+      File.should.exist?(fn)
     ensure
       rm_r fn
     end
@@ -74,47 +57,22 @@ describe :io_binwrite, shared: true do
   end
 
   it "doesn't truncate the file and writes the given string if an offset is given" do
-    if @method == :write
-      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-        IO.send(@method, @filename, "hello, world!", 0)
-        File.read(@filename).should == "hello, world!34567890123456789"
-        IO.send(@method, @filename, "hello, world!", 20)
-        File.read(@filename).should == "hello, world!3456789hello, world!"
-      end
-    else
-      IO.send(@method, @filename, "hello, world!", 0)
-      File.read(@filename).should == "hello, world!34567890123456789"
-      IO.send(@method, @filename, "hello, world!", 20)
-      File.read(@filename).should == "hello, world!3456789hello, world!"
-    end
+    IO.send(@method, @filename, "hello, world!", 0)
+    File.read(@filename).should == "hello, world!34567890123456789"
+    IO.send(@method, @filename, "hello, world!", 20)
+    File.read(@filename).should == "hello, world!3456789hello, world!"
   end
 
   it "doesn't truncate and writes at the given offset after passing empty opts" do
-    if @method == :write
-      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-        IO.send(@method, @filename, "hello world!", 1, **{})
-        File.read(@filename).should == "0hello world!34567890123456789"
-      end
-    else
-      IO.send(@method, @filename, "hello world!", 1, **{})
-      File.read(@filename).should == "0hello world!34567890123456789"
-    end
+    IO.send(@method, @filename, "hello world!", 1, **{})
+    File.read(@filename).should == "0hello world!34567890123456789"
   end
 
   it "accepts a :mode option" do
-    if @method == :write
-      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-        IO.send(@method, @filename, "hello, world!", mode: 'a')
-        File.read(@filename).should == "012345678901234567890123456789hello, world!"
-        IO.send(@method, @filename, "foo", 2, mode: 'w')
-        File.read(@filename).should == "\0\0foo"
-      end
-    else
-      IO.send(@method, @filename, "hello, world!", mode: 'a')
-      File.read(@filename).should == "012345678901234567890123456789hello, world!"
-      IO.send(@method, @filename, "foo", 2, mode: 'w')
-      File.read(@filename).should == "\0\0foo"
-    end
+    IO.send(@method, @filename, "hello, world!", mode: 'a')
+    File.read(@filename).should == "012345678901234567890123456789hello, world!"
+    IO.send(@method, @filename, "foo", 2, mode: 'w')
+    File.read(@filename).should == "\0\0foo"
   end
 
   it "accepts a :flags option without :mode one" do

--- a/spec/core/io/shared/binwrite.rb
+++ b/spec/core/io/shared/binwrite.rb
@@ -23,7 +23,7 @@ describe :io_binwrite, shared: true do
 
   it "accepts options as a keyword argument" do
     if @method == :write
-      NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
         IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
 
         -> {
@@ -103,7 +103,7 @@ describe :io_binwrite, shared: true do
 
   it "accepts a :mode option" do
     if @method == :write
-      NATFIXME 'Keyword arguments (exact exception differs between callers)' do
+      NATFIXME "Add offset to IO.#{@method}", exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
         IO.send(@method, @filename, "hello, world!", mode: 'a')
         File.read(@filename).should == "012345678901234567890123456789hello, world!"
         IO.send(@method, @filename, "foo", 2, mode: 'w')
@@ -123,13 +123,7 @@ describe :io_binwrite, shared: true do
   end
 
   it "raises an error if readonly mode is specified" do
-    if @method == :write
-      NATFIXME 'Keyword arguments', exception: SpecFailedException do
-        -> { IO.send(@method, @filename, "abcde", mode: "r") }.should raise_error(IOError)
-      end
-    else
-      -> { IO.send(@method, @filename, "abcde", mode: "r") }.should raise_error(IOError)
-    end
+    -> { IO.send(@method, @filename, "abcde", mode: "r") }.should raise_error(IOError)
   end
 
   it "truncates if empty :opts provided and offset skipped" do

--- a/spec/core/io/shared/binwrite.rb
+++ b/spec/core/io/shared/binwrite.rb
@@ -23,7 +23,7 @@ describe :io_binwrite, shared: true do
 
   it "accepts options as a keyword argument" do
     if @method == :write
-      NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 2)' do
+      NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
         IO.send(@method, @filename, "hi", 0, flags: File::CREAT).should == 2
 
         -> {
@@ -118,15 +118,8 @@ describe :io_binwrite, shared: true do
   end
 
   it "accepts a :flags option without :mode one" do
-    if @method == :write
-      NATFIXME 'Keyword arguments', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-        IO.send(@method, @filename, "hello, world!", flags: File::CREAT)
-        File.read(@filename).should == "hello, world!"
-      end
-    else
-      IO.send(@method, @filename, "hello, world!", flags: File::CREAT)
-      File.read(@filename).should == "hello, world!"
-    end
+    IO.send(@method, @filename, "hello, world!", flags: File::CREAT)
+    File.read(@filename).should == "hello, world!"
   end
 
   it "raises an error if readonly mode is specified" do

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -160,10 +160,8 @@ describe "IO.write" do
   end
 
   it "disregards other options if :open_args is given" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
-      IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
-      File.read(@filename).should == "\0\0hi"
-    end
+    IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
+    File.read(@filename).should == "\0\0hi"
   end
 
   it "requires mode to be specified in :open_args" do

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -154,13 +154,13 @@ describe "IO.write" do
   it_behaves_like :io_binwrite, :write
 
   it "uses an :open_args option" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'unknown keyword: :open_args' do
       IO.write(@filename, 'hi', open_args: ["w", nil, {encoding: Encoding::UTF_32LE}]).should == 8
     end
   end
 
   it "disregards other options if :open_args is given" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 4, expected 2)' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
       IO.write(@filename, 'hi', 2, mode: "r", encoding: Encoding::UTF_32LE, open_args: ["w"]).should == 2
       File.read(@filename).should == "\0\0hi"
     end
@@ -173,7 +173,7 @@ describe "IO.write" do
       }.should raise_error(IOError, "not opened for writing")
     end
 
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'unknown keyword: :open_args' do
       IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true}]).should == 8
       IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, mode: "w"}]).should == 8
     end
@@ -191,7 +191,7 @@ describe "IO.write" do
   end
 
   it "uses the given encoding and returns the number of bytes written" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'mode specified twice' do
       IO.write(@filename, 'hi', mode: "w", encoding: Encoding::UTF_32LE).should == 8
     end
   end
@@ -210,7 +210,7 @@ describe "IO.write" do
 
   it "writes the file with the permissions in the :perm parameter" do
     rm_r @filename
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'wrong number of arguments (given 3, expected 2)' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'mode specified twice' do
       IO.write(@filename, 'write :perm spec', mode: "w", perm: 0o755).should == 16
       (File.stat(@filename).mode & 0o777) == 0o755
     end

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -154,7 +154,7 @@ describe "IO.write" do
   it_behaves_like :io_binwrite, :write
 
   it "uses an :open_args option" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'unknown keyword: :open_args' do
+    NATFIXME 'Encoding', exception: SpecFailedException do
       IO.write(@filename, 'hi', open_args: ["w", nil, {encoding: Encoding::UTF_32LE}]).should == 8
     end
   end
@@ -167,24 +167,22 @@ describe "IO.write" do
   end
 
   it "requires mode to be specified in :open_args" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: SpecFailedException do
-      -> {
-        IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true}])
-      }.should raise_error(IOError, "not opened for writing")
-    end
+    -> {
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true}])
+    }.should raise_error(IOError, "not opened for writing")
 
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'unknown keyword: :open_args' do
+    NATFIXME 'Encoding', exception: SpecFailedException do
       IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true}]).should == 8
       IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, mode: "w"}]).should == 8
     end
   end
 
   it "requires mode to be specified in :open_args even if flags option passed" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: SpecFailedException do
-      -> {
-        IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}])
-      }.should raise_error(IOError, "not opened for writing")
+    -> {
+      IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}])
+    }.should raise_error(IOError, "not opened for writing")
 
+    NATFIXME 'Encoding', exception: SpecFailedException do
       IO.write(@filename, 'hi', open_args: ["w", {encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT}]).should == 8
       IO.write(@filename, 'hi', open_args: [{encoding: Encoding::UTF_32LE, binmode: true, flags: File::CREAT, mode: "w"}]).should == 8
     end

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -191,26 +191,24 @@ describe "IO.write" do
   end
 
   it "uses the given encoding and returns the number of bytes written" do
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'mode specified twice' do
+    NATFIXME 'Encoding', exception: SpecFailedException do
       IO.write(@filename, 'hi', mode: "w", encoding: Encoding::UTF_32LE).should == 8
     end
   end
 
   it "raises ArgumentError if encoding is specified in mode parameter and is given as :encoding option" do
-    NATFIXME 'Keyword arguments', exception: SpecFailedException do
-      -> {
-        IO.write(@filename, 'hi', mode: "w:UTF-16LE:UTF-16BE", encoding: Encoding::UTF_32LE)
-      }.should raise_error(ArgumentError, "encoding specified twice")
+    -> {
+      IO.write(@filename, 'hi', mode: "w:UTF-16LE:UTF-16BE", encoding: Encoding::UTF_32LE)
+    }.should raise_error(ArgumentError, "encoding specified twice")
 
-      -> {
-        IO.write(@filename, 'hi', mode: "w:UTF-16BE", encoding: Encoding::UTF_32LE)
-      }.should raise_error(ArgumentError, "encoding specified twice")
-    end
+    -> {
+      IO.write(@filename, 'hi', mode: "w:UTF-16BE", encoding: Encoding::UTF_32LE)
+    }.should raise_error(ArgumentError, "encoding specified twice")
   end
 
   it "writes the file with the permissions in the :perm parameter" do
     rm_r @filename
-    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'mode specified twice' do
+    NATFIXME 'Add keyword arguments to IO.write', exception: ArgumentError, message: 'unknown keyword: :perm' do
       IO.write(@filename, 'write :perm spec', mode: "w", perm: 0o755).should == 16
       (File.stat(@filename).mode & 0o777) == 0o755
     end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -119,28 +119,12 @@ Value IoObject::binread(Env *env, Value filename, Value length, Value offset) {
 
 Value IoObject::binwrite(Env *env, Args args) {
     auto kwargs = args.pop_keyword_hash();
-    args.ensure_argc_between(env, 2, 3);
-    auto filename = args.at(0);
-    auto string = args.at(1);
-    auto offset = args.at(2, nullptr);
-    ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
-    auto mode = O_WRONLY | O_CREAT | O_CLOEXEC;
-    if (!offset || offset->is_nil())
-        mode |= O_TRUNC;
-    if (kwargs) {
-        kwargs = kwargs->dup(env)->as_hash();
-    } else {
+    if (!kwargs)
         kwargs = new HashObject {};
-    }
-    if (!kwargs->has_key(env, "mode"_s))
-        kwargs->put(env, "mode"_s, IntegerObject::create(mode));
     kwargs->put(env, "binmode"_s, TrueObject::the());
-    FileObject *file = _new(env, File, Args({ filename, kwargs }, true), nullptr)->as_file();
-    if (offset && !offset->is_nil())
-        file->set_pos(env, offset);
-    auto result = file->write(env, string);
-    file->close(env);
-    return IntegerObject::create(result);
+    auto args_array = args.to_array();
+    args_array->push(kwargs);
+    return write_file(env, Args { args_array, true });
 }
 
 Value IoObject::dup(Env *env) const {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -281,11 +281,11 @@ Value IoObject::write_file(Env *env, Args args) {
     args.ensure_argc_is(env, 2);
     auto filename = args.at(0);
     auto string = args.at(1);
-    Value flags = new StringObject { "w" };
+    Value mode = new StringObject { "w" };
     if (kwargs && kwargs->has_key(env, "mode"_s))
-        flags = kwargs->delete_key(env, "mode"_s, nullptr);
+        mode = kwargs->delete_key(env, "mode"_s, nullptr);
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
-    FileObject *file = _new(env, File, Args({ filename, flags, kwargs }, true), nullptr)->as_file();
+    FileObject *file = _new(env, File, Args({ filename, mode, kwargs }, true), nullptr)->as_file();
     int bytes_written = file->write(env, string);
     file->close(env);
     return Value::integer(bytes_written);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -282,6 +282,8 @@ Value IoObject::write_file(Env *env, Args args) {
     auto filename = args.at(0);
     auto string = args.at(1);
     Value flags = new StringObject { "w" };
+    if (kwargs && kwargs->has_key(env, "mode"_s))
+        flags = kwargs->delete_key(env, "mode"_s, nullptr);
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, Args({ filename, flags, kwargs }, true), nullptr)->as_file();
     int bytes_written = file->write(env, string);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -277,12 +277,13 @@ Value IoObject::read_file(Env *env, Args args) {
 }
 
 Value IoObject::write_file(Env *env, Args args) {
+    auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_is(env, 2);
     auto filename = args.at(0);
     auto string = args.at(1);
     Value flags = new StringObject { "w" };
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
-    FileObject *file = _new(env, File, { filename, flags }, nullptr)->as_file();
+    FileObject *file = _new(env, File, Args({ filename, flags, kwargs }, true), nullptr)->as_file();
     int bytes_written = file->write(env, string);
     file->close(env);
     return Value::integer(bytes_written);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -276,7 +276,10 @@ Value IoObject::read_file(Env *env, Args args) {
     return data;
 }
 
-Value IoObject::write_file(Env *env, Value filename, Value string) {
+Value IoObject::write_file(Env *env, Args args) {
+    args.ensure_argc_is(env, 2);
+    auto filename = args.at(0);
+    auto string = args.at(1);
     Value flags = new StringObject { "w" };
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, { filename, flags }, nullptr)->as_file();

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -1,5 +1,6 @@
 #include "natalie.hpp"
 #include "natalie/ioutil.hpp"
+#include "tm/defer.hpp"
 
 #include <fcntl.h>
 #include <limits.h>
@@ -286,8 +287,8 @@ Value IoObject::write_file(Env *env, Args args) {
         mode = kwargs->delete_key(env, "mode"_s, nullptr);
     ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
     FileObject *file = _new(env, File, Args({ filename, mode, kwargs }, true), nullptr)->as_file();
+    Defer close { [&file, &env]() { file->close(env); } };
     int bytes_written = file->write(env, string);
-    file->close(env);
     return Value::integer(bytes_written);
 }
 


### PR DESCRIPTION
* Add the position argument
* Forward keyword arguments to `File.new`
* Refactor `IO.binwrite`, this now uses `IO.write` which reduces some code duplication

Two issues are still left open in this change. First is our arch nemesis encodings, second is a `:perm` keyword argument that is never documented in the `IO` class.