### PR TITLE
Fix Regexp code generation for embedded `#` character

### DIFF
--- a/lib/natalie/compiler/instructions/push_regexp_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_regexp_instruction.rb
@@ -12,7 +12,8 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:regexp, "Value(RegexpObject::literal(env, #{@regexp.source.inspect}, #{@regexp.options}))")
+        source = @regexp.source.inspect.gsub(/\\#(\$|@)/, '#\1')
+        transform.exec_and_push(:regexp, "Value(RegexpObject::literal(env, #{source}, #{@regexp.options}))")
       end
 
       def execute(vm)

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -15,6 +15,15 @@ describe 'regexp' do
     r.inspect.should == '/foo 2/'
   end
 
+  it 'can handle the # character with or without string interpolation' do
+    /\#foo/.should =~ '#foo'
+    /#foo/.should =~ '#foo'
+    /#$1/.should =~ '#$1'
+    @bar = 'x'
+    /#@bar/.should =~ 'x'
+    /\#@bar/.should =~ '#@bar'
+  end
+
   describe '.new' do
     it 'can be created with a string or another regexp' do
       r1 = Regexp.new('foo.*bar')


### PR DESCRIPTION
This is the second yak I had to shave to get the `uri` gem to work. With this it's possible to compile the gem. It still doesn't work, so there's still a herd of hairy yaks waiting.