### PR TITLE
Remove the end document marker from YAML output

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -152,7 +152,7 @@ Value YAML_dump(Env *env, Value self, Args args, Block *) {
 
     emit_value(env, value, emitter, event);
 
-    yaml_document_end_event_initialize(&event, 0);
+    yaml_document_end_event_initialize(&event, 1);
     emit(env, emitter, event);
 
     yaml_stream_end_event_initialize(&event);

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -904,7 +904,6 @@ class YAMLExpectation
 
   def prepare_yaml(yaml)
     yaml
-      .delete_suffix!("...\n")
       .gsub(/^---\n/, "--- \n")
   end
 end


### PR DESCRIPTION
Before:
```
ruby -ryaml -e 'print YAML.dump([1,2,3])'; echo ''; bin/natalie -ryaml -e 'print YAML.dump([1,2,3])'
---
- 1
- 2
- 3

---
- 1
- 2
- 3
...
```
The `...` is an optional end marker in YAML. MRI does not add this, but we currently do.

After:
```
ruby -ryaml -e 'print YAML.dump([1,2,3])'; echo ''; bin/natalie -ryaml -e 'print YAML.dump([1,2,3])'
---
- 1
- 2
- 3

---
- 1
- 2
- 3
```