### PR TITLE
Fix compilation of IoObject::copy_stream

### DIFF
--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -414,7 +414,7 @@ Value IoObject::copy_stream(Env *env, Value src, Value dst, Value src_length, Va
     } else if (dst->respond_to(env, "write"_s)) {
         return dst->send(env, "write"_s, { data });
     } else {
-        return write_file(env, dst, data);
+        return write_file(env, { dst, data });
     }
 }
 


### PR DESCRIPTION
This used the old version of IoObject::write_file, which had positional arguments. Change to an Args object.

Turns out the combination of #1352 and #1348 did not work as expected.