### PR TITLE
Make MatchData#regexp spec compliant

### DIFF
--- a/spec/core/matchdata/regexp_spec.rb
+++ b/spec/core/matchdata/regexp_spec.rb
@@ -19,8 +19,6 @@ describe "MatchData#regexp" do
 
   it "returns a Regexp for the result of gsub(String)" do
     'he[[o'.gsub('[', ']')
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `regexp' for nil:NilClass" do
-      $~.regexp.should == /\[/
-    end
+    $~.regexp.should == /\[/
   end
 end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1899,6 +1899,8 @@ Value StringObject::gsub(Env *env, Value find, Value replacement_value, Block *b
             match = nullptr;
             result = result->regexp_sub(env, find->as_regexp(), replacement, &match, &expanded_replacement, start_index, block);
             if (match) {
+                Env *caller_env = env->caller();
+                caller_env->set_last_match(match);
                 start_index = match->beg_byte_index(0) + expanded_replacement->length();
                 if (match->group(0)->as_string()->is_empty() && start_index >= result->bytesize())
                     break;


### PR DESCRIPTION
The `$~` variable is already implemented. There's a similar problem with MatchData#string which I can't figure out a fix for right now, but last match needs to be set somewhere for String#gsub calls.

