### PR TITLE
Add OPENSSL_VERSION and OPENSSL_VERSION_NUMBER constants

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -151,6 +151,9 @@ Value init(Env *env, Value self) {
     };
     OpenSSL->const_set("VERSION"_s, VERSION);
 
+    OpenSSL->const_set("OPENSSL_VERSION"_s, new StringObject { OPENSSL_VERSION_TEXT });
+    OpenSSL->const_set("OPENSSL_VERSION_NUMBER"_s, new IntegerObject { OPENSSL_VERSION_NUMBER });
+
     auto Digest = OpenSSL->const_get("Digest"_s);
     if (!Digest) {
         Digest = GlobalEnv::the()->Object()->subclass(env, "Digest");

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -1,0 +1,14 @@
+require_relative '../../spec/spec_helper'
+require 'openssl'
+
+describe "OpenSSL::OPENSSL_VERSION_NUMBER" do
+  it "is a number" do
+    OpenSSL::OPENSSL_VERSION_NUMBER.should be_kind_of(Integer)
+  end
+end
+
+describe "OpenSSL::OPENSSL_VERSION" do
+  it "is a string" do
+    OpenSSL::OPENSSL_VERSION.should be_kind_of(String)
+  end
+end


### PR DESCRIPTION
I'm trying to get the specs for PBKDF2 upstream (https://github.com/ruby/spec/pull/1092), and I need these constants to detect the OpenSSL version.