### PR TITLE
Fix alias to new global variable

### DIFF
--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -46,8 +46,11 @@ Value GlobalEnv::global_alias(Env *env, SymbolObject *new_name, SymbolObject *ol
         env->raise_name_error(old_name, "`{}' is not allowed as a global variable name", old_name->string());
 
     auto info = m_global_variables.get(old_name, env);
-    if (info)
-        m_global_variables.put(new_name, info, env);
+    if (!info) {
+        global_set(env, old_name, NilObject::the());
+        info = m_global_variables.get(old_name, env);
+    }
+    m_global_variables.put(new_name, info, env);
     return info->object();
 }
 

--- a/test/natalie/alias_test.rb
+++ b/test/natalie/alias_test.rb
@@ -1,0 +1,12 @@
+require_relative '../spec_helper'
+
+describe 'global aliases' do
+  it 'should create a new global if the alias destination does not exist' do
+    code = <<~RUBY
+      alias $foo $bar
+      $bar = 'bar'
+      puts $foo
+    RUBY
+    ruby_exe(code).should == "bar\n"
+  end
+end


### PR DESCRIPTION
The old version resulted in a segfault. MRI's behaviour is to add the target global with the default `nil` value.