### PR TITLE
Eval locals

### DIFF
--- a/lib/natalie/compiler/instruction_manager.rb
+++ b/lib/natalie/compiler/instruction_manager.rb
@@ -44,6 +44,12 @@ module Natalie
         @instructions[@ip]
       end
 
+      # If you've already grabbed an instruction with `next` and you're working on it,
+      # you will need to use an offset of 2 to get back to the previous one.
+      def peek_back(offset = 1)
+        @instructions[@ip - offset]
+      end
+
       def replace_at(ip, instruction)
         raise 'expected instruction' unless instruction.is_a?(BaseInstruction)
         @instructions[ip] = instruction

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -22,12 +22,14 @@ module Natalie
 
         # We need a way to associate `retry` with the `rescue` block it
         # belongs to. Using a stack of object ids seems to work ok.
-        # See the Rescue class for how it's used.
         @retry_context = []
 
         # We need to know if we're at the top level (left-most indent)
         # of a file, which enables certain macros.
         @depth = 0
+
+        # Our MacroExpander and our REPL need to know local variables.
+        @locals_stack = []
       end
 
       INLINE_CPP_MACROS = %i[
@@ -45,8 +47,22 @@ module Natalie
 
       # pass used: true to leave the final result on the stack
       def transform(used: false)
-        raise 'unexpected AST input' unless @ast.type == :statements_node
-        transform_statements_node(@ast, used: used).flatten
+        case @ast.type
+        when :program_node
+          transform_program_node(@ast, used: used).flatten
+        when :statements_node
+          with_locals([]) do
+            transform_statements_node(@ast, used: used).flatten
+          end
+        else
+          raise 'unexpected AST input'
+        end
+      end
+
+      def transform_program_node(node, used:)
+        with_locals(node.locals) do
+          transform_statements_node(node.statements, used: used).flatten
+        end
       end
 
       def transform_expression(node, used:)
@@ -76,7 +92,8 @@ module Natalie
       end
 
       def expand_macros(node)
-        @macro_expander.expand(node, depth: @depth)
+        locals = @locals_stack.last
+        @macro_expander.expand(node, locals: locals, depth: @depth)
       end
 
       def transform_body(body, used:)
@@ -328,6 +345,7 @@ module Natalie
 
       def transform_block_node(node, used:, is_lambda:)
         arity = Arity.new(node.parameters, is_proc: !is_lambda).arity
+
         instructions = []
         instructions << DefineBlockInstruction.new(arity: arity)
         if is_lambda
@@ -335,7 +353,11 @@ module Natalie
         else
           instructions << transform_block_args(node.parameters, used: true)
         end
-        instructions << transform_expression(node.body || Prism.nil_node, used: true)
+
+        with_locals(node.locals) do
+          instructions << transform_expression(node.body || Prism.nil_node, used: true)
+        end
+
         instructions << EndInstruction.new(:define_block)
         instructions
       end
@@ -741,7 +763,9 @@ module Natalie
           file: node.location.path,
           line: node.location.start_line,
         )
-        instructions += transform_body(node.body, used: true)
+        with_locals(node.locals) do
+          instructions += transform_body(node.body, used: true)
+        end
         instructions << EndInstruction.new(:define_class)
         instructions << PopInstruction.new unless used
         instructions
@@ -860,7 +884,9 @@ module Natalie
         instructions << [
           DefineMethodInstruction.new(name: node.name, arity: arity),
           transform_defn_args(node.parameters, used: true),
-          transform_body([node.body], used: true),
+          with_locals(node.locals) do
+            transform_body([node.body], used: true)
+          end,
           EndInstruction.new(:define_method),
         ]
 
@@ -1708,7 +1734,9 @@ module Natalie
           file: node.location.path,
           line: node.location.start_line,
         )
-        instructions += transform_body(node.body, used: true)
+        with_locals(node.locals) do
+          instructions += transform_body(node.body, used: true)
+        end
         instructions << EndInstruction.new(:define_module)
         instructions << PopInstruction.new unless used
         instructions
@@ -2176,6 +2204,13 @@ module Natalie
 
       def repl?
         @compiler_context[:repl]
+      end
+
+      def with_locals(locals)
+        @locals_stack << locals
+        yield
+      ensure
+        @locals_stack.pop
       end
 
       class << self

--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -116,16 +116,16 @@ module Natalie
       end
     end
 
-    def initialize(code_str, path)
+    def initialize(code_str, path, locals: [])
       @code_str = code_str
       @path = path
+      @locals = locals
     end
 
     def ast
       Prism
-        .parse(@code_str, filepath: @path)
+        .parse(@code_str, filepath: @path, scopes: [@locals])
         .value
-        .statements
         .accept(PathVisitor.new(@path))
     end
   end

--- a/lib/natalie/repl/main.rb
+++ b/lib/natalie/repl/main.rb
@@ -27,15 +27,16 @@ module Natalie
             next :next
           end
 
-          next :continue if ast.body.empty?
-          last_node = ast.body.pop
-          ast.body << Prism.call_node(
-                        receiver: nil,
-                        name: :puts,
-                        arguments: [
-                          Prism.call_node(receiver: Prism.local_variable_write_node(name: :_, value: last_node), name: :inspect)
-                        ]
-                      )
+          next :continue if ast.statements.body.empty?
+          last_node = ast.statements.body.pop
+          puts_and_set_underscore_variable = Prism.call_node(
+            receiver: nil,
+            name: :puts,
+            arguments: [
+              Prism.call_node(receiver: Prism.local_variable_write_node(name: :_, value: last_node), name: :inspect)
+            ]
+          )
+          ast.statements.body << puts_and_set_underscore_variable
           temp = Tempfile.create('natalie.so')
           compiler = Compiler.new(ast, '(repl)')
           compiler.repl = true

--- a/lib/natalie/repl/main.rb
+++ b/lib/natalie/repl/main.rb
@@ -19,7 +19,7 @@ module Natalie
               cmd = requires.join + cmd
             end
 
-            ast = Natalie::Parser.new(cmd, '(repl)').ast
+            ast = Natalie::Parser.new(cmd, '(repl)', locals: vars.keys).ast
           rescue Parser::IncompleteExpression
             next :continue
           rescue SyntaxError => e

--- a/spec/language/alias_spec.rb
+++ b/spec/language/alias_spec.rb
@@ -53,7 +53,7 @@ describe "The alias keyword" do
   end
 
   it "works with an interpolated symbol with non-literal embedded expression on the left-hand side" do
-    NATFIXME 'implement class_eval with string (maybe)', exception: SyntaxError, message: 'eval() only works on static strings' do
+    NATFIXME 'implement class_eval with string (maybe)', exception: TypeError, message: 'eval() only works on static strings' do
       @meta.class_eval do
         eval %Q{
           alias :"#{'a' + ''.to_s}" value
@@ -92,7 +92,7 @@ describe "The alias keyword" do
   end
 
   it "works with an interpolated symbol with non-literal embedded expression on the right-hand side" do
-    NATFIXME 'implement class_eval with string (maybe)', exception: SyntaxError, message: 'eval() only works on static strings' do
+    NATFIXME 'implement class_eval with string (maybe)', exception: TypeError, message: 'eval() only works on static strings' do
       @meta.class_eval do
         eval %Q{
           alias a :"#{'value' + ''.to_s}"

--- a/test/natalie/eval_test.rb
+++ b/test/natalie/eval_test.rb
@@ -1,5 +1,3 @@
-# skip-ruby
-
 require_relative '../spec_helper'
 
 describe 'eval macro' do
@@ -10,14 +8,45 @@ describe 'eval macro' do
   it 'can compile static strings' do
     eval('1 + 1').should == 2
     eval('three').should == 3
-
-    # FIXME: need to be able to pass in locals into Parser
-    # BLOCKER: we need to implement local_variables first
-    #four = 4
-    #eval("four").should == 4
   end
 
-  it 'raises a SyntaxError for anything else' do
-    -> { eval("1 + #{1}") }.should raise_error(SyntaxError)
+  def eval_in_method_with_locals
+    two = 2
+    eval('two')
+  end
+
+  it 'can reference local variables' do
+    # in a block
+    one = 1
+    eval('one').should == 1
+
+    # in a method
+    eval_in_method_with_locals.should == 2
+
+    # in a module
+    module M
+      three = 3
+      eval('three').should == 3
+    end
+
+    # in a class
+    class C
+      four = 4
+      eval('four').should == 4
+    end
+
+    # at the top level of a program
+    ruby_exe("five = 5; print eval('five')").should == '5'
+  end
+
+  it 'raises an TypeError for interpolated strings or other values' do
+    if RUBY_ENGINE == 'natalie'
+      -> { eval("1 + #{1}") }.should raise_error(TypeError)
+    end
+    -> { eval(1) }.should raise_error(TypeError)
+  end
+
+  it 'raises a SyntaxError for invalid parse' do
+    -> { eval('())))') }.should raise_error(SyntaxError)
   end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -235,7 +235,11 @@ end
 
 def ruby_exe(code = nil, options: nil, args: nil, escape: true, exit_status: 0, env: {})
   env = env.map { |key, value| "#{key}=#{value} " }.join
-  binary = ENV['NAT_BINARY'] || 'bin/natalie'
+  binary = if RUBY_ENGINE == 'ruby'
+             'ruby'
+           else
+             ENV.fetch('NAT_BINARY', 'bin/natalie')
+           end
   if code.nil?
     return binary if args.nil?
 


### PR DESCRIPTION
This fixes `eval()` so it can see local variables like this:

```ruby
four = 4
eval('four + 5') # => 9
```

As a side effect of this work, we can remove the REPL variable hack, which is nice.