### PR TITLE
Add IO#syswrite

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -103,6 +103,7 @@ public:
     bool sync(Env *) const;
     Value sysread(Env *, Value, Value = nullptr);
     Value sysseek(Env *, Value, Value = nullptr);
+    Value syswrite(Env *, Value);
     IoObject *to_io(Env *);
     static Value try_convert(Env *, Value);
     Value ungetbyte(Env *, Value);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -83,7 +83,7 @@ public:
     void puts(Env *, Value);
     void putstr(Env *, StringObject *);
     void putary(Env *, ArrayObject *);
-    Value print(Env *, Args) const;
+    Value print(Env *, Args);
     Value pwrite(Env *, Value, Value);
     Value seek(Env *, Value, Value);
     Value set_close_on_exec(Env *, Value);
@@ -107,7 +107,7 @@ public:
     static Value try_convert(Env *, Value);
     Value ungetbyte(Env *, Value);
 
-    Value write(Env *, Args) const;
+    Value write(Env *, Args);
     static Value write_file(Env *, Args);
 
     Value get_path() const;
@@ -116,7 +116,7 @@ public:
 
 protected:
     void raise_if_closed(Env *) const;
-    int write(Env *, Value) const;
+    int write(Env *, Value);
 
 private:
     EncodingObject *m_external_encoding { nullptr };

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -897,6 +897,7 @@ gen.binding('IO', 'sync', 'IoObject', 'sync', argc: 0, pass_env: true, pass_bloc
 gen.binding('IO', 'sync=', 'IoObject', 'set_sync', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'sysread', 'IoObject', 'sysread', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'sysseek', 'IoObject', 'sysseek', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'syswrite', 'IoObject', 'syswrite', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'tell', 'IoObject', 'pos', argc: 0, pass_env: true, pass_block: false, aliases: ['pos'], return_type: :int)
 gen.binding('IO', 'to_io', 'IoObject', 'to_io', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetbyte', 'IoObject', 'ungetbyte', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/select_spec.rb
+++ b/spec/core/io/select_spec.rb
@@ -15,9 +15,7 @@ describe "IO.select" do
   end
 
   it "returns immediately all objects that are ready for I/O when timeout is 0" do
-    NATFIXME 'Implement IO#syswrite', exception: NoMethodError, message: "undefined method `syswrite'" do
-      @wr.syswrite("be ready")
-    end
+    @wr.syswrite("be ready")
     @wr.write("be ready")
     IO.pipe do |_, wr|
       result = IO.select [@rd], [wr], nil, 0

--- a/spec/core/io/sysread_spec.rb
+++ b/spec/core/io/sysread_spec.rb
@@ -67,11 +67,9 @@ describe "IO#sysread on a file" do
   end
 
   it "does not raise error if called after IO#read followed by IO#syswrite" do
-    NATFIXME 'Implement IO#syswrite', exception: NoMethodError, message: "undefined method `syswrite'" do
-      @file.read(5)
-      @file.syswrite("abcde")
-      -> { @file.sysread(5) }.should_not raise_error(IOError)
-    end
+    @file.read(5)
+    @file.syswrite("abcde")
+    -> { @file.sysread(5) }.should_not raise_error(IOError)
   end
 
   it "reads updated content after the flushed buffered IO#write" do
@@ -124,10 +122,8 @@ describe "IO#sysread" do
   end
 
   it "returns a smaller string if less than size bytes are available" do
-    NATFIXME 'Implement IO#syswrite', exception: NoMethodError, message: "undefined method `syswrite'" do
-      @write.syswrite "ab"
-      @read.sysread(3).should == "ab"
-    end
+    @write.syswrite "ab"
+    @read.sysread(3).should == "ab"
   end
 
   guard_not -> { platform_is :windows and ruby_version_is ""..."3.2" } do # https://bugs.ruby-lang.org/issues/18880

--- a/spec/core/io/syswrite_spec.rb
+++ b/spec/core/io/syswrite_spec.rb
@@ -1,0 +1,82 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/write'
+
+describe "IO#syswrite on a file" do
+  before :each do
+    @filename = tmp("IO_syswrite_file") + $$.to_s
+    File.open(@filename, "w") do |file|
+      file.syswrite("012345678901234567890123456789")
+    end
+    @file = File.open(@filename, "r+")
+    @readonly_file = File.open(@filename)
+  end
+
+  after :each do
+    @file.close
+    @readonly_file.close
+    rm_r @filename
+  end
+
+  it "writes all of the string's bytes but does not buffer them" do
+    written = @file.syswrite("abcde")
+    written.should == 5
+    File.open(@filename) do |file|
+      file.sysread(10).should == "abcde56789"
+      file.seek(0)
+      @file.fsync
+      file.sysread(10).should == "abcde56789"
+    end
+  end
+
+  it "does not modify the passed argument" do
+    File.open(@filename, "w") do |f|
+      f.set_encoding(Encoding::IBM437)
+      # A character whose codepoint differs between UTF-8 and IBM437
+      f.syswrite("ƒ".freeze)
+    end
+
+    File.binread(@filename).bytes.should == [198, 146]
+  end
+
+  it "warns if called immediately after a buffered IO#write" do
+    @file.write("abcde")
+    -> { @file.syswrite("fghij") }.should complain(/syswrite/)
+  end
+
+  it "does not warn if called after IO#write with intervening IO#sysread" do
+    @file.syswrite("abcde")
+    @file.sysread(5)
+    -> { @file.syswrite("fghij") }.should_not complain
+  end
+
+  it "writes to the actual file position when called after buffered IO#read" do
+    @file.read(5)
+    @file.syswrite("abcde")
+    File.open(@filename) do |file|
+      file.sysread(10).should == "01234abcde"
+    end
+  end
+end
+
+describe "IO#syswrite on a pipe" do
+  it "returns the written bytes if the fd is in nonblock mode and write would block" do
+    require 'io/nonblock'
+    r, w = IO.pipe
+    begin
+      w.nonblock = true
+      larger_than_pipe_capacity = 2 * 1024 * 1024
+      written = w.syswrite("a"*larger_than_pipe_capacity)
+      written.should > 0
+      written.should < larger_than_pipe_capacity
+    ensure
+      w.close
+      r.close
+    end
+  end
+end
+
+describe "IO#syswrite" do
+  it_behaves_like :io_write, :syswrite
+  it_behaves_like :io_write_no_transcode, :syswrite
+end

--- a/spec/core/io/syswrite_spec.rb
+++ b/spec/core/io/syswrite_spec.rb
@@ -40,8 +40,10 @@ describe "IO#syswrite on a file" do
   end
 
   it "warns if called immediately after a buffered IO#write" do
-    @file.write("abcde")
-    -> { @file.syswrite("fghij") }.should complain(/syswrite/)
+    NATFIXME 'Rewrite buffered IO to FILE * functions (like fopen(3))', exception: SpecFailedException do
+      @file.write("abcde")
+      -> { @file.syswrite("fghij") }.should complain(/syswrite/)
+    end
   end
 
   it "does not warn if called after IO#write with intervening IO#sysread" do
@@ -61,17 +63,19 @@ end
 
 describe "IO#syswrite on a pipe" do
   it "returns the written bytes if the fd is in nonblock mode and write would block" do
-    require 'io/nonblock'
-    r, w = IO.pipe
-    begin
-      w.nonblock = true
-      larger_than_pipe_capacity = 2 * 1024 * 1024
-      written = w.syswrite("a"*larger_than_pipe_capacity)
-      written.should > 0
-      written.should < larger_than_pipe_capacity
-    ensure
-      w.close
-      r.close
+    NATFIXME 'Add "io/nonblock"', exception: LoadError, message: 'cannot load such file io/nonblock' do
+      require 'io/nonblock'
+      r, w = IO.pipe
+      begin
+        w.nonblock = true
+        larger_than_pipe_capacity = 2 * 1024 * 1024
+        written = w.syswrite("a"*larger_than_pipe_capacity)
+        written.should > 0
+        written.should < larger_than_pipe_capacity
+      ensure
+        w.close
+        r.close
+      end
     end
   end
 end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -428,7 +428,7 @@ Value IoObject::copy_stream(Env *env, Value src, Value dst, Value src_length, Va
     }
 }
 
-int IoObject::write(Env *env, Value obj) const {
+int IoObject::write(Env *env, Value obj) {
     raise_if_closed(env);
     obj = obj->to_s(env);
     obj->assert_type(env, Object::Type::String, "String");
@@ -438,7 +438,7 @@ int IoObject::write(Env *env, Value obj) const {
     return result;
 }
 
-Value IoObject::write(Env *env, Args args) const {
+Value IoObject::write(Env *env, Args args) {
     args.ensure_argc_at_least(env, 1);
     int bytes_written = 0;
     for (size_t i = 0; i < args.size(); i++) {
@@ -579,7 +579,7 @@ Value IoObject::puts(Env *env, Args args) {
     return NilObject::the();
 }
 
-Value IoObject::print(Env *env, Args args) const {
+Value IoObject::print(Env *env, Args args) {
     if (args.size() > 0) {
         auto fsep = env->output_file_separator();
         auto valid_fsep = !fsep->is_nil();

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -817,6 +817,10 @@ Value IoObject::sysseek(Env *env, Value amount, Value whence) {
     return IntegerObject::create(pos(env));
 }
 
+Value IoObject::syswrite(Env *env, Value obj) {
+    return write(env, Args { obj });
+}
+
 Value IoObject::select(Env *env, Value read_ios, Value write_ios, Value error_ios, Value timeout) {
     int nfds = 0;
     timeval timeout_tv = { 0, 0 }, *timeout_ptr = nullptr;


### PR DESCRIPTION
This makes another issue with the IO show up: the buffered IO read implemented in #1354 is not the correct implementation. Instead, it should use `fopen(3)` and friends, and work wilt a `FILE` pointer instead of a fd `int`. This is kind of hidden in the docs of IO, where `sysread` is explained as `using low level functions instead`.

This changeset still does resolve some issues, so it adds some value.