### PR TITLE
Refresh specs for Kernel.Integer

### DIFF
--- a/spec/core/kernel/Integer_spec.rb
+++ b/spec/core/kernel/Integer_spec.rb
@@ -145,7 +145,7 @@ describe :kernel_integer, shared: true do
   end
 end
 
-describe "Integer() given a String", shared: true do
+describe :kernel_integer_string, shared: true do
   it "raises an ArgumentError if the String is a null byte" do
     -> { Integer("\0") }.should raise_error(ArgumentError)
   end
@@ -348,7 +348,7 @@ describe "Integer() given a String", shared: true do
   end
 end
 
-describe "Integer() given a String and base", shared: true do
+describe :kernel_integer_string_base, shared: true do
   it "raises an ArgumentError if the String is a null byte" do
     -> { Integer("\0", 2) }.should raise_error(ArgumentError)
   end
@@ -573,16 +573,31 @@ describe "Integer() given a String and base", shared: true do
         -> { Integer("0#{d}1", base) }.should raise_error(ArgumentError)
       end
     end
+  end
 
-    it "raises an ArgumentError if a base is given for a non-String value" do
-      -> { Integer(98, 15) }.should raise_error(ArgumentError)
+  it "raises an ArgumentError if a base is given for a non-String value" do
+    -> { Integer(98, 15) }.should raise_error(ArgumentError)
+  end
+
+  it "tries to convert the base to an integer using to_int" do
+    obj = mock('8')
+    obj.should_receive(:to_int).and_return(8)
+
+    Integer("777", obj).should == 0777
+  end
+
+  # https://bugs.ruby-lang.org/issues/19349
+  ruby_version_is ''...'3.3' do
+    it "ignores the base if it is not an integer and does not respond to #to_i" do
+      Integer("777", "8").should == 777
     end
+  end
 
-    it "tries to convert the base to an integer using to_int" do
-      obj = mock('8')
-      obj.should_receive(:to_int).and_return(8)
-
-      Integer("777", obj).should == 0777
+  ruby_version_is '3.3' do
+    it "raises a TypeError if it is not an integer and does not respond to #to_i" do
+      -> {
+        Integer("777", "8")
+      }.should raise_error(TypeError, "no implicit conversion of String into Integer")
     end
   end
 
@@ -784,9 +799,9 @@ describe "Kernel.Integer" do
 
   # TODO: fix these specs
   it_behaves_like :kernel_integer, :Integer, Kernel
-  it_behaves_like "Integer() given a String", :Integer
+  it_behaves_like :kernel_integer_string, :Integer
 
-  it_behaves_like "Integer() given a String and base", :Integer
+  it_behaves_like :kernel_integer_string_base, :Integer
 
   it "is a public method" do
     Kernel.Integer(10).should == 10
@@ -798,9 +813,9 @@ describe "Kernel#Integer" do
 
   # TODO: fix these specs
   it_behaves_like :kernel_integer, :Integer, Object.new
-  it_behaves_like "Integer() given a String", :Integer
+  it_behaves_like :kernel_integer_string, :Integer
 
-  it_behaves_like "Integer() given a String and base", :Integer
+  it_behaves_like :kernel_integer_string_base, :Integer
 
   it "is a private method" do
     Kernel.should have_private_instance_method(:Integer)

--- a/test/natalie/kernel_integer_test.rb
+++ b/test/natalie/kernel_integer_test.rb
@@ -28,9 +28,4 @@ describe 'Kernel.Integer' do
     Integer('0010', 8).should == 8
     Integer('0010', 10).should == 10
   end
-
-  # NATFIXME: Probably a bug in Ruby: https://bugs.ruby-lang.org/issues/19349
-  it 'ignores a base argument that does not respond to #to_int' do
-    Integer('10', '8').should == 10
-  end
 end


### PR DESCRIPTION
And remove our local test for a base argument that cannot be coerced into an integer, these have been accepted upstream (including version guards and a spec for the fix in Ruby 3.3).