### PR TITLE
Fix Socket.open with block

### DIFF
--- a/src/io.rb
+++ b/src/io.rb
@@ -10,7 +10,7 @@ class IO
         yield(obj)
       ensure
         begin
-          obj.fsync unless obj.tty?
+          obj.fsync unless obj.tty? || obj.respond_to?(:setsockopt)
           obj.close
         rescue IOError => e
           raise unless e.message == 'closed stream'


### PR DESCRIPTION
This is required to make this code work:
```
TCPSocket.open('natalie-lang.org', 80) do |socket|
  socket.print("GET / HTTP/1.1\r\nHost: natalie-lang.org\r\nConnection: close\r\n\r\n")

  p socket.read
end
```
This was an issue I ran into while looking at  #1441