### PR TITLE
Switch nightly spec runner back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/run_all_specs.yml
+++ b/.github/workflows/run_all_specs.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   specs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
[The current CI runs are crashing](https://github.com/natalie-lang/natalie/actions/runs/6924196633/job/18838675024)
I'm not sure if this is related to the Ubuntu version or something else, but it is kind of suspicious that it started crashing the day we bumped the version.