### PR TITLE
Add Object::to_hash

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -353,6 +353,7 @@ public:
 
     ArrayObject *to_ary(Env *env);
     FloatObject *to_f(Env *env);
+    HashObject *to_hash(Env *env);
     IoObject *to_io(Env *env);
     IntegerObject *to_int(Env *env);
     StringObject *to_s(Env *env);

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -215,14 +215,14 @@ Value HashObject::square_new(Env *env, Args args, ClassObject *klass) {
     } else if (args.size() == 1) {
         Value value = args[0];
         if (!value->is_hash() && value->respond_to(env, "to_hash"_s))
-            value = value.send(env, "to_hash"_s);
+            value = value->to_hash(env);
         if (value->is_hash()) {
             auto hash = new HashObject { env, *value->as_hash() };
             hash->m_klass = klass;
             return hash;
         } else {
             if (!value->is_array() && value->respond_to(env, "to_ary"_s))
-                value = value.send(env, "to_ary"_s);
+                value = value->to_ary(env);
             if (value->is_array()) {
                 HashObject *hash = new HashObject { klass };
                 for (auto &pair : *value->as_array()) {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -331,11 +331,7 @@ Value HashObject::rehash(Env *env) {
 }
 
 Value HashObject::replace(Env *env, Value other) {
-    if (!other->is_hash() && other->respond_to(env, "to_hash"_s))
-        other = other->send(env, "to_hash"_s);
-    other->assert_type(env, Type::Hash, "Hash");
-
-    auto other_hash = other->as_hash();
+    auto other_hash = other->to_hash(env);
 
     clear(env);
     for (auto node : *other_hash) {
@@ -434,11 +430,7 @@ bool HashObject::eql(Env *env, Value other_value) {
 }
 
 bool HashObject::gte(Env *env, Value other) {
-    if (!other->is_hash() && other->respond_to(env, "to_hash"_s))
-        other = other->send(env, "to_hash"_s);
-
-    other->assert_type(env, Object::Type::Hash, "Hash");
-    auto other_hash = other->as_hash();
+    auto other_hash = other->to_hash(env);
 
     for (auto &node : *other_hash) {
         Value value = get(env, node.key);
@@ -450,20 +442,13 @@ bool HashObject::gte(Env *env, Value other) {
 }
 
 bool HashObject::gt(Env *env, Value other) {
-    if (!other->is_hash() && other->respond_to(env, "to_hash"_s))
-        other = other->send(env, "to_hash"_s);
+    auto other_hash = other->to_hash(env);
 
-    other->assert_type(env, Object::Type::Hash, "Hash");
-
-    return gte(env, other) && other->as_hash()->size() != size();
+    return gte(env, other) && other_hash->size() != size();
 }
 
 bool HashObject::lte(Env *env, Value other) {
-    if (!other->is_hash() && other->respond_to(env, "to_hash"_s))
-        other = other->send(env, "to_hash"_s);
-
-    other->assert_type(env, Object::Type::Hash, "Hash");
-    auto other_hash = other->as_hash();
+    auto other_hash = other->to_hash(env);
 
     for (auto &node : *this) {
         Value value = other_hash->get(env, node.key);
@@ -475,12 +460,9 @@ bool HashObject::lte(Env *env, Value other) {
 }
 
 bool HashObject::lt(Env *env, Value other) {
-    if (!other->is_hash() && other->respond_to(env, "to_hash"_s))
-        other = other->send(env, "to_hash"_s);
+    auto other_hash = other->to_hash(env);
 
-    other->assert_type(env, Object::Type::Hash, "Hash");
-
-    return lte(env, other) && other->as_hash()->size() != size();
+    return lte(env, other) && other_hash->size() != size();
 }
 
 Value HashObject::each(Env *env, Block *block) {
@@ -665,14 +647,7 @@ Value HashObject::merge_in_place(Env *env, Args args, Block *block) {
     this->assert_not_frozen(env);
 
     for (size_t i = 0; i < args.size(); i++) {
-        auto h = args[i];
-
-        if (!h->is_hash() && h->respond_to(env, "to_hash"_s))
-            h = h->send(env, "to_hash"_s);
-
-        h->assert_type(env, Object::Type::Hash, "Hash");
-
-        for (auto node : *h->as_hash()) {
+        for (auto node : *args[i]->to_hash(env)) {
             auto new_value = node.val;
             if (block) {
                 auto old_value = get(env, node.key);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -283,13 +283,7 @@ Value KernelModule::Hash(Env *env, Value value) {
         return new HashObject;
     }
 
-    if (!value->respond_to(env, "to_hash"_s)) {
-        env->raise("TypeError", "can't convert {} into Hash", value->klass()->inspect_str());
-    }
-
-    value = value.send(env, "to_hash"_s);
-    value->assert_type(env, Object::Type::Hash, "Hash");
-    return value;
+    return value->to_hash(env);
 }
 
 Value KernelModule::hash(Env *env) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1308,6 +1308,35 @@ FloatObject *Object::to_f(Env *env) {
     return result->as_float();
 }
 
+HashObject *Object::to_hash(Env *env) {
+    if (is_hash()) {
+        return as_hash();
+    }
+
+    auto original_class = klass()->inspect_str();
+
+    auto to_hash = "to_hash"_s;
+
+    if (!respond_to(env, to_hash)) {
+        if (is_nil()) {
+            env->raise("TypeError", "no implicit conversion of nil into Hash");
+        }
+        env->raise("TypeError", "no implicit conversion of {} into Hash", original_class);
+    }
+
+    Value val = send(env, to_hash);
+
+    if (val->is_hash()) {
+        return val->as_hash();
+    }
+
+    env->raise(
+        "TypeError", "can't convert {} to Hash ({}#to_hash gives {})",
+        original_class,
+        original_class,
+        val->klass()->inspect_str());
+}
+
 StringObject *Object::to_s(Env *env) {
     auto str = send(env, "to_s"_s);
     if (!str->is_string())


### PR DESCRIPTION
This is the same type of coercion method as to_ary or to_str. Use this to remove some code duplication.

This is some code of  #1434 split off into a separate branch.