### PR TITLE
Refactor compiler backend

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -153,8 +153,8 @@ class Runner
       if options[:interpret]
         puts compiler.instructions.map(&:to_s)
       else
-        compiler.write_file
-        print_cpp_source(compiler.c_path)
+        path = compiler.write_file_for_debugging
+        print_cpp_source(path)
       end
     elsif options[:debug] == 'S'
       show_assembly

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -51,16 +51,13 @@ module Natalie
 
     def build_context
       {
-        var_num:             0,
-        is_obj:              !!write_obj_path,
-        repl:                !!repl,
-        vars:                vars || {},
         inline_cpp_enabled:  inline_cpp_enabled,
-        compile_cxx_flags:   [],
-        compile_ld_flags:    [],
-        source_path:         @path,
+        repl:                !!repl,
         required_cpp_files:  {},
         required_ruby_files: {},
+        source_path:         @path,
+        var_num:             0,
+        vars:                vars || {},
       }
     end
 

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -158,6 +158,10 @@ module Natalie
       !!options[:interpret]
     end
 
+    def dynamic_linking?
+      !!options[:dynamic_linking]
+    end
+
     def inc_paths
       INC_PATHS.map { |path| "-I #{path}" }.join(' ')
     end
@@ -168,14 +172,6 @@ module Natalie
 
     def shared?
       !!repl
-    end
-
-    def libraries
-      if options[:dynamic_linking]
-        LIBRARIES_FOR_DYNAMIC_LINKING
-      else
-        LIBRARIES_FOR_STATIC_LINKING
-      end
     end
 
     def link_flags

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -17,7 +17,6 @@ module Natalie
 
     ROOT_DIR = File.expand_path('../../', __dir__)
     BUILD_DIR = File.join(ROOT_DIR, 'build')
-    SRC_PATH = File.join(ROOT_DIR, 'src')
     INC_PATHS = [
       File.join(ROOT_DIR, 'include'),
       File.join(ROOT_DIR, 'ext/tm/include'),
@@ -64,9 +63,6 @@ module Natalie
 
     RB_LIB_PATH = File.expand_path('..', __dir__)
 
-    MAIN_TEMPLATE = File.read(File.join(SRC_PATH, 'main.cpp'))
-    OBJ_TEMPLATE = File.read(File.join(SRC_PATH, 'obj_unit.cpp'))
-
     class CompileError < StandardError
     end
 
@@ -110,7 +106,6 @@ module Natalie
       {
         var_prefix:          var_prefix,
         var_num:             0,
-        template:            template,
         is_obj:              !!write_obj_path,
         repl:                !!repl,
         vars:                vars || {},
@@ -181,6 +176,12 @@ module Natalie
         libraries.join(' '),
         link_flags,
       ].map(&:to_s).join(' ')
+    end
+
+    def obj_name
+      # FIXME: I don't like that this method "knows" how to ignore the build/generated directory
+      # Maybe we need another arg to specify the init name...
+      write_obj_path.sub(/\.rb\.cpp/, '').sub(%r{.*build/generated/}, '').tr('/', '_')
     end
 
     private
@@ -281,16 +282,6 @@ module Natalie
       else
         ''
       end
-    end
-
-    def obj_name
-      # FIXME: I don't like that this method "knows" how to ignore the build/generated directory
-      # Maybe we need another arg to specify the init name...
-      write_obj_path.sub(/\.rb\.cpp/, '').sub(%r{.*build/generated/}, '').tr('/', '_')
-    end
-
-    def template
-      write_obj_path ? OBJ_TEMPLATE.gsub(/OBJ_NAME/, obj_name) : MAIN_TEMPLATE
     end
 
     def macro_expander

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -93,19 +93,9 @@ module Natalie
     attr_writer :load_path, :out_path
 
     def compile
-      return write_file if write_obj_path
+      return backend.write_file if write_obj_path
       check_build
-      write_file
-      compile_c_to_binary
-    end
-
-    def compile_c_to_binary
-      cmd = compiler_command
-      out = `#{cmd} 2>&1`
-      File.unlink(backend.cpp_path) unless keep_cpp? || $? != 0
-      puts "cpp file path is: #{c_path}" if keep_cpp?
-      warn out if out.strip != ''
-      raise CompileError, 'There was an error compiling.' if $? != 0
+      backend.compile_to_binary
     end
 
     def check_build
@@ -113,10 +103,6 @@ module Natalie
         puts 'please run: rake'
         exit 1
       end
-    end
-
-    def write_file
-      backend.write_file
     end
 
     def build_context

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -44,6 +44,10 @@ module Natalie
       backend.compile_to_binary
     end
 
+    def write_file_for_debugging
+      backend.write_file_for_debugging
+    end
+
     def build_context
       {
         inline_cpp_enabled:  inline_cpp_enabled,

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -13,8 +13,6 @@ require_relative '../../build/generated/numbers'
 
 module Natalie
   class Compiler
-    include Flags
-
     ROOT_DIR = File.expand_path('../../', __dir__)
     BUILD_DIR = File.join(ROOT_DIR, 'build')
 
@@ -121,10 +119,6 @@ module Natalie
       !!options[:dynamic_linking]
     end
 
-    def build_flags
-      "#{base_build_flags.join(' ')} #{ENV['NAT_CXX_FLAGS']} #{@context[:compile_cxx_flags].join(' ')}"
-    end
-
     def shared?
       !!repl
     end
@@ -167,21 +161,6 @@ module Natalie
       end
 
       main_file.fetch(:instructions)
-    end
-
-    def base_build_flags
-      case build
-      when 'release'
-        RELEASE_FLAGS
-      when 'debug', nil
-        DEBUG_FLAGS
-      when 'asan'
-        ASAN_FLAGS
-      when 'coverage'
-        COVERAGE_FLAGS
-      else
-        raise "unknown build mode: #{build.inspect}"
-      end
     end
 
     def macro_expander

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -104,7 +104,6 @@ module Natalie
 
     def build_context
       {
-        var_prefix:          var_prefix,
         var_num:             0,
         is_obj:              !!write_obj_path,
         repl:                !!repl,
@@ -136,7 +135,7 @@ module Natalie
     end
 
     def backend
-      @backend ||= CppBackend.new(instructions, compiler_context: @context, compiler: self)
+      @backend ||= CppBackend.new(instructions, compiler: self, compiler_context: @context)
     end
 
     def load_path
@@ -176,12 +175,6 @@ module Natalie
         libraries.join(' '),
         link_flags,
       ].map(&:to_s).join(' ')
-    end
-
-    def obj_name
-      # FIXME: I don't like that this method "knows" how to ignore the build/generated directory
-      # Maybe we need another arg to specify the init name...
-      write_obj_path.sub(/\.rb\.cpp/, '').sub(%r{.*build/generated/}, '').tr('/', '_')
     end
 
     private
@@ -271,16 +264,6 @@ module Natalie
         COVERAGE_FLAGS
       else
         raise "unknown build mode: #{build.inspect}"
-      end
-    end
-
-    def var_prefix
-      if write_obj_path
-        "#{obj_name}_"
-      elsif repl
-        "repl#{repl_num}_"
-      else
-        ''
       end
     end
 

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -28,7 +28,6 @@ module Natalie
       @var_num = 0
       @path = path
       @options = options
-      @cxx_flags = []
       @inline_cpp_enabled = {}
     end
 
@@ -40,8 +39,7 @@ module Natalie
                   :vars,
                   :options,
                   :c_path,
-                  :inline_cpp_enabled,
-                  :cxx_flags
+                  :inline_cpp_enabled
 
     attr_writer :load_path, :out_path
 
@@ -58,7 +56,7 @@ module Natalie
         repl:                !!repl,
         vars:                vars || {},
         inline_cpp_enabled:  inline_cpp_enabled,
-        compile_cxx_flags:   cxx_flags,
+        compile_cxx_flags:   [],
         compile_ld_flags:    [],
         source_path:         @path,
         required_cpp_files:  {},

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -17,49 +17,8 @@ module Natalie
 
     ROOT_DIR = File.expand_path('../../', __dir__)
     BUILD_DIR = File.join(ROOT_DIR, 'build')
-    INC_PATHS = [
-      File.join(ROOT_DIR, 'include'),
-      File.join(ROOT_DIR, 'ext/tm/include'),
-      File.join(ROOT_DIR, 'ext/minicoro'),
-      File.join(BUILD_DIR),
-      File.join(BUILD_DIR, 'onigmo/include'),
-    ]
-    LIB_PATHS = [
-      BUILD_DIR,
-      File.join(BUILD_DIR, 'onigmo/lib'),
-      File.join(BUILD_DIR, 'zlib'),
-    ]
-
-    # TODO: make this configurable from Ruby source via a macro of some sort
-    %w[
-      openssl
-      libffi
-    ].each do |package|
-      next unless system("pkg-config --exists #{package}")
-
-      unless (inc_path = `pkg-config --cflags #{package}`.strip).empty?
-        INC_PATHS << inc_path.sub(/^-I/, '')
-      end
-      unless (lib_path = `pkg-config --libs-only-L #{package}`.strip).empty?
-        LIB_PATHS << lib_path.sub(/^-L/, '')
-      end
-    end
 
     DL_EXT = RbConfig::CONFIG['DLEXT']
-
-    CRYPT_LIBRARIES = RUBY_PLATFORM =~ /darwin/ ? [] : %w[-lcrypt]
-
-    # When running `bin/natalie script.rb`, we use dynamic linking to speed things up.
-    LIBRARIES_FOR_DYNAMIC_LINKING = %w[
-      -lnatalie_base
-      -lonigmo
-    ] + CRYPT_LIBRARIES
-
-    # When using the REPL or compiling a binary with the `-c` option,
-    # we use static linking for compatibility.
-    LIBRARIES_FOR_STATIC_LINKING = %w[
-      -lnatalie
-    ] + CRYPT_LIBRARIES
 
     RB_LIB_PATH = File.expand_path('..', __dir__)
 
@@ -160,10 +119,6 @@ module Natalie
 
     def dynamic_linking?
       !!options[:dynamic_linking]
-    end
-
-    def inc_paths
-      INC_PATHS.map { |path| "-I #{path}" }.join(' ')
     end
 
     def build_flags

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -46,17 +46,9 @@ module Natalie
     attr_writer :load_path, :out_path
 
     def compile
-      return backend.write_file if write_obj_path
+      return backend.compile_to_object if write_obj_path
 
-      check_build
       backend.compile_to_binary
-    end
-
-    def check_build
-      unless File.file?(File.join(BUILD_DIR, "libnatalie_base.#{DL_EXT}"))
-        puts 'please run: rake'
-        exit 1
-      end
     end
 
     def build_context

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -94,6 +94,7 @@ module Natalie
 
     def compile
       return backend.write_file if write_obj_path
+
       check_build
       backend.compile_to_binary
     end
@@ -107,17 +108,17 @@ module Natalie
 
     def build_context
       {
-        var_prefix: var_prefix,
-        var_num: 0,
-        template: template,
-        is_obj: !!write_obj_path,
-        repl: !!repl,
-        vars: vars || {},
-        inline_cpp_enabled: inline_cpp_enabled,
-        compile_cxx_flags: cxx_flags,
-        compile_ld_flags: [],
-        source_path: @path,
-        required_cpp_files: {},
+        var_prefix:          var_prefix,
+        var_num:             0,
+        template:            template,
+        is_obj:              !!write_obj_path,
+        repl:                !!repl,
+        vars:                vars || {},
+        inline_cpp_enabled:  inline_cpp_enabled,
+        compile_cxx_flags:   cxx_flags,
+        compile_ld_flags:    [],
+        source_path:         @path,
+        required_cpp_files:  {},
         required_ruby_files: {},
       }
     end
@@ -191,7 +192,7 @@ module Natalie
       instructions = Pass1.new(
         ast,
         compiler_context: @context,
-        macro_expander: macro_expander
+        macro_expander:   macro_expander
       ).transform(
         used: keep_final_value_on_stack
       )
@@ -294,10 +295,10 @@ module Natalie
 
     def macro_expander
       @macro_expander ||= MacroExpander.new(
-        path: @path,
-        load_path: load_path,
-        interpret: interpret?,
-        log_load_error: options[:log_load_error],
+        path:             @path,
+        load_path:        load_path,
+        interpret:        interpret?,
+        log_load_error:   options[:log_load_error],
         compiler_context: @context,
       )
     end

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -47,7 +47,7 @@ module Natalie
     def build_context
       {
         inline_cpp_enabled:  inline_cpp_enabled,
-        repl:                !!repl,
+        repl:                repl?,
         required_cpp_files:  {},
         required_ruby_files: {},
         source_path:         @path,
@@ -101,7 +101,7 @@ module Natalie
       !!options[:dynamic_linking]
     end
 
-    def shared?
+    def repl?
       !!repl
     end
 

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -13,11 +13,6 @@ require_relative '../../build/generated/numbers'
 
 module Natalie
   class Compiler
-    ROOT_DIR = File.expand_path('../../', __dir__)
-    BUILD_DIR = File.join(ROOT_DIR, 'build')
-
-    DL_EXT = RbConfig::CONFIG['DLEXT']
-
     RB_LIB_PATH = File.expand_path('..', __dir__)
 
     class CompileError < StandardError
@@ -32,14 +27,14 @@ module Natalie
     end
 
     attr_accessor :ast,
-                  :write_obj_path,
+                  :context,
+                  :c_path,
+                  :inline_cpp_enabled,
+                  :options,
                   :repl,
                   :repl_num,
-                  :context,
                   :vars,
-                  :options,
-                  :c_path,
-                  :inline_cpp_enabled
+                  :write_obj_path
 
     attr_writer :load_path, :out_path
 

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -129,17 +129,6 @@ module Natalie
       !!repl
     end
 
-    def link_flags
-      flags = if build == 'asan'
-                ['-fsanitize=address']
-              else
-                []
-              end
-      flags += @context[:compile_ld_flags].join(' ').split
-      flags -= unnecessary_link_flags
-      flags.join(' ')
-    end
-
     private
 
     def transform
@@ -178,10 +167,6 @@ module Natalie
       end
 
       main_file.fetch(:instructions)
-    end
-
-    def unnecessary_link_flags
-      RUBY_PLATFORM =~ /openbsd/ ? ['-ldl'] : []
     end
 
     def base_build_flags

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -162,7 +162,7 @@ module Natalie
       def var_prefix
         if write_object_file?
           "#{obj_name}_"
-        elsif @compiler.repl
+        elsif @compiler.repl?
           "repl#{@compiler.repl_num}_"
         else
           ''
@@ -255,7 +255,7 @@ module Natalie
       end
 
       def shared?
-        !!@compiler.repl
+        @compiler.repl?
       end
 
       def declarations

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -92,6 +92,11 @@ module Natalie
         ].map(&:to_s).join(' ')
       end
 
+      def write_file_for_debugging
+        write_file
+        @cpp_path
+      end
+
       private
 
       def write_file

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -58,6 +58,7 @@ module Natalie
       attr_reader :cpp_path
 
       def compile_to_binary
+        check_build
         write_file
         cmd = compiler_command
         out = `#{cmd} 2>&1`
@@ -67,16 +68,9 @@ module Natalie
         raise Compiler::CompileError, 'There was an error compiling.' if $? != 0
       end
 
-      def write_file
+      def compile_to_object
         cpp = generate
-        if @compiler.write_obj_path
-          File.write(@compiler.write_obj_path, cpp)
-        else
-          temp_cpp = Tempfile.create('natalie.cpp')
-          temp_cpp.write(cpp)
-          temp_cpp.close
-          @cpp_path = temp_cpp.path
-        end
+        File.write(@compiler.write_obj_path, cpp)
       end
 
       def compiler_command
@@ -95,6 +89,21 @@ module Natalie
       end
 
       private
+
+      def write_file
+        cpp = generate
+        temp_cpp = Tempfile.create('natalie.cpp')
+        temp_cpp.write(cpp)
+        temp_cpp.close
+        @cpp_path = temp_cpp.path
+      end
+
+      def check_build
+        return if File.file?(File.join(BUILD_DIR, "libnatalie_base.#{DL_EXT}"))
+
+        puts 'please run: rake'
+        exit 1
+      end
 
       def generate
         string_of_cpp = transform_instructions

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -131,7 +131,7 @@ module Natalie
       end
 
       def template
-        if @compiler.write_obj_path
+        if write_object_file?
           OBJ_TEMPLATE.gsub(/OBJ_NAME/, obj_name)
         else
           MAIN_TEMPLATE
@@ -157,7 +157,7 @@ module Natalie
       end
 
       def var_prefix
-        if @compiler.write_obj_path
+        if write_object_file?
           "#{obj_name}_"
         elsif @compiler.repl
           "repl#{@compiler.repl_num}_"
@@ -247,6 +247,10 @@ module Natalie
         OPENBSD ? ['-ldl'] : []
       end
 
+      def write_object_file?
+        !!@compiler.write_obj_path
+      end
+
       def declarations
         [
           object_file_declarations,
@@ -288,7 +292,7 @@ module Natalie
       end
 
       def init_dollar_zero_global
-        return if @compiler_context[:is_obj]
+        return if write_object_file?
 
         "env->global_set(\"$0\"_s, new StringObject { #{@compiler_context[:source_path].inspect} });"
       end
@@ -335,7 +339,9 @@ module Natalie
 
       def augment_compiler_context
         @compiler_context.merge!(
-          var_prefix: var_prefix,
+          compile_cxx_flags: [],
+          compile_ld_flags:  [],
+          var_prefix:        var_prefix,
         )
       end
     end

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -50,9 +50,9 @@ module Natalie
       def transform_instructions
         transform = Transform.new(
           @instructions,
-          top: @top,
+          top:              @top,
           compiler_context: @compiler_context,
-          symbols: @symbols,
+          symbols:          @symbols,
           inline_functions: @inline_functions,
         )
         transform.transform

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -17,6 +17,16 @@ module Natalie
 
       attr_reader :cpp_path
 
+      def compile_to_binary
+        write_file
+        cmd = @compiler.compiler_command
+        out = `#{cmd} 2>&1`
+        File.unlink(@cpp_path) unless @compiler.keep_cpp? || $? != 0
+        puts "cpp file path is: #{@cpp_path}" if @compiler.keep_cpp?
+        warn out if out.strip != ''
+        raise Compiler::CompileError, 'There was an error compiling.' if $? != 0
+      end
+
       def write_file
         cpp = generate
         if @compiler.write_obj_path

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -6,6 +6,11 @@ module Natalie
     class CppBackend
       include StringToCpp
 
+      ROOT_DIR = File.expand_path('../../../../', __dir__)
+      SRC_PATH = File.join(ROOT_DIR, 'src')
+      MAIN_TEMPLATE = File.read(File.join(SRC_PATH, 'main.cpp'))
+      OBJ_TEMPLATE = File.read(File.join(SRC_PATH, 'obj_unit.cpp'))
+
       def initialize(instructions, compiler_context:, compiler:)
         @instructions = instructions
         @compiler_context = compiler_context
@@ -59,11 +64,19 @@ module Natalie
       end
 
       def merge_cpp_with_template(string_of_cpp)
-        @compiler_context[:template]
+        template
           .sub('/*' + 'NAT_DECLARATIONS' + '*/') { declarations }
           .sub('/*' + 'NAT_OBJ_INIT' + '*/') { init_object_files.join("\n") }
           .sub('/*' + 'NAT_EVAL_INIT' + '*/') { init_matter }
           .sub('/*' + 'NAT_EVAL_BODY' + '*/') { string_of_cpp }
+      end
+
+      def template
+        if @compiler.write_obj_path
+          OBJ_TEMPLATE.gsub(/OBJ_NAME/, @compiler.obj_name)
+        else
+          MAIN_TEMPLATE
+        end
       end
 
       def declarations

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -1,5 +1,6 @@
 require_relative './cpp_backend/transform'
 require_relative '../string_to_cpp'
+require_relative '../flags'
 
 module Natalie
   class Compiler

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -15,7 +15,8 @@ module Natalie
 
       DARWIN = RUBY_PLATFORM.match?(/darwin/)
       OPENBSD = RUBY_PLATFORM.match?(/openbsd/)
-      CRYPT_LIBRARIES = DARWIN ? [] : %w[-lcrypt]
+
+      DL_EXT = RbConfig::CONFIG['DLEXT']
 
       INC_PATHS = [
         File.join(ROOT_DIR, 'include'),
@@ -24,6 +25,8 @@ module Natalie
         File.join(BUILD_DIR),
         File.join(BUILD_DIR, 'onigmo/include'),
       ].freeze
+
+      CRYPT_LIBRARIES = DARWIN ? [] : %w[-lcrypt]
 
       # When running `bin/natalie script.rb`, we use dynamic linking to speed things up.
       LIBRARIES_FOR_DYNAMIC_LINKING = %w[
@@ -77,7 +80,7 @@ module Natalie
         [
           cc,
           build_flags,
-          (@compiler.shared? ? '-fPIC -shared' : ''),
+          (shared? ? '-fPIC -shared' : ''),
           inc_paths.map { |path| "-I #{path}" }.join(' '),
           "-o #{@compiler.out_path}",
           '-x c++ -std=c++17',
@@ -249,6 +252,10 @@ module Natalie
 
       def write_object_file?
         !!@compiler.write_obj_path
+      end
+
+      def shared?
+        !!@compiler.repl
       end
 
       def declarations

--- a/lib/natalie/compiler/instruction_manager.rb
+++ b/lib/natalie/compiler/instruction_manager.rb
@@ -21,6 +21,10 @@ module Natalie
         @instructions.each_with_index(&block)
       end
 
+      def map(&block)
+        @instructions.map(&block)
+      end
+
       def walk
         while @ip < @instructions.size
           instruction = self.next

--- a/lib/natalie/compiler/instructions/load_file_instruction.rb
+++ b/lib/natalie/compiler/instructions/load_file_instruction.rb
@@ -23,9 +23,9 @@ module Natalie
         unless fn
           fn = transform.temp('load_file_fn')
           transform.compiled_files[@filename] = fn
-          file_info = @required_ruby_files.fetch(@filename)
+          loaded_file = @required_ruby_files.fetch(@filename)
           transform.top("Value #{fn}(Env *, Value, bool);")
-          transform.with_new_scope(file_info.fetch(:instructions)) do |t|
+          transform.with_new_scope(loaded_file.instructions) do |t|
             fn_code = []
             fn_code << "Value #{fn}(Env *env, Value self, bool require_once) {"
             fn_code << "if (require_once && #{transform.files_var_name}.get(#{filename_sym})) return FalseObject::the();"

--- a/lib/natalie/compiler/loaded_file.rb
+++ b/lib/natalie/compiler/loaded_file.rb
@@ -1,0 +1,14 @@
+module Natalie
+  class Compiler
+    class LoadedFile
+      def initialize(path:, ast: nil, instructions: nil)
+        @path = path
+        @ast = ast
+        @instructions = instructions
+      end
+
+      attr_accessor :ast,
+                    :instructions
+    end
+  end
+end

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -224,10 +224,10 @@ module Natalie
       def load_file(path, require_once:, location:)
         return load_cpp_file(path, require_once: require_once, location: location) if path =~ /\.cpp$/
 
-        unless (file_info = @required_ruby_files[path])
+        unless (loaded_file = @required_ruby_files[path])
           code = File.read(path)
           ast = Natalie::Parser.new(code, path).ast
-          @required_ruby_files[path] = { ast: ast }
+          @required_ruby_files[path] = LoadedFile.new(path: path, ast: ast)
         end
 
         [:load_file, path, require_once]

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2104,13 +2104,12 @@ module Natalie
       def transform_load_file_fake_node(exp, used:)
         depth_was = @depth
         _, filename, require_once = exp
-        file_info = @required_ruby_files.fetch(filename)
+        loaded_file = @required_ruby_files.fetch(filename)
 
-        unless file_info[:instructions]
-          file_info[:instructions] = :generating # set this to avoid endless loop
+        unless loaded_file.instructions
+          loaded_file.instructions = :generating # set this to avoid endless loop
           @depth = 0
-          ast = file_info.fetch(:ast)
-          file_info[:instructions] = transform_expression(ast, used: true)
+          loaded_file.instructions = transform_expression(loaded_file.ast, used: true)
           @depth = depth_was
         end
 


### PR DESCRIPTION
Following from #1495 I want to do some additional optimizations in the compiler, but the Compiler was in bad need some some love before I do that. This moves most of the C++ related compilation into the CppBackend, where it belongs. I also clarified some options and added a new LoadedFile class to have a place to store info about loaded Ruby files.