### PR TITLE
Fix variable ||= and &&= compilation

### DIFF
--- a/lib/natalie/compiler/backends/cpp_backend/transform.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/transform.rb
@@ -131,6 +131,7 @@ module Natalie
           )
           yield(t)
           @stack_sizes << stack.size if @stack_sizes
+          stack.size
         end
 
         # truncate resulting stack to minimum size of any
@@ -138,7 +139,6 @@ module Natalie
         def normalize_stack
           @stack_sizes = []
           yield
-          @stack_sizes << stack.size
           @stack[@stack_sizes.min..] = []
           @stack_sizes = nil
         end

--- a/lib/natalie/compiler/instructions/if_instruction.rb
+++ b/lib/natalie/compiler/instructions/if_instruction.rb
@@ -28,15 +28,20 @@ module Natalie
 
         transform.normalize_stack do
           code << "if (#{condition}->is_truthy()) {"
-          transform.with_same_scope(true_body) do |t|
+          if_size = transform.with_same_scope(true_body) do |t|
             code << t.transform("#{result} =")
           end
 
           code << '} else {'
-          transform.with_same_scope(false_body) do |t|
+          else_size = transform.with_same_scope(false_body) do |t|
             code << t.transform("#{result} =")
           end
           code << '}'
+
+          if if_size != else_size
+            puts code
+            raise "branch sizes uneven! #{if_size} != #{else_size}"
+          end
         end
 
         transform.exec(code)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -809,15 +809,15 @@ module Natalie
       def transform_class_variable_and_write_node(node, used:)
         instructions = [
           ClassVariableGetInstruction.new(node.name, default_to_nil: true),
+          DupInstruction.new, # duplicate for falsey case
           IfInstruction.new,
+          PopInstruction.new, # remove duplicated truthy value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           ClassVariableSetInstruction.new(node.name),
-          ClassVariableGetInstruction.new(node.name),
           ElseInstruction.new(:if),
-          ClassVariableGetInstruction.new(node.name, default_to_nil: true),
           EndInstruction.new(:if)
         ]
-
         instructions << PopInstruction.new unless used
         instructions
       end
@@ -843,12 +843,13 @@ module Natalie
       def transform_class_variable_or_write_node(node, used:)
         instructions = [
           ClassVariableGetInstruction.new(node.name, default_to_nil: true),
+          DupInstruction.new, # duplicate for truthy case
           IfInstruction.new,
-          ClassVariableGetInstruction.new(node.name, default_to_nil: true),
           ElseInstruction.new(:if),
+          PopInstruction.new, # remove duplicated falsey value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           ClassVariableSetInstruction.new(node.name),
-          ClassVariableGetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]
         instructions << PopInstruction.new unless used
@@ -1148,11 +1149,13 @@ module Natalie
       def transform_global_variable_and_write_node(node, used:)
         instructions = [
           GlobalVariableGetInstruction.new(node.name),
+          DupInstruction.new, # duplicate for falsey case
           IfInstruction.new,
+          PopInstruction.new, # remove duplicated truthy value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           GlobalVariableSetInstruction.new(node.name),
           ElseInstruction.new(:if),
-          GlobalVariableGetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]
         instructions << PopInstruction.new unless used
@@ -1180,10 +1183,13 @@ module Natalie
       def transform_global_variable_or_write_node(node, used:)
         instructions = [
           GlobalVariableGetInstruction.new(node.name),
+          DupInstruction.new, # duplicate for truthy case
           IfInstruction.new,
           GlobalVariableGetInstruction.new(node.name),
           ElseInstruction.new(:if),
+          PopInstruction.new, # remove duplicated falsey value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           GlobalVariableSetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]
@@ -1273,12 +1279,14 @@ module Natalie
       def transform_instance_variable_and_write_node(node, used:)
         instructions = [
           InstanceVariableGetInstruction.new(node.name),
+          DupInstruction.new, # duplicate for falsey case
           IfInstruction.new,
+          PopInstruction.new, # remove duplicated truthy value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           InstanceVariableSetInstruction.new(node.name),
           ElseInstruction.new(:if),
-          InstanceVariableGetInstruction.new(node.name),
-          EndInstruction.new(:if),
+          EndInstruction.new(:if)
         ]
         instructions << PopInstruction.new unless used
         instructions
@@ -1305,10 +1313,13 @@ module Natalie
       def transform_instance_variable_or_write_node(node, used:)
         instructions = [
           InstanceVariableGetInstruction.new(node.name),
+          DupInstruction.new, # duplicate for truthy case
           IfInstruction.new,
           InstanceVariableGetInstruction.new(node.name),
           ElseInstruction.new(:if),
+          PopInstruction.new, # remove duplicated falsey value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           InstanceVariableSetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]
@@ -1411,11 +1422,13 @@ module Natalie
       def transform_local_variable_and_write_node(node, used:)
         instructions = [
           VariableGetInstruction.new(node.name, default_to_nil: true),
+          DupInstruction.new, # duplicate for falsey case
           IfInstruction.new,
+          PopInstruction.new, # remove duplicated truthy value
           transform_expression(node.value, used: true),
+          DupInstruction.new, # duplicate value for return
           VariableSetInstruction.new(node.name),
           ElseInstruction.new(:if),
-          VariableGetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]
         instructions << PopInstruction.new unless used
@@ -1443,11 +1456,12 @@ module Natalie
       def transform_local_variable_or_write_node(node, used:)
         instructions = [
           VariableGetInstruction.new(node.name, default_to_nil: true),
+          DupInstruction.new, # duplicate for truthy case
           IfInstruction.new,
-          VariableGetInstruction.new(node.name),
           ElseInstruction.new(:if),
+          PopInstruction.new, # remove duplicated falsey value
           transform_expression(node.value, used: true),
-          DupInstruction.new,
+          DupInstruction.new, # duplicate value for return
           VariableSetInstruction.new(node.name),
           EndInstruction.new(:if),
         ]

--- a/test/natalie/assign_test.rb
+++ b/test/natalie/assign_test.rb
@@ -190,9 +190,9 @@ describe 'assignment' do
   it 'can optionally assign a variable with ||=' do
     a ||= 1
     a.should == 1
-    a ||= 2
+    (a ||= 2).should == 1
     a.should == 1
-    a += 1
+    (a += 1).should == 2
     a.should == 2
 
     b = nil
@@ -220,11 +220,11 @@ describe 'assignment' do
     def e; :e; end
 
     h = {}
-    h[e] ||= 5
+    (h[e] ||= 5).should == 5
     h[e].should == 5
     h[e] ||= 6
     h[e].should == 5
-    h[e] += 1
+    (h[e] += 1).should == 6
     h[e].should == 6
     h[e] -= 1
     h[e].should == 5
@@ -238,6 +238,50 @@ describe 'assignment' do
 
     index = h[:e] ||= h.size
     index.should == 5
+
+    (@i ||= 1).should == 1
+    @i.should == 1
+    (@i ||= 2).should == 1
+    @i.should == 1
+    (@i &&= 3).should == 3
+    @i.should == 3
+    @i = nil
+    (@i &&= 3).should == nil
+    @i.should == nil
+    @i = 3
+    (@i += 1).should == 4
+    @i.should == 4
+
+    ($j ||= 1).should == 1
+    $j.should == 1
+    ($j ||= 2).should == 1
+    $j.should == 1
+    ($j &&= 3).should == 3
+    $j.should == 3
+    $j = nil
+    ($j &&= 3).should == nil
+    $j.should == nil
+    $j = 3
+    ($j += 1).should == 4
+    $j.should == 4
+
+    class ClassVariableHolder
+      def test
+        (@@k ||= 1).should == 1
+        @@k.should == 1
+        (@@k ||= 2).should == 1
+        @@k.should == 1
+        (@@k &&= 3).should == 3
+        @@k.should == 3
+        @@k = nil
+        (@@k &&= 3).should == nil
+        @@k.should == nil
+        @@k = 3
+        (@@k += 1).should == 4
+        @@k.should == 4
+      end
+    end
+    ClassVariableHolder.new.test
   end
 
   it 'can optionally assign in a when branch' do
@@ -259,18 +303,18 @@ describe 'assignment' do
   end
 
   it 'can optionally override a variable with &&=' do
-    a &&= 1
+    (a &&= 1).should == nil
     a.should == nil
 
     b = 1
-    b &&= 2
+    (b &&= 2).should == 2
     b.should == 2
   end
 
   it 'can add to an attr with +=' do
     a = AttrAssign.new
     a.foo = 1
-    a.foo += 2
+    (a.foo += 2).should == 3
     a.foo.should == 3
   end
 

--- a/test/natalie/assign_test.rb
+++ b/test/natalie/assign_test.rb
@@ -295,12 +295,43 @@ describe 'assignment' do
 
   it 'can optionally call an attr writer with ||=' do
     a = AttrAssign.new
-    a.foo ||= 'foo'
+    (a.foo ||= 'foo').should == 'foo'
     a.foo.should == 'foo'
 
-    a.foo ||= 'bar'
+    (a.foo ||= 'bar').should == 'foo'
     a.foo.should == 'foo'
   end
+
+  # NATFIXME: implement CallAndWriteNode
+  #it 'can optionally call an attr writer with &&=' do
+    #a = AttrAssign.new
+    #(a.foo &&= 'foo').should == nil
+    #a.foo.should == nil
+
+    #a.foo == 'foo'
+
+    #(a.foo &&= 'bar').should == 'bar'
+    #a.foo.should == 'bar'
+  #end
+
+  it 'can optionally update a ref with ||=' do
+    a = [1]
+    (a[0] ||= 'foo').should == 1
+    a[0].should == 1
+
+    (a[10] ||= 'bar').should == 'bar'
+    a[10].should == 'bar'
+  end
+
+  # NATFIXME: implement CallAndWriteNode
+  #it 'can optionally update a ref with &&=' do
+    #a = [1]
+    #(a[0] &&= 'foo').should == 'foo'
+    #a[0].should == 'foo'
+
+    #(a[1] &&= 'bar').should == nil
+    #a[1].should == nil
+  #end
 
   it 'can optionally override a variable with &&=' do
     (a &&= 1).should == nil


### PR DESCRIPTION
Following from the discovery in #1411, this should fix all the variable `||=` and `&&=` transforms.