### PR TITLE
Revert "Remove next from scheduler"

### DIFF
--- a/test/natalie/fiber/shared/scheduler.rb
+++ b/test/natalie/fiber/shared/scheduler.rb
@@ -8,11 +8,10 @@ class Scheduler
   def run
     until @waiting.empty?
       fiber, = @waiting.find { |fiber, timeout| fiber.alive? && timeout <= current_time }
+      next if fiber.nil?
 
-      unless fiber.nil?
-        @waiting.delete(fiber)
-        fiber.resume
-      end
+      @waiting.delete(fiber)
+      fiber.resume
     end
   end
 


### PR DESCRIPTION
This reverts commit b6b8f8c1b65e20fef2791f1ea368b5151659c098.

We now have a working `next` instruction, so we can go back to my original code.