### PR TITLE
Refresh YAML specs

### DIFF
--- a/spec/library/yaml/fixtures/strings.rb
+++ b/spec/library/yaml/fixtures/strings.rb
@@ -1,36 +1,26 @@
-$complex_key_1 = <<EOY
-    ? # PLAY SCHEDULE
-      - Detroit Tigers
-      - Chicago Cubs
-    :
-      - 2001-07-23
+module YAMLSpecs
+  COMPLEX_KEY_1 = <<~EOY
+      ? # PLAY SCHEDULE
+        - Detroit Tigers
+        - Chicago Cubs
+      :
+        - 2001-07-23
 
-    ? [ New York Yankees,
-        Atlanta Braves ]
-    : [ 2001-07-02, 2001-08-12,
-       2001-08-14 ]
-EOY
+      ? [ New York Yankees,
+          Atlanta Braves ]
+      : [ 2001-07-02, 2001-08-12,
+         2001-08-14 ]
+  EOY
 
-$to_yaml_hash =
-<<EOY
--
-  avg: 0.278
-  hr: 65
-  name: Mark McGwire
--
-  avg: 0.288
-  hr: 63
-  name: Sammy Sosa
-EOY
+  MULTIDOCUMENT = <<~EOY
+  ---
+  - Mark McGwire
+  - Sammy Sosa
+  - Ken Griffey
 
-$multidocument = <<EOY
----
-- Mark McGwire
-- Sammy Sosa
-- Ken Griffey
-
-# Team ranking
----
-- Chicago Cubs
-- St Louis Cardinals
-EOY
+  # Team ranking
+  ---
+  - Chicago Cubs
+  - St Louis Cardinals
+  EOY
+end

--- a/spec/library/yaml/shared/load.rb
+++ b/spec/library/yaml/shared/load.rb
@@ -107,7 +107,7 @@ describe :yaml_load_unsafe, shared: true do
                                                     Date.new( 2001, 8, 14 ) ]
     }
     NATFIXME 'Implement YAML.unsafe_load', exception: SpecFailedException do
-      YAML.send(@method, $complex_key_1).should == expected
+      YAML.send(@method, YAMLSpecs::COMPLEX_KEY_1).should == expected
     end
   end
 


### PR DESCRIPTION
This replaces some globals with constants

Upstream fix: https://github.com/ruby/spec/pull/1118