### PR TITLE
Add 'asan' build mode that enables AddressSanitizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,11 @@ jobs:
         run: git submodule update --init --recursive
       - name: build self-hosted binary
         run: rake docker_test_self_hosted
+  asan:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: checkout submodules
+        run: git submodule update --init --recursive
+      - name: test with AddressSanitizer
+        run: rake docker_test_asan

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,11 @@ task build_debug: %i[set_build_debug libnatalie prism_c_ext ctags] do
   puts 'Build mode: debug'
 end
 
+desc 'Build Natalie with AddressSanitizer enabled'
+task build_asan: %i[set_build_asan libnatalie prism_c_ext] do
+  puts 'Build mode: asan'
+end
+
 desc 'Build Natalie with release optimizations enabled and warnings off'
 task build_release: %i[set_build_release libnatalie prism_c_ext] do
   puts 'Build mode: release'
@@ -255,6 +260,11 @@ task(:set_build_debug) do
   File.write('.build', 'debug')
 end
 
+task(:set_build_asan) do
+  ENV['BUILD'] = 'asan'
+  File.write('.build', 'asan')
+end
+
 task(:set_build_release) do
   ENV['BUILD'] = 'release'
   File.write('.build', 'release')
@@ -488,6 +498,8 @@ def cxx_flags
     case ENV['BUILD']
     when 'release'
       Natalie::Compiler::Flags::RELEASE_FLAGS
+    when 'asan'
+      Natalie::Compiler::Flags::ASAN_FLAGS
     else
       Natalie::Compiler::Flags::DEBUG_FLAGS
     end

--- a/bin/natalie
+++ b/bin/natalie
@@ -33,12 +33,13 @@ OptionParser.new do |opts|
       'kcachegrind'   => 'run the resulting binary with valgrind (callgrind) and open the profile in kcachegrind',
       'strace'        => 'run the resulting binary with strace',
       '{gdb,lldb}'    => 'run the resulting binary with gdb or lldb',
+      'asan'          => 'enable AddressSanitizer',
     },
   ) do |type|
     case type
     when true, 'c', 'cpp', 'c++'
       options[:debug] = 'cpp'
-    when /^p\d/, 'S', 'edit', 'cc-cmd', 'valgrind', 'kcachegrind', 'strace'
+    when /^p\d/, 'S', 'edit', 'cc-cmd', 'valgrind', 'kcachegrind', 'strace', 'asan'
       options[:debug] = type
     when 'gdb', 'lldb'
       options[:debug] = type
@@ -127,11 +128,8 @@ OptionParser.new do |opts|
 end.parse!
 
 build_type_path = File.expand_path('../.build', __dir__)
-if File.exist?(build_type_path) && File.read(build_type_path).strip == 'release'
-  options[:build] = 'release'
-else
-  options[:build] = 'debug'
-end
+build_setting = File.exist?(build_type_path) ? File.read(build_type_path).strip : 'debug'
+options[:build] = build_setting
 
 class Runner
   def initialize(options)

--- a/examples/boardslam.rb
+++ b/examples/boardslam.rb
@@ -109,7 +109,7 @@ class BoardSlam
   end
 
   def missing
-    BOARD.to_a - results.keys
+    @missing ||= (BOARD.to_a - results.keys)
   end
 end
 

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -122,6 +122,11 @@ extern "C" {
 #include "onigmo.h"
 }
 
+#ifdef __SANITIZE_ADDRESS__
+extern "C" void *__asan_get_current_fake_stack();
+extern "C" void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg, void **end);
+#endif
+
 void init_bindings(Env *);
 
 Env *build_top_env();

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -50,6 +50,7 @@ public:
         }
         auto user_data = (coroutine_user_data *)m_coroutine->user_data;
         delete user_data;
+        mco_destroy(m_coroutine);
     }
 
     static void build_main_fiber(void *start_of_stack) {

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -105,6 +105,8 @@ public:
     }
 
     virtual void visit_children(Visitor &) override final;
+    void visit_children_from_stack(Visitor &) const;
+    void visit_children_from_asan_fake_stack(Visitor &, Cell *) const;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         auto size = m_coroutine ? m_coroutine->stack_size : 0;
@@ -134,6 +136,9 @@ private:
     mco_coro *m_coroutine {};
     void *m_start_of_stack { nullptr };
     void *m_end_of_stack { nullptr };
+#ifdef __SANITIZE_ADDRESS__
+    void *m_asan_fake_stack { nullptr };
+#endif
     Status m_status { Status::Created };
     TM::Optional<TM::String> m_file {};
     TM::Optional<size_t> m_line {};

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -99,6 +99,7 @@ private:
         m_allocators.push(new Allocator(1024));
     }
 
+    void gather_roots_from_asan_fake_stack(Hashmap<Cell *>, Cell *);
     TM::Hashmap<Cell *> gather_conservative_roots();
 
     void sweep();

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -72,3 +72,5 @@
 #else
 #define NAT_GC_GUARD_VALUE(val)
 #endif
+
+#define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -268,7 +268,14 @@ module Natalie
     end
 
     def link_flags
-      (@context[:compile_ld_flags].join(' ').split.uniq - unnecessary_link_flags).join(' ')
+      flags = if build == 'asan'
+                ['-fsanitize=address']
+              else
+                []
+              end
+      flags += @context[:compile_ld_flags].join(' ').split
+      flags -= unnecessary_link_flags
+      flags.join(' ')
     end
 
     def unnecessary_link_flags
@@ -281,6 +288,8 @@ module Natalie
         RELEASE_FLAGS
       when 'debug', nil
         DEBUG_FLAGS
+      when 'asan'
+        ASAN_FLAGS
       when 'coverage'
         COVERAGE_FLAGS
       else

--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -23,6 +23,11 @@ module Natalie
         -DNAT_GC_GUARD
       ].freeze
 
+      ASAN_FLAGS = DEBUG_FLAGS + %w[
+        -fsanitize=address
+        -fno-omit-frame-pointer
+      ]
+
       COVERAGE_FLAGS = DEBUG_FLAGS + %w[
         -fprofile-arcs
         -ftest-coverage

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -105,7 +105,7 @@ Value FiberObject::resume(Env *env, Args args) {
     set_args(args);
 
     Heap::the().set_start_of_stack(m_start_of_stack);
-    suspending_fiber->m_end_of_stack = &args;
+    suspending_fiber->m_end_of_stack = __builtin_frame_address(0);
 
     auto res = mco_resume(m_coroutine);
     assert(res == MCO_SUCCESS);
@@ -179,7 +179,7 @@ Value FiberObject::yield(Env *env, Args args) {
     if (!current_fiber->m_previous_fiber)
         env->raise("FiberError", "can't yield from root fiber");
     current_fiber->set_status(Status::Suspended);
-    current_fiber->m_end_of_stack = &args;
+    current_fiber->m_end_of_stack = __builtin_frame_address(0);
     current_fiber->swap_current(env, args);
 
     mco_yield(mco_running());
@@ -203,7 +203,7 @@ void FiberObject::swap_current(Env *env, Args args) {
     Heap::the().set_start_of_stack(s_current->start_of_stack());
 }
 
-void FiberObject::visit_children(Visitor &visitor) {
+NO_SANITIZE_ADDRESS void FiberObject::visit_children(Visitor &visitor) {
     Object::visit_children(visitor);
     for (auto arg : m_args)
         visitor.visit(arg);

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -26,7 +26,7 @@ void MarkingVisitor::visit(Value val) {
     visit(val.object_or_null());
 }
 
-TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
+NO_SANITIZE_ADDRESS TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
     void *dummy;
     void *end_of_stack = &dummy;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,10 +45,9 @@ int main(int argc, char *argv[]) {
 #ifdef NAT_NATIVE_PROFILER
     NativeProfiler::enable();
 #endif
-    Heap::the().set_start_of_stack(&argv);
-#ifdef NAT_GC_COLLECT_ALL_AT_EXIT
-    Heap::the().set_collect_all_at_exit(true);
-#endif
+
+    Heap::the().set_start_of_stack(__builtin_frame_address(0));
+
     setvbuf(stdout, nullptr, _IOLBF, 1024);
 
     Env *env = ::build_top_env();
@@ -56,6 +55,9 @@ int main(int argc, char *argv[]) {
 
 #ifndef NAT_GC_DISABLE
     Heap::the().gc_enable();
+#endif
+#ifdef NAT_GC_COLLECT_ALL_AT_EXIT
+    Heap::the().set_collect_all_at_exit(true);
 #endif
 
     if (argc > 0) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -881,6 +881,7 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
     ModuleObject *klass = singleton_class();
     if (!klass)
         klass = m_klass;
+    assert(klass);
     auto method_info = klass->find_method(env, method_name);
 
     if (!method_info.is_defined()) {

--- a/test/natalie/file_test.rb
+++ b/test/natalie/file_test.rb
@@ -1,5 +1,8 @@
 require_relative '../spec_helper'
 
+tmp_path = File.expand_path('../tmp', __dir__)
+Dir.mkdir(tmp_path) unless File.exist?(tmp_path)
+
 describe 'File' do
   it 'is an IO object' do
     f = File.new('test/support/file.txt')


### PR DESCRIPTION
I'm going to try to revive an oldie but a goodie: #55

By teaching our Fibers and GC to jump through some extra hoops, we are able to run our code with AddressSanitizer enabled.

There are some failing tests, memory leaks reported, etc. but this is a good start, and we can address the remaining issues as we get time.

I don't think that we'll run the entire test suite with AddressSanitizer enabled (it will be too slow), but I'm hoping to find a good representative sample of tests that we can get running.