### PR TITLE
Only close IO object on destruction if autoclose is enabled

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -31,9 +31,9 @@ public:
     virtual ~IoObject() override {
         if (m_fileno == STDIN_FILENO || m_fileno == STDOUT_FILENO || m_fileno == STDERR_FILENO)
             return;
-        if (!m_closed && m_fileno != -1) {
-            ::close(m_fileno);
+        if (m_autoclose && !m_closed && m_fileno != -1) {
             m_closed = true;
+            m_fileno = -1;
         }
     }
 
@@ -125,7 +125,7 @@ private:
     int m_fileno { -1 };
     int m_lineno { 0 };
     bool m_closed { false };
-    bool m_autoclose { false };
+    bool m_autoclose { true };
     bool m_sync { false };
     StringObject *m_path { nullptr };
     TM::String m_read_buffer {};

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -607,13 +607,14 @@ Value IoObject::pwrite(Env *env, Value data, Value offset) {
 Value IoObject::close(Env *env) {
     if (m_closed)
         return NilObject::the();
+
     int result = ::close(m_fileno);
-    if (result == -1) {
+    if (result == -1)
         env->raise_errno();
-    } else {
-        m_closed = true;
-        return NilObject::the();
-    }
+
+    m_closed = true;
+    m_fileno = -1;
+    return NilObject::the();
 }
 
 Value IoObject::seek(Env *env, Value amount_value, Value whence_value) {


### PR DESCRIPTION
...and default autoclose to true.

This fixes #1452.