### PR TITLE
[Bytecode] Convert size elements to BER encoded integers

### DIFF
--- a/lib/natalie/compiler/instructions/push_string_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_string_instruction.rb
@@ -32,7 +32,7 @@ module Natalie
           instruction_number,
           @bytesize,
           @string,
-        ].pack("CQa#{@bytesize}")
+        ].pack("Cwa#{@bytesize}")
       end
     end
   end

--- a/lib/natalie/compiler/instructions/send_instruction.rb
+++ b/lib/natalie/compiler/instructions/send_instruction.rb
@@ -139,7 +139,7 @@ module Natalie
           with_block ? 1 : 0,
           args_array_on_stack ? 1 : 0,
           has_keyword_hash ? 1 : 0,
-        ].pack("CLa#{message_string.bytesize}CCCC")
+        ].pack("Cwa#{message_string.bytesize}CCCC")
       end
 
       private


### PR DESCRIPTION
This is a dynamically sized integer. A byte is split into 7 data bits and 1 continuation bit (the rightmost bit). If the continuation bit is set, the data bits are shifted right 7 positions and the next byte is interpreted. If the continuation bit is not set, the 7 data bits are used as they are. This can be chained for as long as the continuation bit is set. This means we now have a dynamic sized data type, which resolves the discussion about whether 16, 32 or 64 bits should be used to indicate the size.

I wrote a quick program to print the strings "hello world" and a string consisting of 200 dots. This results in the following bytecode:
```
00000000: 4849 0b68 656c 6c6f 2077 6f72 6c64 3a01  HI.hello world:.
00000010: 004f 0470 7574 7301 0000 0037 4849 8148  .O.puts....7HI.H
00000020: 2e2e 2e2e 2e2e 2e2e 2e2e 2e2e 2e2e 2e2e  ................
xxxxxxxx: A couple more lines of 2e
000000e0: 2e2e 2e2e 2e2e 2e2e 3a01 004f 0470 7574  ........:..O.put
000000f0: 7301 0000 0037                           s....7
```

The size for the "hello world" and the "puts" instruction are simply encoded as a single byte: 0b and 04. The size for the 200 dots is encoded as 8148. The binary interpretation if that is 10000001 00010010. The first byte has the continuation bit set, so we take the remaining bits and right-shift them 7 positions, which results in 128. The next byte does not have the continuation bit set, so we can simply interpret them as a binary number, which results in 72. This adds up to 200, exactly the length of the source string.

Ruby has native support for packing and unpacking this format. If we ever need it in C++, it's not that hard to implement (see `IntegerHandler::pack_w`).

I suspect this is the best trade off between byte size and flexibility: most strings/method names will be less than 128 bytes, so that size will fit into a single byte, but it still supports sizes larger than that.