### PR TITLE
Implement Fiber#hash

### DIFF
--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -140,6 +140,7 @@ public:
 #endif
     }
 
+    Value hash(Env *);
     Value inspect(Env *);
     bool is_alive() const;
     bool is_blocking() const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -548,6 +548,7 @@ gen.static_binding('Fiber', 'set_scheduler', 'FiberObject', 'set_scheduler', arg
 gen.static_binding('Fiber', 'yield', 'FiberObject', 'yield', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'alive?', 'FiberObject', 'is_alive', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Fiber', 'blocking?', 'FiberObject', 'is_blocking', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Fiber', 'hash', 'FiberObject', 'hash', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'initialize', 'FiberObject', 'initialize', argc: 0, kwargs: [:blocking, :storage], pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Fiber', 'resume', 'FiberObject', 'resume', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'status', 'FiberObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -52,6 +52,12 @@ FiberObject *FiberObject::initialize(Env *env, Value blocking, Value storage, Bl
     return this;
 }
 
+Value FiberObject::hash(Env *env) {
+    const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
+    const auto hash = String::format("{}{}{}", m_klass->inspect_str(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed), file_and_line).djb2_hash();
+    return Value::integer(hash);
+}
+
 Value FiberObject::inspect(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
     return StringObject::format("#<{}:{}{} ({})>", m_klass->inspect_str(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed), file_and_line, status(env));

--- a/test/natalie/fiber/shared/scheduler.rb
+++ b/test/natalie/fiber/shared/scheduler.rb
@@ -7,10 +7,10 @@ class Scheduler
 
   def run
     until @waiting.empty?
-      obj_id, (fiber, _) = @waiting.find { |_, (fiber, timeout)| fiber.alive? && timeout <= current_time }
+      fiber, = @waiting.find { |fiber, timeout| fiber.alive? && timeout <= current_time }
 
-      unless obj_id.nil?
-        @waiting.delete(obj_id)
+      unless fiber.nil?
+        @waiting.delete(fiber)
         fiber.resume
       end
     end
@@ -28,8 +28,7 @@ class Scheduler
       return
     end
 
-    # NATFIXME: Issues when using Fiber objects as hash key, use object_id for the time being.
-    @waiting[Fiber.current.object_id] = [Fiber.current, current_time + duration]
+    @waiting[Fiber.current] = current_time + duration
     Fiber.yield
   end
 


### PR DESCRIPTION
The default hash implementation uses the inspect string as a basis for the hash. In the case of Fibers, this includes the status, which means the hash is not stable and it breaks when we use it in a hashmap object.

We probably have the same issue with IO objects, this adds `(closed)` to the inspect string if the IO handle is closed.

Closes #1338