### PR TITLE
Fix bug in local_variable_or_write transform

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1447,6 +1447,7 @@ module Natalie
           VariableGetInstruction.new(node.name),
           ElseInstruction.new(:if),
           transform_expression(node.value, used: true),
+          DupInstruction.new,
           VariableSetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]

--- a/test/natalie/assign_test.rb
+++ b/test/natalie/assign_test.rb
@@ -240,6 +240,15 @@ describe 'assignment' do
     index.should == 5
   end
 
+  it 'can optionally assign in a when branch' do
+    text = nil
+    case 1
+    when 1
+      text ||= "test"
+    end
+    text.should == "test"
+  end
+
   it 'can optionally call an attr writer with ||=' do
     a = AttrAssign.new
     a.foo ||= 'foo'


### PR DESCRIPTION
The value that might be assigned to the local variable has to be duped. Otherwise, exiting the current scope of the conditional assignment would pop of any value of the stack that was there before, potentially erasing something from the stack that's important. This broke for instance the following example:

```ruby
case 1
when 1
  text ||= ""
end
```