### PR TITLE
Implement OpenSSL::X509::Name.parse

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -353,6 +353,7 @@ public:
 
     ArrayObject *to_ary(Env *env);
     FloatObject *to_f(Env *env);
+    HashObject *to_hash(Env *env);
     IoObject *to_io(Env *env);
     IntegerObject *to_int(Env *env);
     StringObject *to_s(Env *env);

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -118,20 +118,21 @@ module Natalie
         )
       end
 
-      def generate_constant(transform, name, type)
+      def generate_constant(transform, name, type, value = name)
         name = comptime_string(name)
         type = comptime_string(type)
+        value = comptime_string(value)
 
         code = case type
                when 'int', 'unsigned short'
-                 "self->const_set(\"#{name}\"_s, Value::integer(#{name}))"
+                 "self->const_set(\"#{name}\"_s, Value::integer(#{value}))"
                when 'bigint'
-                 "self->const_set(\"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{name}))));"
+                 "self->const_set(\"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
                else
                  raise "I don't yet know how to handle constant of type #{type.inspect}"
                end
 
-        transform.exec("#ifdef #{name}")
+        transform.exec("#ifdef #{value}")
         transform.exec(code)
         transform.exec('#endif')
         transform.push_nil

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -364,38 +364,6 @@ Value init(Env *env, Value self) {
     OpenSSL->const_set("OPENSSL_VERSION_NUMBER"_s, new IntegerObject { OPENSSL_VERSION_NUMBER });
     OpenSSL->define_singleton_method(env, "fixed_length_secure_compare"_s, OpenSSL_fixed_length_secure_compare, 2);
 
-    auto ASN1 = OpenSSL->const_get("ASN1"_s);
-    if (!ASN1) {
-        ASN1 = new ModuleObject { "ASN1" };
-        OpenSSL->const_set("ASN1"_s, ASN1);
-    }
-    ASN1->const_set("EOC"_s, Value::integer(V_ASN1_EOC));
-    ASN1->const_set("BOOLEAN"_s, Value::integer(V_ASN1_BOOLEAN));
-    ASN1->const_set("INTEGER"_s, Value::integer(V_ASN1_INTEGER));
-    ASN1->const_set("BIT_STRING"_s, Value::integer(V_ASN1_BIT_STRING));
-    ASN1->const_set("OCTET_STRING"_s, Value::integer(V_ASN1_OCTET_STRING));
-    ASN1->const_set("NULL"_s, Value::integer(V_ASN1_NULL));
-    ASN1->const_set("OBJECT"_s, Value::integer(V_ASN1_OBJECT));
-    ASN1->const_set("OBJECT_DESCRIPTOR"_s, Value::integer(V_ASN1_OBJECT_DESCRIPTOR));
-    ASN1->const_set("EXTERNAL"_s, Value::integer(V_ASN1_EXTERNAL));
-    ASN1->const_set("REAL"_s, Value::integer(V_ASN1_REAL));
-    ASN1->const_set("ENUMERATED"_s, Value::integer(V_ASN1_ENUMERATED));
-    ASN1->const_set("UTF8STRING"_s, Value::integer(V_ASN1_UTF8STRING));
-    ASN1->const_set("SEQUENCE"_s, Value::integer(V_ASN1_SEQUENCE));
-    ASN1->const_set("SET"_s, Value::integer(V_ASN1_SET));
-    ASN1->const_set("NUMERICSTRING"_s, Value::integer(V_ASN1_NUMERICSTRING));
-    ASN1->const_set("PRINTABLESTRING"_s, Value::integer(V_ASN1_PRINTABLESTRING));
-    ASN1->const_set("T61STRING"_s, Value::integer(V_ASN1_T61STRING));
-    ASN1->const_set("VIDEOTEXSTRING"_s, Value::integer(V_ASN1_VIDEOTEXSTRING));
-    ASN1->const_set("IA5STRING"_s, Value::integer(V_ASN1_IA5STRING));
-    ASN1->const_set("UTCTIME"_s, Value::integer(V_ASN1_UTCTIME));
-    ASN1->const_set("GENERALIZEDTIME"_s, Value::integer(V_ASN1_GENERALIZEDTIME));
-    ASN1->const_set("GRAPHICSTRING"_s, Value::integer(V_ASN1_GRAPHICSTRING));
-    ASN1->const_set("ISO64STRING"_s, Value::integer(V_ASN1_ISO64STRING));
-    ASN1->const_set("GENERALSTRING"_s, Value::integer(V_ASN1_GENERALSTRING));
-    ASN1->const_set("UNIVERSALSTRING"_s, Value::integer(V_ASN1_UNIVERSALSTRING));
-    ASN1->const_set("BMPSTRING"_s, Value::integer(V_ASN1_BMPSTRING));
-
     auto Cipher = OpenSSL->const_get("Cipher"_s);
     if (!Cipher) {
         Cipher = GlobalEnv::the()->Object()->subclass(env, "Cipher");

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -364,6 +364,38 @@ Value init(Env *env, Value self) {
     OpenSSL->const_set("OPENSSL_VERSION_NUMBER"_s, new IntegerObject { OPENSSL_VERSION_NUMBER });
     OpenSSL->define_singleton_method(env, "fixed_length_secure_compare"_s, OpenSSL_fixed_length_secure_compare, 2);
 
+    auto ASN1 = OpenSSL->const_get("ASN1"_s);
+    if (!ASN1) {
+        ASN1 = new ModuleObject { "ASN1" };
+        OpenSSL->const_set("ASN1"_s, ASN1);
+    }
+    ASN1->const_set("EOC"_s, Value::integer(V_ASN1_EOC));
+    ASN1->const_set("BOOLEAN"_s, Value::integer(V_ASN1_BOOLEAN));
+    ASN1->const_set("INTEGER"_s, Value::integer(V_ASN1_INTEGER));
+    ASN1->const_set("BIT_STRING"_s, Value::integer(V_ASN1_BIT_STRING));
+    ASN1->const_set("OCTET_STRING"_s, Value::integer(V_ASN1_OCTET_STRING));
+    ASN1->const_set("NULL"_s, Value::integer(V_ASN1_NULL));
+    ASN1->const_set("OBJECT"_s, Value::integer(V_ASN1_OBJECT));
+    ASN1->const_set("OBJECT_DESCRIPTOR"_s, Value::integer(V_ASN1_OBJECT_DESCRIPTOR));
+    ASN1->const_set("EXTERNAL"_s, Value::integer(V_ASN1_EXTERNAL));
+    ASN1->const_set("REAL"_s, Value::integer(V_ASN1_REAL));
+    ASN1->const_set("ENUMERATED"_s, Value::integer(V_ASN1_ENUMERATED));
+    ASN1->const_set("UTF8STRING"_s, Value::integer(V_ASN1_UTF8STRING));
+    ASN1->const_set("SEQUENCE"_s, Value::integer(V_ASN1_SEQUENCE));
+    ASN1->const_set("SET"_s, Value::integer(V_ASN1_SET));
+    ASN1->const_set("NUMERICSTRING"_s, Value::integer(V_ASN1_NUMERICSTRING));
+    ASN1->const_set("PRINTABLESTRING"_s, Value::integer(V_ASN1_PRINTABLESTRING));
+    ASN1->const_set("T61STRING"_s, Value::integer(V_ASN1_T61STRING));
+    ASN1->const_set("VIDEOTEXSTRING"_s, Value::integer(V_ASN1_VIDEOTEXSTRING));
+    ASN1->const_set("IA5STRING"_s, Value::integer(V_ASN1_IA5STRING));
+    ASN1->const_set("UTCTIME"_s, Value::integer(V_ASN1_UTCTIME));
+    ASN1->const_set("GENERALIZEDTIME"_s, Value::integer(V_ASN1_GENERALIZEDTIME));
+    ASN1->const_set("GRAPHICSTRING"_s, Value::integer(V_ASN1_GRAPHICSTRING));
+    ASN1->const_set("ISO64STRING"_s, Value::integer(V_ASN1_ISO64STRING));
+    ASN1->const_set("GENERALSTRING"_s, Value::integer(V_ASN1_GENERALSTRING));
+    ASN1->const_set("UNIVERSALSTRING"_s, Value::integer(V_ASN1_UNIVERSALSTRING));
+    ASN1->const_set("BMPSTRING"_s, Value::integer(V_ASN1_BMPSTRING));
+
     auto Cipher = OpenSSL->const_get("Cipher"_s);
     if (!Cipher) {
         Cipher = GlobalEnv::the()->Object()->subclass(env, "Cipher");

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -117,8 +117,14 @@ module OpenSSL
         'emailAddress' => ASN1::IA5STRING
       }.tap { |hash| hash.default = ASN1::UTF8STRING }.freeze
 
+      __constant__('COMPAT', 'int', 'XN_FLAG_COMPAT')
+      __constant__('RFC2253', 'int', 'XN_FLAG_RFC2253')
+      __constant__('ONELINE', 'int', 'XN_FLAG_ONELINE')
+      __constant__('MULTILINE', 'int', 'XN_FLAG_MULTILINE')
+
       __bind_method__ :initialize, :OpenSSL_X509_Name_initialize
       __bind_method__ :add_entry, :OpenSSL_X509_Name_add_entry
+      __bind_method__ :to_s, :OpenSSL_X509_Name_to_s
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -124,6 +124,7 @@ module OpenSSL
 
       __bind_method__ :initialize, :OpenSSL_X509_Name_initialize
       __bind_method__ :add_entry, :OpenSSL_X509_Name_add_entry
+      __bind_method__ :to_a, :OpenSSL_X509_Name_to_a
       __bind_method__ :to_s, :OpenSSL_X509_Name_to_s
     end
   end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -104,6 +104,8 @@ module OpenSSL
   end
 
   module X509
+    class NameError < OpenSSLError; end
+
     class Name
       OBJECT_TYPE_TEMPLATE = {
         'C' => ASN1::PRINTABLESTRING,
@@ -114,6 +116,8 @@ module OpenSSL
         'domainComponent' => ASN1::IA5STRING,
         'emailAddress' => ASN1::IA5STRING
       }.tap { |hash| hash.default = ASN1::UTF8STRING }.freeze
+
+      __bind_method__ :initialize, :OpenSSL_X509_Name_initialize
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -102,4 +102,18 @@ module OpenSSL
   module KDF
     class KDFError < OpenSSLError; end
   end
+
+  module X509
+    class Name
+      OBJECT_TYPE_TEMPLATE = {
+        'C' => ASN1::PRINTABLESTRING,
+        'countryName' => ASN1::PRINTABLESTRING,
+        'serialNumber' => ASN1::PRINTABLESTRING,
+        'dnQualifier' => ASN1::PRINTABLESTRING,
+        'DC' => ASN1::IA5STRING,
+        'domainComponent' => ASN1::IA5STRING,
+        'emailAddress' => ASN1::IA5STRING
+      }.tap { |hash| hash.default = ASN1::UTF8STRING }.freeze
+    end
+  end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -126,6 +126,21 @@ module OpenSSL
       __bind_method__ :add_entry, :OpenSSL_X509_Name_add_entry
       __bind_method__ :to_a, :OpenSSL_X509_Name_to_a
       __bind_method__ :to_s, :OpenSSL_X509_Name_to_s
+
+      class <<self
+        def parse_openssl(str, template = OBJECT_TYPE_TEMPLATE)
+          ary = if str.start_with?('/')
+                  str.split('/')[1..-1]
+                else
+                  str.split(/,\s*/)
+                end
+          ary = ary.map { |e| e.split('=') }
+          raise TypeError, 'invalid OpenSSL::X509::Name input' unless ary.all? { |e| e.size == 2}
+          new(ary, template)
+        end
+
+        alias parse parse_openssl
+      end
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -118,6 +118,7 @@ module OpenSSL
       }.tap { |hash| hash.default = ASN1::UTF8STRING }.freeze
 
       __bind_method__ :initialize, :OpenSSL_X509_Name_initialize
+      __bind_method__ :add_entry, :OpenSSL_X509_Name_add_entry
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -12,6 +12,35 @@ module OpenSSL
     fixed_length_secure_compare(sha1_a, sha1_b) && a == b
   end
 
+  module ASN1
+    __constant__('EOC', 'int', 'V_ASN1_EOC')
+    __constant__('BOOLEAN', 'int', 'V_ASN1_BOOLEAN')
+    __constant__('INTEGER', 'int', 'V_ASN1_INTEGER')
+    __constant__('BIT_STRING', 'int', 'V_ASN1_BIT_STRING')
+    __constant__('OCTET_STRING', 'int', 'V_ASN1_OCTET_STRING')
+    __constant__('NULL', 'int', 'V_ASN1_NULL')
+    __constant__('OBJECT', 'int', 'V_ASN1_OBJECT')
+    __constant__('OBJECT_DESCRIPTOR', 'int', 'V_ASN1_OBJECT_DESCRIPTOR')
+    __constant__('EXTERNAL', 'int', 'V_ASN1_EXTERNAL')
+    __constant__('REAL', 'int', 'V_ASN1_REAL')
+    __constant__('ENUMERATED', 'int', 'V_ASN1_ENUMERATED')
+    __constant__('UTF8STRING', 'int', 'V_ASN1_UTF8STRING')
+    __constant__('SEQUENCE', 'int', 'V_ASN1_SEQUENCE')
+    __constant__('SET', 'int', 'V_ASN1_SET')
+    __constant__('NUMERICSTRING', 'int', 'V_ASN1_NUMERICSTRING')
+    __constant__('PRINTABLESTRING', 'int', 'V_ASN1_PRINTABLESTRING')
+    __constant__('T61STRING', 'int', 'V_ASN1_T61STRING')
+    __constant__('VIDEOTEXSTRING', 'int', 'V_ASN1_VIDEOTEXSTRING')
+    __constant__('IA5STRING', 'int', 'V_ASN1_IA5STRING')
+    __constant__('UTCTIME', 'int', 'V_ASN1_UTCTIME')
+    __constant__('GENERALIZEDTIME', 'int', 'V_ASN1_GENERALIZEDTIME')
+    __constant__('GRAPHICSTRING', 'int', 'V_ASN1_GRAPHICSTRING')
+    __constant__('ISO64STRING', 'int', 'V_ASN1_ISO64STRING')
+    __constant__('GENERALSTRING', 'int', 'V_ASN1_GENERALSTRING')
+    __constant__('UNIVERSALSTRING', 'int', 'V_ASN1_UNIVERSALSTRING')
+    __constant__('BMPSTRING', 'int', 'V_ASN1_BMPSTRING')
+  end
+
   module Random
     __bind_static_method__ :random_bytes, :OpenSSL_Random_random_bytes
   end

--- a/spec/library/openssl/x509/name/parse_spec.rb
+++ b/spec/library/openssl/x509/name/parse_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../../../spec_helper'
+require 'openssl'
+
+describe "OpenSSL::X509::Name.parse" do
+  it "parses a /-delimited string of key-value pairs into a Name" do
+    dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
+    name = OpenSSL::X509::Name.parse(dn)
+
+    name.to_s.should == dn
+
+    ary = name.to_a
+
+    ary[0][0].should == "DC"
+    ary[1][0].should == "DC"
+    ary[2][0].should == "CN"
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+    ary[0][2].should == OpenSSL::ASN1::IA5STRING
+    ary[1][2].should == OpenSSL::ASN1::IA5STRING
+    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+  end
+
+  it "parses a comma-delimited string of key-value pairs into a name" do
+    dn = "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
+    name = OpenSSL::X509::Name.parse(dn)
+
+    name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
+
+    ary = name.to_a
+
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+  end
+
+  it "raises TypeError if the given string contains no key/value pairs" do
+    -> do
+      OpenSSL::X509::Name.parse("hello")
+    end.should raise_error(TypeError)
+  end
+
+  it "raises OpenSSL::X509::NameError if the given string contains invalid keys" do
+    -> do
+      OpenSSL::X509::Name.parse("hello=goodbye")
+    end.should raise_error(OpenSSL::X509::NameError)
+  end
+end

--- a/spec/library/openssl/x509/name/parse_spec.rb
+++ b/spec/library/openssl/x509/name/parse_spec.rb
@@ -4,13 +4,7 @@ require 'openssl'
 describe "OpenSSL::X509::Name.parse" do
   it "parses a /-delimited string of key-value pairs into a Name" do
     dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
-    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: NoMethodError, message: "undefined method `parse' for OpenSSL::X509::Name:Class" do
-      name = OpenSSL::X509::Name.parse(dn)
-    end
-    name = OpenSSL::X509::Name.new
-    name.add_entry('DC', 'org')
-    name.add_entry('DC', 'ruby-lang')
-    name.add_entry('CN', 'www.ruby-lang.org')
+    name = OpenSSL::X509::Name.parse(dn)
 
     name.to_s.should == dn
 
@@ -29,13 +23,7 @@ describe "OpenSSL::X509::Name.parse" do
 
   it "parses a comma-delimited string of key-value pairs into a name" do
     dn = "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
-    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: NoMethodError, message: "undefined method `parse' for OpenSSL::X509::Name:Class" do
-      name = OpenSSL::X509::Name.parse(dn)
-    end
-    name = OpenSSL::X509::Name.new
-    name.add_entry('DC', 'org')
-    name.add_entry('DC', 'ruby-lang')
-    name.add_entry('CN', 'www.ruby-lang.org')
+    name = OpenSSL::X509::Name.parse(dn)
 
     name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
 
@@ -47,18 +35,14 @@ describe "OpenSSL::X509::Name.parse" do
   end
 
   it "raises TypeError if the given string contains no key/value pairs" do
-    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: SpecFailedException do
-      -> do
-        OpenSSL::X509::Name.parse("hello")
-      end.should raise_error(TypeError)
-    end
+    -> do
+      OpenSSL::X509::Name.parse("hello")
+    end.should raise_error(TypeError)
   end
 
   it "raises OpenSSL::X509::NameError if the given string contains invalid keys" do
-    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: SpecFailedException do
-      -> do
-        OpenSSL::X509::Name.parse("hello=goodbye")
-      end.should raise_error(OpenSSL::X509::NameError)
-    end
+    -> do
+      OpenSSL::X509::Name.parse("hello=goodbye")
+    end.should raise_error(OpenSSL::X509::NameError)
   end
 end

--- a/spec/library/openssl/x509/name/parse_spec.rb
+++ b/spec/library/openssl/x509/name/parse_spec.rb
@@ -4,45 +4,65 @@ require 'openssl'
 describe "OpenSSL::X509::Name.parse" do
   it "parses a /-delimited string of key-value pairs into a Name" do
     dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
-    name = OpenSSL::X509::Name.parse(dn)
+    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: NoMethodError, message: "undefined method `parse' for OpenSSL::X509::Name:Class" do
+      name = OpenSSL::X509::Name.parse(dn)
+    end
+    name = OpenSSL::X509::Name.new
+    name.add_entry('DC', 'org')
+    name.add_entry('DC', 'ruby-lang')
+    name.add_entry('CN', 'www.ruby-lang.org')
 
     name.to_s.should == dn
 
-    ary = name.to_a
+    NATFIXME 'Implement OpenSSL::X509::Name#to_a', exception: NoMethodError, message: "undefined method `to_a'" do
+      ary = name.to_a
 
-    ary[0][0].should == "DC"
-    ary[1][0].should == "DC"
-    ary[2][0].should == "CN"
-    ary[0][1].should == "org"
-    ary[1][1].should == "ruby-lang"
-    ary[2][1].should == "www.ruby-lang.org"
-    ary[0][2].should == OpenSSL::ASN1::IA5STRING
-    ary[1][2].should == OpenSSL::ASN1::IA5STRING
-    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+      ary[0][0].should == "DC"
+      ary[1][0].should == "DC"
+      ary[2][0].should == "CN"
+      ary[0][1].should == "org"
+      ary[1][1].should == "ruby-lang"
+      ary[2][1].should == "www.ruby-lang.org"
+      ary[0][2].should == OpenSSL::ASN1::IA5STRING
+      ary[1][2].should == OpenSSL::ASN1::IA5STRING
+      ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+    end
   end
 
   it "parses a comma-delimited string of key-value pairs into a name" do
     dn = "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
-    name = OpenSSL::X509::Name.parse(dn)
+    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: NoMethodError, message: "undefined method `parse' for OpenSSL::X509::Name:Class" do
+      name = OpenSSL::X509::Name.parse(dn)
+    end
+    name = OpenSSL::X509::Name.new
+    name.add_entry('DC', 'org')
+    name.add_entry('DC', 'ruby-lang')
+    name.add_entry('CN', 'www.ruby-lang.org')
 
     name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
 
-    ary = name.to_a
+    NATFIXME 'Implement OpenSSL::X509::Name#to_a', exception: NoMethodError, message: "undefined method `to_a'" do
+      ary = name.to_a
 
-    ary[0][1].should == "org"
-    ary[1][1].should == "ruby-lang"
-    ary[2][1].should == "www.ruby-lang.org"
+      ary[0][1].should == "org"
+      ary[1][1].should == "ruby-lang"
+      ary[2][1].should == "www.ruby-lang.org"
+    end
   end
 
   it "raises TypeError if the given string contains no key/value pairs" do
-    -> do
-      OpenSSL::X509::Name.parse("hello")
-    end.should raise_error(TypeError)
+    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: SpecFailedException do
+      -> do
+        OpenSSL::X509::Name.parse("hello")
+      end.should raise_error(TypeError)
+    end
   end
 
   it "raises OpenSSL::X509::NameError if the given string contains invalid keys" do
-    -> do
-      OpenSSL::X509::Name.parse("hello=goodbye")
-    end.should raise_error(OpenSSL::X509::NameError)
+    NATFIXME 'Implement OpenSSL::X509::Name.parse', exception: SpecFailedException do
+      -> do
+        OpenSSL::X509::Name.parse("hello=goodbye")
+      end.should raise_error(OpenSSL::X509::NameError)
+    end
   end
 end

--- a/spec/library/openssl/x509/name/parse_spec.rb
+++ b/spec/library/openssl/x509/name/parse_spec.rb
@@ -14,19 +14,17 @@ describe "OpenSSL::X509::Name.parse" do
 
     name.to_s.should == dn
 
-    NATFIXME 'Implement OpenSSL::X509::Name#to_a', exception: NoMethodError, message: "undefined method `to_a'" do
-      ary = name.to_a
+    ary = name.to_a
 
-      ary[0][0].should == "DC"
-      ary[1][0].should == "DC"
-      ary[2][0].should == "CN"
-      ary[0][1].should == "org"
-      ary[1][1].should == "ruby-lang"
-      ary[2][1].should == "www.ruby-lang.org"
-      ary[0][2].should == OpenSSL::ASN1::IA5STRING
-      ary[1][2].should == OpenSSL::ASN1::IA5STRING
-      ary[2][2].should == OpenSSL::ASN1::UTF8STRING
-    end
+    ary[0][0].should == "DC"
+    ary[1][0].should == "DC"
+    ary[2][0].should == "CN"
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+    ary[0][2].should == OpenSSL::ASN1::IA5STRING
+    ary[1][2].should == OpenSSL::ASN1::IA5STRING
+    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
   end
 
   it "parses a comma-delimited string of key-value pairs into a name" do
@@ -41,13 +39,11 @@ describe "OpenSSL::X509::Name.parse" do
 
     name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
 
-    NATFIXME 'Implement OpenSSL::X509::Name#to_a', exception: NoMethodError, message: "undefined method `to_a'" do
-      ary = name.to_a
+    ary = name.to_a
 
-      ary[0][1].should == "org"
-      ary[1][1].should == "ruby-lang"
-      ary[2][1].should == "www.ruby-lang.org"
-    end
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
   end
 
   it "raises TypeError if the given string contains no key/value pairs" do

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1308,6 +1308,35 @@ FloatObject *Object::to_f(Env *env) {
     return result->as_float();
 }
 
+HashObject *Object::to_hash(Env *env) {
+    if (is_hash()) {
+        return as_hash();
+    }
+
+    auto original_class = klass()->inspect_str();
+
+    auto to_hash = "to_hash"_s;
+
+    if (!respond_to(env, to_hash)) {
+        if (is_nil()) {
+            env->raise("TypeError", "no implicit conversion of nil into Hash");
+        }
+        env->raise("TypeError", "no implicit conversion of {} into Hash", original_class);
+    }
+
+    Value val = send(env, to_hash);
+
+    if (val->is_hash()) {
+        return val->as_hash();
+    }
+
+    env->raise(
+        "TypeError", "can't convert {} to Hash ({}#to_hash gives {})",
+        original_class,
+        original_class,
+        val->klass()->inspect_str());
+}
+
 StringObject *Object::to_s(Env *env) {
     auto str = send(env, "to_s"_s);
     if (!str->is_string())

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -131,6 +131,29 @@ describe "OpenSSL::X509::Name#initialize" do
     ary[1][2].should == OpenSSL::ASN1::IA5STRING
     ary[2][2].should == OpenSSL::ASN1::UTF8STRING
   end
+
+  it "can use a custom template" do
+    template = { "DC" => OpenSSL::ASN1::UTF8STRING}
+    template.default = OpenSSL::ASN1::IA5STRING
+    input = [
+      ["DC", "org"],
+      ["DC", "ruby-lang"],
+      ["CN", "www.ruby-lang.org"]
+    ]
+    name = OpenSSL::X509::Name.new(input, template)
+
+    ary = name.to_a
+
+    ary[0][0].should == "DC"
+    ary[1][0].should == "DC"
+    ary[2][0].should == "CN"
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+    ary[0][2].should == OpenSSL::ASN1::UTF8STRING
+    ary[1][2].should == OpenSSL::ASN1::UTF8STRING
+    ary[2][2].should == OpenSSL::ASN1::IA5STRING
+  end
 end
 
 describe "OpenSSL::X509::Name#to_s" do

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -88,3 +88,22 @@ describe "OpenSSL.secure_compare" do
     }.should raise_error(TypeError, 'no implicit conversion of Object into String')
   end
 end
+
+describe "OpenSSL::X509::Name#to_s" do
+  it "returns the correct string" do
+    name = OpenSSL::X509::Name.new
+    name.add_entry("DC", "org")
+    name.add_entry("DC", "ruby-lang")
+    name.add_entry("CN", "www.ruby-lang.org")
+
+    name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
+    name.to_s(OpenSSL::X509::Name::COMPAT).should == "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
+    name.to_s(OpenSSL::X509::Name::RFC2253).should == "CN=www.ruby-lang.org,DC=ruby-lang,DC=org"
+    name.to_s(OpenSSL::X509::Name::ONELINE).should == "DC = org, DC = ruby-lang, CN = www.ruby-lang.org"
+    name.to_s(OpenSSL::X509::Name::MULTILINE).should == <<~NAME.chomp
+      domainComponent           = org
+      domainComponent           = ruby-lang
+      commonName                = www.ruby-lang.org
+    NAME
+  end
+end

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -89,6 +89,50 @@ describe "OpenSSL.secure_compare" do
   end
 end
 
+describe "OpenSSL::X509::Name#initialize" do
+  it "can handle input with types" do
+    input = [
+      ["DC", "org", OpenSSL::ASN1::IA5STRING],
+      ["DC", "ruby-lang", OpenSSL::ASN1::IA5STRING],
+      ["CN", "www.ruby-lang.org", OpenSSL::ASN1::UTF8STRING]
+    ]
+    name = OpenSSL::X509::Name.new(input)
+
+    ary = name.to_a
+
+    ary[0][0].should == "DC"
+    ary[1][0].should == "DC"
+    ary[2][0].should == "CN"
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+    ary[0][2].should == OpenSSL::ASN1::IA5STRING
+    ary[1][2].should == OpenSSL::ASN1::IA5STRING
+    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+  end
+
+  it "can handle input without types" do
+    input = [
+      ["DC", "org"],
+      ["DC", "ruby-lang"],
+      ["CN", "www.ruby-lang.org"]
+    ]
+    name = OpenSSL::X509::Name.new(input)
+
+    ary = name.to_a
+
+    ary[0][0].should == "DC"
+    ary[1][0].should == "DC"
+    ary[2][0].should == "CN"
+    ary[0][1].should == "org"
+    ary[1][1].should == "ruby-lang"
+    ary[2][1].should == "www.ruby-lang.org"
+    ary[0][2].should == OpenSSL::ASN1::IA5STRING
+    ary[1][2].should == OpenSSL::ASN1::IA5STRING
+    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+  end
+end
+
 describe "OpenSSL::X509::Name#to_s" do
   it "returns the correct string" do
     name = OpenSSL::X509::Name.new


### PR DESCRIPTION
I was just trying to finish up the remaining specs for OpenSSL. It turns out this test is pretty much an integration test, it needs a bunch of additional methods implemented before I can even start working on the spec itself. And the last OpenSSL spec looks even worse in terms of functionality required to even run the test.
But at least I'm learning a lot about OpenSSL this way :partying_face: 