### PR TITLE
Fix \& in String#sub and similar methods

### DIFF
--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -3,27 +3,28 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe :string_gsub_named_capture, shared: true do
-  # NATFIXME: Unknown backslash reference: \k
-  xit "replaces \\k named backreferences with the regexp's corresponding capture" do
+  it "replaces \\k named backreferences with the regexp's corresponding capture" do
     str = "hello"
 
-    str.gsub(/(?<foo>[aeiou])/, '<\k<foo>>').should == "h<e>ll<o>"
-    str.gsub(/(?<foo>.)/, '\k<foo>\k<foo>').should == "hheelllloo"
+    NATFIXME 'Unknown backslash reference: \k', exception: SpecFailedException do
+      str.gsub(/(?<foo>[aeiou])/, '<\k<foo>>').should == "h<e>ll<o>"
+      str.gsub(/(?<foo>.)/, '\k<foo>\k<foo>').should == "hheelllloo"
+    end
   end
 end
 
 describe "String#gsub with pattern and replacement" do
-  # NATFIXME: Fix infinite loop
-  xit "inserts the replacement around every character when the pattern collapses" do
+  it "inserts the replacement around every character when the pattern collapses" do
     "hello".gsub(//, ".").should == ".h.e.l.l.o."
   end
 
-  # NATFIXME: Fix infinite loop
-  xit "respects unicode when the pattern collapses" do
+  it "respects unicode when the pattern collapses" do
     str = "こにちわ"
     reg = %r!!
 
-    str.gsub(reg, ".").should == ".こ.に.ち.わ."
+    NATFIXME 'respects unicode when the pattern collapses', exception: SpecFailedException do
+      str.gsub(reg, ".").should == ".こ.に.ち.わ."
+    end
   end
 
   it "doesn't freak out when replacing ^" do
@@ -37,9 +38,10 @@ describe "String#gsub with pattern and replacement" do
     str = "hello homely world. hah!"
     str.gsub(/\Ah\S+\s*/, "huh? ").should == "huh? homely world. hah!"
 
-    # NATFIXME: Fix infinite loop
-    # str = "¿por qué?"
-    # str.gsub(/([a-z\d]*)/, "*").should == "*¿** **é*?*"
+    str = "¿por qué?"
+    NATFIXME 'respects unicode when the pattern collapses', exception: SpecFailedException do
+      str.gsub(/([a-z\d]*)/, "*").should == "*¿** **é*?*"
+    end
   end
 
   it "ignores a block if supplied" do
@@ -85,12 +87,10 @@ describe "String#gsub with pattern and replacement" do
   it "treats \\1 sequences without corresponding captures as empty strings" do
     str = "hello!"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub("", '<\1>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub("", '<\1>').should == "<>h<>e<>l<>l<>o<>!<>"
     str.gsub("h", '<\1>').should == "<>ello!"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub(//, '<\1>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub(//, '<\1>').should == "<>h<>e<>l<>l<>o<>!<>"
     str.gsub(/./, '\1\2\3').should == ""
     str.gsub(/.(.{20})?/, '\1').should == ""
   end
@@ -112,77 +112,80 @@ describe "String#gsub with pattern and replacement" do
     str.gsub(/(.)./, '<\0>').should == "<he><ll><o!>"
   end
 
-  # NATFIXME: .Unknown backslash reference: \`
-  xit "replaces \\` with everything before the current match" do
+  it "replaces \\` with everything before the current match" do
     str = "hello!"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub("", '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
-    str.gsub("h", '<\`>').should == "<>ello!"
-    str.gsub("l", '<\`>').should == "he<he><hel>o!"
-    str.gsub("!", '<\`>').should == "hello<hello>"
+    NATFIXME 'Unknown backslash reference: \`', exception: SpecFailedException do
+      str.gsub("", '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
+      str.gsub("h", '<\`>').should == "<>ello!"
+      str.gsub("l", '<\`>').should == "he<he><hel>o!"
+      str.gsub("!", '<\`>').should == "hello<hello>"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub(//, '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
-    str.gsub(/../, '<\`>').should == "<><he><hell>"
+      str.gsub(//, '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
+      str.gsub(/../, '<\`>').should == "<><he><hell>"
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \'
-  xit "replaces \\' with everything after the current match" do
+  it "replaces \\' with everything after the current match" do
     str = "hello!"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub("", '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
-    str.gsub("h", '<\\\'>').should == "<ello!>ello!"
-    str.gsub("ll", '<\\\'>').should == "he<o!>o!"
-    str.gsub("!", '<\\\'>').should == "hello<>"
+    NATFIXME 'Unknown backslash reference: \'', exception: SpecFailedException do
+      str.gsub("", '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
+      str.gsub("h", '<\\\'>').should == "<ello!>ello!"
+      str.gsub("ll", '<\\\'>').should == "he<o!>o!"
+      str.gsub("!", '<\\\'>').should == "hello<>"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub(//, '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
-    str.gsub(/../, '<\\\'>').should == "<llo!><o!><>"
+      str.gsub(//, '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
+      str.gsub(/../, '<\\\'>').should == "<llo!><o!><>"
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \+
-  xit "replaces \\+ with the last paren that actually matched" do
+  it "replaces \\+ with the last paren that actually matched" do
     str = "hello!"
 
-    str.gsub(/(.)(.)/, '\+').should == "el!"
-    str.gsub(/(.)(.)+/, '\+').should == "!"
-    str.gsub(/(.)()/, '\+').should == ""
-    str.gsub(/(.)(.{20})?/, '<\+>').should == "<h><e><l><l><o><!>"
+    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
+      str.gsub(/(.)(.)/, '\+').should == "el!"
+      str.gsub(/(.)(.)+/, '\+').should == "!"
+      str.gsub(/(.)()/, '\+').should == ""
+      str.gsub(/(.)(.{20})?/, '<\+>').should == "<h><e><l><l><o><!>"
 
-    str = "ABCDEFGHIJKLabcdefghijkl"
-    re = /#{"(.)" * 12}/
-    str.gsub(re, '\+').should == "Ll"
+      str = "ABCDEFGHIJKLabcdefghijkl"
+      re = /#{"(.)" * 12}/
+      str.gsub(re, '\+').should == "Ll"
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \+
-  xit "treats \\+ as an empty string if there was no captures" do
-    "hello!".gsub(/./, '\+').should == ""
+  it "treats \\+ as an empty string if there was no captures" do
+    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
+      "hello!".gsub(/./, '\+').should == ""
+    end
   end
 
   it "maps \\\\ in replacement to \\" do
     "hello".gsub(/./, '\\\\').should == '\\' * 5
   end
 
-  # NATFIXME: .Unknown backslash reference: \x
-  xit "leaves unknown \\x escapes in replacement untouched" do
-    "hello".gsub(/./, '\\x').should == '\\x' * 5
-    "hello".gsub(/./, '\\y').should == '\\y' * 5
+  it "leaves unknown \\x escapes in replacement untouched" do
+    NATFIXME 'Unknown backslash reference: \x', exception: SpecFailedException do
+      "hello".gsub(/./, '\\x').should == '\\x' * 5
+      "hello".gsub(/./, '\\y').should == '\\y' * 5
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \
-  xit "leaves \\ at the end of replacement untouched" do
-    "hello".gsub(/./, 'hah\\').should == 'hah\\' * 5
+  it "leaves \\ at the end of replacement untouched" do
+    NATFIXME 'Unknown backslash reference: \\', exception: SpecFailedException do
+      "hello".gsub(/./, 'hah\\').should == 'hah\\' * 5
+    end
   end
 
   it_behaves_like :string_gsub_named_capture, :gsub
 
-  # NATFIXME: Fix infinite loop
-  xit "handles pattern collapse" do
+  it "handles pattern collapse" do
     str = "こにちわ"
     reg = %r!!
-    str.gsub(reg, ".").should == ".こ.に.ち.わ."
+    NATFIXME 'respects unicode when the pattern collapses', exception: SpecFailedException do
+      str.gsub(reg, ".").should == ".こ.に.ち.わ."
+    end
   end
 
   it "tries to convert pattern to a string using to_str" do
@@ -216,8 +219,7 @@ describe "String#gsub with pattern and replacement" do
   end
 
   it "returns String instances when called on a subclass" do
-    # NATFIXME: Fix infinite loop
-    # StringSpecs::MyString.new("").gsub(//, "").should be_an_instance_of(String)
+    StringSpecs::MyString.new("").gsub(//, "").should be_an_instance_of(String)
     StringSpecs::MyString.new("").gsub(/foo/, "").should be_an_instance_of(String)
     StringSpecs::MyString.new("foo").gsub(/foo/, "").should be_an_instance_of(String)
     StringSpecs::MyString.new("foo").gsub("foo", "").should be_an_instance_of(String)
@@ -299,9 +301,9 @@ describe "String#gsub with pattern and Hash" do
     hsh.default=[]
     hsh['o'] = 0
     obj = mock('!')
-    # obj.should_receive(:to_s).and_return('!')
-    hsh['!'] = obj
     NATFIXME 'Support hash argument', exception: TypeError, message: 'no implicit conversion of Hash into String' do
+      obj.should_receive(:to_s).and_return('!')
+      hsh['!'] = obj
       "food!".gsub(/./, hsh).should == "[]00[]!"
     end
   end
@@ -586,11 +588,12 @@ describe "String#gsub! with pattern and replacement" do
     a.should == "h*ll*"
   end
 
-  # NATFIXME: Fix infinite loop
-  xit "modifies self in place with multi-byte characters and returns self" do
+  it "modifies self in place with multi-byte characters and returns self" do
     a = "¿por qué?"
-    a.gsub!(/([a-z\d]*)/, "*").should equal(a)
-    a.should == "*¿** **é*?*"
+    NATFIXME 'respects unicode when the pattern collapses', exception: SpecFailedException do
+      a.gsub!(/([a-z\d]*)/, "*").should equal(a)
+      a.should == "*¿** **é*?*"
+    end
   end
 
   it "returns nil if no modifications were made" do

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -98,21 +98,17 @@ describe "String#gsub with pattern and replacement" do
   it "replaces \\& and \\0 with the complete match" do
     str = "hello!"
 
-    # NATFIXME: Fix infinite loop
-    # str.gsub("", '<\0>').should == "<>h<>e<>l<>l<>o<>!<>"
-    # str.gsub("", '<\&>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub("", '<\0>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub("", '<\&>').should == "<>h<>e<>l<>l<>o<>!<>"
     str.gsub("he", '<\0>').should == "<he>llo!"
-    # NATFIXME: Unknown backslash reference: \&
-    # str.gsub("he", '<\&>').should == "<he>llo!"
+    str.gsub("he", '<\&>').should == "<he>llo!"
     str.gsub("l", '<\0>').should == "he<l><l>o!"
-    # NATFIXME: Unknown backslash reference: \&
-    # str.gsub("l", '<\&>').should == "he<l><l>o!"
+    str.gsub("l", '<\&>').should == "he<l><l>o!"
 
-    # str.gsub(//, '<\0>').should == "<>h<>e<>l<>l<>o<>!<>"
-    # str.gsub(//, '<\&>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub(//, '<\0>').should == "<>h<>e<>l<>l<>o<>!<>"
+    str.gsub(//, '<\&>').should == "<>h<>e<>l<>l<>o<>!<>"
     str.gsub(/../, '<\0>').should == "<he><ll><o!>"
-    # NATFIXME: Unknown backslash reference: \&
-    # str.gsub(/../, '<\&>').should == "<he><ll><o!>"
+    str.gsub(/../, '<\&>').should == "<he><ll><o!>"
     str.gsub(/(.)./, '<\0>').should == "<he><ll><o!>"
   end
 

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -68,21 +68,18 @@ describe "String#sub with pattern, replacement" do
   it "replaces \\& and \\0 with the complete match" do
     str = "hello!"
 
-    NATFIXME 'replaces \\& and \\0 with the complete match', exception: SpecFailedException do
-      str.sub("", '<\0>').should == "<>hello!"
-      str.sub("", '<\&>').should == "<>hello!"
-      str.sub("he", '<\0>').should == "<he>llo!"
-      str.sub("he", '<\&>').should == "<he>llo!"
-      str.sub("l", '<\0>').should == "he<l>lo!"
-      str.sub("l", '<\&>').should == "he<l>lo!"
-    end
+    str.sub("", '<\0>').should == "<>hello!"
+    str.sub("", '<\&>').should == "<>hello!"
+    str.sub("he", '<\0>').should == "<he>llo!"
+    str.sub("he", '<\&>').should == "<he>llo!"
+    str.sub("l", '<\0>').should == "he<l>lo!"
+    str.sub("l", '<\&>').should == "he<l>lo!"
 
-    # NATFIXME: Unknown backslash reference: \&
-    # str.sub(//, '<\0>').should == "<>hello!"
-    # str.sub(//, '<\&>').should == "<>hello!"
-    # str.sub(/../, '<\0>').should == "<he>llo!"
-    # str.sub(/../, '<\&>').should == "<he>llo!"
-    # str.sub(/(.)./, '<\0>').should == "<he>llo!"
+    str.sub(//, '<\0>').should == "<>hello!"
+    str.sub(//, '<\&>').should == "<>hello!"
+    str.sub(/../, '<\0>').should == "<he>llo!"
+    str.sub(/../, '<\&>').should == "<he>llo!"
+    str.sub(/(.)./, '<\0>').should == "<he>llo!"
   end
 
   it "replaces \\` with everything before the current match" do

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -59,10 +59,9 @@ describe "String#sub with pattern, replacement" do
     str.sub("", '<\1>').should == "<>hello!"
     str.sub("h", '<\1>').should == "<>ello!"
 
-    # NATFIXME: Natalie::StringObject* Natalie::Object::as_string(): Assertion `is_string()' failed.
-    # str.sub(//, '<\1>').should == "<>hello!"
-    # str.sub(/./, '\1\2\3').should == "ello!"
-    # str.sub(/.(.{20})?/, '\1').should == "ello!"
+    str.sub(//, '<\1>').should == "<>hello!"
+    str.sub(/./, '\1\2\3').should == "ello!"
+    str.sub(/.(.{20})?/, '\1').should == "ello!"
   end
 
   it "replaces \\& and \\0 with the complete match" do
@@ -90,11 +89,10 @@ describe "String#sub with pattern, replacement" do
       str.sub("h", '<\`>').should == "<>ello!"
       str.sub("l", '<\`>').should == "he<he>lo!"
       str.sub("!", '<\`>').should == "hello<hello>"
-    end
 
-    # NATFIXME: Unknown backslash reference: \`
-    # str.sub(//, '<\`>').should == "<>hello!"
-    # str.sub(/..o/, '<\`>').should == "he<he>!"
+      str.sub(//, '<\`>').should == "<>hello!"
+      str.sub(/..o/, '<\`>').should == "he<he>!"
+    end
   end
 
   it "replaces \\' with everything after the current match" do
@@ -105,49 +103,52 @@ describe "String#sub with pattern, replacement" do
       str.sub("h", '<\\\'>').should == "<ello!>ello!"
       str.sub("ll", '<\\\'>').should == "he<o!>o!"
       str.sub("!", '<\\\'>').should == "hello<>"
-    end
 
-    # NATFIXME: Unknown backslash reference: \'
-    # str.sub(//, '<\\\'>').should == "<hello!>hello!"
-    # str.sub(/../, '<\\\'>').should == "<llo!>llo!"
+      str.sub(//, '<\\\'>').should == "<hello!>hello!"
+      str.sub(/../, '<\\\'>').should == "<llo!>llo!"
+    end
   end
 
   it "replaces \\\\\\+ with \\\\+" do
     "x".sub(/x/, '\\\+').should == "\\+"
   end
 
-  # NATFIXME: Unknown backslash reference: \+
-  xit "replaces \\+ with the last paren that actually matched" do
+  it "replaces \\+ with the last paren that actually matched" do
     str = "hello!"
 
-    str.sub(/(.)(.)/, '\+').should == "ello!"
-    str.sub(/(.)(.)+/, '\+').should == "!"
-    str.sub(/(.)()/, '\+').should == "ello!"
-    str.sub(/(.)(.{20})?/, '<\+>').should == "<h>ello!"
+    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
+      str.sub(/(.)(.)/, '\+').should == "ello!"
+      str.sub(/(.)(.)+/, '\+').should == "!"
+      str.sub(/(.)()/, '\+').should == "ello!"
+      str.sub(/(.)(.{20})?/, '<\+>').should == "<h>ello!"
 
-    str = "ABCDEFGHIJKL"
-    re = /#{"(.)" * 12}/
-    str.sub(re, '\+').should == "L"
+      str = "ABCDEFGHIJKL"
+      re = /#{"(.)" * 12}/
+      str.sub(re, '\+').should == "L"
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \+
-  xit "treats \\+ as an empty string if there was no captures" do
-    "hello!".sub(/./, '\+').should == "ello!"
+  it "treats \\+ as an empty string if there was no captures" do
+    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
+      "hello!".sub(/./, '\+').should == "ello!"
+    end
   end
 
   it "maps \\\\ in replacement to \\" do
     "hello".sub(/./, '\\\\').should == '\\ello'
   end
 
-  # NATFIXME: Unknown backslash reference: \x
-  xit "leaves unknown \\x escapes in replacement untouched" do
-    "hello".sub(/./, '\\x').should == '\\xello'
-    "hello".sub(/./, '\\y').should == '\\yello'
+  it "leaves unknown \\x escapes in replacement untouched" do
+    NATFIXME 'Unknown backslash reference: \x', exception: SpecFailedException do
+      "hello".sub(/./, '\\x').should == '\\xello'
+      "hello".sub(/./, '\\y').should == '\\yello'
+    end
   end
 
-  # NATFIXME: Unknown backslash reference: \
-  xit "leaves \\ at the end of replacement untouched" do
-    "hello".sub(/./, 'hah\\').should == 'hah\\ello'
+  it "leaves \\ at the end of replacement untouched" do
+    NATFIXME 'Unknown backslash reference: \\', exception: SpecFailedException do
+      "hello".sub(/./, 'hah\\').should == 'hah\\ello'
+    end
   end
 
   it "tries to convert pattern to a string using to_str" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2081,7 +2081,10 @@ StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDa
             case '\\':
                 expanded->append_char(c);
                 break;
-            // TODO: there are other back references we need to handle, e.g. \&, \', \`, and \+
+            case '&':
+                expanded->append(match->group(0));
+                break;
+            // TODO: there are other back references we need to handle, e.g. \', \`, and \+
             default:
                 expanded->append(String::format("<unhandled backref: {}>", c));
                 break;


### PR DESCRIPTION
Which is required to get `ipaddr` to work, which in turn is a dependency of `uri`, so we've gotten ourselves another bald yak.
I added a bit of cleanup to the specs, a lot of them were disabled for infinite loops, but that issue has been fixed.