### PR TITLE
Use Eduardo Bart's minicoro library for Fibers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "ext/prism"]
 	path = ext/prism
 	url = https://github.com/ruby/prism
+[submodule "ext/minicoro"]
+	path = ext/minicoro
+	url = https://github.com/edubart/minicoro.git

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | ---------------- | --------------------------------- | ----------------- |
 | `big_int.*`      | Syed Faheel Ahmad                 | MIT               |
 | `dtoa.c`         | David M. Gay, Lucent Technologies | custom permissive |
-| `fiber_object.*` | Evan Jones                        | MIT               |
+| `minicoro.h`     | Eduardo Bart                      | MIT               |
 | `pp.rb`          | Yukihiro Matsumoto                | BSD               |
 | `prettyprint.rb` | Yukihiro Matsumoto                | BSD               |
 | `spec/*`         | Engine Yard, Inc.                 | MIT               |

--- a/Rakefile
+++ b/Rakefile
@@ -501,6 +501,7 @@ def include_paths
   [
     File.expand_path('include', __dir__),
     File.expand_path('ext/tm/include', __dir__),
+    File.expand_path('ext/minicoro', __dir__),
     File.expand_path('build', __dir__),
     File.expand_path('build/onigmo/include', __dir__),
     File.expand_path('build/prism/include', __dir__),

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -1,35 +1,11 @@
-/* Copyright (c) 2020 Evan Jones
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * ----
- *
- * Large portions of this file were copied from Even Jones' libfiber library
- * made available at: https://github.com/evanj/libfiber
- */
-
 #pragma once
 
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <sys/mman.h>
+
+#include "minicoro.h"
 
 #include "natalie/array_object.hpp"
 #include "natalie/class_object.hpp"
@@ -42,13 +18,12 @@
 #include "natalie/symbol_object.hpp"
 
 extern "C" {
-typedef struct {
-    void **stack;
-} fiber_stack_struct;
+void fiber_wrapper_func(mco_coro *co);
 
-extern int fiber_asm_switch(fiber_stack_struct *, fiber_stack_struct *, int, Natalie::Env *, Natalie::FiberObject *);
-extern void fiber_wrapper_func(Natalie::Env *, Natalie::FiberObject *);
-extern void fiber_exit();
+typedef struct {
+    Natalie::Env *env;
+    Natalie::FiberObject *fiber;
+} coroutine_user_data;
 }
 
 namespace Natalie {
@@ -69,13 +44,12 @@ public:
         : Object { Object::Type::Fiber, klass } { }
 
     ~FiberObject() {
-        if (!m_stack_memory)
+        if (!m_coroutine) {
+            // FiberObject::initialize() can raise before the m_coroutine is created.
             return;
-        int err = munmap(m_stack_memory, STACK_SIZE);
-        if (err != 0) {
-            fprintf(stderr, "unmapping failed (errno=%d)\n", errno);
-            abort();
         }
+        auto user_data = (coroutine_user_data *)m_coroutine->user_data;
+        delete user_data;
     }
 
     static void build_main_fiber(void *start_of_stack) {
@@ -93,53 +67,6 @@ public:
 
     static Value yield(Env *env, Args args);
 
-    void create_stack(Env *env, int stack_size) {
-#if defined(__x86_64)
-        // x86-64: rbx, rbp, r12, r13, r14, r15
-        static const int NUM_REGISTERS = 6;
-#elif defined(__aarch64__)
-        // aarch64: x9-x28
-        static const int NUM_REGISTERS = 20;
-#else
-        // x86: ebx, ebp, edi, esi
-        static const int NUM_REGISTERS = 4;
-#endif
-        assert(stack_size % 16 == 0);
-
-#ifdef __OpenBSD__
-        auto mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK;
-#else
-        auto mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS;
-#endif
-        m_stack_memory = mmap(nullptr, stack_size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
-        if (m_stack_memory == MAP_FAILED) {
-            fprintf(stderr, "mapping failed (errno=%d)\n", errno);
-            abort();
-        }
-
-        // FIXME: Fibers only support stacks that grow toward lower addresses
-        void *comparison_ptr = &stack_size;
-        assert(comparison_ptr < Heap::the().start_of_stack());
-
-        m_start_of_stack = reinterpret_cast<char *>(m_stack_memory) + stack_size;
-        m_fiber.stack = reinterpret_cast<void **>(m_start_of_stack);
-#ifdef __APPLE__
-        assert((uintptr_t)m_fiber.stack % 16 == 0);
-#endif
-
-        // this is here in case there's a bug (we shouldn't ever call fiber_exit)
-        *(--m_fiber.stack) = (void *)((uintptr_t)&fiber_exit);
-        // we'll "return" to this function
-        *(--m_fiber.stack) = (void *)((uintptr_t)&fiber_wrapper_func);
-        // push NULL words to initialize the registers loaded by fiber_asm_switch
-        for (int i = 0; i < NUM_REGISTERS; ++i) {
-            *(--m_fiber.stack) = 0;
-        }
-#ifdef __APPLE__
-        assert((uintptr_t)m_fiber.stack % 16 == 0);
-#endif
-    }
-
     Value hash(Env *);
     Value inspect(Env *);
     bool is_alive() const;
@@ -154,11 +81,11 @@ public:
     static Value set_scheduler(Env *, Value);
     Value set_storage(Env *, Value);
     Value storage(Env *) const;
-    void yield_back(Env *env, Args args);
+    void swap_current(Env *env, Args args);
 
     void *start_of_stack() { return m_start_of_stack; }
 
-    fiber_stack_struct *fiber() { return &m_fiber; }
+    mco_coro *coroutine() { return m_coroutine; }
     Block *block() { return m_block; }
     void set_status(Status status) { m_status = status; }
     void set_end_of_stack(void *ptr) { m_end_of_stack = ptr; }
@@ -180,13 +107,14 @@ public:
     virtual void visit_children(Visitor &) override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
+        auto size = m_coroutine ? m_coroutine->stack_size : 0;
         snprintf(
             buf,
             len,
             "<FiberObject %p stack=%p..%p>",
             this,
             m_start_of_stack,
-            reinterpret_cast<char *>(m_start_of_stack) + STACK_SIZE);
+            reinterpret_cast<char *>(m_start_of_stack) + size);
     }
 
     static FiberObject *current() { return s_current; }
@@ -203,8 +131,7 @@ private:
     Block *m_block { nullptr };
     bool m_blocking { false };
     HashObject *m_storage { nullptr };
-    ::fiber_stack_struct m_fiber {};
-    void *m_stack_memory { nullptr };
+    mco_coro *m_coroutine {};
     void *m_start_of_stack { nullptr };
     void *m_end_of_stack { nullptr };
     Status m_status { Status::Created };

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -21,6 +21,7 @@ module Natalie
     INC_PATHS = [
       File.join(ROOT_DIR, 'include'),
       File.join(ROOT_DIR, 'ext/tm/include'),
+      File.join(ROOT_DIR, 'ext/minicoro'),
       File.join(BUILD_DIR),
       File.join(BUILD_DIR, 'onigmo/include'),
     ]


### PR DESCRIPTION
This lets us remove some bespoke x64 and aarch64 assembly in favor of a library that is battle-tested. Also, the library already had support for AddressSanitizer, so I was able to build off of that for #1455.

https://github.com/edubart/minicoro