### PR TITLE
Implement Set#pretty_print_cycle

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -296,6 +296,10 @@ class Set
     self
   end
 
+  def pretty_print_cycle(pp)
+    pp.text('#<Set: {...}>')
+  end
+
   def proper_subset?(other)
     unless other.is_a?(self.class)
       raise ArgumentError, 'value must be a set'

--- a/spec/library/set/pretty_print_cycle_spec.rb
+++ b/spec/library/set/pretty_print_cycle_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require 'set'
+
+describe "Set#pretty_print_cycle" do
+  it "passes the 'pretty print' representation of a self-referencing Set to the pretty print writer" do
+    pp = mock("PrettyPrint")
+    pp.should_receive(:text).with("#<Set: {...}>")
+    Set[1, 2, 3].pretty_print_cycle(pp)
+  end
+end


### PR DESCRIPTION
It contains a tiny bit of duplication with `#to_s`, but every possible abstraction would be a disproportional amount of work, so it didn't seem worth it doing it in any other way.