### PR TITLE
Try to resolve constants in Object

### DIFF
--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -193,8 +193,9 @@ Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject
     if (this != GlobalEnv::the()->Object() && search_mode == ConstLookupSearchMode::NotStrict) {
         // lastly, search on the global, i.e. Object namespace
         search_parent = GlobalEnv::the()->Object();
-        if (found_in_module) *found_in_module = search_parent;
-        constant = search_parent->m_constants.get(name);
+        ModuleObject *found = nullptr;
+        constant = search_parent->find_constant(env, name, &found, search_mode);
+        if (found_in_module) *found_in_module = found;
     }
 
     if (constant) check_valid(constant);

--- a/test/natalie/constant_test.rb
+++ b/test/natalie/constant_test.rb
@@ -7,6 +7,10 @@ class Object
   CONST_IN_OBJECT = :object
 end
 
+module Kernel
+  CONST_IN_KERNEL = :kernel
+end
+
 module Mixin
   CONST_IN_MIXIN = :mixin
 
@@ -44,6 +48,14 @@ class TheClass < TheSuperclass
   def mixin_constant
     mixin_method
   end
+
+  def object_const
+    CONST_IN_OBJECT
+  end
+
+  def kernel_const
+    CONST_IN_KERNEL
+  end
 end
 
 describe 'constants' do
@@ -72,6 +84,14 @@ describe 'constants' do
 
   it 'does not find the constant on the Object class' do
     -> { TheClass::CONST_IN_OBJECT }.should raise_error(NameError)
+  end
+
+  it 'does find constant from Object class if referenced in other class' do
+    TheClass.new.object_const.should == :object
+  end
+
+  it 'does find constant from Kernel module if referenced in other class' do
+    TheClass.new.kernel_const.should == :kernel
   end
 
   it 'finds constants in a mixin when resolved from a subclass' do


### PR DESCRIPTION
Previously we were directly searching the constant list of Object which missed constants defined in included modules of Object.

One example where this failed was with constants defined in the Kernel module that is included into the Object class. This produced errors with the SprintfFormatter class defined in the Kernel module when sprintf is called inside of a class.