### PR TITLE
Improve NATFIXME description in matchdata/regexp_spec

### DIFF
--- a/spec/core/matchdata/regexp_spec.rb
+++ b/spec/core/matchdata/regexp_spec.rb
@@ -19,7 +19,7 @@ describe "MatchData#regexp" do
 
   it "returns a Regexp for the result of gsub(String)" do
     'he[[o'.gsub('[', ']')
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `regexp' for nil:NilClass" do
+    NATFIXME 'Set $~ in String#gsub', exception: NoMethodError, message: "undefined method `regexp' for nil:NilClass" do
       $~.regexp.should == /\[/
     end
   end


### PR DESCRIPTION
This is a reaction to #1419, where @timcraft  stated "The `$~` variable is already implemented", which is true. This change should make the actual issue a bit more clear