### PR TITLE
Implement digest singleton methods for Digest subclasses

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -85,6 +85,9 @@ module OpenSSL
       raise if name.to_s != normalized_name
       klass = Class.new(self) do
         define_method(:initialize) { |*args| super(normalized_name, *args) }
+        define_singleton_method(:digest) { |*args| Digest.digest(normalized_name, *args) }
+        define_singleton_method(:base64digest) { |*args| Digest.base64digest(normalized_name, *args) }
+        define_singleton_method(:hexdigest) { |*args| Digest.hexdigest(normalized_name, *args) }
       end
       const_set(name, klass)
       klass

--- a/spec/library/digest/sha1/digest_spec.rb
+++ b/spec/library/digest/sha1/digest_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/constants'
+
+describe "Digest::SHA1#digest" do
+
+  it "returns a digest" do
+    cur_digest = Digest::SHA1.new
+    cur_digest.digest().should == SHA1Constants::BlankDigest
+    cur_digest.digest(SHA1Constants::Contents).should == SHA1Constants::Digest
+  end
+
+end
+
+describe "Digest::SHA1.digest" do
+
+  it "returns a digest" do
+    Digest::SHA1.digest(SHA1Constants::Contents).should == SHA1Constants::Digest
+  end
+
+end


### PR DESCRIPTION
This shall henceforth be known as the start of the great unification of digest classes.

Our current implementation of the Digest classes is to simply assign the related OpenSSL digest classes to the constant. This kind of works, but there are a lot of failing specs. Sometimes that's simply because methods are named differently, but the failures in the added specs were simply because our `OpenSSL::Digest` implementation was lacking. I've tested this by replacing `Digest` with `OpenSSL::Digest` and running the test with MRI.

I'm going to try to convert the upstream specs for `Digest` and `OpenSSL::Digest` to shared specs so we can remove some duplication and improve both test suites by merging them together.