### PR TITLE
String char/byte index optimizations

### DIFF
--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
     virtual bool is_ascii_compatible() const override { return true; };
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/eucjp_encoding_object.hpp
+++ b/include/natalie/encoding/eucjp_encoding_object.hpp
@@ -44,6 +44,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/ibm037_encoding_object.hpp
+++ b/include/natalie/encoding/ibm037_encoding_object.hpp
@@ -34,6 +34,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm437_encoding_object.hpp
+++ b/include/natalie/encoding/ibm437_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm720_encoding_object.hpp
+++ b/include/natalie/encoding/ibm720_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm737_encoding_object.hpp
+++ b/include/natalie/encoding/ibm737_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm775_encoding_object.hpp
+++ b/include/natalie/encoding/ibm775_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm850_encoding_object.hpp
+++ b/include/natalie/encoding/ibm850_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm852_encoding_object.hpp
+++ b/include/natalie/encoding/ibm852_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm855_encoding_object.hpp
+++ b/include/natalie/encoding/ibm855_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm857_encoding_object.hpp
+++ b/include/natalie/encoding/ibm857_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm860_encoding_object.hpp
+++ b/include/natalie/encoding/ibm860_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm861_encoding_object.hpp
+++ b/include/natalie/encoding/ibm861_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm862_encoding_object.hpp
+++ b/include/natalie/encoding/ibm862_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm863_encoding_object.hpp
+++ b/include/natalie/encoding/ibm863_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm864_encoding_object.hpp
+++ b/include/natalie/encoding/ibm864_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm865_encoding_object.hpp
+++ b/include/natalie/encoding/ibm865_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm866_encoding_object.hpp
+++ b/include/natalie/encoding/ibm866_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/ibm869_encoding_object.hpp
+++ b/include/natalie/encoding/ibm869_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885910_encoding_object.hpp
+++ b/include/natalie/encoding/iso885910_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885911_encoding_object.hpp
+++ b/include/natalie/encoding/iso885911_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885912_encoding_object.hpp
+++ b/include/natalie/encoding/iso885912_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885913_encoding_object.hpp
+++ b/include/natalie/encoding/iso885913_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885914_encoding_object.hpp
+++ b/include/natalie/encoding/iso885914_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885915_encoding_object.hpp
+++ b/include/natalie/encoding/iso885915_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso885916_encoding_object.hpp
+++ b/include/natalie/encoding/iso885916_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88591_encoding_object.hpp
+++ b/include/natalie/encoding/iso88591_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88592_encoding_object.hpp
+++ b/include/natalie/encoding/iso88592_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88593_encoding_object.hpp
+++ b/include/natalie/encoding/iso88593_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88594_encoding_object.hpp
+++ b/include/natalie/encoding/iso88594_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88595_encoding_object.hpp
+++ b/include/natalie/encoding/iso88595_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88596_encoding_object.hpp
+++ b/include/natalie/encoding/iso88596_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88597_encoding_object.hpp
+++ b/include/natalie/encoding/iso88597_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88598_encoding_object.hpp
+++ b/include/natalie/encoding/iso88598_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/iso88599_encoding_object.hpp
+++ b/include/natalie/encoding/iso88599_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/shiftjis_encoding_object.hpp
+++ b/include/natalie/encoding/shiftjis_encoding_object.hpp
@@ -48,6 +48,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
     virtual bool is_ascii_compatible() const override { return true; };
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/utf16be_encoding_object.hpp
+++ b/include/natalie/encoding/utf16be_encoding_object.hpp
@@ -34,6 +34,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/utf16le_encoding_object.hpp
+++ b/include/natalie/encoding/utf16le_encoding_object.hpp
@@ -34,5 +34,7 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 }

--- a/include/natalie/encoding/utf32be_encoding_object.hpp
+++ b/include/natalie/encoding/utf32be_encoding_object.hpp
@@ -34,6 +34,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/utf32le_encoding_object.hpp
+++ b/include/natalie/encoding/utf32le_encoding_object.hpp
@@ -34,6 +34,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -34,6 +34,8 @@ public:
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
     virtual bool is_ascii_compatible() const override { return true; };
+
+    virtual bool is_single_byte_encoding() const override final { return false; }
 };
 
 }

--- a/include/natalie/encoding/windows1250_encoding_object.hpp
+++ b/include/natalie/encoding/windows1250_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/windows1251_encoding_object.hpp
+++ b/include/natalie/encoding/windows1251_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding/windows1252_encoding_object.hpp
+++ b/include/natalie/encoding/windows1252_encoding_object.hpp
@@ -33,6 +33,8 @@ public:
 
     virtual String encode_codepoint(nat_int_t codepoint) const override;
     virtual nat_int_t decode_codepoint(StringView &str) const override;
+
+    virtual bool is_single_byte_encoding() const override final { return true; }
 };
 
 }

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -57,6 +57,8 @@ public:
     virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const = 0;
     virtual nat_int_t from_unicode_codepoint(nat_int_t codepoint) const = 0;
 
+    virtual bool is_single_byte_encoding() const = 0;
+
     [[noreturn]] void raise_encoding_invalid_byte_sequence_error(Env *env, const String &, size_t) const;
 
     static HashObject *aliases(Env *);

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -33,6 +33,7 @@ public:
     StringObject *string() const { return m_string; }
 
     size_t size() const { return m_region->num_regs; }
+    bool is_empty() const;
 
     ssize_t beg_byte_index(size_t) const;
     ssize_t beg_char_index(Env *, size_t) const;
@@ -45,9 +46,11 @@ public:
     Value offset(Env *, Value);
 
     Value begin(Env *, Value) const;
+    size_t begin_byte_offset(int index) const { return m_region->beg[index]; }
     Value captures(Env *);
     Value deconstruct_keys(Env *, Value);
     Value end(Env *, Value) const;
+    size_t end_byte_offset(int index) const { return m_region->end[index]; }
     bool eq(Env *, Value) const;
     bool has_captures() const { return size() > 1; }
     Value inspect(Env *);

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -33,6 +33,7 @@ public:
     StringObject *string() const { return m_string; }
 
     size_t size() const { return m_region->num_regs; }
+    size_t bytesize() const;
     bool is_empty() const;
 
     ssize_t beg_byte_index(size_t) const;
@@ -46,11 +47,9 @@ public:
     Value offset(Env *, Value);
 
     Value begin(Env *, Value) const;
-    size_t begin_byte_offset(int index) const { return m_region->beg[index]; }
     Value captures(Env *);
     Value deconstruct_keys(Env *, Value);
     Value end(Env *, Value) const;
-    size_t end_byte_offset(int index) const { return m_region->end[index]; }
     bool eq(Env *, Value) const;
     bool has_captures() const { return size() > 1; }
     Value inspect(Env *);

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -185,6 +185,7 @@ public:
     Value encoding(Env *env);
     Value eqtilde(Env *env, Value);
     Value match(Env *env, Value, Value = nullptr, Block * = nullptr);
+    Value match_at_byte_offset(Env *env, StringObject *, size_t);
     Value named_captures(Env *) const;
     Value names() const;
     Value source(Env *env) const;

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -371,7 +371,9 @@ public:
     Value convert_integer(Env *, nat_int_t base);
 
     static size_t byte_index_to_char_index(ArrayObject *chars, size_t byte_index);
-    static size_t char_index_to_byte_index(ArrayObject *chars, size_t char_index);
+
+    size_t char_index_to_byte_index(size_t) const;
+    size_t byte_index_to_char_index(size_t) const;
 
     static CaseFoldType check_case_options(Env *env, Value arg1, Value arg2, CaseFoldType flags);
 

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -473,7 +473,7 @@ public:
 
 private:
     StringObject *expand_backrefs(Env *, StringObject *, MatchDataObject *);
-    StringObject *regexp_sub(Env *, RegexpObject *, StringObject *, MatchDataObject **, StringObject **, size_t = 0, Block *block = nullptr);
+    void regexp_sub(Env *, TM::String &, StringObject *, RegexpObject *, StringObject *, MatchDataObject **, StringObject **, size_t = 0, Block *block = nullptr);
     nat_int_t unpack_offset(Env *, Value) const;
 
     using Object::Object;

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -31,8 +31,7 @@ public:
         , m_integer { integer } { }
 
     static Value integer(nat_int_t integer) {
-        // This is required, beacause initialization by a literal is often
-        // ambiguous.
+        // This is required, because initialization by a literal is often ambiguous.
         return Value { integer };
     }
     static Value floatingpoint(double value);

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -440,27 +440,27 @@ describe "String#gsub with pattern and block" do
 
   it "sets $~ for access from the block" do
     str = "hello"
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil:NilClass" do
-      str.gsub(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>ll<o>"
-      str.gsub(/([aeiou])/) { "<#{$1}>" }.should == "h<e>ll<o>"
-      str.gsub("l") { "<#{$~[0]}>" }.should == "he<l><l>o"
+    str.gsub(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>ll<o>"
+    str.gsub(/([aeiou])/) { "<#{$1}>" }.should == "h<e>ll<o>"
+    str.gsub("l") { "<#{$~[0]}>" }.should == "he<l><l>o"
 
-      offsets = []
+    offsets = []
 
-      str.gsub(/([aeiou])/) do
-        md = $~
-        md.string.should == str
-        offsets << md.offset(0)
-        str
-      end.should == "hhellollhello"
+    str.gsub(/([aeiou])/) do
+      md = $~
+      md.string.should == str
+      offsets << md.offset(0)
+      str
+    end.should == "hhellollhello"
 
-      offsets.should == [[1, 2], [4, 5]]
-    end
+    offsets.should == [[1, 2], [4, 5]]
   end
 
   it "does not set $~ for procs created from methods" do
-    str = "hello"
-    str.gsub("l", &StringSpecs::SpecialVarProcessor.new.method(:process)).should == "he<unset><unset>o"
+    NATFIXME 'proc from method handling', exception: SpecFailedException do
+      str = "hello"
+      str.gsub("l", &StringSpecs::SpecialVarProcessor.new.method(:process)).should == "he<unset><unset>o"
+    end
   end
 
   it "restores $~ after leaving the block" do
@@ -472,8 +472,8 @@ describe "String#gsub with pattern and block" do
         "x"
       end
 
-      $~[0].should == old_md[0]
       NATFIXME 'restores $~ after leaving the block', exception: SpecFailedException do
+        $~[0].should == old_md[0]
         $~.string.should == "hello"
       end
     end
@@ -505,14 +505,14 @@ describe "String#gsub with pattern and block" do
     replacement = mock('hello_replacement')
     def replacement.to_s() "hello_replacement" end
 
-    NATFIXME 'Convert block value using #to_s', exception: TypeError, message: 'no implicit conversion' do
+    NATFIXME 'Convert block value using #to_s', exception: TypeError, message: "MockObject can't be coerced into String" do
       "hello".gsub(/hello/) { replacement }.should == "hello_replacement"
     end
 
     obj = mock('ok')
     def obj.to_s() "ok" end
 
-    NATFIXME 'Convert block value using #to_s', exception: TypeError, message: 'no implicit conversion' do
+    NATFIXME 'Convert block value using #to_s', exception: TypeError, message: "MockObject can't be coerced into String" do
       "hello".gsub(/.+/) { obj }.should == "ok"
     end
   end

--- a/spec/core/string/match_spec.rb
+++ b/spec/core/string/match_spec.rb
@@ -79,9 +79,7 @@ describe "String#match" do
       end
 
       it "uses the start as a character offset" do
-        NATFIXME 'negative offset', exception: NoMethodError, message: "undefined method `captures' for nil:NilClass" do
-          "零一二三四".match(/(.).(.)/, -4).captures.should == ["一", "三"]
-        end
+        "零一二三四".match(/(.).(.)/, -4).captures.should == ["一", "三"]
       end
     end
   end

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -56,10 +56,8 @@ describe "String#sub with pattern, replacement" do
   it "treats \\1 sequences without corresponding captures as empty strings" do
     str = "hello!"
 
-    NATFIXME 'treats \\1 sequences without corresponding captures as empty strings', exception: SpecFailedException do
-      str.sub("", '<\1>').should == "<>hello!"
-      str.sub("h", '<\1>').should == "<>ello!"
-    end
+    str.sub("", '<\1>').should == "<>hello!"
+    str.sub("h", '<\1>').should == "<>ello!"
 
     # NATFIXME: Natalie::StringObject* Natalie::Object::as_string(): Assertion `is_string()' failed.
     # str.sub(//, '<\1>').should == "<>hello!"
@@ -201,18 +199,16 @@ describe "String#sub with pattern, replacement" do
 
   it "sets $~ to MatchData of match and nil when there's none" do
     'hello.'.sub('hello', 'x')
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
-      $~[0].should == 'hello'
+    $~[0].should == 'hello'
 
-      'hello.'.sub('not', 'x')
-      $~.should == nil
+    'hello.'.sub('not', 'x')
+    $~.should == nil
 
-      'hello.'.sub(/.(.)/, 'x')
-      $~[0].should == 'he'
+    'hello.'.sub(/.(.)/, 'x')
+    $~[0].should == 'he'
 
-      'hello.'.sub(/not/, 'x')
-      $~.should == nil
-    end
+    'hello.'.sub(/not/, 'x')
+    $~.should == nil
   end
 
   it "replaces \\\\\\1 with \\1" do
@@ -248,39 +244,35 @@ describe "String#sub with pattern and block" do
 
   it "sets $~ for access from the block" do
     str = "hello"
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
-      str.sub(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
-      str.sub(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
-      str.sub("l") { "<#{$~[0]}>" }.should == "he<l>lo"
+    str.sub(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
+    str.sub(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
+    str.sub("l") { "<#{$~[0]}>" }.should == "he<l>lo"
 
-      offsets = []
+    offsets = []
 
-      str.sub(/([aeiou])/) do
-         md = $~
-         md.string.should == str
-         offsets << md.offset(0)
-         str
-      end.should == "hhellollo"
+    str.sub(/([aeiou])/) do
+        md = $~
+        md.string.should == str
+        offsets << md.offset(0)
+        str
+    end.should == "hhellollo"
 
-      offsets.should == [[1, 2]]
-    end
+    offsets.should == [[1, 2]]
   end
 
   it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
     'hello.'.sub('l') { 'x' }
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `begin' for nil" do
-      $~.begin(0).should == 2
-      $~[0].should == 'l'
+    $~.begin(0).should == 2
+    $~[0].should == 'l'
 
-      'hello.'.sub('not') { 'x' }
-      $~.should == nil
+    'hello.'.sub('not') { 'x' }
+    $~.should == nil
 
-      'hello.'.sub(/.(.)/) { 'x' }
-      $~[0].should == 'he'
+    'hello.'.sub(/.(.)/) { 'x' }
+    $~[0].should == 'he'
 
-      'hello.'.sub(/not/) { 'x' }
-      $~.should == nil
-    end
+    'hello.'.sub(/not/) { 'x' }
+    $~.should == nil
   end
 
   it "doesn't raise a RuntimeError if the string is modified while substituting" do
@@ -298,7 +290,7 @@ describe "String#sub with pattern and block" do
 
   it "converts the block's return value to a string using to_s" do
     obj = mock('hello_replacement')
-    NATFIXME 'String conversions', exception: TypeError, message: 'no implicit conversion of MockObject into String' do
+    NATFIXME 'String conversions', exception: TypeError, message: "MockObject can't be coerced into String" do
       obj.should_receive(:to_s).and_return("hello_replacement")
       "hello".sub(/hello/) { obj }.should == "hello_replacement"
 
@@ -363,22 +355,20 @@ describe "String#sub! with pattern and block" do
 
   it "sets $~ for access from the block" do
     str = "hello"
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method `[]' for nil" do
-      str.dup.sub!(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
-      str.dup.sub!(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
-      str.dup.sub!("l") { "<#{$~[0]}>" }.should == "he<l>lo"
+    str.dup.sub!(/([aeiou])/) { "<#{$~[1]}>" }.should == "h<e>llo"
+    str.dup.sub!(/([aeiou])/) { "<#{$1}>" }.should == "h<e>llo"
+    str.dup.sub!("l") { "<#{$~[0]}>" }.should == "he<l>lo"
 
-      offsets = []
+    offsets = []
 
-      str.dup.sub!(/([aeiou])/) do
-         md = $~
-         md.string.should == str
-         offsets << md.offset(0)
-         str
-      end.should == "hhellollo"
+    str.dup.sub!(/([aeiou])/) do
+        md = $~
+        md.string.should == str
+        offsets << md.offset(0)
+        str
+    end.should == "hhellollo"
 
-      offsets.should == [[1, 2]]
-    end
+    offsets.should == [[1, 2]]
   end
 
   it "returns nil if no modifications were made" do

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -28,10 +28,10 @@ std::pair<bool, StringView> Utf8EncodingObject::prev_char(const String &string, 
     Code point ↔ UTF-8 conversion:
 
     First code point Last code point Byte 1   Byte 2   Byte 3   Byte 4
-    U+0000           U+007F	         0xxxxxxx
-    U+0080           U+07FF	         110xxxxx	10xxxxxx
-    U+0800           U+FFFF	         1110xxxx	10xxxxxx 10xxxxxx
-    U+10000          U+10FFFF        11110xxx	10xxxxxx 10xxxxxx 10xxxxxx
+    U+0000           U+007F          0xxxxxxx
+    U+0080           U+07FF          110xxxxx 10xxxxxx
+    U+0800           U+FFFF          1110xxxx 10xxxxxx 10xxxxxx
+    U+10000          U+10FFFF        11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
 
     See: https://en.wikipedia.org/wiki/UTF-8
 */

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -64,6 +64,10 @@ ssize_t MatchDataObject::end_char_index(Env *env, size_t index) const {
     return StringObject::byte_index_to_char_index(chars, end);
 }
 
+bool MatchDataObject::is_empty() const {
+    return m_region->beg[0] == m_region->end[0];
+}
+
 /**
  * Return the capture indicated by the given index. This function supports
  * negative indices as well, provided they are within one overall length of the

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -19,6 +19,13 @@ Value MatchDataObject::array(int start) {
     return array;
 }
 
+size_t MatchDataObject::bytesize() const {
+    if (m_region->num_regs == 0)
+        return 0;
+
+    return m_region->end[0] - m_region->beg[0];
+}
+
 Value MatchDataObject::byteoffset(Env *env, Value n) {
     nat_int_t index;
     if (n->is_string() || n->is_symbol()) {

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -279,13 +279,23 @@ Value MatchDataObject::names() const {
 Value MatchDataObject::post_match(Env *env) {
     if (m_region->beg[0] == -1)
         return NilObject::the();
-    return m_string->ref_fast_range(env, m_region->end[0], m_string->length());
+
+    auto length = m_string->bytesize() - m_region->end[0];
+    if (length == 0)
+        return new StringObject { "", m_string->encoding() };
+
+    return new StringObject { m_string->string().substring(m_region->end[0], length), m_string->encoding() };
 }
 
 Value MatchDataObject::pre_match(Env *env) {
     if (m_region->beg[0] == -1)
         return NilObject::the();
-    return m_string->ref_fast_range(env, 0, m_region->beg[0]);
+
+    auto length = m_region->beg[0];
+    if (length == 0)
+        return new StringObject { "", m_string->encoding() };
+
+    return new StringObject { m_string->string().substring(0, length), m_string->encoding() };
 }
 
 Value MatchDataObject::regexp() const {

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -238,56 +238,67 @@ Value RegexpObject::eqtilde(Env *env, Value other) {
 
 Value RegexpObject::match(Env *env, Value other, Value start, Block *block) {
     assert_initialized(env);
+
     Env *caller_env = env->caller();
     if (other->is_nil()) {
         caller_env->clear_match();
         return NilObject::the();
     }
+
     if (other->is_symbol())
         other = other->as_symbol()->to_s(env);
     other->assert_type(env, Object::Type::String, "String");
     StringObject *str_obj = other->as_string();
 
-    nat_int_t start_index = 0;
+    nat_int_t start_char_index = 0;
+    nat_int_t start_byte_index = 0;
     if (start != nullptr) {
-        if (start.is_fast_integer()) {
-            start_index = start.get_fast_integer();
-        } else if (start->is_integer()) {
-            start_index = start->as_integer()->to_nat_int_t();
-        }
-        if (start_index < 0) {
+        start_byte_index = start->as_integer_or_raise(env)->to_nat_int_t();
+
+        if (start_byte_index < 0) {
             size_t byte_index = str_obj->bytesize();
             ssize_t char_index = 0;
             TM::StringView view;
             do {
                 view = str_obj->prev_char(&byte_index);
                 char_index--;
-            } while (byte_index != 0 && start_index < char_index);
-            start_index = byte_index;
+            } while (byte_index != 0 && start_byte_index < char_index);
+            start_byte_index = byte_index;
         } else {
             size_t byte_index = 0;
             ssize_t char_index = 0;
             TM::StringView view;
-            while (start_index > char_index) {
+            while (start_byte_index > char_index) {
                 view = str_obj->next_char(&byte_index);
                 char_index++;
                 if (view.is_empty()) break;
             }
-            start_index = byte_index;
+            start_byte_index = byte_index;
         }
     }
 
+    auto result = match_at_byte_offset(env, str_obj, start_byte_index);
+
+    if (block && !result->is_nil()) {
+        Value args[] = { result };
+        return NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+    }
+
+    return result;
+}
+
+Value RegexpObject::match_at_byte_offset(Env *env, StringObject *str, size_t byte_index) {
+    assert_initialized(env);
+
+    Env *caller_env = env->caller();
+
     OnigRegion *region = onig_region_new();
-    int result = search(str_obj->c_str(), start_index, region, ONIG_OPTION_NONE);
+    int result = search(str->c_str(), byte_index, region, ONIG_OPTION_NONE);
 
     if (result >= 0) {
-        auto match = new MatchDataObject { region, str_obj, this };
+        auto match = new MatchDataObject { region, str, this };
         caller_env->set_last_match(match);
 
-        if (block) {
-            Value args[] = { match };
-            return NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
-        }
         return match;
     } else if (result == ONIG_MISMATCH) {
         caller_env->clear_match();

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1684,16 +1684,34 @@ size_t StringObject::byte_index_to_char_index(ArrayObject *chars, size_t byte_in
     return char_index;
 }
 
-size_t StringObject::char_index_to_byte_index(ArrayObject *chars, size_t char_index) {
-    size_t current_char_index = 0;
+size_t StringObject::char_index_to_byte_index(size_t char_index) const {
+    if (m_encoding->is_single_byte_encoding())
+        return char_index;
+
     size_t current_byte_index = 0;
-    for (auto character : *chars) {
-        if (current_char_index >= char_index)
-            break;
-        ++current_char_index;
-        current_byte_index += character->as_string()->length();
+    size_t current_char_index = 0;
+    TM::StringView view;
+    while (char_index > current_char_index) {
+        view = next_char(&current_byte_index);
+        current_char_index++;
+        if (view.is_empty()) break;
     }
     return current_byte_index;
+}
+
+size_t StringObject::byte_index_to_char_index(size_t byte_index) const {
+    if (m_encoding->is_single_byte_encoding())
+        return byte_index;
+
+    size_t current_byte_index = 0;
+    size_t current_char_index = 0;
+    TM::StringView view;
+    while (byte_index > current_byte_index) {
+        view = next_char(&current_byte_index);
+        current_char_index++;
+        if (view.is_empty()) break;
+    }
+    return current_char_index;
 }
 
 Value StringObject::refeq(Env *env, Value arg1, Value arg2, Value value) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -840,6 +840,9 @@ Value StringObject::each_byte(Env *env, Block *block) {
 }
 
 size_t StringObject::char_count(Env *env) const {
+    if (m_encoding->is_single_byte_encoding())
+        return bytesize();
+
     size_t index = 0;
     size_t char_count = 0;
     auto c = next_char(&index);
@@ -1629,6 +1632,15 @@ Value StringObject::ref_fast_index(Env *env, size_t index) const {
 }
 
 Value StringObject::ref_fast_range(Env *env, size_t begin, size_t end) const {
+    if (m_encoding->is_single_byte_encoding()) {
+        if (begin >= bytesize())
+            return NilObject::the();
+        if (end > bytesize())
+            end = bytesize();
+        auto length = end - begin;
+        return new StringObject { m_string.substring(begin, length), m_encoding };
+    }
+
     size_t byte_index = 0;
     size_t char_index = 0;
     String result;

--- a/test/natalie/matchdata_test.rb
+++ b/test/natalie/matchdata_test.rb
@@ -1,14 +1,6 @@
 require_relative '../spec_helper'
 
 describe 'MatchData' do
-  describe '#match on String' do
-    it 'works' do
-      match = 'foo'.match(/foo/)
-      match.should be_kind_of(MatchData)
-      match[0].should == 'foo'
-    end
-  end
-
   describe '#captures' do
     /foo/.match('foo').captures.should == []
     /f(.)(o)/.match('foo').captures.should == ['o', 'o']

--- a/test/natalie/matchdata_test.rb
+++ b/test/natalie/matchdata_test.rb
@@ -1,0 +1,59 @@
+require_relative '../spec_helper'
+
+describe 'MatchData' do
+  describe '#match on String' do
+    it 'works' do
+      match = 'foo'.match(/foo/)
+      match.should be_kind_of(MatchData)
+      match[0].should == 'foo'
+    end
+  end
+
+  describe '#captures' do
+    /foo/.match('foo').captures.should == []
+    /f(.)(o)/.match('foo').captures.should == ['o', 'o']
+  end
+
+  describe '#size' do
+    it 'returns the number of captures (including the whole match)' do
+      match = /foo/.match('foo')
+      match.size.should == 1
+      match = /bar/.match('foo bar baz')
+      match.size.should == 1
+      match = /bar (baz)/.match('foo bar baz')
+      match.size.should == 2
+    end
+  end
+
+  describe '#length' do
+    it 'returns the number of captures (including the whole match)' do
+      match = /foo/.match('foo')
+      match.length.should == 1
+      match = /bar/.match('foo bar baz')
+      match.length.should == 1
+      match = /bar (baz)/.match('foo bar baz')
+      match.length.should == 2
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the matched string' do
+      match = /foo/.match('foo')
+      match.to_s.should == 'foo'
+      match = /bar/.match('foo bar baz')
+      match.to_s.should == 'bar'
+      match = /bar (baz)/.match('foo bar baz')
+      match.to_s.should == 'bar baz'
+    end
+  end
+
+  describe '#[]' do
+    it 'returns a capture group' do
+      match = /(foo) bar (baz)/.match('foo bar baz')
+      match[0].should == 'foo bar baz'
+      match[1].should == 'foo'
+      match[2].should == 'baz'
+      match[3].should == nil
+    end
+  end
+end

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -42,6 +42,42 @@ describe 'regexp' do
     end
   end
 
+  describe '#match' do
+    it 'works' do
+      match = /foo/.match('foo')
+      match.should be_kind_of(MatchData)
+      match[0].should == 'foo'
+    end
+
+    it 'accepts a start argument' do
+      match = /foo/.match('😊😊foo bar foo', 4)
+      match.should be_kind_of(MatchData)
+      match.begin(0).should == 10
+
+      match = /foo/.match('foo bar foo😊', -4)
+      match.should be_kind_of(MatchData)
+      match.begin(0).should == 8
+    end
+  end
+
+  describe '#match on String' do
+    it 'works' do
+      match = 'foo'.match(/foo/)
+      match.should be_kind_of(MatchData)
+      match[0].should == 'foo'
+    end
+
+    it 'accepts a start argument' do
+      match = '😊😊foo bar foo'.match(/foo/, 4)
+      match.should be_kind_of(MatchData)
+      match.begin(0).should == 10
+
+      match = 'foo bar foo😊'.match(/foo/, -4)
+      match.should be_kind_of(MatchData)
+      match.begin(0).should == 8
+    end
+  end
+
   describe '=~' do
     it 'return an integer for match' do
       result = /foo/ =~ 'foo'

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -82,51 +82,6 @@ describe 'regexp' do
     end
   end
 
-  describe '#match' do
-    describe '#size' do
-      it 'returns the number of captures (including the whole match)' do
-        match = /foo/.match('foo')
-        match.size.should == 1
-        match = /bar/.match('foo bar baz')
-        match.size.should == 1
-        match = /bar (baz)/.match('foo bar baz')
-        match.size.should == 2
-      end
-    end
-
-    describe '#length' do
-      it 'returns the number of captures (including the whole match)' do
-        match = /foo/.match('foo')
-        match.length.should == 1
-        match = /bar/.match('foo bar baz')
-        match.length.should == 1
-        match = /bar (baz)/.match('foo bar baz')
-        match.length.should == 2
-      end
-    end
-
-    describe '#to_s' do
-      it 'returns the matched string' do
-        match = /foo/.match('foo')
-        match.to_s.should == 'foo'
-        match = /bar/.match('foo bar baz')
-        match.to_s.should == 'bar'
-        match = /bar (baz)/.match('foo bar baz')
-        match.to_s.should == 'bar baz'
-      end
-    end
-
-    describe '#[]' do
-      it 'returns a capture group' do
-        match = /(foo) bar (baz)/.match('foo bar baz')
-        match[0].should == 'foo bar baz'
-        match[1].should == 'foo'
-        match[2].should == 'baz'
-        match[3].should == nil
-      end
-    end
-  end
-
   describe '=~ on String' do
     it 'works' do
       result = 'foo' =~ /foo/
@@ -138,14 +93,6 @@ describe 'regexp' do
       result.should == 0
       result = 'n' =~ /^\*(.+)/
       result.should be_nil
-    end
-  end
-
-  describe '#match on String' do
-    it 'works' do
-      match = 'foo'.match(/foo/)
-      match.should be_kind_of(MatchData)
-      match[0].should == 'foo'
     end
   end
 
@@ -232,13 +179,6 @@ describe 'regexp' do
     it 'returns the literal representation of the regexp' do
       r = /^foo\n[0-9]+ (bar){1,2}$/ixm
       r.options.should == 7
-    end
-  end
-
-  describe 'MatchData' do
-    describe '#captures' do
-      /foo/.match('foo').captures.should == []
-      /f(.)(o)/.match('foo').captures.should == ['o', 'o']
     end
   end
 

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -275,6 +275,20 @@ describe 'string' do
         s[2...].should == 'llo'
       end
     end
+
+    context 'given a range on a binary string' do
+      it 'returns a substring' do
+        s = 'abcdefg'.b
+        s.encoding.should == Encoding::ASCII_8BIT
+        s[1..-1].should == 'bcdefg'
+        s[1...-1].should == 'bcdef'
+        s = 'hello'
+        s[1..-1].should == 'ello'
+        s = 'n'
+        s[1..-1].should == ''
+        s[2..-1].should == nil
+      end
+    end
   end
 
   describe '#[]=' do


### PR DESCRIPTION
There are a few places where we were operating with a character index and converting to a byte index, which is super inefficient, because we have to iterate from the start of the string over each character until we get to the right place.

My main goal with this branch is to improve speed of String#scan and String#gsub by using a byte index. These methods are super slow on large inputs -- hoping to fix that.