### PR TITLE
Implement Dir.glob

### DIFF
--- a/include/natalie/dir_object.hpp
+++ b/include/natalie/dir_object.hpp
@@ -26,6 +26,8 @@ public:
     DirObject(ClassObject *klass)
         : Object { Object::Type::Dir, klass } { }
 
+    virtual ~DirObject();
+
     virtual void visit_children(Visitor &visitor) override {
         Object::visit_children(visitor);
         visitor.visit(m_path);

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -160,7 +160,7 @@ class Date
   end
 
   def downto(min)
-    return to_enum(:downto, max) unless block_given?
+    return to_enum(:downto, min) unless block_given?
     date = self
     while date >= min
       yield date

--- a/spec/core/dir/chdir_spec.rb
+++ b/spec/core/dir/chdir_spec.rb
@@ -30,10 +30,8 @@ describe "Dir.chdir" do
   end
 
   it "changes to the specified directory" do
-    NATFIXME 'broken due to spec tmp() realpath issue', exception: SpecFailedException do
-      Dir.chdir DirSpecs.mock_dir
-      Dir.pwd.should == DirSpecs.mock_dir
-    end
+    Dir.chdir DirSpecs.mock_dir
+    Dir.pwd.should == DirSpecs.mock_dir
   end
 
   it "returns 0 when successfully changing directory" do
@@ -84,11 +82,9 @@ describe "Dir.chdir" do
 
   it "changes to the specified directory for the duration of the block" do
     ar = Dir.chdir(DirSpecs.mock_dir) { |dir| [dir, Dir.pwd] }
-    NATFIXME 'broken due to spec tmp() realpath issue', exception: SpecFailedException do
-      ar.should == [DirSpecs.mock_dir, DirSpecs.mock_dir]
+    ar.should == [DirSpecs.mock_dir, DirSpecs.mock_dir]
 
-      Dir.pwd.should == @original
-    end
+    Dir.pwd.should == @original
   end
 
   it "raises an Errno::ENOENT if the directory does not exist" do

--- a/spec/core/dir/glob_spec.rb
+++ b/spec/core/dir/glob_spec.rb
@@ -173,9 +173,7 @@ describe "Dir.glob" do
     ary = []
     ret = Dir.glob(["file_o*", "file_t*"]) { |t| ary << t }
     ret.should be_nil
-    NATFIXME 'out of order', exception: SpecFailedException do
-      ary.should == %w!file_one.ext file_two.ext!
-    end
+    #NATFIXME ordering issue: ary.should == %w!file_one.ext file_two.ext!
     ary.sort.should == %w!file_one.ext file_two.ext!
   end
 

--- a/spec/core/dir/glob_spec.rb
+++ b/spec/core/dir/glob_spec.rb
@@ -87,9 +87,7 @@ describe "Dir.glob" do
     ]
 
 
-    NATFIXME 'special/ln should not appear (it is a duplicate of subdir_one/)', exception: SpecFailedException do
-      Dir.glob('**/', File::FNM_DOTMATCH).sort.should == expected
-    end
+    Dir.glob('**/', File::FNM_DOTMATCH).sort.should == expected
   end
 
   ruby_version_is ''...'3.1' do
@@ -143,9 +141,7 @@ describe "Dir.glob" do
       ./subdir_two/
     ]
 
-    NATFIXME 'why is ./special/ln/ in our list????', exception: SpecFailedException do
-      Dir.glob('./**/', File::FNM_DOTMATCH).sort.should == expected
-    end
+    Dir.glob('./**/', File::FNM_DOTMATCH).sort.should == expected
   end
 
   it "matches a list of paths by concatenating their individual results" do
@@ -385,15 +381,13 @@ describe "Dir.glob" do
     end
 
     it "will follow symlinks when testing directory after recursive directory in pattern" do
-      NATFIXME 'special case of **/* and symlink', exception: SpecFailedException do
-        expected = %w[
-          deeply/nondotfile
-          special/ln/nondotfile
-          subdir_one/nondotfile
-          subdir_two/nondotfile
-        ]
-        Dir.glob('**/*/nondotfile').sort.should == expected
-      end
+      expected = %w[
+        deeply/nondotfile
+        special/ln/nondotfile
+        subdir_one/nondotfile
+        subdir_two/nondotfile
+      ]
+      Dir.glob('**/*/nondotfile').sort.should == expected
     end
   end
 end

--- a/spec/core/dir/glob_spec.rb
+++ b/spec/core/dir/glob_spec.rb
@@ -86,7 +86,10 @@ describe "Dir.glob" do
       subdir_two/
     ]
 
-    Dir.glob('**/', File::FNM_DOTMATCH).sort.should == expected
+
+    NATFIXME 'special/ln should not appear (it is a duplicate of subdir_one/)', exception: SpecFailedException do
+      Dir.glob('**/', File::FNM_DOTMATCH).sort.should == expected
+    end
   end
 
   ruby_version_is ''...'3.1' do
@@ -106,13 +109,15 @@ describe "Dir.glob" do
   ruby_version_is '3.1' do
     it "recursively matches files and directories in nested dot subdirectory except . with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH" do
       expected = %w[
-       nested/.
-       nested/.dotsubir
-       nested/.dotsubir/.dotfile
-       nested/.dotsubir/nondotfile
-     ]
+        nested/.
+        nested/.dotsubir
+        nested/.dotsubir/.dotfile
+        nested/.dotsubir/nondotfile
+      ]
 
-      Dir.glob('nested/**/*', File::FNM_DOTMATCH).sort.should == expected.sort
+      NATFIXME 'nested/. is missing', exception: SpecFailedException do
+        Dir.glob('nested/**/*', File::FNM_DOTMATCH).sort.should == expected.sort
+      end
     end
   end
 
@@ -153,7 +158,9 @@ describe "Dir.glob" do
       subdir_two/nondotfile.ext
     ]
 
-    Dir.glob('{deeply/**/,subdir_two/*}').sort.should == expected
+    NATFIXME 'expansions', exception: SpecFailedException do
+      Dir.glob('{deeply/**/,subdir_two/*}').sort.should == expected
+    end
   end
 
   it "preserves multiple /s before a **" do

--- a/spec/core/dir/glob_spec.rb
+++ b/spec/core/dir/glob_spec.rb
@@ -1,0 +1,387 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+require_relative 'shared/glob'
+
+describe "Dir.glob" do
+  it_behaves_like :dir_glob, :glob
+end
+
+describe "Dir.glob" do
+  it_behaves_like :dir_glob_recursive, :glob
+end
+
+describe "Dir.glob" do
+  before :each do
+    DirSpecs.create_mock_dirs
+
+    @cwd = Dir.pwd
+    Dir.chdir DirSpecs.mock_dir
+  end
+
+  after :each do
+    Dir.chdir @cwd
+
+    DirSpecs.delete_mock_dirs
+  end
+
+  it "can take an array of patterns" do
+    Dir.glob(["file_o*", "file_t*"]).should ==
+               %w!file_one.ext file_two.ext!
+  end
+
+  it 'returns matching file paths when supplied :base keyword argument' do
+    dir = tmp('dir_glob_base')
+    file_1 = "#{dir}/lib/bloop.rb"
+    file_2 = "#{dir}/lib/soup.rb"
+    file_3 = "#{dir}/lib/mismatched_file_type.txt"
+    file_4 = "#{dir}/mismatched_directory.rb"
+
+    touch file_1
+    touch file_2
+    touch file_3
+    touch file_4
+
+    Dir.glob('**/*.rb', base: "#{dir}/lib").sort.should == ["bloop.rb", "soup.rb"].sort
+  ensure
+    rm_r dir
+  end
+
+  it "calls #to_path to convert multiple patterns" do
+    pat1 = mock('file_one.ext')
+    pat1.should_receive(:to_path).and_return('file_one.ext')
+    pat2 = mock('file_two.ext')
+    pat2.should_receive(:to_path).and_return('file_two.ext')
+
+    Dir.glob([pat1, pat2]).should == %w[file_one.ext file_two.ext]
+  end
+
+  it "matches both dot and non-dotfiles with '*' and option File::FNM_DOTMATCH" do
+    Dir.glob('*', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
+  end
+
+  it "matches files with any beginning with '*<non-special characters>' and option File::FNM_DOTMATCH" do
+    Dir.glob('*file', File::FNM_DOTMATCH).sort.should == %w|.dotfile nondotfile|.sort
+  end
+
+  it "matches any files in the current directory with '**' and option File::FNM_DOTMATCH" do
+    Dir.glob('**', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
+  end
+
+  it "recursively matches any subdirectories except './' or '../' with '**/' from the current directory and option File::FNM_DOTMATCH" do
+    expected = %w[
+      .dotsubdir/
+      brace/
+      deeply/
+      deeply/nested/
+      deeply/nested/directory/
+      deeply/nested/directory/structure/
+      dir/
+      nested/
+      nested/.dotsubir/
+      special/
+      special/test\ +()[]{}/
+      special/test{1}/
+      special/{}/
+      subdir_one/
+      subdir_two/
+    ]
+
+    Dir.glob('**/', File::FNM_DOTMATCH).sort.should == expected
+  end
+
+  ruby_version_is ''...'3.1' do
+    it "recursively matches files and directories in nested dot subdirectory with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH" do
+      expected = %w[
+        nested/.
+        nested/.dotsubir
+        nested/.dotsubir/.
+        nested/.dotsubir/.dotfile
+        nested/.dotsubir/nondotfile
+      ]
+
+      Dir.glob('nested/**/*', File::FNM_DOTMATCH).sort.should == expected.sort
+    end
+  end
+
+  ruby_version_is '3.1' do
+    it "recursively matches files and directories in nested dot subdirectory except . with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH" do
+      expected = %w[
+       nested/.
+       nested/.dotsubir
+       nested/.dotsubir/.dotfile
+       nested/.dotsubir/nondotfile
+     ]
+
+      Dir.glob('nested/**/*', File::FNM_DOTMATCH).sort.should == expected.sort
+    end
+  end
+
+  # This is a separate case to check **/ coming after a constant
+  # directory as well.
+  it "recursively matches any subdirectories except './' or '../' with '**/' and option File::FNM_DOTMATCH" do
+    expected = %w[
+      ./
+      ./.dotsubdir/
+      ./brace/
+      ./deeply/
+      ./deeply/nested/
+      ./deeply/nested/directory/
+      ./deeply/nested/directory/structure/
+      ./dir/
+      ./nested/
+      ./nested/.dotsubir/
+      ./special/
+      ./special/test\ +()[]{}/
+      ./special/test{1}/
+      ./special/{}/
+      ./subdir_one/
+      ./subdir_two/
+    ]
+
+    Dir.glob('./**/', File::FNM_DOTMATCH).sort.should == expected
+  end
+
+  it "matches a list of paths by concatenating their individual results" do
+    expected = %w[
+      deeply/
+      deeply/nested/
+      deeply/nested/directory/
+      deeply/nested/directory/structure/
+      subdir_two/nondotfile
+      subdir_two/nondotfile.ext
+    ]
+
+    Dir.glob('{deeply/**/,subdir_two/*}').sort.should == expected
+  end
+
+  it "preserves multiple /s before a **" do
+    expected = %w[
+      deeply//nested/directory/structure
+    ]
+
+    Dir.glob('{deeply//**/structure}').sort.should == expected
+  end
+
+  it "accepts a block and yields it with each elements" do
+    ary = []
+    ret = Dir.glob(["file_o*", "file_t*"]) { |t| ary << t }
+    ret.should be_nil
+    ary.should == %w!file_one.ext file_two.ext!
+  end
+
+  it "ignores non-dirs when traversing recursively" do
+    touch "spec"
+    Dir.glob("spec/**/*.rb").should == []
+  end
+
+  it "matches nothing when given an empty list of paths" do
+    Dir.glob('{}').should == []
+  end
+
+  it "handles infinite directory wildcards" do
+    Dir.glob('**/**/**').should_not.empty?
+  end
+
+  it "handles **/** with base keyword argument" do
+    Dir.glob('**/**', base: "dir").should == ["filename_ordering"]
+
+    expected = %w[
+      nested
+      nested/directory
+      nested/directory/structure
+      nested/directory/structure/bar
+      nested/directory/structure/baz
+      nested/directory/structure/file_one
+      nested/directory/structure/file_one.ext
+      nested/directory/structure/foo
+      nondotfile
+    ].sort
+
+    Dir.glob('**/**', base: "deeply").sort.should == expected
+  end
+
+  it "handles **/ with base keyword argument" do
+    expected = %w[
+      /
+      directory/
+      directory/structure/
+    ]
+    Dir.glob('**/', base: "deeply/nested").sort.should == expected
+  end
+
+  it "handles **/nondotfile with base keyword argument" do
+    expected = %w[
+      deeply/nondotfile
+      nondotfile
+      subdir_one/nondotfile
+      subdir_two/nondotfile
+    ]
+    Dir.glob('**/nondotfile', base: ".").sort.should == expected
+  end
+
+  it "handles **/nondotfile with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotsubdir/nondotfile
+      deeply/nondotfile
+      nested/.dotsubir/nondotfile
+      nondotfile
+      subdir_one/nondotfile
+      subdir_two/nondotfile
+    ]
+    Dir.glob('**/nondotfile', File::FNM_DOTMATCH, base: ".").sort.should == expected
+  end
+
+  it "handles **/.dotfile with base keyword argument" do
+    expected = %w[
+      .dotfile
+      deeply/.dotfile
+      subdir_one/.dotfile
+    ]
+    Dir.glob('**/.dotfile', base: ".").sort.should == expected
+  end
+
+  it "handles **/.dotfile with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotfile
+      .dotsubdir/.dotfile
+      deeply/.dotfile
+      nested/.dotsubir/.dotfile
+      subdir_one/.dotfile
+    ]
+    Dir.glob('**/.dotfile', File::FNM_DOTMATCH, base: ".").sort.should == expected
+  end
+
+  it "handles **/.* with base keyword argument" do
+    expected = %w[
+      .dotfile.ext
+      directory/structure/.ext
+    ].sort
+
+    Dir.glob('**/.*', base: "deeply/nested").sort.should == expected
+  end
+
+  # < 3.1 include a "." entry for every dir: ["directory/.", "directory/structure/.", ...]
+  ruby_version_is '3.1' do
+    it "handles **/.* with base keyword argument and FNM_DOTMATCH" do
+      expected = %w[
+        .
+        .dotfile.ext
+        directory/structure/.ext
+      ].sort
+
+      Dir.glob('**/.*', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+    end
+
+    it "handles **/** with base keyword argument and FNM_DOTMATCH" do
+      expected = %w[
+        .
+        .dotfile.ext
+        directory
+        directory/structure
+        directory/structure/.ext
+        directory/structure/bar
+        directory/structure/baz
+        directory/structure/file_one
+        directory/structure/file_one.ext
+        directory/structure/foo
+      ].sort
+
+      Dir.glob('**/**', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+    end
+  end
+
+  it "handles **/*pattern* with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotfile.ext
+      directory/structure/file_one
+      directory/structure/file_one.ext
+    ]
+
+    Dir.glob('**/*file*', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+  end
+
+  it "handles **/glob with base keyword argument and FNM_EXTGLOB" do
+    expected = %w[
+      directory/structure/bar
+      directory/structure/file_one
+      directory/structure/file_one.ext
+    ]
+
+    Dir.glob('**/*{file,bar}*', File::FNM_EXTGLOB, base: "deeply/nested").sort.should == expected
+  end
+
+  it "handles simple filename patterns" do
+    Dir.glob('.dotfile').should == ['.dotfile']
+  end
+
+  it "handles simple directory patterns" do
+    NATFIXME 'directory name with trailing slash', exception: SpecFailedException do
+      Dir.glob('.dotsubdir/').should == ['.dotsubdir/']
+    end
+  end
+
+  it "handles simple directory patterns applied to non-directories" do
+    Dir.glob('nondotfile/').should == []
+  end
+
+  platform_is_not(:windows) do
+    it "matches the literal character '\\' with option File::FNM_NOESCAPE" do
+      NATFIXME 'FNM_NOESCAPE', exception: SpecFailedException do
+        Dir.mkdir 'foo?bar'
+
+        begin
+          Dir.glob('foo?bar', File::FNM_NOESCAPE).should == %w|foo?bar|
+          Dir.glob('foo\?bar', File::FNM_NOESCAPE).should == []
+        ensure
+          Dir.rmdir 'foo?bar'
+        end
+
+        Dir.mkdir 'foo\?bar'
+
+        begin
+          Dir.glob('foo\?bar', File::FNM_NOESCAPE).should == %w|foo\\?bar|
+        ensure
+          Dir.rmdir 'foo\?bar'
+        end
+      end
+    end
+
+    it "returns nil for directories current user has no permission to read" do
+      Dir.mkdir('no_permission')
+      File.chmod(0, 'no_permission')
+
+      begin
+        Dir.glob('no_permission/*').should == []
+      ensure
+        Dir.rmdir('no_permission')
+      end
+    end
+
+    it "will follow symlinks when processing a `*/` pattern." do
+      expected = ['special/ln/nondotfile']
+      Dir.glob('special/*/nondotfile').should == expected
+    end
+
+    it "will not follow symlinks when recursively traversing directories" do
+      expected = %w[
+        deeply/nondotfile
+        nondotfile
+        subdir_one/nondotfile
+        subdir_two/nondotfile
+      ]
+      Dir.glob('**/nondotfile').sort.should == expected
+    end
+
+    it "will follow symlinks when testing directory after recursive directory in pattern" do
+      NATFIXME 'special case of **/* and symlink', exception: SpecFailedException do
+        expected = %w[
+          deeply/nondotfile
+          special/ln/nondotfile
+          subdir_one/nondotfile
+          subdir_two/nondotfile
+        ]
+        Dir.glob('**/*/nondotfile').sort.should == expected
+      end
+    end
+  end
+end

--- a/spec/core/dir/glob_spec.rb
+++ b/spec/core/dir/glob_spec.rb
@@ -138,7 +138,9 @@ describe "Dir.glob" do
       ./subdir_two/
     ]
 
-    Dir.glob('./**/', File::FNM_DOTMATCH).sort.should == expected
+    NATFIXME 'why is ./special/ln/ in our list????', exception: SpecFailedException do
+      Dir.glob('./**/', File::FNM_DOTMATCH).sort.should == expected
+    end
   end
 
   it "matches a list of paths by concatenating their individual results" do
@@ -159,14 +161,19 @@ describe "Dir.glob" do
       deeply//nested/directory/structure
     ]
 
-    Dir.glob('{deeply//**/structure}').sort.should == expected
+    NATFIXME 'preserve double slash', exception: SpecFailedException do
+      Dir.glob('{deeply//**/structure}').sort.should == expected
+    end
   end
 
   it "accepts a block and yields it with each elements" do
     ary = []
     ret = Dir.glob(["file_o*", "file_t*"]) { |t| ary << t }
     ret.should be_nil
-    ary.should == %w!file_one.ext file_two.ext!
+    NATFIXME 'out of order', exception: SpecFailedException do
+      ary.should == %w!file_one.ext file_two.ext!
+    end
+    ary.sort.should == %w!file_one.ext file_two.ext!
   end
 
   it "ignores non-dirs when traversing recursively" do
@@ -315,9 +322,7 @@ describe "Dir.glob" do
   end
 
   it "handles simple directory patterns" do
-    NATFIXME 'directory name with trailing slash', exception: SpecFailedException do
-      Dir.glob('.dotsubdir/').should == ['.dotsubdir/']
-    end
+    Dir.glob('.dotsubdir/').should == ['.dotsubdir/']
   end
 
   it "handles simple directory patterns applied to non-directories" do

--- a/spec/core/dir/shared/glob.rb
+++ b/spec/core/dir/shared/glob.rb
@@ -246,9 +246,7 @@ describe :dir_glob, shared: true do
       subdir_two/
     ]
 
-    NATFIXME 'subdirectory matching', exception: SpecFailedException do
-      Dir.send(@method, '**/').sort.should == expected
-    end
+    Dir.send(@method, '**/').sort.should == expected
   end
 
   it "recursively matches any subdirectories except './' or '../' with '**/' from the base directory if that is specified" do

--- a/spec/core/dir/shared/glob.rb
+++ b/spec/core/dir/shared/glob.rb
@@ -12,8 +12,10 @@ describe :dir_glob, shared: true do
   end
 
   it "raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII" do
-    pattern = "file*".force_encoding Encoding::UTF_16BE
-    -> { Dir.send(@method, pattern) }.should raise_error(Encoding::CompatibilityError)
+    NATFIXME 'Encoding::CompatibilityError', exception: NameError do
+      pattern = "file*".force_encoding Encoding::UTF_16BE
+      -> { Dir.send(@method, pattern) }.should raise_error(Encoding::CompatibilityError)
+    end
   end
 
   it "calls #to_path to convert a pattern" do
@@ -90,16 +92,22 @@ describe :dir_glob, shared: true do
   end
 
   it "matches directories with special characters when escaped" do
-    Dir.send(@method, 'special/\{}/special').should == ["special/{}/special"]
+    NATFIXME 'escaped characters', exception: SyntaxError do
+      Dir.send(@method, 'special/\{}/special').should == ["special/{}/special"]
+    end
   end
 
   platform_is_not :windows do
     it "matches regexp special *" do
-      Dir.send(@method, 'special/\*').should == ['special/*']
+      NATFIXME 'escaped characters', exception: SpecFailedException do
+        Dir.send(@method, 'special/\*').should == ['special/*']
+      end
     end
 
     it "matches regexp special ?" do
-      Dir.send(@method, 'special/\?').should == ['special/?']
+      NATFIXME 'escaped characters', exception: SpecFailedException do
+        Dir.send(@method, 'special/\?').should == ['special/?']
+      end
     end
 
     it "matches regexp special |" do
@@ -111,7 +119,9 @@ describe :dir_glob, shared: true do
     end
 
     it "matches directory with special characters in their name in complex patterns" do
-      Dir.glob("special/test +()\\[\\]\\{\\}/hello_world{.{en},}{.{html},}{+{phone},}{.{erb},}").should == ['special/test +()[]{}/hello_world.erb']
+      NATFIXME 'escaped characters', exception: SpecFailedException do
+        Dir.glob("special/test +()\\[\\]\\{\\}/hello_world{.{en},}{.{html},}{+{phone},}{.{erb},}").should == ['special/test +()[]{}/hello_world.erb']
+      end
     end
   end
 
@@ -148,7 +158,9 @@ describe :dir_glob, shared: true do
   end
 
   it "matches paths with glob patterns" do
-    Dir.send(@method, 'special/test\{1\}/*').should == ['special/test{1}/file[1]']
+    NATFIXME 'escaped characters', exception: SpecFailedException do
+      Dir.send(@method, 'special/test\{1\}/*').should == ['special/test{1}/file[1]']
+    end
   end
 
   ruby_version_is ''...'3.1' do
@@ -234,7 +246,9 @@ describe :dir_glob, shared: true do
       subdir_two/
     ]
 
-    Dir.send(@method, '**/').sort.should == expected
+    NATFIXME 'subdirectory matching', exception: SpecFailedException do
+      Dir.send(@method, '**/').sort.should == expected
+    end
   end
 
   it "recursively matches any subdirectories except './' or '../' with '**/' from the base directory if that is specified" do
@@ -255,8 +269,10 @@ describe :dir_glob, shared: true do
 
   ruby_version_is '3.1' do
     it "recursively matches any subdirectories including ./ with '.**/'" do
-      Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
-        Dir.send(@method, '.**/').should == ['./']
+      NATFIXME 'special . directory', exception: SpecFailedException do
+        Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
+          Dir.send(@method, '.**/').should == ['./']
+        end
       end
     end
   end
@@ -300,17 +316,23 @@ describe :dir_glob, shared: true do
   end
 
   it "matches dot or non-dotfiles with '{,.}*'" do
-    Dir.send(@method, '{,.}*').sort.should == DirSpecs.expected_glob_paths
+    NATFIXME 'special . directory', exception: SpecFailedException do
+      Dir.send(@method, '{,.}*').sort.should == DirSpecs.expected_glob_paths
+    end
   end
 
   it "respects the order of {} expressions, expanding left most first" do
-    files = Dir.send(@method, "brace/a{.js,.html}{.erb,.rjs}")
-    files.should == %w!brace/a.js.rjs brace/a.html.erb!
+    NATFIXME 'order of expansion', exception: SpecFailedException do
+      files = Dir.send(@method, "brace/a{.js,.html}{.erb,.rjs}")
+      files.should == %w!brace/a.js.rjs brace/a.html.erb!
+    end
   end
 
   it "respects the optional nested {} expressions" do
-    files = Dir.send(@method, "brace/a{.{js,html},}{.{erb,rjs},}")
-    files.should == %w!brace/a.js.rjs brace/a.js brace/a.html.erb brace/a.erb brace/a!
+    NATFIXME 'nested expansion', exception: SpecFailedException do
+      files = Dir.send(@method, "brace/a{.{js,html},}{.{erb,rjs},}")
+      files.should == %w!brace/a.js.rjs brace/a.js brace/a.html.erb brace/a.erb brace/a!
+    end
   end
 
   it "matches special characters by escaping with a backslash with '\\<character>'" do
@@ -387,14 +409,16 @@ describe :dir_glob, shared: true do
     it "accepts both relative and absolute paths" do
       require 'pathname'
 
-      path_abs = File.join(@mock_dir, "a/b/c")
-      path_rel = Pathname.new(path_abs).relative_path_from(Pathname.new(Dir.pwd))
+      NATFIXME 'Pathname#relative_path_from' do
+        path_abs = File.join(@mock_dir, "a/b/c")
+        path_rel = Pathname.new(path_abs).relative_path_from(Pathname.new(Dir.pwd))
 
-      result_abs = Dir.send(@method, "*", base: path_abs).sort
-      result_rel = Dir.send(@method, "*", base: path_rel).sort
+        result_abs = Dir.send(@method, "*", base: path_abs).sort
+        result_rel = Dir.send(@method, "*", base: path_rel).sort
 
-      result_abs.should == %w( d y )
-      result_rel.should == %w( d y )
+        result_abs.should == %w( d y )
+        result_rel.should == %w( d y )
+      end
     end
 
     it "returns [] if specified path does not exist" do

--- a/spec/core/dir/shared/glob.rb
+++ b/spec/core/dir/shared/glob.rb
@@ -269,10 +269,8 @@ describe :dir_glob, shared: true do
 
   ruby_version_is '3.1' do
     it "recursively matches any subdirectories including ./ with '.**/'" do
-      NATFIXME 'special . directory', exception: SpecFailedException do
-        Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
-          Dir.send(@method, '.**/').should == ['./']
-        end
+      Dir.chdir("#{DirSpecs.mock_dir}/subdir_one") do
+        Dir.send(@method, '.**/').should == ['./']
       end
     end
   end

--- a/spec/core/file/shared/fnmatch.rb
+++ b/spec/core/file/shared/fnmatch.rb
@@ -252,6 +252,19 @@ describe :file_fnmatch, shared: true do
     File.send(@method, pattern, 'a/.b/c/foo', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
   end
 
+  it "has special handling for ./ when using * and FNM_PATHNAME" do
+    File.send(@method, './*', '.', File::FNM_PATHNAME).should be_false
+    File.send(@method, './*', './', File::FNM_PATHNAME).should be_true
+    File.send(@method, './*/', './', File::FNM_PATHNAME).should be_false
+    File.send(@method, './**', './', File::FNM_PATHNAME).should be_true
+    File.send(@method, './**/', './', File::FNM_PATHNAME).should be_true
+    File.send(@method, './*', '.', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_false
+    File.send(@method, './*', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+    File.send(@method, './*/', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_false
+    File.send(@method, './**', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+    File.send(@method, './**/', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+  end
+
   it "accepts an object that has a #to_path method" do
     File.send(@method, '\*', mock_to_path('a')).should == false
   end

--- a/spec/core/file/shared/fnmatch.rb
+++ b/spec/core/file/shared/fnmatch.rb
@@ -265,11 +265,18 @@ describe :file_fnmatch, shared: true do
     File.send(@method, './**/', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
   end
 
-  it "matches **/* with FNM_PATHNAME as if it were just **" do
+  it "matches **/* with FNM_PATHNAME to recurse directories" do
     File.send(@method, 'nested/**/*', 'nested/subdir', File::FNM_PATHNAME).should be_true
     File.send(@method, 'nested/**/*', 'nested/subdir/file', File::FNM_PATHNAME).should be_true
     File.send(@method, 'nested/**/*', 'nested/.dotsubdir', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
     File.send(@method, 'nested/**/*', 'nested/.dotsubir/.dotfile', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+  end
+
+  it "matches ** with FNM_PATHNAME only in current directory" do
+    File.send(@method, 'nested/**', 'nested/subdir', File::FNM_PATHNAME).should be_true
+    File.send(@method, 'nested/**', 'nested/subdir/file', File::FNM_PATHNAME).should be_false
+    File.send(@method, 'nested/**', 'nested/.dotsubdir', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+    File.send(@method, 'nested/**', 'nested/.dotsubir/.dotfile', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_false
   end
 
   it "accepts an object that has a #to_path method" do

--- a/spec/core/file/shared/fnmatch.rb
+++ b/spec/core/file/shared/fnmatch.rb
@@ -26,7 +26,7 @@ describe :file_fnmatch, shared: true do
     File.send(@method, "{aa,bb,cc,dd}", "bb", File::FNM_EXTGLOB).should == true
     File.send(@method, "{aa,bb,cc,dd}", "cc", File::FNM_EXTGLOB).should == true
     File.send(@method, "{aa,bb,cc,dd}", "dd", File::FNM_EXTGLOB).should == true
-    NATFIXME 'nexted {} patterns', exception: SpecFailedException do
+    NATFIXME 'nested {} patterns', exception: SpecFailedException do
       File.send(@method, "{1,5{a,b{c,d}}}", "1", File::FNM_EXTGLOB).should == true
       File.send(@method, "{1,5{a,b{c,d}}}", "5a", File::FNM_EXTGLOB).should == true
       File.send(@method, "{1,5{a,b{c,d}}}", "5bc", File::FNM_EXTGLOB).should == true
@@ -191,6 +191,14 @@ describe :file_fnmatch, shared: true do
     File.send(@method, '.*', '.profile', File::FNM_PATHNAME).should == true
     File.send(@method, ".*file", "nondotfile").should == false
     File.send(@method, ".*file", "nondotfile", File::FNM_PATHNAME).should == false
+  end
+
+  it "does not match directories with leading periods by default with FNM_PATHNAME" do
+    File.send(@method, '.*', '.directory/nondotfile', File::FNM_PATHNAME).should == false
+    File.send(@method, '.*', '.directory/.profile', File::FNM_PATHNAME).should == false
+    File.send(@method, '.*', 'foo/.directory/nondotfile', File::FNM_PATHNAME).should == false
+    File.send(@method, '.*', 'foo/.directory/.profile', File::FNM_PATHNAME).should == false
+    File.send(@method, '**/.dotfile', '.dotsubdir/.dotfile', File::FNM_PATHNAME).should == false
   end
 
   it "matches leading periods in filenames when flags includes FNM_DOTMATCH" do

--- a/spec/core/file/shared/fnmatch.rb
+++ b/spec/core/file/shared/fnmatch.rb
@@ -265,6 +265,13 @@ describe :file_fnmatch, shared: true do
     File.send(@method, './**/', './', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
   end
 
+  it "matches **/* with FNM_PATHNAME as if it were just **" do
+    File.send(@method, 'nested/**/*', 'nested/subdir', File::FNM_PATHNAME).should be_true
+    File.send(@method, 'nested/**/*', 'nested/subdir/file', File::FNM_PATHNAME).should be_true
+    File.send(@method, 'nested/**/*', 'nested/.dotsubdir', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+    File.send(@method, 'nested/**/*', 'nested/.dotsubir/.dotfile', File::FNM_PATHNAME | File::FNM_DOTMATCH).should be_true
+  end
+
   it "accepts an object that has a #to_path method" do
     File.send(@method, '\*', mock_to_path('a')).should == false
   end

--- a/spec/core/file/shared/fnmatch.rb
+++ b/spec/core/file/shared/fnmatch.rb
@@ -186,9 +186,11 @@ describe :file_fnmatch, shared: true do
     File.should_not.send(@method, '*/*', 'dave/.profile', File::FNM_PATHNAME)
   end
 
-  it "matches patterns with leading periods to dotfiles by default" do
+  it "matches patterns with leading periods to dotfiles" do
     File.send(@method, '.*', '.profile').should == true
+    File.send(@method, '.*', '.profile', File::FNM_PATHNAME).should == true
     File.send(@method, ".*file", "nondotfile").should == false
+    File.send(@method, ".*file", "nondotfile", File::FNM_PATHNAME).should == false
   end
 
   it "matches leading periods in filenames when flags includes FNM_DOTMATCH" do

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -57,7 +57,7 @@ class Dir
           yield dir_to_match
         end
 
-        Dir.each_child(dir) do |path|
+        Dir.children(dir)&.each do |path|
           full_path = File.join(dir, path)
           full_path.sub!(%r{^\./}, '') unless dot_slash
           if File.directory?(full_path)
@@ -73,6 +73,8 @@ class Dir
       Dir.chdir(base) do
         recurse.('.')
       end
+
+      nil
     end
 
     alias [] glob

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -33,9 +33,6 @@ class Dir
         end
       end
 
-      # remove ./ from front of patterns
-      #patterns.map! { |pattern| pattern.sub(%r{\A\./}, '') }
-
       raise ArgumentError, 'nul-separated glob pattern' if patterns.any? { |pat| pat.include?("\0") }
 
       follow_symlinks = true unless patterns.grep(/\*\*/).any?
@@ -52,8 +49,6 @@ class Dir
             dir_to_match = dir + '/'
           end
         end
-        #p({dir: dir, patterns: patterns, isdir: File.directory?(dir), symlink: File.symlink?(dir)})
-        #p patterns.map { |pattern| File.fnmatch(pattern, dir, flags) }
         if patterns.any? { |pattern| File.fnmatch(pattern, dir_to_match, flags) }
           yield dir_to_match
         end
@@ -61,7 +56,6 @@ class Dir
         Dir.each_child(dir) do |path|
           full_path = File.join(dir, path)
           full_path.sub!(%r{^\./}, '') unless dot_slash
-          #p({dir: dir, path: path, full_path: full_path, patterns: patterns, isdir: File.directory?(full_path)})
           if File.directory?(full_path)
             recurse.(full_path)
           elsif patterns.any? { |pattern| File.fnmatch(pattern, full_path, flags) }

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -33,20 +33,35 @@ class Dir
         end
       end
 
+      # remove ./ from front of patterns
+      #patterns.map! { |pattern| pattern.sub(%r{\A\./}, '') }
+
       raise ArgumentError, 'nul-separated glob pattern' if patterns.any? { |pat| pat.include?("\0") }
 
       follow_symlinks = true unless patterns.grep(/\*\*/).any?
+      start_with_dot = patterns.grep(/\A\./).any?
+      dot_slash = patterns.grep(%r{\A\./}).any?
+      end_with_slash = patterns.first.end_with?('/')
 
       recurse = lambda do |dir|
-        #p({dir: dir, patterns: patterns})
-        dir += '/' if patterns.last.end_with?('/')
-        if patterns.any? { |pattern| File.fnmatch(pattern, dir, flags) }
-          yield dir
+        dir_to_match = dir
+        if end_with_slash && !dir.end_with?('/')
+          if dir == '.' && !start_with_dot
+            dir_to_match = '/'
+          else
+            dir_to_match = dir + '/'
+          end
+        end
+        #p({dir: dir, patterns: patterns, isdir: File.directory?(dir), symlink: File.symlink?(dir)})
+        #p patterns.map { |pattern| File.fnmatch(pattern, dir, flags) }
+        if patterns.any? { |pattern| File.fnmatch(pattern, dir_to_match, flags) }
+          yield dir_to_match
         end
         return if File.symlink?(dir) && !follow_symlinks
         Dir.each_child(dir) do |path|
-          full_path = File.join(dir, path).sub(%r{^\./}, '')
-          #p({full_path: full_path, patterns: patterns})
+          full_path = File.join(dir, path)
+          full_path.sub!(%r{^\./}, '') unless dot_slash
+          #p({dir: dir, path: path, full_path: full_path, patterns: patterns, isdir: File.directory?(full_path)})
           if File.directory?(full_path)
             recurse.(full_path)
           elsif patterns.any? { |pattern| File.fnmatch(pattern, full_path, flags) }

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -10,5 +10,58 @@ class Dir
     def tmpdir
       '/tmp'
     end
+
+    def glob(patterns, flags = 0, base: nil, sort: true)
+      if sort != true && sort != false
+        raise ArgumentError, "expected true or false as sort: #{sort.inspect}"
+      end
+
+      unless block_given?
+        result = to_enum(:glob, patterns, flags, base: base).to_a
+        return sort ? result.sort : result
+      end
+
+      flags |= File::FNM_PATHNAME | File::FNM_EXTGLOB
+      base = Dir.pwd if base.nil? || base == ''
+      return unless File.directory?(base)
+
+      patterns = Array(patterns).map do |pattern|
+        if pattern.is_a?(String)
+          pattern
+        elsif pattern.respond_to?(:to_path)
+          pattern.to_path
+        end
+      end
+
+      raise ArgumentError, 'nul-separated glob pattern' if patterns.any? { |pat| pat.include?("\0") }
+
+      follow_symlinks = true unless patterns.grep(/\*\*/).any?
+
+      recurse = lambda do |dir|
+        #p({dir: dir, patterns: patterns})
+        dir += '/' if patterns.last.end_with?('/')
+        if patterns.any? { |pattern| File.fnmatch(pattern, dir, flags) }
+          yield dir
+        end
+        return if File.symlink?(dir) && !follow_symlinks
+        Dir.each_child(dir) do |path|
+          full_path = File.join(dir, path).sub(%r{^\./}, '')
+          #p({full_path: full_path, patterns: patterns})
+          if File.directory?(full_path)
+            recurse.(full_path)
+          elsif patterns.any? { |pattern| File.fnmatch(pattern, full_path, flags) }
+            yield full_path
+          end
+        end
+      rescue Errno::EACCES
+        :noop
+      end
+
+      Dir.chdir(base) do
+        recurse.('.')
+      end
+    end
+
+    alias [] glob
   end
 end

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -252,7 +252,12 @@ Value DirObject::mkdir(Env *env, Value path, Value mode) {
 }
 
 Value DirObject::pwd(Env *env) {
-    return new StringObject { std::filesystem::current_path().c_str() };
+    std::error_code ec;
+    auto path = std::filesystem::current_path(ec);
+    errno = ec.value();
+    if (errno)
+        env->raise_errno();
+    return new StringObject { path.c_str() };
 }
 
 Value DirObject::rmdir(Env *env, Value path) {

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -8,6 +8,10 @@
 
 namespace Natalie {
 
+DirObject::~DirObject() {
+    ::closedir(m_dir);
+}
+
 Value DirObject::open(Env *env, Value path, Value encoding, Block *block) {
     auto dir = new DirObject {};
     dir->initialize(env, path, encoding);

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -202,6 +202,9 @@ Value DirObject::each_child(Env *env, Block *block) {
 Value DirObject::children(Env *env, Value path, Value encoding) {
     auto dir = new DirObject {};
     dir->initialize(env, path, encoding);
+    Defer close_dir([&]() {
+        dir->close(env);
+    });
     return dir->children(env);
 }
 

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -9,7 +9,9 @@
 namespace Natalie {
 
 DirObject::~DirObject() {
-    ::closedir(m_dir);
+    if (m_dir)
+        ::closedir(m_dir);
+    m_dir = nullptr;
 }
 
 Value DirObject::open(Env *env, Value path, Value encoding, Block *block) {

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -49,6 +49,8 @@ int DirObject::fileno(Env *env) {
 }
 
 Value DirObject::close(Env *env) {
+    if (m_dir)
+        ::closedir(m_dir);
     m_dir = nullptr;
     return NilObject::the();
 }

--- a/src/file.rb
+++ b/src/file.rb
@@ -133,11 +133,15 @@ class File
     end
 
     if flags & FNM_PATHNAME != 0
+      return true if path == ".#{SEPARATOR}" && pattern.start_with?("\\.#{SEPARATOR}**")
+
       if flags & FNM_DOTMATCH == 0
-        file = File.split(path).last
-        dir = path[...-file.size]
-        file_pattern = File.split(pattern).last
-        dir_pattern = pattern[...-file_pattern.size]
+        return false if path == '.' && pattern != '\.**' && pattern != '\.*'
+
+        file = path.match(/(?<=#{SEPARATOR})[^#{SEPARATOR}]*\z/)&.to_s || path
+        dir = path.slice(0, path.size - file.size)
+        file_pattern = pattern.match(/(?<=#{SEPARATOR})[^#{SEPARATOR}]*\z/)&.to_s || pattern
+        dir_pattern = pattern.slice(0, pattern.size - file_pattern.size)
         #p(path: path, pattern: pattern, dir: dir, file: file, dir_pattern: dir_pattern, file_pattern: file_pattern)
         if dir =~ /^\.|#{SEPARATOR}\./ && dir_pattern !~ /^\\\.|#{SEPARATOR}\\\./
           # directory part of pattern does not allow hidden directories

--- a/src/file.rb
+++ b/src/file.rb
@@ -133,7 +133,7 @@ class File
     end
 
     if flags & FNM_PATHNAME != 0
-      return false if flags & FNM_DOTMATCH == 0 && path =~ /^\.|#{SEPARATOR}\./
+      return false if flags & FNM_DOTMATCH == 0 && path =~ /^\.|#{SEPARATOR}\./ && !pattern.start_with?('\.')
       pattern = pattern.gsub(/\*?\*(#{SEPARATOR}?)/) do |m|
         if m == "**#{SEPARATOR}"
           "(.*#{SEPARATOR}|^)"

--- a/src/file.rb
+++ b/src/file.rb
@@ -24,7 +24,7 @@ class File
     when 0 then ""
     when 1 then parts[0].dup
     else
-      parts.join(SEPARATOR)
+      parts.join(SEPARATOR).gsub(/#{SEPARATOR}{2,}/, SEPARATOR)
     end
   end
 

--- a/src/file.rb
+++ b/src/file.rb
@@ -155,12 +155,14 @@ class File
         end
       end
 
-      pattern = pattern.gsub(/\*\*(#{SEPARATOR}.)?|\*#{SEPARATOR}?/) do |m|
+      pattern = pattern.gsub(/\*\*(#{SEPARATOR}.?)?|\*#{SEPARATOR}?/) do |m|
         case m
         when "**#{SEPARATOR}*", "*#{SEPARATOR}*"
           '.*'
         when /^\*\*#{SEPARATOR}(.)/
-          ".*#{$1}"
+          "(.*#{SEPARATOR}|\\A)#{$1}"
+        when "**#{SEPARATOR}"
+          ".*#{SEPARATOR}"
         when '**', '*'
           "[^#{SEPARATOR}]*"
         when "*#{SEPARATOR}"

--- a/src/file.rb
+++ b/src/file.rb
@@ -142,14 +142,11 @@ class File
         dir = path.slice(0, path.size - file.size)
         file_pattern = pattern.match(/(?<=#{SEPARATOR})[^#{SEPARATOR}]*\z/)&.to_s || pattern
         dir_pattern = pattern.slice(0, pattern.size - file_pattern.size)
-        #p(path: path, pattern: pattern, dir: dir, file: file, dir_pattern: dir_pattern, file_pattern: file_pattern)
         if dir =~ /^\.|#{SEPARATOR}\./ && dir_pattern !~ /^\\\.|#{SEPARATOR}\\\./
-          #p 1
           # directory part of pattern does not allow hidden directories
           return false
         end
         if file =~ /^\.|#{SEPARATOR}\./ && file_pattern !~ /^\\\.|#{SEPARATOR}\\\./
-          #p 2
           # file part of pattern does not allow hidden files
           return false
         end
@@ -182,7 +179,6 @@ class File
     return false if pattern.include?('[]')
 
     pattern = pattern.gsub(/\[\\!/, '[^')
-    #p(pattern: pattern, path: path, match: Regexp.new('\A' + pattern + '\z').match?(path))
 
     Regexp.new('\A' + pattern + '\z').match?(path)
   end

--- a/src/file.rb
+++ b/src/file.rb
@@ -143,11 +143,13 @@ class File
         file_pattern = pattern.match(/(?<=#{SEPARATOR})[^#{SEPARATOR}]*\z/)&.to_s || pattern
         dir_pattern = pattern.slice(0, pattern.size - file_pattern.size)
         #p(path: path, pattern: pattern, dir: dir, file: file, dir_pattern: dir_pattern, file_pattern: file_pattern)
-        if dir =~ /^\.|#{SEPARATOR}\./ && dir_pattern !~ /^\\\.|#{SEPARATOR}\\\./
+        if dir =~ /^\.[^#{SEPARATOR}]|#{SEPARATOR}\./ && dir_pattern !~ /^\\\.|#{SEPARATOR}\\\./
+          #p 1
           # directory part of pattern does not allow hidden directories
           return false
         end
         if file =~ /^\.|#{SEPARATOR}\./ && file_pattern !~ /^\\\.|#{SEPARATOR}\\\./
+          #p 2
           # file part of pattern does not allow hidden files
           return false
         end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -437,12 +437,12 @@ class Matcher
   def eq(other)
     if @subject != other
       if @subject.is_a?(String) && other.is_a?(String) && (@subject.size >= MIN_STRING_SIZE_TO_RUN_DIFF || other.size >= MIN_STRING_SIZE_TO_RUN_DIFF) && $natfixme_depth == 0
-        diff(@subject, other)
+        diff(other, @subject)
         raise SpecFailedException, 'two strings should match'
       elsif @subject.is_a?(Array) && other.is_a?(Array) && (@subject.size >= MIN_ARRAY_SIZE_TO_RUN_DIFF || other.size >= MIN_ARRAY_SIZE_TO_RUN_DIFF) && $natfixme_depth == 0
         diff(
-          "[\n" + @subject.map(&:inspect).join("\n") + "\n]",
           "[\n" + other.map(&:inspect).join("\n") + "\n]",
+          "[\n" + @subject.map(&:inspect).join("\n") + "\n]",
         )
         raise SpecFailedException, @subject.inspect + ' should be == to ' + other.inspect
       else


### PR DESCRIPTION
There are some edge cases I'm leaving unimplemented. This is good-enough for any case I've seen where `Dir[]` and `Dir.glob` were used.