### PR TITLE
Add missing Digest subclasses

### DIFF
--- a/lib/digest.rb
+++ b/lib/digest.rb
@@ -1,2 +1,3 @@
+require 'digest/md5'
 require 'digest/sha1'
 require 'digest/sha2'

--- a/lib/digest/md5.rb
+++ b/lib/digest/md5.rb
@@ -1,0 +1,5 @@
+require 'openssl'
+
+module Digest
+  MD5 = OpenSSL::Digest::MD5
+end

--- a/lib/digest/sha2.rb
+++ b/lib/digest/sha2.rb
@@ -1,6 +1,7 @@
 require 'openssl'
 
 module Digest
+  SHA2 = OpenSSL::Digest::SHA256
   SHA256 = OpenSSL::Digest::SHA256
   SHA384 = OpenSSL::Digest::SHA384
   SHA512 = OpenSSL::Digest::SHA512


### PR DESCRIPTION
With this we can run the full test suite of `spec/library/digest` without crashes. This increases the visibility on what we're still missing for the Digest classes.