### PR TITLE
Fix YAML.dump for numbers in String format

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -130,9 +130,10 @@ static void emit_value(Env *env, RegexpObject *value, yaml_emitter_t &emitter, y
 }
 
 static void emit_value(Env *env, StringObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
+    auto numeric = KernelModule::Float(env, value, false);
+    const auto style = numeric ? YAML_SINGLE_QUOTED_SCALAR_STYLE : YAML_PLAIN_SCALAR_STYLE;
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)YAML_STR_TAG,
-        (yaml_char_t *)(value->as_string()->c_str()), value->as_string()->bytesize(),
-        1, 0, YAML_PLAIN_SCALAR_STYLE);
+        (yaml_char_t *)(value->c_str()), value->bytesize(), 1, 1, style);
     emit(env, emitter, event);
 }
 

--- a/spec/library/yaml/to_yaml_spec.rb
+++ b/spec/library/yaml/to_yaml_spec.rb
@@ -6,9 +6,7 @@ require 'yaml'
 describe "Object#to_yaml" do
 
   it "returns the YAML representation of an Array object" do
-    NATFIXME 'Dump string integers in quotes', exception: SpecFailedException do
-      %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
-    end
+    %w( 30 ruby maz irb 99 ).to_yaml.gsub("'", '"').should match_yaml("--- \n- \"30\"\n- ruby\n- maz\n- irb\n- \"99\"\n")
   end
 
   it "returns the YAML representation of a Hash object" do


### PR DESCRIPTION
The output of the enabled test is not exactly the same as MRI.