### PR TITLE
Thread#wakeup and sleeping thread fixes

### DIFF
--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -139,8 +139,6 @@ private:
     Vector<Value> m_args {};
     FiberObject *m_previous_fiber { nullptr };
     ExceptionObject *m_error { nullptr };
-
-    inline static Value s_scheduler { nullptr };
 };
 
 }

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -86,7 +86,9 @@ public:
     Value join(Env *);
     Value kill(Env *) const;
     Value raise(Env *, Value = nullptr, Value = nullptr);
-    Value wakeup() { return NilObject::the(); }
+    Value wakeup(Env *);
+
+    void sleep(int);
 
     void set_value(Value value) { m_value = value; }
     Value value(Env *);
@@ -163,7 +165,11 @@ private:
     std::atomic<bool> m_joined { false };
     TM::Optional<TM::String> m_file {};
     TM::Optional<size_t> m_line {};
+
     bool m_sleeping { false };
+    pthread_cond_t m_sleep_cond = PTHREAD_COND_INITIALIZER;
+    pthread_mutex_t m_sleep_lock = PTHREAD_MUTEX_INITIALIZER;
+
     TM::Hashmap<Thread::MutexObject *> m_mutexes {};
 
     inline static pthread_t s_main_id = 0;

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -117,6 +117,9 @@ public:
 
     void unlock_mutexes() const;
 
+    Value fiber_scheduler() const { return m_fiber_scheduler; }
+    void set_fiber_scheduler(Value scheduler) { m_fiber_scheduler = scheduler; }
+
     virtual void visit_children(Visitor &) override final;
     void visit_children_from_stack(Visitor &) const;
     void visit_children_from_asan_fake_stack(Visitor &, Cell *) const;
@@ -171,6 +174,8 @@ private:
     pthread_mutex_t m_sleep_lock = PTHREAD_MUTEX_INITIALIZER;
 
     TM::Hashmap<Thread::MutexObject *> m_mutexes {};
+
+    Value m_fiber_scheduler { nullptr };
 
     inline static pthread_t s_main_id = 0;
     inline static ThreadObject *s_main = nullptr;

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -88,7 +88,7 @@ public:
     Value raise(Env *, Value = nullptr, Value = nullptr);
     Value wakeup(Env *);
 
-    void sleep(int);
+    Value sleep(Env *, float);
 
     void set_value(Value value) { m_value = value; }
     Value value(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1312,7 +1312,7 @@ gen.binding('Thread', 'kill', 'ThreadObject', 'kill', argc: 0, pass_env: true, p
 gen.binding('Thread', 'raise', 'ThreadObject', 'raise', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'status', 'ThreadObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'value', 'ThreadObject', 'value', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Thread', 'wakeup', 'ThreadObject', 'wakeup', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.binding('Thread', 'wakeup', 'ThreadObject', 'wakeup', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.binding('Thread::Mutex', 'lock', 'Thread::MutexObject', 'lock', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread::Mutex', 'locked?', 'Thread::MutexObject', 'is_locked', argc: 0, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/kernel/sleep_spec.rb
+++ b/spec/core/kernel/sleep_spec.rb
@@ -40,18 +40,15 @@ describe "Kernel#sleep" do
     running = false
     t = Thread.new do
       running = true
-      # NATFIXME: Thread#wakeup below should stop the thread from sleeping?
-      #sleep
-      #5
+      sleep
+      5
     end
 
     Thread.pass until running
     Thread.pass while t.status and t.status != "sleep"
 
     t.wakeup
-    NATFIXME 'Fix the Thread#wakeup issue above', exception: SpecFailedException do
-      t.value.should == 5
-    end
+    t.value.should == 5
   end
 
   ruby_version_is ""..."3.3" do

--- a/spec/core/thread/fixtures/classes.rb
+++ b/spec/core/thread/fixtures/classes.rb
@@ -1,0 +1,297 @@
+module ThreadSpecs
+
+  class SubThread < Thread
+    def initialize(*args)
+      super { args.first << 1 }
+    end
+  end
+
+  class Status
+    attr_reader :thread, :inspect, :status, :to_s
+    def initialize(thread)
+      @thread = thread
+      @alive = thread.alive?
+      @inspect = thread.inspect
+      @to_s = thread.to_s
+      @status = thread.status
+      @stop = thread.stop?
+    end
+
+    def alive?
+      @alive
+    end
+
+    def stop?
+      @stop
+    end
+  end
+
+  # TODO: In the great Thread spec rewrite, abstract this
+  class << self
+    attr_accessor :state
+  end
+
+  def self.clear_state
+    @state = nil
+  end
+
+  def self.spin_until_sleeping(t)
+    Thread.pass while t.status and t.status != "sleep"
+  end
+
+  def self.sleeping_thread
+    Thread.new do
+      begin
+        sleep
+        ScratchPad.record :woken
+      rescue Object => e
+        ScratchPad.record e
+      end
+    end
+  end
+
+  def self.running_thread
+    Thread.new do
+      begin
+        ThreadSpecs.state = :running
+        loop { Thread.pass }
+        ScratchPad.record :woken
+      rescue Object => e
+        ScratchPad.record e
+      end
+    end
+  end
+
+  def self.completed_thread
+    Thread.new {}
+  end
+
+  def self.status_of_current_thread
+    Thread.new { Status.new(Thread.current) }.value
+  end
+
+  def self.status_of_running_thread
+    t = running_thread
+    Thread.pass while t.status and t.status != "run"
+    status = Status.new t
+    t.kill
+    t.join
+    status
+  end
+
+  def self.status_of_completed_thread
+    t = completed_thread
+    t.join
+    Status.new t
+  end
+
+  def self.status_of_sleeping_thread
+    t = sleeping_thread
+    Thread.pass while t.status and t.status != 'sleep'
+    status = Status.new t
+    t.run
+    t.join
+    status
+  end
+
+  def self.status_of_blocked_thread
+    m = Mutex.new
+    m.lock
+    t = Thread.new { m.lock }
+    Thread.pass while t.status and t.status != 'sleep'
+    status = Status.new t
+    m.unlock
+    t.join
+    status
+  end
+
+  def self.status_of_killed_thread
+    t = Thread.new { sleep }
+    Thread.pass while t.status and t.status != 'sleep'
+    t.kill
+    t.join
+    Status.new t
+  end
+
+  def self.status_of_thread_with_uncaught_exception
+    t = Thread.new {
+      Thread.current.report_on_exception = false
+      raise "error"
+    }
+    begin
+      t.join
+    rescue RuntimeError
+    end
+    Status.new t
+  end
+
+  def self.status_of_dying_running_thread
+    status = nil
+    t = dying_thread_ensures { status = Status.new Thread.current }
+    t.join
+    status
+  end
+
+  def self.status_of_dying_sleeping_thread
+    t = dying_thread_ensures { Thread.stop; }
+    Thread.pass while t.status and t.status != 'sleep'
+    status = Status.new t
+    t.wakeup
+    t.join
+    status
+  end
+
+  def self.status_of_dying_thread_after_sleep
+    status = nil
+    t = dying_thread_ensures {
+      Thread.stop
+      status = Status.new(Thread.current)
+    }
+    Thread.pass while t.status and t.status != 'sleep'
+    t.wakeup
+    Thread.pass while t.status and t.status == 'sleep'
+    t.join
+    status
+  end
+
+  def self.dying_thread_ensures(kill_method_name=:kill)
+    Thread.new do
+      Thread.current.report_on_exception = false
+      begin
+        Thread.current.send(kill_method_name)
+      ensure
+        yield
+      end
+    end
+  end
+
+  def self.dying_thread_with_outer_ensure(kill_method_name=:kill)
+    Thread.new do
+      Thread.current.report_on_exception = false
+      begin
+        begin
+          Thread.current.send(kill_method_name)
+        ensure
+          raise "In dying thread"
+        end
+      ensure
+        yield
+      end
+    end
+  end
+
+  def self.join_dying_thread_with_outer_ensure(kill_method_name=:kill)
+    t = dying_thread_with_outer_ensure(kill_method_name) { yield }
+    -> { t.join }.should raise_error(RuntimeError, "In dying thread")
+    return t
+  end
+
+  def self.wakeup_dying_sleeping_thread(kill_method_name=:kill)
+    t = ThreadSpecs.dying_thread_ensures(kill_method_name) { yield }
+    Thread.pass while t.status and t.status != 'sleep'
+    t.wakeup
+    t.join
+  end
+
+  def self.critical_is_reset
+    # Create another thread to verify that it can call Thread.critical=
+    t = Thread.new do
+      initial_critical = Thread.critical
+      Thread.critical = true
+      Thread.critical = false
+      initial_critical == false && Thread.critical == false
+    end
+    v = t.value
+    t.join
+    v
+  end
+
+  def self.counter
+    @@counter
+  end
+
+  def self.counter= c
+    @@counter = c
+  end
+
+  def self.increment_counter(incr)
+    incr.times do
+      begin
+        Thread.critical = true
+        @@counter += 1
+      ensure
+        Thread.critical = false
+      end
+    end
+  end
+
+  def self.critical_thread1
+    Thread.critical = true
+    Thread.current.key?(:thread_specs).should == false
+  end
+
+  def self.critical_thread2(is_thread_stop)
+    Thread.current[:thread_specs].should == 101
+    Thread.critical.should == !is_thread_stop
+    unless is_thread_stop
+      Thread.critical = false
+    end
+  end
+
+  def self.main_thread1(critical_thread, is_thread_sleep, is_thread_stop)
+    # Thread.stop resets Thread.critical. Also, with native threads, the Thread.Stop may not have executed yet
+    # since the main thread will race with the critical thread
+    unless is_thread_stop
+      Thread.critical.should == true
+    end
+    critical_thread[:thread_specs] = 101
+    if is_thread_sleep or is_thread_stop
+      # Thread#wakeup calls are not queued up. So we need to ensure that the thread is sleeping before calling wakeup
+      Thread.pass while critical_thread.status and critical_thread.status != "sleep"
+      critical_thread.wakeup
+    end
+  end
+
+  def self.main_thread2(critical_thread)
+    Thread.pass # The join below seems to cause a deadlock with CRuby unless Thread.pass is called first
+    critical_thread.join
+    Thread.critical.should == false
+  end
+
+  def self.critical_thread_yields_to_main_thread(is_thread_sleep=false, is_thread_stop=false)
+    @@after_first_sleep = false
+
+    critical_thread = Thread.new do
+      Thread.pass while Thread.main.status and Thread.main.status != "sleep"
+      critical_thread1()
+      Thread.main.wakeup
+      yield
+      Thread.pass while @@after_first_sleep != true # Need to ensure that the next statement does not see the first sleep itself
+      Thread.pass while Thread.main.status and Thread.main.status != "sleep"
+      critical_thread2(is_thread_stop)
+      Thread.main.wakeup
+    end
+
+    sleep 5
+    @@after_first_sleep = true
+    main_thread1(critical_thread, is_thread_sleep, is_thread_stop)
+    sleep 5
+    main_thread2(critical_thread)
+  end
+
+  def self.create_critical_thread
+    Thread.new do
+      Thread.critical = true
+      yield
+      Thread.critical = false
+    end
+  end
+
+  def self.create_and_kill_critical_thread(pass_after_kill=false)
+    ThreadSpecs.create_critical_thread do
+      Thread.current.kill
+      Thread.pass if pass_after_kill
+      ScratchPad.record("status=" + Thread.current.status)
+    end
+  end
+end

--- a/spec/core/thread/shared/exit.rb
+++ b/spec/core/thread/shared/exit.rb
@@ -1,0 +1,219 @@
+describe :thread_exit, shared: true do
+  before :each do
+    ScratchPad.clear
+  end
+
+  # This spec randomly kills mspec worker like: https://ci.appveyor.com/project/ruby/ruby/builds/19390874/job/wv1bsm8skd4e1pxl
+  # TODO: Investigate the cause or at least print helpful logs, and remove this `platform_is_not` guard.
+  platform_is_not :mingw do
+
+  it "kills sleeping thread" do
+    sleeping_thread = Thread.new do
+      sleep
+      ScratchPad.record :after_sleep
+    end
+    Thread.pass while sleeping_thread.status and sleeping_thread.status != "sleep"
+    sleeping_thread.send(@method)
+    sleeping_thread.join
+    ScratchPad.recorded.should == nil
+  end
+
+  it "kills current thread" do
+    thread = Thread.new do
+      Thread.current.send(@method)
+      ScratchPad.record :after_sleep
+    end
+    thread.join
+    ScratchPad.recorded.should == nil
+  end
+
+  it "runs ensure clause" do
+    thread = ThreadSpecs.dying_thread_ensures(@method) { ScratchPad.record :in_ensure_clause }
+    thread.join
+    ScratchPad.recorded.should == :in_ensure_clause
+  end
+
+  it "runs nested ensure clauses" do
+    ScratchPad.record []
+    @outer = Thread.new do
+      begin
+        @inner = Thread.new do
+          begin
+            sleep
+          ensure
+            ScratchPad << :inner_ensure_clause
+          end
+        end
+        sleep
+      ensure
+        ScratchPad << :outer_ensure_clause
+        @inner.send(@method)
+        @inner.join
+      end
+    end
+    Thread.pass while @outer.status and @outer.status != "sleep"
+    Thread.pass until @inner
+    Thread.pass while @inner.status and @inner.status != "sleep"
+    @outer.send(@method)
+    @outer.join
+    ScratchPad.recorded.should include(:inner_ensure_clause)
+    ScratchPad.recorded.should include(:outer_ensure_clause)
+  end
+
+  it "does not set $!" do
+    thread = ThreadSpecs.dying_thread_ensures(@method) { ScratchPad.record $! }
+    thread.join
+    ScratchPad.recorded.should == nil
+  end
+
+  it "does not reset $!" do
+    ScratchPad.record []
+
+    exc = RuntimeError.new("foo")
+    thread = Thread.new do
+      begin
+        raise exc
+      ensure
+        ScratchPad << $!
+        begin
+          Thread.current.send(@method)
+        ensure
+          ScratchPad << $!
+        end
+      end
+    end
+    thread.join
+    ScratchPad.recorded.should == [exc, exc]
+  end
+
+  it "cannot be rescued" do
+    thread = Thread.new do
+      begin
+        Thread.current.send(@method)
+      rescue Exception
+        ScratchPad.record :in_rescue
+      end
+      ScratchPad.record :end_of_thread_block
+    end
+
+    thread.join
+    ScratchPad.recorded.should == nil
+  end
+
+  it "kills the entire thread when a fiber is active" do
+    t = Thread.new do
+      Fiber.new do
+        sleep
+      end.resume
+      ScratchPad.record :fiber_resumed
+    end
+    Thread.pass while t.status and t.status != "sleep"
+    t.send(@method)
+    t.join
+    ScratchPad.recorded.should == nil
+  end
+
+  it "kills other fibers of that thread without running their ensure clauses" do
+    t = Thread.new do
+      f = Fiber.new do
+        ScratchPad.record :fiber_resumed
+        begin
+          Fiber.yield
+        ensure
+          ScratchPad.record :fiber_ensure
+        end
+      end
+      f.resume
+      sleep
+    end
+    Thread.pass until t.stop?
+    t.send(@method)
+    t.join
+    ScratchPad.recorded.should == :fiber_resumed
+  end
+
+  # This spec is a mess. It fails randomly, it hangs on MRI, it needs to be removed
+  quarantine! do
+  it "killing dying running does nothing" do
+    in_ensure_clause = false
+    exit_loop = true
+    t = ThreadSpecs.dying_thread_ensures do
+      in_ensure_clause = true
+      loop { if exit_loop then break end }
+      ScratchPad.record :after_stop
+    end
+
+    Thread.pass until in_ensure_clause == true
+    10.times { t.send(@method); Thread.pass }
+    exit_loop = true
+    t.join
+    ScratchPad.recorded.should == :after_stop
+  end
+  end
+
+  quarantine! do
+
+    it "propagates inner exception to Thread.join if there is an outer ensure clause" do
+      thread = ThreadSpecs.dying_thread_with_outer_ensure(@method) { }
+      -> { thread.join }.should raise_error(RuntimeError, "In dying thread")
+    end
+
+    it "runs all outer ensure clauses even if inner ensure clause raises exception" do
+      ThreadSpecs.join_dying_thread_with_outer_ensure(@method) { ScratchPad.record :in_outer_ensure_clause }
+      ScratchPad.recorded.should == :in_outer_ensure_clause
+    end
+
+    it "sets $! in outer ensure clause if inner ensure clause raises exception" do
+      ThreadSpecs.join_dying_thread_with_outer_ensure(@method) { ScratchPad.record $! }
+      ScratchPad.recorded.to_s.should == "In dying thread"
+    end
+  end
+
+  it "can be rescued by outer rescue clause when inner ensure clause raises exception" do
+    thread = Thread.new do
+      begin
+        begin
+          Thread.current.send(@method)
+        ensure
+          raise "In dying thread"
+        end
+      rescue Exception
+        ScratchPad.record $!
+      end
+      :end_of_thread_block
+    end
+
+    thread.value.should == :end_of_thread_block
+    ScratchPad.recorded.to_s.should == "In dying thread"
+  end
+
+  it "is deferred if ensure clause does Thread.stop" do
+    ThreadSpecs.wakeup_dying_sleeping_thread(@method) { Thread.stop; ScratchPad.record :after_sleep }
+    ScratchPad.recorded.should == :after_sleep
+  end
+
+  # Hangs on 1.8.6.114 OS X, possibly also on Linux
+  quarantine! do
+    it "is deferred if ensure clause sleeps" do
+      ThreadSpecs.wakeup_dying_sleeping_thread(@method) { sleep; ScratchPad.record :after_sleep }
+      ScratchPad.recorded.should == :after_sleep
+    end
+  end
+
+  # This case occurred in JRuby where native threads are used to provide
+  # the same behavior as MRI green threads. Key to this issue was the fact
+  # that the thread which called #exit in its block was also being explicitly
+  # sent #join from outside the thread. The 100.times provides a certain
+  # probability that the deadlock will occur. It was sufficient to reliably
+  # reproduce the deadlock in JRuby.
+  it "does not deadlock when called from within the thread while being joined from without" do
+    100.times do
+      t = Thread.new { Thread.stop; Thread.current.send(@method) }
+      Thread.pass while t.status and t.status != "sleep"
+      t.wakeup.should == t
+      t.join.should == t
+    end
+  end
+
+  end # platform_is_not :mingw
+end

--- a/spec/core/thread/shared/start.rb
+++ b/spec/core/thread/shared/start.rb
@@ -1,0 +1,41 @@
+describe :thread_start, shared: true do
+  before :each do
+    ScratchPad.clear
+  end
+
+  it "raises an ArgumentError if not passed a block" do
+    -> {
+      Thread.send(@method)
+    }.should raise_error(ArgumentError)
+  end
+
+  it "spawns a new Thread running the block" do
+    run = false
+    t = Thread.send(@method) { run = true }
+    t.should be_kind_of(Thread)
+    t.join
+
+    run.should be_true
+  end
+
+  it "respects Thread subclasses" do
+    c = Class.new(Thread)
+    t = c.send(@method) { }
+    t.should be_kind_of(c)
+
+    t.join
+  end
+
+  it "does not call #initialize" do
+    c = Class.new(Thread) do
+      def initialize
+        ScratchPad.record :bad
+      end
+    end
+
+    t = c.send(@method) { }
+    t.join
+
+    ScratchPad.recorded.should == nil
+  end
+end

--- a/spec/core/thread/shared/to_s.rb
+++ b/spec/core/thread/shared/to_s.rb
@@ -1,0 +1,53 @@
+require_relative '../fixtures/classes'
+
+describe :thread_to_s, shared: true do
+  it "returns a description including file and line number" do
+    thread, line = Thread.new { "hello" }, __LINE__
+    thread.join
+    thread.send(@method).should =~ /^#<Thread:([^ ]*?) #{Regexp.escape __FILE__}:#{line} \w+>$/
+  end
+
+  it "has a binary encoding" do
+    ThreadSpecs.status_of_current_thread.send(@method).encoding.should == Encoding::BINARY
+  end
+
+  it "can check it's own status" do
+    ThreadSpecs.status_of_current_thread.send(@method).should include('run')
+  end
+
+  it "describes a running thread" do
+    ThreadSpecs.status_of_running_thread.send(@method).should include('run')
+  end
+
+  it "describes a sleeping thread" do
+    ThreadSpecs.status_of_sleeping_thread.send(@method).should include('sleep')
+  end
+
+  it "describes a blocked thread" do
+    ThreadSpecs.status_of_blocked_thread.send(@method).should include('sleep')
+  end
+
+  it "describes a completed thread" do
+    ThreadSpecs.status_of_completed_thread.send(@method).should include('dead')
+  end
+
+  it "describes a killed thread" do
+    ThreadSpecs.status_of_killed_thread.send(@method).should include('dead')
+  end
+
+  it "describes a thread with an uncaught exception" do
+    ThreadSpecs.status_of_thread_with_uncaught_exception.send(@method).should include('dead')
+  end
+
+  it "describes a dying sleeping thread" do
+    ThreadSpecs.status_of_dying_sleeping_thread.send(@method).should include('sleep')
+  end
+
+  it "reports aborting on a killed thread" do
+    ThreadSpecs.status_of_dying_running_thread.send(@method).should include('aborting')
+  end
+
+  it "reports aborting on a killed thread after sleep" do
+    ThreadSpecs.status_of_dying_thread_after_sleep.send(@method).should include('aborting')
+  end
+end

--- a/spec/core/thread/shared/wakeup.rb
+++ b/spec/core/thread/shared/wakeup.rb
@@ -1,0 +1,66 @@
+describe :thread_wakeup, shared: true do
+  it "can interrupt Kernel#sleep" do
+    exit_loop = false
+    after_sleep1 = false
+    after_sleep2 = false
+
+    t = Thread.new do
+      while true
+        break if exit_loop == true
+        Thread.pass
+      end
+
+      sleep
+      after_sleep1 = true
+
+      sleep 10000
+      after_sleep2 = true
+    end
+
+    10.times { t.send(@method); Thread.pass }
+    t.status.should_not == "sleep"
+
+    exit_loop = true
+
+    10.times { sleep 0.1 if t.status and t.status != "sleep" }
+    after_sleep1.should == false # t should be blocked on the first sleep
+    t.send(@method)
+
+    10.times { sleep 0.1 if after_sleep1 != true }
+    10.times { sleep 0.1 if t.status and t.status != "sleep" }
+    after_sleep2.should == false # t should be blocked on the second sleep
+    t.send(@method)
+
+    t.join
+  end
+
+  it "does not result in a deadlock" do
+    NATFIXME 'Implement Thread.stop', exception: SpecFailedException do
+      Thread.methods.should include(:stop)
+    end
+
+    t = Thread.new do
+      #10.times { Thread.stop }
+    end
+
+    while t.status
+      begin
+        t.send(@method)
+      rescue ThreadError
+        # The thread might die right after.
+        t.status.should == false
+      end
+      Thread.pass
+      sleep 0.001
+    end
+
+    t.status.should == false
+    t.join
+  end
+
+  it "raises a ThreadError when trying to wake up a dead thread" do
+    t = Thread.new { 1 }
+    t.join
+    -> { t.send @method }.should raise_error(ThreadError)
+  end
+end

--- a/spec/core/thread/wakeup_spec.rb
+++ b/spec/core/thread/wakeup_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/wakeup'
+
+describe "Thread#wakeup" do
+  it_behaves_like :thread_wakeup, :wakeup
+end

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -571,13 +571,13 @@ Value KernelModule::remove_instance_variable(Env *env, Value name_val) {
 }
 
 Value KernelModule::sleep(Env *env, Value length) {
-    if (!length) {
-        if (FiberObject::scheduler_is_relevant())
-            FiberObject::scheduler()->send(env, "kernel_sleep"_s);
-        else
-            ThreadObject::current()->sleep(-1);
-        return NilObject::the();
+    if (FiberObject::scheduler_is_relevant()) {
+        if (!length) length = NilObject::the();
+        return FiberObject::scheduler()->send(env, "kernel_sleep"_s, { length });
     }
+
+    if (!length)
+        return ThreadObject::current()->sleep(env, -1.0);
 
     float secs;
     if (length->is_integer()) {
@@ -597,42 +597,7 @@ Value KernelModule::sleep(Env *env, Value length) {
     if (secs < 0.0)
         env->raise("ArgumentError", "time interval must not be negative");
 
-    timespec ts, t_begin, t_end;
-    ts.tv_sec = ::floor(secs);
-    ts.tv_nsec = (secs - ts.tv_sec) * 1000000000;
-    if (::clock_gettime(CLOCK_MONOTONIC, &t_begin) < 0)
-        env->raise_errno();
-
-    if (FiberObject::scheduler_is_relevant()) {
-        ts.tv_sec += t_begin.tv_sec;
-        ts.tv_nsec += t_begin.tv_nsec;
-        if (ts.tv_nsec >= 1000000000) {
-            ts.tv_sec++;
-            ts.tv_nsec -= 1000000000;
-        }
-        while (true) {
-            FiberObject::scheduler()->send(env, "kernel_sleep"_s, { length });
-            // When we get here, the scheduler should have checked our timeout. But loop in case we got
-            // restarted too early
-            if (::clock_gettime(CLOCK_MONOTONIC, &t_end) < 0)
-                env->raise_errno();
-            if (t_end.tv_sec > ts.tv_sec || (t_end.tv_sec == ts.tv_sec && t_end.tv_nsec > ts.tv_nsec))
-                break;
-            secs = t_end.tv_sec - ts.tv_sec;
-            secs += (t_end.tv_nsec - ts.tv_nsec) / 1000000000.0;
-            length = new FloatObject { secs };
-        }
-    } else {
-        Defer done_sleeping([] { ThreadObject::set_current_sleeping(false); });
-        ThreadObject::set_current_sleeping(true);
-        nanosleep(&ts, nullptr);
-        if (::clock_gettime(CLOCK_MONOTONIC, &t_end) < 0)
-            env->raise_errno();
-    }
-
-    int elapsed = t_end.tv_sec - t_begin.tv_sec;
-    if (t_end.tv_nsec < t_begin.tv_nsec) elapsed--;
-    return IntegerObject::create(elapsed);
+    return ThreadObject::current()->sleep(env, secs);
 }
 
 Value KernelModule::spawn(Env *env, Args args) {

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -348,6 +348,7 @@ void ThreadObject::visit_children(Visitor &visitor) {
     visitor.visit(m_value);
     for (auto pair : m_mutexes)
         visitor.visit(pair.first);
+    visitor.visit(m_fiber_scheduler);
     visit_children_from_stack(visitor);
 }
 

--- a/test/natalie/fiber/scheduler_sleep_test.rb
+++ b/test/natalie/fiber/scheduler_sleep_test.rb
@@ -44,14 +44,17 @@ describe 'Fiber.scheduler with Kernel.sleep' do
       events << 'Coffee'
     end
 
-    NATFIXME 'handle infinite sleep in Fiber Scheduler', exception: TypeError, message: /nil.*to.*float/i do
-      sleeper.resume
+    Thread.new do
+      sleep 1
+      scheduler.wakeup(sleeper)
     end
+
+    sleeper.resume
     barista.resume
 
     scheduler.close
 
-    events.should == ['Going to sleep', 'Coffee']
+    events.should == ['Going to sleep', 'Coffee', 'Woken up']
   end
 
   it 'does not interleave blocking fibers' do

--- a/test/natalie/fiber/scheduler_sleep_test.rb
+++ b/test/natalie/fiber/scheduler_sleep_test.rb
@@ -44,7 +44,9 @@ describe 'Fiber.scheduler with Kernel.sleep' do
       events << 'Coffee'
     end
 
-    sleeper.resume
+    NATFIXME 'handle infinite sleep in Fiber Scheduler', exception: TypeError, message: /nil.*to.*float/i do
+      sleeper.resume
+    end
     barista.resume
 
     scheduler.close

--- a/test/natalie/fiber/shared/scheduler.rb
+++ b/test/natalie/fiber/shared/scheduler.rb
@@ -20,13 +20,6 @@ class Scheduler
   end
 
   def kernel_sleep(duration = nil)
-    # NATFIXME: We don't have any mechanism to stop a fiber with an infinite sleep, so we should not
-    # resume that one.
-    if duration.nil?
-      Fiber.yield
-      return
-    end
-
     @waiting[Fiber.current] = current_time + duration
     Fiber.yield
   end

--- a/test/natalie/fiber/shared/scheduler.rb
+++ b/test/natalie/fiber/shared/scheduler.rb
@@ -20,8 +20,16 @@ class Scheduler
   end
 
   def kernel_sleep(duration = nil)
-    @waiting[Fiber.current] = current_time + duration
+    if duration
+      @waiting[Fiber.current] = current_time + duration
+    else
+      @waiting[Fiber.current] = Float::INFINITY
+    end
     Fiber.yield
+  end
+
+  def wakeup(fiber)
+    @waiting[fiber] = 0
   end
 
   def current_time


### PR DESCRIPTION
This makes `Kernel#sleep` work in threads along with `Thread#wakeup`. The current Fiber::Scheduler is now also set on the current active thread.