### PR TITLE
Move GlobalVariableInfo class to its own files

### DIFF
--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -5,6 +5,7 @@
 #include "natalie/encodings.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/gc.hpp"
+#include "natalie/global_variable_info.hpp"
 #include "natalie/method_missing_reason.hpp"
 #include "tm/hashmap.hpp"
 
@@ -16,20 +17,6 @@ extern "C" {
 
 class GlobalEnv : public Cell {
 public:
-    class GlobalVariableInfo : public Cell {
-    public:
-        GlobalVariableInfo(Object *object)
-            : m_object { object } { }
-
-        void set_object(Object *object) { m_object = object; }
-        Object *object() { return m_object; }
-
-        virtual void visit_children(Visitor &visitor) override final;
-
-    private:
-        class Object *m_object { nullptr };
-    };
-
     static GlobalEnv *the() {
         if (s_instance)
             return s_instance;

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "natalie/forward.hpp"
+#include "natalie/gc.hpp"
+
+namespace Natalie {
+class GlobalVariableInfo : public Cell {
+public:
+    GlobalVariableInfo(Object *object)
+        : m_object { object } { }
+
+    void set_object(Object *object) { m_object = object; }
+    Object *object() { return m_object; }
+
+    virtual void visit_children(Visitor &visitor) override final;
+
+private:
+    class Object *m_object { nullptr };
+};
+
+}

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -33,7 +33,7 @@ Value GlobalEnv::global_set(Env *env, SymbolObject *name, Value val) {
     if (info) {
         info->set_object(val.object());
     } else {
-        auto info = new GlobalEnv::GlobalVariableInfo { val.object() };
+        auto info = new GlobalVariableInfo { val.object() };
         m_global_variables.put(name, info, env);
     }
     return val;
@@ -76,10 +76,6 @@ void GlobalEnv::visit_children(Visitor &visitor) {
     visitor.visit(m_Time);
     visitor.visit(m_main_obj);
     visitor.visit(m_main_env);
-}
-
-void GlobalEnv::GlobalVariableInfo::visit_children(Visitor &visitor) {
-    visitor.visit(m_object);
 }
 
 }

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -1,0 +1,9 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+void GlobalVariableInfo::visit_children(Visitor &visitor) {
+    visitor.visit(m_object);
+}
+
+}


### PR DESCRIPTION
This seems to fix the bug compiling with GCC 13.2 described in #1425.