### PR TITLE
Add more types to YAML.dump

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -47,6 +47,12 @@ static void emit_value(Env *env, IntegerObject *value, yaml_emitter_t &emitter, 
     emit(env, emitter, event);
 }
 
+static void emit_value(Env *env, NilObject *, yaml_emitter_t &emitter, yaml_event_t &event) {
+    yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_NULL_TAG,
+        (yaml_char_t *)"", 0, 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    emit(env, emitter, event);
+}
+
 static void emit_value(Env *env, StringObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_STR_TAG,
         (yaml_char_t *)(value->as_string()->c_str()), value->as_string()->bytesize(),
@@ -78,6 +84,8 @@ static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_even
         emit_value(env, value->as_float(), emitter, event);
     } else if (value->is_integer()) {
         emit_value(env, value->as_integer(), emitter, event);
+    } else if (value->is_nil()) {
+        emit_value(env, value->as_nil(), emitter, event);
     } else if (value->is_string()) {
         emit_value(env, value->as_string(), emitter, event);
     } else if (value->is_symbol()) {

--- a/spec/library/yaml/dump_spec.rb
+++ b/spec/library/yaml/dump_spec.rb
@@ -29,9 +29,7 @@ describe "YAML.dump" do
   end
 
   it "dumps hashes into YAML key-values" do
-    NATFIXME 'dumps hashes into YAML key-values', exception: NotImplementedError, message: 'TODO: Implement YAML output for Hash' do
-      YAML.dump({ "a" => "b" }).should match_yaml("--- \na: b\n")
-    end
+    YAML.dump({ "a" => "b" }).should match_yaml("--- \na: b\n")
   end
 
   it "dumps Arrays into YAML collection" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -50,9 +50,7 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of a NilClass object" do
     nil_klass = nil
     nil_klass.should be_kind_of(NilClass)
-    NATFIXME 'YAML.dump for nil', exception: NotImplementedError, message: 'TODO: Implement YAML output for NilClass' do
-      nil_klass.to_yaml.should match_yaml("--- \n")
-    end
+    nil_klass.to_yaml.should match_yaml("--- \n")
   end
 
   it "returns the YAML representation of a RegExp object" do

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -11,9 +11,7 @@ describe "Object#to_yaml" do
   end
 
   it "returns the YAML representation of a Hash object" do
-    NATFIXME 'YAML.dump for Hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Hash' do
-      { "a" => "b"}.to_yaml.should match_yaml("--- \na: b\n")
-    end
+    { "a" => "b"}.to_yaml.should match_yaml("--- \na: b\n")
   end
 
   it "returns the YAML representation of a Class object" do
@@ -115,8 +113,6 @@ describe "Object#to_yaml" do
 
   it "returns the YAML representation of an array of hashes" do
     players = [{"a" => "b"}, {"b" => "c"}]
-    NATFIXME 'YAML.dump for hashes', exception: NotImplementedError, message: 'TODO: Implement YAML output for Hash' do
-      players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
-    end
+    players.to_yaml.should match_yaml("--- \n- a: b\n- b: c\n")
   end
 end


### PR DESCRIPTION
This adds support for `nil` and Hash objects. We should now be able to dump most data structures used in YAML.