### PR TITLE
Support more types in YAML.dump

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -19,9 +19,19 @@ static void emit_value(Env *env, StringObject *value, yaml_emitter_t &emitter, y
     emit(env, emitter, event);
 }
 
+static void emit_value(Env *env, SymbolObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
+    TM::String str = value->string();
+    str.prepend_char(':');
+    yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_STR_TAG,
+        (yaml_char_t *)(str.c_str()), str.size(), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    emit(env, emitter, event);
+}
+
 static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
     if (value->is_string()) {
         emit_value(env, value->as_string(), emitter, event);
+    } else if (value->is_symbol()) {
+        emit_value(env, value->as_symbol(), emitter, event);
     } else {
         env->raise("NotImplementedError", "TODO: Implement YAML output for {}", value->klass()->inspect_str());
     }

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -12,6 +12,13 @@ static void emit(Env *env, yaml_emitter_t &emitter, yaml_event_t &event) {
         env->raise("RuntimeError", "Error in yaml_emitter_emit");
 }
 
+static void emit_value(Env *env, FloatObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
+    const auto str = value->to_s()->as_string()->string();
+    yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_FLOAT_TAG,
+        (yaml_char_t *)(str.c_str()), str.size(), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    emit(env, emitter, event);
+}
+
 static void emit_value(Env *env, IntegerObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
     const auto str = value->to_s();
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_INT_TAG,
@@ -35,7 +42,9 @@ static void emit_value(Env *env, SymbolObject *value, yaml_emitter_t &emitter, y
 }
 
 static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    if (value->is_integer()) {
+    if (value->is_float()) {
+        emit_value(env, value->as_float(), emitter, event);
+    } else if (value->is_integer()) {
         emit_value(env, value->as_integer(), emitter, event);
     } else if (value->is_string()) {
         emit_value(env, value->as_string(), emitter, event);

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -12,6 +12,13 @@ static void emit(Env *env, yaml_emitter_t &emitter, yaml_event_t &event) {
         env->raise("RuntimeError", "Error in yaml_emitter_emit");
 }
 
+static void emit_value(Env *env, IntegerObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
+    const auto str = value->to_s();
+    yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_INT_TAG,
+        (yaml_char_t *)(str.c_str()), str.size(), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    emit(env, emitter, event);
+}
+
 static void emit_value(Env *env, StringObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_STR_TAG,
         (yaml_char_t *)(value->as_string()->c_str()), value->as_string()->bytesize(),
@@ -28,7 +35,9 @@ static void emit_value(Env *env, SymbolObject *value, yaml_emitter_t &emitter, y
 }
 
 static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    if (value->is_string()) {
+    if (value->is_integer()) {
+        emit_value(env, value->as_integer(), emitter, event);
+    } else if (value->is_string()) {
         emit_value(env, value->as_string(), emitter, event);
     } else if (value->is_symbol()) {
         emit_value(env, value->as_symbol(), emitter, event);

--- a/lib/yaml.rb
+++ b/lib/yaml.rb
@@ -6,3 +6,9 @@ __ld_flags__ '-lyaml'
 module YAML
   __bind_static_method__ :dump, :YAML_dump
 end
+
+class Object
+  def to_yaml
+    YAML.dump(self)
+  end
+end

--- a/spec/library/yaml/dump_spec.rb
+++ b/spec/library/yaml/dump_spec.rb
@@ -23,7 +23,7 @@ describe "YAML.dump" do
   end
 
   it "returns the same string that #to_yaml on objects" do
-    NATFIXME 'Implement Object#to_yaml', exception: NoMethodError, message: "undefined method `to_yaml'" do
+    NATFIXME 'Dump Array', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
       ["a", "b", "c"].to_yaml.should == YAML.dump(["a", "b", "c"])
     end
   end

--- a/spec/library/yaml/dump_spec.rb
+++ b/spec/library/yaml/dump_spec.rb
@@ -17,9 +17,7 @@ describe "YAML.dump" do
   end
 
   it "returns a string containing dumped YAML when no io provided" do
-    NATFIXME 'Dump Symbol', exception: NotImplementedError, message: 'TODO: Implement YAML output for Symbol' do
-      YAML.dump( :locked ).should match_yaml("--- :locked\n")
-    end
+    YAML.dump( :locked ).should match_yaml("--- :locked\n")
   end
 
   it "returns the same string that #to_yaml on objects" do

--- a/spec/library/yaml/dump_spec.rb
+++ b/spec/library/yaml/dump_spec.rb
@@ -8,7 +8,7 @@ describe "YAML.dump" do
   end
 
   it "converts an object to YAML and write result to io when io provided" do
-    NATFIXME 'Dump Array, support IO argument', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
+    NATFIXME 'support IO argument, implement YAML.load_file', exception: NoMethodError, message: "undefined method `load_file' for YAML:Module" do
       File.open($test_file, 'w' ) do |io|
         YAML.dump( ['badger', 'elephant', 'tiger'], io )
       end
@@ -21,9 +21,7 @@ describe "YAML.dump" do
   end
 
   it "returns the same string that #to_yaml on objects" do
-    NATFIXME 'Dump Array', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
-      ["a", "b", "c"].to_yaml.should == YAML.dump(["a", "b", "c"])
-    end
+    ["a", "b", "c"].to_yaml.should == YAML.dump(["a", "b", "c"])
   end
 
   it "dumps strings into YAML strings" do
@@ -37,9 +35,7 @@ describe "YAML.dump" do
   end
 
   it "dumps Arrays into YAML collection" do
-    NATFIXME 'dumps Arrays into YAML collection', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
-      YAML.dump(["a", "b", "c"]).should match_yaml("--- \n- a\n- b\n- c\n")
-    end
+    YAML.dump(["a", "b", "c"]).should match_yaml("--- \n- a\n- b\n- c\n")
   end
 
   it "dumps an OpenStruct" do

--- a/spec/library/yaml/fixtures/example_class.rb
+++ b/spec/library/yaml/fixtures/example_class.rb
@@ -1,0 +1,7 @@
+module YAMLSpecs
+  class Example
+    def initialize(name)
+      @name = name
+    end
+  end
+end

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -1,0 +1,98 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+require_relative 'fixtures/example_class'
+
+describe "Object#to_yaml" do
+
+  it "returns the YAML representation of an Array object" do
+    %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
+  end
+
+  it "returns the YAML representation of a Hash object" do
+    { "a" => "b"}.to_yaml.should match_yaml("--- \na: b\n")
+  end
+
+  it "returns the YAML representation of a Class object" do
+    YAMLSpecs::Example.new("baz").to_yaml.should match_yaml("--- !ruby/object:YAMLSpecs::Example\nname: baz\n")
+  end
+
+  it "returns the YAML representation of a Date object" do
+    require 'date'
+    Date.parse('1997/12/30').to_yaml.should match_yaml("--- 1997-12-30\n")
+  end
+
+  it "returns the YAML representation of a FalseClass" do
+    false_klass = false
+    false_klass.should be_kind_of(FalseClass)
+    false_klass.to_yaml.should match_yaml("--- false\n")
+  end
+
+  it "returns the YAML representation of a Float object" do
+    float = 1.2
+    float.should be_kind_of(Float)
+    float.to_yaml.should match_yaml("--- 1.2\n")
+  end
+
+  it "returns the YAML representation of an Integer object" do
+    int = 20
+    int.should be_kind_of(Integer)
+    int.to_yaml.should match_yaml("--- 20\n")
+  end
+
+  it "returns the YAML representation of a NilClass object" do
+    nil_klass = nil
+    nil_klass.should be_kind_of(NilClass)
+    nil_klass.to_yaml.should match_yaml("--- \n")
+  end
+
+  it "returns the YAML representation of a RegExp object" do
+    Regexp.new('^a-z+:\\s+\w+').to_yaml.should match_yaml("--- !ruby/regexp /^a-z+:\\s+\\w+/\n")
+  end
+
+  it "returns the YAML representation of a String object" do
+    "I love Ruby".to_yaml.should match_yaml("--- I love Ruby\n")
+  end
+
+  it "returns the YAML representation of a Struct object" do
+    Person = Struct.new(:name, :gender)
+    Person.new("Jane", "female").to_yaml.should match_yaml("--- !ruby/struct:Person\nname: Jane\ngender: female\n")
+  end
+
+  it "returns the YAML representation of a Symbol object" do
+    :symbol.to_yaml.should match_yaml("--- :symbol\n")
+  end
+
+  it "returns the YAML representation of a Time object" do
+    Time.utc(2000,"jan",1,20,15,1).to_yaml.sub(/\.0+/, "").should match_yaml("--- 2000-01-01 20:15:01 Z\n")
+  end
+
+  it "returns the YAML representation of a TrueClass" do
+    true_klass = true
+    true_klass.should be_kind_of(TrueClass)
+    true_klass.to_yaml.should match_yaml("--- true\n")
+  end
+
+  it "returns the YAML representation of a Error object" do
+    StandardError.new("foobar").to_yaml.should match_yaml("--- !ruby/exception:StandardError\nmessage: foobar\nbacktrace: \n")
+  end
+
+  it "returns the YAML representation for Range objects" do
+    yaml = Range.new(1,3).to_yaml
+    yaml.include?("!ruby/range").should be_true
+    yaml.include?("begin: 1").should be_true
+    yaml.include?("end: 3").should be_true
+    yaml.include?("excl: false").should be_true
+  end
+
+  it "returns the YAML representation of numeric constants" do
+    nan_value.to_yaml.downcase.should match_yaml("--- .nan\n")
+    infinity_value.to_yaml.downcase.should match_yaml("--- .inf\n")
+    (-infinity_value).to_yaml.downcase.should match_yaml("--- -.inf\n")
+    (0.0).to_yaml.should match_yaml("--- 0.0\n")
+  end
+
+  it "returns the YAML representation of an array of hashes" do
+    players = [{"a" => "b"}, {"b" => "c"}]
+    players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
+  end
+end

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -32,9 +32,7 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of a FalseClass" do
     false_klass = false
     false_klass.should be_kind_of(FalseClass)
-    NATFIXME 'YAML.dump for booleans', exception: NotImplementedError, message: 'TODO: Implement YAML output for FalseClass' do
-      false_klass.to_yaml.should match_yaml("--- false\n")
-    end
+    false_klass.to_yaml.should match_yaml("--- false\n")
   end
 
   it "returns the YAML representation of a Float object" do
@@ -87,9 +85,7 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of a TrueClass" do
     true_klass = true
     true_klass.should be_kind_of(TrueClass)
-    NATFIXME 'YAML.dump for booleans', exception: NotImplementedError, message: 'TODO: Implement YAML output for TrueClass' do
-      true_klass.to_yaml.should match_yaml("--- true\n")
-    end
+    true_klass.to_yaml.should match_yaml("--- true\n")
   end
 
   it "returns the YAML representation of a Error object" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -40,9 +40,7 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of a Float object" do
     float = 1.2
     float.should be_kind_of(Float)
-    NATFIXME 'YAML.dump for floats', exception: NotImplementedError, message: 'TODO: Implement YAML output for Float' do
-      float.to_yaml.should match_yaml("--- 1.2\n")
-    end
+    float.to_yaml.should match_yaml("--- 1.2\n")
   end
 
   it "returns the YAML representation of an Integer object" do
@@ -111,12 +109,14 @@ describe "Object#to_yaml" do
   end
 
   it "returns the YAML representation of numeric constants" do
-    NATFIXME 'YAML.dump for floats', exception: NotImplementedError, message: 'TODO: Implement YAML output for Float' do
+    NATFIXME 'Fix YAML dump of Float::NAN', exception: SpecFailedException do
       nan_value.to_yaml.downcase.should match_yaml("--- .nan\n")
+    end
+    NATFIXME 'Fix YAML dump of Float::INFINITY', exception: SpecFailedException do
       infinity_value.to_yaml.downcase.should match_yaml("--- .inf\n")
       (-infinity_value).to_yaml.downcase.should match_yaml("--- -.inf\n")
-      (0.0).to_yaml.should match_yaml("--- 0.0\n")
     end
+    (0.0).to_yaml.should match_yaml("--- 0.0\n")
   end
 
   it "returns the YAML representation of an array of hashes" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -5,48 +5,66 @@ require_relative 'fixtures/example_class'
 describe "Object#to_yaml" do
 
   it "returns the YAML representation of an Array object" do
-    %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
+    NATFIXME 'YAML.dump for Arrays', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
+      %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
+    end
   end
 
   it "returns the YAML representation of a Hash object" do
-    { "a" => "b"}.to_yaml.should match_yaml("--- \na: b\n")
+    NATFIXME 'YAML.dump for Hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Hash' do
+      { "a" => "b"}.to_yaml.should match_yaml("--- \na: b\n")
+    end
   end
 
   it "returns the YAML representation of a Class object" do
-    YAMLSpecs::Example.new("baz").to_yaml.should match_yaml("--- !ruby/object:YAMLSpecs::Example\nname: baz\n")
+    NATFIXME 'YAML.dump for Class objects', exception: NotImplementedError, message: 'TODO: Implement YAML output for YAMLSpecs::Example' do
+      YAMLSpecs::Example.new("baz").to_yaml.should match_yaml("--- !ruby/object:YAMLSpecs::Example\nname: baz\n")
+    end
   end
 
   it "returns the YAML representation of a Date object" do
     require 'date'
-    Date.parse('1997/12/30').to_yaml.should match_yaml("--- 1997-12-30\n")
+    NATFIXME 'Implement Date.parse', exception: NoMethodError, message: "undefined method `parse' for Date:Class" do
+      Date.parse('1997/12/30').to_yaml.should match_yaml("--- 1997-12-30\n")
+    end
   end
 
   it "returns the YAML representation of a FalseClass" do
     false_klass = false
     false_klass.should be_kind_of(FalseClass)
-    false_klass.to_yaml.should match_yaml("--- false\n")
+    NATFIXME 'YAML.dump for booleans', exception: NotImplementedError, message: 'TODO: Implement YAML output for FalseClass' do
+      false_klass.to_yaml.should match_yaml("--- false\n")
+    end
   end
 
   it "returns the YAML representation of a Float object" do
     float = 1.2
     float.should be_kind_of(Float)
-    float.to_yaml.should match_yaml("--- 1.2\n")
+    NATFIXME 'YAML.dump for floats', exception: NotImplementedError, message: 'TODO: Implement YAML output for Float' do
+      float.to_yaml.should match_yaml("--- 1.2\n")
+    end
   end
 
   it "returns the YAML representation of an Integer object" do
     int = 20
     int.should be_kind_of(Integer)
-    int.to_yaml.should match_yaml("--- 20\n")
+    NATFIXME 'YAML.dump for Integers', exception: NotImplementedError, message: 'TODO: Implement YAML output for Integer' do
+      int.to_yaml.should match_yaml("--- 20\n")
+    end
   end
 
   it "returns the YAML representation of a NilClass object" do
     nil_klass = nil
     nil_klass.should be_kind_of(NilClass)
-    nil_klass.to_yaml.should match_yaml("--- \n")
+    NATFIXME 'YAML.dump for nil', exception: NotImplementedError, message: 'TODO: Implement YAML output for NilClass' do
+      nil_klass.to_yaml.should match_yaml("--- \n")
+    end
   end
 
   it "returns the YAML representation of a RegExp object" do
-    Regexp.new('^a-z+:\\s+\w+').to_yaml.should match_yaml("--- !ruby/regexp /^a-z+:\\s+\\w+/\n")
+    NATFIXME 'YAML.dump for Regexps', exception: NotImplementedError, message: 'TODO: Implement YAML output for Regexp' do
+      Regexp.new('^a-z+:\\s+\w+').to_yaml.should match_yaml("--- !ruby/regexp /^a-z+:\\s+\\w+/\n")
+    end
   end
 
   it "returns the YAML representation of a String object" do
@@ -55,44 +73,60 @@ describe "Object#to_yaml" do
 
   it "returns the YAML representation of a Struct object" do
     Person = Struct.new(:name, :gender)
-    Person.new("Jane", "female").to_yaml.should match_yaml("--- !ruby/struct:Person\nname: Jane\ngender: female\n")
+    NATFIXME 'YAML.dump for Struct objects', exception: NotImplementedError, message: 'TODO: Implement YAML output for Person' do
+      Person.new("Jane", "female").to_yaml.should match_yaml("--- !ruby/struct:Person\nname: Jane\ngender: female\n")
+    end
   end
 
   it "returns the YAML representation of a Symbol object" do
-    :symbol.to_yaml.should match_yaml("--- :symbol\n")
+    NATFIXME 'YAML.dump for Symbols', exception: NotImplementedError, message: 'TODO: Implement YAML output for Symbol' do
+      :symbol.to_yaml.should match_yaml("--- :symbol\n")
+    end
   end
 
   it "returns the YAML representation of a Time object" do
-    Time.utc(2000,"jan",1,20,15,1).to_yaml.sub(/\.0+/, "").should match_yaml("--- 2000-01-01 20:15:01 Z\n")
+    NATFIXME 'YAML.dump for Time objects', exception: NotImplementedError, message: 'Implement YAML output for Time' do
+      Time.utc(2000,"jan",1,20,15,1).to_yaml.sub(/\.0+/, "").should match_yaml("--- 2000-01-01 20:15:01 Z\n")
+    end
   end
 
   it "returns the YAML representation of a TrueClass" do
     true_klass = true
     true_klass.should be_kind_of(TrueClass)
-    true_klass.to_yaml.should match_yaml("--- true\n")
+    NATFIXME 'YAML.dump for booleans', exception: NotImplementedError, message: 'TODO: Implement YAML output for TrueClass' do
+      true_klass.to_yaml.should match_yaml("--- true\n")
+    end
   end
 
   it "returns the YAML representation of a Error object" do
-    StandardError.new("foobar").to_yaml.should match_yaml("--- !ruby/exception:StandardError\nmessage: foobar\nbacktrace: \n")
+    NATFIXME 'YAML.dump for Error objects', exception: NotImplementedError, message: 'TODO: Implement YAML output for StandardError' do
+      StandardError.new("foobar").to_yaml.should match_yaml("--- !ruby/exception:StandardError\nmessage: foobar\nbacktrace: \n")
+    end
   end
 
   it "returns the YAML representation for Range objects" do
-    yaml = Range.new(1,3).to_yaml
-    yaml.include?("!ruby/range").should be_true
-    yaml.include?("begin: 1").should be_true
-    yaml.include?("end: 3").should be_true
-    yaml.include?("excl: false").should be_true
+    NATFIXME 'YAML.dump for ranges', exception: NotImplementedError, message: 'TODO: Implement YAML output for Range' do
+      yaml = Range.new(1,3).to_yaml
+      yaml.include?("!ruby/range").should be_true
+      yaml.include?("begin: 1").should be_true
+      yaml.include?("end: 3").should be_true
+      yaml.include?("excl: false").should be_true
+    end
   end
 
   it "returns the YAML representation of numeric constants" do
-    nan_value.to_yaml.downcase.should match_yaml("--- .nan\n")
-    infinity_value.to_yaml.downcase.should match_yaml("--- .inf\n")
-    (-infinity_value).to_yaml.downcase.should match_yaml("--- -.inf\n")
-    (0.0).to_yaml.should match_yaml("--- 0.0\n")
+    NATFIXME 'YAML.dump for floats', exception: NotImplementedError, message: 'TODO: Implement YAML output for Float' do
+      nan_value.to_yaml.downcase.should match_yaml("--- .nan\n")
+      infinity_value.to_yaml.downcase.should match_yaml("--- .inf\n")
+      (-infinity_value).to_yaml.downcase.should match_yaml("--- -.inf\n")
+      (0.0).to_yaml.should match_yaml("--- 0.0\n")
+    end
   end
 
   it "returns the YAML representation of an array of hashes" do
     players = [{"a" => "b"}, {"b" => "c"}]
-    players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
+    NATFIXME 'YAML.dump for arrays and hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
+      players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
+    end
   end
 end

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -79,9 +79,7 @@ describe "Object#to_yaml" do
   end
 
   it "returns the YAML representation of a Symbol object" do
-    NATFIXME 'YAML.dump for Symbols', exception: NotImplementedError, message: 'TODO: Implement YAML output for Symbol' do
-      :symbol.to_yaml.should match_yaml("--- :symbol\n")
-    end
+    :symbol.to_yaml.should match_yaml("--- :symbol\n")
   end
 
   it "returns the YAML representation of a Time object" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -48,9 +48,7 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of an Integer object" do
     int = 20
     int.should be_kind_of(Integer)
-    NATFIXME 'YAML.dump for Integers', exception: NotImplementedError, message: 'TODO: Implement YAML output for Integer' do
-      int.to_yaml.should match_yaml("--- 20\n")
-    end
+    int.to_yaml.should match_yaml("--- 20\n")
   end
 
   it "returns the YAML representation of a NilClass object" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -5,7 +5,7 @@ require_relative 'fixtures/example_class'
 describe "Object#to_yaml" do
 
   it "returns the YAML representation of an Array object" do
-    NATFIXME 'YAML.dump for Arrays', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
+    NATFIXME 'Dump string integers in quotes', exception: SpecFailedException do
       %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
     end
   end
@@ -117,7 +117,7 @@ describe "Object#to_yaml" do
 
   it "returns the YAML representation of an array of hashes" do
     players = [{"a" => "b"}, {"b" => "c"}]
-    NATFIXME 'YAML.dump for arrays and hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Array' do
+    NATFIXME 'YAML.dump for hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Hash' do
       players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
     end
   end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -889,15 +889,23 @@ class YAMLExpectation
   end
 
   def match(subject)
-    if subject.delete_suffix!("...\n") != @expected
+    if prepare_yaml(subject) != @expected
       raise SpecFailedException, "#{subject.inspect} should be equal to #{@expected.inspect}"
     end
   end
 
   def inverted_match(subject)
-    if subject.delete_suffix!("...\n") == @expected
+    if prepare_yaml(subject) == @expected
       raise SpecFailedException, "#{subject.inspect} should not be equal to #{@expected.inspect}"
     end
+  end
+
+  private
+
+  def prepare_yaml(yaml)
+    yaml
+      .delete_suffix!("...\n")
+      .gsub(/^---\n/, "--- \n")
   end
 end
 


### PR DESCRIPTION
Add support for symbol, simple numeric values, booleans and arrays. The arrays work with recursion.
The method `Object#to_yaml` has been added as well, since these tests are better tests for `YAML.dump` than the regular tests for `YAML.dump`