### PR TITLE
Refresh specs of IO#pwrite

### DIFF
--- a/spec/core/io/pwrite_spec.rb
+++ b/spec/core/io/pwrite_spec.rb
@@ -28,16 +28,42 @@ guard -> { platform_is_not :windows or ruby_version_is "3.3" } do
       @file.pread(6, 0).should == "foobar"
     end
 
+    it "calls #to_s on the object to be written" do
+      object = mock("to_s")
+      object.should_receive(:to_s).and_return("foo")
+      @file.pwrite(object, 0)
+      @file.pread(3, 0).should == "foo"
+    end
+
+    it "calls #to_int on the offset" do
+      offset = mock("to_int")
+      offset.should_receive(:to_int).and_return(2)
+      @file.pwrite("foo", offset)
+      @file.pread(3, 2).should == "foo"
+    end
+
     it "raises IOError when file is not open in write mode" do
       File.open(@fname, "r") do |file|
-        -> { file.pwrite("foo", 1) }.should raise_error(IOError)
+        -> { file.pwrite("foo", 1) }.should raise_error(IOError, "not opened for writing")
       end
     end
 
     it "raises IOError when file is closed" do
       file = File.open(@fname, "w+")
       file.close
-      -> { file.pwrite("foo", 1) }.should raise_error(IOError)
+      -> { file.pwrite("foo", 1) }.should raise_error(IOError, "closed stream")
+    end
+
+    it "raises a NoMethodError if object does not respond to #to_s" do
+      -> {
+        @file.pwrite(BasicObject.new, 0)
+      }.should raise_error(NoMethodError, /undefined method `to_s'/)
+    end
+
+    it "raises a TypeError if the offset cannot be converted to an Integer" do
+      -> {
+        @file.pwrite("foo", Object.new)
+      }.should raise_error(TypeError, "no implicit conversion of Object into Integer")
     end
   end
 end

--- a/test/natalie/io_test.rb
+++ b/test/natalie/io_test.rb
@@ -71,35 +71,9 @@ describe "IO#gets" do
   end
 end
 
-describe "IO#pwrite" do
-  before :each do
-    @name = tmp('io_pwrite')
-    @io = File.open(@name, 'w')
-  end
-
-  after :each do
-    @io.close
-    rm_r @name
-  end
-
-  it 'calls to_s on the object to be written' do
-    data = mock('data')
-    data.should_receive(:to_s).and_return('x')
-    @io.pwrite(data, 0)
-    File.read(@name).should == 'x'
-  end
-
-  it 'calls to_int on the offset' do
-    offset = mock('offset')
-    offset.should_receive(:to_int).and_return(0)
-    @io.pwrite('x', offset)
-    File.read(@name).should == 'x'
-  end
-end
-
 describe "IO#ungetbyte" do
   before :each do
-    @name = tmp('io_pwrite')
+    @name = tmp('io_ungetbyte')
     @io = File.open(@name, 'a+')
   end
 


### PR DESCRIPTION
Our local tests have been accepted upstream, so update the spec file and remove our local tests. Fix a small copy-paste oversight in the specs of IO#ungetbyte to remove the term pwrite from these tests.