### PR TITLE
Fix PP.pp with generic object

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -297,7 +297,7 @@ class PP < PrettyPrint
           text '='
           group(1) {
             breakable ''
-            pp(obj.instance_eval(v))
+            pp(obj.instance_variable_get(v))
           }
         }
       }

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -295,6 +295,8 @@ class StringIO
     argument.bytes.size
   end
 
+  alias << write
+
   private def __assert_not_read_closed
     raise IOError, 'not opened for reading' if closed_read?
   end

--- a/test/natalie/pp_test.rb
+++ b/test/natalie/pp_test.rb
@@ -1,0 +1,19 @@
+require_relative '../spec_helper'
+require 'stringio'
+require 'pp'
+
+class Foo
+  def initialize
+    @foo = 'foo'
+  end
+end
+
+describe 'PP' do
+  it 'it handles generic objects' do
+    out = ''
+    io = StringIO.new(out)
+    obj = Foo.new
+    PP.pp obj, io
+    out.should =~ /\A#<Foo:0x[0-9a-f]+ @foo="foo">\n\z/
+  end
+end


### PR DESCRIPTION
We don't support instance_eval with a string, but instance_variable_get works fine here.