### PR TITLE
Support more backreferences in String#sub

### DIFF
--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -137,22 +137,18 @@ describe "String#gsub with pattern and replacement" do
   it "replaces \\+ with the last paren that actually matched" do
     str = "hello!"
 
-    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
-      str.gsub(/(.)(.)/, '\+').should == "el!"
-      str.gsub(/(.)(.)+/, '\+').should == "!"
-      str.gsub(/(.)()/, '\+').should == ""
-      str.gsub(/(.)(.{20})?/, '<\+>').should == "<h><e><l><l><o><!>"
+    str.gsub(/(.)(.)/, '\+').should == "el!"
+    str.gsub(/(.)(.)+/, '\+').should == "!"
+    str.gsub(/(.)()/, '\+').should == ""
+    str.gsub(/(.)(.{20})?/, '<\+>').should == "<h><e><l><l><o><!>"
 
-      str = "ABCDEFGHIJKLabcdefghijkl"
-      re = /#{"(.)" * 12}/
-      str.gsub(re, '\+').should == "Ll"
-    end
+    str = "ABCDEFGHIJKLabcdefghijkl"
+    re = /#{"(.)" * 12}/
+    str.gsub(re, '\+').should == "Ll"
   end
 
   it "treats \\+ as an empty string if there was no captures" do
-    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
-      "hello!".gsub(/./, '\+').should == ""
-    end
+    "hello!".gsub(/./, '\+').should == ""
   end
 
   it "maps \\\\ in replacement to \\" do

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -125,15 +125,13 @@ describe "String#gsub with pattern and replacement" do
   it "replaces \\' with everything after the current match" do
     str = "hello!"
 
-    NATFIXME 'Unknown backslash reference: \'', exception: SpecFailedException do
-      str.gsub("", '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
-      str.gsub("h", '<\\\'>').should == "<ello!>ello!"
-      str.gsub("ll", '<\\\'>').should == "he<o!>o!"
-      str.gsub("!", '<\\\'>').should == "hello<>"
+    str.gsub("", '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
+    str.gsub("h", '<\\\'>').should == "<ello!>ello!"
+    str.gsub("ll", '<\\\'>').should == "he<o!>o!"
+    str.gsub("!", '<\\\'>').should == "hello<>"
 
-      str.gsub(//, '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
-      str.gsub(/../, '<\\\'>').should == "<llo!><o!><>"
-    end
+    str.gsub(//, '<\\\'>').should == "<hello!>h<ello!>e<llo!>l<lo!>l<o!>o<!>!<>"
+    str.gsub(/../, '<\\\'>').should == "<llo!><o!><>"
   end
 
   it "replaces \\+ with the last paren that actually matched" do

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -113,15 +113,13 @@ describe "String#gsub with pattern and replacement" do
   it "replaces \\` with everything before the current match" do
     str = "hello!"
 
-    NATFIXME 'Unknown backslash reference: \`', exception: SpecFailedException do
-      str.gsub("", '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
-      str.gsub("h", '<\`>').should == "<>ello!"
-      str.gsub("l", '<\`>').should == "he<he><hel>o!"
-      str.gsub("!", '<\`>').should == "hello<hello>"
+    str.gsub("", '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
+    str.gsub("h", '<\`>').should == "<>ello!"
+    str.gsub("l", '<\`>').should == "he<he><hel>o!"
+    str.gsub("!", '<\`>').should == "hello<hello>"
 
-      str.gsub(//, '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
-      str.gsub(/../, '<\`>').should == "<><he><hell>"
-    end
+    str.gsub(//, '<\`>').should == "<>h<h>e<he>l<hel>l<hell>o<hello>!<hello!>"
+    str.gsub(/../, '<\`>').should == "<><he><hell>"
   end
 
   it "replaces \\' with everything after the current match" do

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -82,15 +82,13 @@ describe "String#sub with pattern, replacement" do
   it "replaces \\` with everything before the current match" do
     str = "hello!"
 
-    NATFIXME 'replaces \\` with everything before the current match', exception: SpecFailedException do
-      str.sub("", '<\`>').should == "<>hello!"
-      str.sub("h", '<\`>').should == "<>ello!"
-      str.sub("l", '<\`>').should == "he<he>lo!"
-      str.sub("!", '<\`>').should == "hello<hello>"
+    str.sub("", '<\`>').should == "<>hello!"
+    str.sub("h", '<\`>').should == "<>ello!"
+    str.sub("l", '<\`>').should == "he<he>lo!"
+    str.sub("!", '<\`>').should == "hello<hello>"
 
-      str.sub(//, '<\`>').should == "<>hello!"
-      str.sub(/..o/, '<\`>').should == "he<he>!"
-    end
+    str.sub(//, '<\`>').should == "<>hello!"
+    str.sub(/..o/, '<\`>').should == "he<he>!"
   end
 
   it "replaces \\' with everything after the current match" do

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -110,22 +110,18 @@ describe "String#sub with pattern, replacement" do
   it "replaces \\+ with the last paren that actually matched" do
     str = "hello!"
 
-    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
-      str.sub(/(.)(.)/, '\+').should == "ello!"
-      str.sub(/(.)(.)+/, '\+').should == "!"
-      str.sub(/(.)()/, '\+').should == "ello!"
-      str.sub(/(.)(.{20})?/, '<\+>').should == "<h>ello!"
+    str.sub(/(.)(.)/, '\+').should == "ello!"
+    str.sub(/(.)(.)+/, '\+').should == "!"
+    str.sub(/(.)()/, '\+').should == "ello!"
+    str.sub(/(.)(.{20})?/, '<\+>').should == "<h>ello!"
 
-      str = "ABCDEFGHIJKL"
-      re = /#{"(.)" * 12}/
-      str.sub(re, '\+').should == "L"
-    end
+    str = "ABCDEFGHIJKL"
+    re = /#{"(.)" * 12}/
+    str.sub(re, '\+').should == "L"
   end
 
   it "treats \\+ as an empty string if there was no captures" do
-    NATFIXME 'Unknown backslash reference: \+', exception: SpecFailedException do
-      "hello!".sub(/./, '\+').should == "ello!"
-    end
+    "hello!".sub(/./, '\+').should == "ello!"
   end
 
   it "maps \\\\ in replacement to \\" do

--- a/spec/core/string/sub_spec.rb
+++ b/spec/core/string/sub_spec.rb
@@ -94,15 +94,13 @@ describe "String#sub with pattern, replacement" do
   it "replaces \\' with everything after the current match" do
     str = "hello!"
 
-    NATFIXME "replaces \\' with everything after the current match", exception: SpecFailedException do
-      str.sub("", '<\\\'>').should == "<hello!>hello!"
-      str.sub("h", '<\\\'>').should == "<ello!>ello!"
-      str.sub("ll", '<\\\'>').should == "he<o!>o!"
-      str.sub("!", '<\\\'>').should == "hello<>"
+    str.sub("", '<\\\'>').should == "<hello!>hello!"
+    str.sub("h", '<\\\'>').should == "<ello!>ello!"
+    str.sub("ll", '<\\\'>').should == "he<o!>o!"
+    str.sub("!", '<\\\'>').should == "hello<>"
 
-      str.sub(//, '<\\\'>').should == "<hello!>hello!"
-      str.sub(/../, '<\\\'>').should == "<llo!>llo!"
-    end
+    str.sub(//, '<\\\'>').should == "<hello!>hello!"
+    str.sub(/../, '<\\\'>').should == "<llo!>llo!"
   end
 
   it "replaces \\\\\\+ with \\\\+" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2088,9 +2088,11 @@ StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDa
             case '&':
                 expanded->append(match->group(0));
                 break;
-            // TODO: there are other back references we need to handle, e.g. \', \`, and \+
-            case 'k':
             case '`':
+                expanded->append(match->pre_match(env));
+                break;
+            // TODO: there are other back references we need to handle, e.g. \' and \+
+            case 'k':
             case '\'':
             case '+':
                 expanded->append(String::format("<unhandled backref: {}>", c));

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2094,9 +2094,14 @@ StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDa
             case '\'':
                 expanded->append(match->post_match(env));
                 break;
-            // TODO: there are other back references we need to handle, e.g. \k and \+
+            case '+': {
+                auto captures = match->captures(env)->to_ary(env)->compact(env)->to_ary(env);
+                if (!captures->is_empty())
+                    expanded->append(captures->last());
+                break;
+            }
+            // TODO: there are other back references we need to handle, e.g. \k
             case 'k':
-            case '+':
                 expanded->append(String::format("<unhandled backref: {}>", c));
                 break;
             default:

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2091,9 +2091,11 @@ StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDa
             case '`':
                 expanded->append(match->pre_match(env));
                 break;
-            // TODO: there are other back references we need to handle, e.g. \' and \+
-            case 'k':
             case '\'':
+                expanded->append(match->post_match(env));
+                break;
+            // TODO: there are other back references we need to handle, e.g. \k and \+
+            case 'k':
             case '+':
                 expanded->append(String::format("<unhandled backref: {}>", c));
                 break;


### PR DESCRIPTION
The only one left is `\k`, which is a reference to a capture group, so a little trickier to match.