### PR TITLE
Fix calling private method with self.<method> syntax

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -499,7 +499,7 @@ module Natalie
         instructions << SendInstruction.new(
           message,
           args_array_on_stack: call_args.fetch(:args_array_on_stack),
-          receiver_is_self: receiver.nil?,
+          receiver_is_self: receiver.nil? || receiver.is_a?(Prism::SelfNode),
           with_block: with_block,
           has_keyword_hash: call_args.fetch(:has_keyword_hash),
           forward_args: call_args[:forward_args],

--- a/test/natalie/method_visibility_test.rb
+++ b/test/natalie/method_visibility_test.rb
@@ -9,6 +9,10 @@ class Foo
     private_foo
   end
 
+  def public_foo_calling_private_foo_with_self
+    self.private_foo # rubocop:disable Style/RedundantSelf
+  end
+
   def public_foo_calling_protected_foo
     protected_foo
   end
@@ -100,6 +104,10 @@ describe 'method visibility' do
 
     it 'is not visible from inside a subclass calling the method on another object (not self)' do
       -> { Bar.new.public_bar_calling_private_foo_on_another_object }.should raise_error(NoMethodError)
+    end
+
+    it 'is callable from public method with using self' do
+      Foo.new.public_foo_calling_private_foo_with_self.should == 'private'
     end
   end
 


### PR DESCRIPTION
Not sure if the explicit check for `Prism::SelfNode` is good practice, but it works :sweat_smile: 