### PR TITLE
Very crude test for running the bytecode VM

### DIFF
--- a/test/bytecode/puts_string_test.rb
+++ b/test/bytecode/puts_string_test.rb
@@ -1,0 +1,18 @@
+require_relative '../spec_helper'
+
+describe 'puts a string' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run a puts with a static string' do
+    code = 'puts "foo"'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+  end
+end


### PR DESCRIPTION
Compile a very simple program into bytecode, run it and compare the expected output.

For now it's not part of any automated test, so you have to run the file manually.
I'm not really satisfied with the way we now have to run natalie twice within the test: once to generate the bytecode and once to run it. This could simply be kept in an internal buffer. Once we run the VM internally, we should be able to inspect the stack instead of having to depend on printing the output. (So running `2+3` should result in the number `5` on the stack without having the need to print it).