### PR TITLE
Don't try to convert encoding when encoding does not change

### DIFF
--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -12,6 +12,9 @@ EncodingObject::EncodingObject()
 // TODO:
 // * support encoding options
 Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str) const {
+    if (num() == orig_encoding->num())
+        return str;
+
     StringObject temp_string = StringObject("", (EncodingObject *)this);
     ClassObject *EncodingClass = find_top_level_const(env, "Encoding"_s)->as_class();
 

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -131,12 +131,20 @@ describe 'string' do
     it 'changes the encoding while reinterpreting the characters' do
       s = 'abc123'.encode 'utf-8'
       s.encoding.should == Encoding::UTF_8
+
+      # change to binary
       s2 = s.encode 'ascii-8bit'
       s2.encoding.should == Encoding::ASCII_8BIT
       s2.should == 'abc123'
+
+      # change back to utf-8
       s3 = s2.encode 'utf-8'
       s3.encoding.should == Encoding::UTF_8
       s3.should == 'abc123'
+
+      # change from binary to binary (no change)
+      s4 = "\x86\x86\x86".b.encode 'ascii-8bit'
+      s4.should == "\x86\x86\x86".b
     end
 
     it 'raises an error if a character cannot be converted to the new encoding' do


### PR DESCRIPTION
In [StringIO](https://github.com/natalie-lang/natalie/blob/8e490733386cd325f5d63699d1fcb8dc23c6970b/lib/stringio.rb#L206) we call `result.encode(encoding)` with a binary encoding, but the string was already encoded as binary. This fixes the bug:

```
"\x86" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to ASCII-8BIT (Encoding::UndefinedConversionError)
```

This was the fix I needed to get the self-hosted compiler to run some actual code!

```sh
→ rake bootstrap
→ bin/nat examples/boardslam.rb 3 5 1
3   - 5^0 - 1   = 1
3   - 5^0 * 1   = 2
3   + 5^0 - 1   = 3
3   + 5^0 * 1   = 4
3   + 5^0 + 1   = 5
3^0 + 5   * 1   = 6
3   + 5   - 1   = 7
3   + 5   * 1   = 8
3   + 5   + 1   = 9
3^2 + 5^0 * 1   = 10
3^2 + 5^0 + 1   = 11
5   - 1   * 3   = 12
3^2 + 5   - 1   = 13
3   * 5   - 1   = 14
3   * 5   * 1   = 15
3   * 5   + 1   = 16
5^2 - 3^2 + 1   = 17
5   + 1   * 3   = 18
3   + 1   * 5   = 20
3^3 - 5   - 1   = 21
3^3 - 5   * 1   = 22
3^3 - 5   + 1   = 23
3^0 * 5^2 - 1   = 24
3^0 + 5^2 - 1   = 25
3^0 + 5^2 * 1   = 26
3   + 5^2 - 1   = 27
3   + 5^2 * 1   = 28
3   + 5^2 + 1   = 29
3^3 + 5   - 1   = 31
3^3 + 5   * 1   = 32
3^2 + 5^2 - 1   = 33
3^2 + 5^2 * 1   = 34
3^2 + 5^2 + 1   = 35
5   - 1   * 3^2 = 36

missing answers: 19, 30
```