### PR TITLE
Patch Prism to use Method#arity instead of Method#parameters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -154,6 +154,13 @@ task prism_templated_sources: :build_dir do
     mkdir_p dir unless File.exist?(dir)
     cp File.join(build_dir, src), full_dest
   end
+  # we don't have Method#parameters yet, so change that to use Method#arity
+  serialize_path = File.join(gen_dir, 'lib/prism/serialize.rb')
+  patched_source = File.read(serialize_path).sub(
+    '.parameters.none? { |_, name| name == :offset }',
+    '.arity == 1'
+  )
+  File.write(serialize_path, patched_source)
 end
 
 # # # # Docker Tasks (used for CI) # # # #

--- a/ext/prism-generated/lib/prism/serialize.rb
+++ b/ext/prism-generated/lib/prism/serialize.rb
@@ -8,7 +8,7 @@ if you are looking to modify the template
 require "stringio"
 
 # Polyfill for String#unpack1 with the offset parameter.
-if String.instance_method(:unpack1).parameters.none? { |_, name| name == :offset }
+if String.instance_method(:unpack1).arity == 1
   String.prepend(
     Module.new {
       def unpack1(format, offset: 0)


### PR DESCRIPTION
We don't have Method#parameters yet.