### PR TITLE
Implement OpenSSL::HMAC

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -31,12 +31,12 @@ module OpenSSL
       new(name).hexdigest(data)
     end
 
-    def base64digest(data)
-      [digest(data)].pack('m0')
+    def base64digest(...)
+      [digest(...)].pack('m0')
     end
 
-    def hexdigest(data)
-      digest(data).unpack1('H*')
+    def hexdigest(...)
+      digest(...).unpack1('H*')
     end
 
     def self.const_missing(name)

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -52,6 +52,12 @@ module OpenSSL
     end
   end
 
+  class HMAC
+    def self.hexdigest(digest, key, data)
+      digest(digest, key, data).unpack1('H*')
+    end
+  end
+
   module KDF
     class KDFError < OpenSSLError; end
   end

--- a/spec/library/openssl/hmac/digest_spec.rb
+++ b/spec/library/openssl/hmac/digest_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+require_relative '../shared/constants'
+require 'openssl'
+
+describe "OpenSSL::HMAC.digest" do
+  it "returns an SHA1 digest" do
+    cur_digest = OpenSSL::Digest.new("SHA1")
+    cur_digest.digest.should == HMACConstants::BlankSHA1Digest
+    digest = OpenSSL::HMAC.digest(cur_digest,
+                                        HMACConstants::Key,
+                                        HMACConstants::Contents)
+    digest.should == HMACConstants::SHA1Digest
+  end
+end
+
+# Should add in similar specs for MD5, RIPEMD160, and SHA256

--- a/spec/library/openssl/hmac/hexdigest_spec.rb
+++ b/spec/library/openssl/hmac/hexdigest_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+require_relative '../shared/constants'
+require 'openssl'
+
+describe "OpenSSL::HMAC.hexdigest" do
+  it "returns an SHA1 hex digest" do
+    cur_digest = OpenSSL::Digest.new("SHA1")
+    cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
+    hexdigest = OpenSSL::HMAC.hexdigest(cur_digest,
+                                        HMACConstants::Key,
+                                        HMACConstants::Contents)
+    hexdigest.should == HMACConstants::SHA1Hexdigest
+  end
+end
+
+# Should add in similar specs for MD5, RIPEMD160, and SHA256

--- a/spec/library/openssl/hmac/hexdigest_spec.rb
+++ b/spec/library/openssl/hmac/hexdigest_spec.rb
@@ -5,7 +5,10 @@ require 'openssl'
 describe "OpenSSL::HMAC.hexdigest" do
   it "returns an SHA1 hex digest" do
     cur_digest = OpenSSL::Digest.new("SHA1")
-    cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
+    NATFIXME 'Implement OpenSSL::Digest#hexdigest with 0 arguments' do
+      cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
+    end
+    cur_digest.hexdigest('').should == HMACConstants::BlankSHA1HexDigest
     hexdigest = OpenSSL::HMAC.hexdigest(cur_digest,
                                         HMACConstants::Key,
                                         HMACConstants::Contents)

--- a/spec/library/openssl/hmac/hexdigest_spec.rb
+++ b/spec/library/openssl/hmac/hexdigest_spec.rb
@@ -5,10 +5,7 @@ require 'openssl'
 describe "OpenSSL::HMAC.hexdigest" do
   it "returns an SHA1 hex digest" do
     cur_digest = OpenSSL::Digest.new("SHA1")
-    NATFIXME 'Implement OpenSSL::Digest#hexdigest with 0 arguments' do
-      cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
-    end
-    cur_digest.hexdigest('').should == HMACConstants::BlankSHA1HexDigest
+    cur_digest.hexdigest.should == HMACConstants::BlankSHA1HexDigest
     hexdigest = OpenSSL::HMAC.hexdigest(cur_digest,
                                         HMACConstants::Key,
                                         HMACConstants::Contents)


### PR DESCRIPTION
At least: implement enough of it to pass the specs. Once again, the specs are very lacking. We'll need to write additional specs to get this to feature parity with MRI.