### PR TITLE
Support Regexp objects in YAML.dump

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -67,6 +67,13 @@ static void emit_value(Env *env, NilObject *, yaml_emitter_t &emitter, yaml_even
     emit(env, emitter, event);
 }
 
+static void emit_value(Env *env, RegexpObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
+    auto str = value->inspect_str(env);
+    yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/regexp",
+        (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_PLAIN_SCALAR_STYLE);
+    emit(env, emitter, event);
+}
+
 static void emit_value(Env *env, StringObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_STR_TAG,
         (yaml_char_t *)(value->as_string()->c_str()), value->as_string()->bytesize(),
@@ -102,6 +109,8 @@ static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_even
         emit_value(env, value->as_integer(), emitter, event);
     } else if (value->is_nil()) {
         emit_value(env, value->as_nil(), emitter, event);
+    } else if (value->is_regexp()) {
+        emit_value(env, value->as_regexp(), emitter, event);
     } else if (value->is_string()) {
         emit_value(env, value->as_string(), emitter, event);
     } else if (value->is_symbol()) {

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -51,9 +51,7 @@ describe "Object#to_yaml" do
   end
 
   it "returns the YAML representation of a RegExp object" do
-    NATFIXME 'YAML.dump for Regexps', exception: NotImplementedError, message: 'TODO: Implement YAML output for Regexp' do
-      Regexp.new('^a-z+:\\s+\w+').to_yaml.should match_yaml("--- !ruby/regexp /^a-z+:\\s+\\w+/\n")
-    end
+    Regexp.new('^a-z+:\\s+\w+').to_yaml.should match_yaml("--- !ruby/regexp /^a-z+:\\s+\\w+/\n")
   end
 
   it "returns the YAML representation of a String object" do


### PR DESCRIPTION
Which was pretty much brute forcing options until the output matched. The authors of libyaml kind of forgot to write documentation for the API.