### PR TITLE
Fix `super` with keywords

### DIFF
--- a/lib/natalie/compiler/instructions/super_instruction.rb
+++ b/lib/natalie/compiler/instructions/super_instruction.rb
@@ -3,9 +3,10 @@ require_relative './base_instruction'
 module Natalie
   class Compiler
     class SuperInstruction < BaseInstruction
-      def initialize(args_array_on_stack:, with_block:)
+      def initialize(args_array_on_stack:, with_block:, has_keyword_hash: false)
         @args_array_on_stack = args_array_on_stack
         @with_block = with_block
+        @has_keyword_hash = has_keyword_hash
       end
 
       def to_s
@@ -36,7 +37,7 @@ module Natalie
         current_method_block = 'block'
         block = @with_block ? "to_block(env, #{transform.pop})" : current_method_block
 
-        transform.exec_and_push :super, "super(env, #{receiver}, Args(#{arg_count}, #{args_array_on_stack}), #{block})"
+        transform.exec_and_push :super, "super(env, #{receiver}, Args(#{arg_count}, #{args_array_on_stack}, #{@has_keyword_hash ? 'true' : 'false'}), #{block})"
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1823,6 +1823,7 @@ module Natalie
         instructions << SuperInstruction.new(
           args_array_on_stack: call_args.fetch(:args_array_on_stack),
           with_block: with_block || call_args.fetch(:with_block_pass),
+          has_keyword_hash: call_args.fetch(:has_keyword_hash)
         )
         instructions << PopInstruction.new unless used
         instructions

--- a/test/natalie/super_test.rb
+++ b/test/natalie/super_test.rb
@@ -48,6 +48,10 @@ class Greeter
   def greet_without_super
     super
   end
+
+  def greet_with_keyword(value:)
+    value
+  end
 end
 
 class PirateGreeter < Greeter
@@ -90,6 +94,10 @@ class PirateGreeter < Greeter
 
   def greet_using_block
     super { 'ARRRR. Hello using a block.' }
+  end
+
+  def greet_with_keyword
+    super(value: 'ARRRRR')
   end
 end
 
@@ -158,5 +166,10 @@ describe 'super' do
   it 'works with an aliased method' do
     greeter = PirateGreeter.new
     greeter.aliased_greet.should == 'ARRRR. Hello.'
+  end
+
+  it 'works with keyword arguments' do
+    greeter = PirateGreeter.new
+    greeter.greet_with_keyword.should == 'ARRRRR'
   end
 end


### PR DESCRIPTION
Previously the SuperInstruction did not know about keyword arguments that may be present. As a result of this, the keyword argument hash was passed as a positional argument which led to a "wrong number of arguments" error.