### PR TITLE
Support IO argument in YAML.dump

### DIFF
--- a/spec/library/yaml/dump_spec.rb
+++ b/spec/library/yaml/dump_spec.rb
@@ -12,7 +12,7 @@ describe "YAML.dump" do
   end
 
   it "converts an object to YAML and write result to io when io provided" do
-    NATFIXME 'support IO argument, implement YAML.load_file', exception: NoMethodError, message: "undefined method `load_file' for YAML:Module" do
+    NATFIXME 'implement YAML.load_file', exception: NoMethodError, message: "undefined method `load_file' for YAML:Module" do
       File.open(@test_file, 'w' ) do |io|
         YAML.dump( ['badger', 'elephant', 'tiger'], io )
       end

--- a/test/natalie/yaml_test.rb
+++ b/test/natalie/yaml_test.rb
@@ -1,0 +1,15 @@
+require_relative '../spec_helper'
+require 'yaml'
+
+describe 'YAML.dump' do
+  it 'supports an IO object as a second argument' do
+    filename = tmp('yaml_dump')
+    File.open(filename, 'w') do |fh|
+      res = YAML.dump(['a', 'b'], fh)
+      res.should == fh
+    end
+    File.read(filename).should == YAML.dump(['a', 'b'])
+  ensure
+    rm_r filename
+  end
+end


### PR DESCRIPTION
Which needs a `FILE*` buffer, so this serves as a reminder to myself that I really should look at # #1395.