### PR TITLE
Encoding fixups

### DIFF
--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 255;
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint < 256;
     }
 

--- a/include/natalie/encoding/eucjp_encoding_object.hpp
+++ b/include/natalie/encoding/eucjp_encoding_object.hpp
@@ -17,7 +17,7 @@ public:
 
     virtual bool valid_codepoint(nat_int_t codepoint) const override;
 
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 0x8ffefe;
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm037_encoding_object.hpp
+++ b/include/natalie/encoding/ibm037_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm437_encoding_object.hpp
+++ b/include/natalie/encoding/ibm437_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm720_encoding_object.hpp
+++ b/include/natalie/encoding/ibm720_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm737_encoding_object.hpp
+++ b/include/natalie/encoding/ibm737_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm775_encoding_object.hpp
+++ b/include/natalie/encoding/ibm775_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm850_encoding_object.hpp
+++ b/include/natalie/encoding/ibm850_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm852_encoding_object.hpp
+++ b/include/natalie/encoding/ibm852_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm855_encoding_object.hpp
+++ b/include/natalie/encoding/ibm855_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm857_encoding_object.hpp
+++ b/include/natalie/encoding/ibm857_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm860_encoding_object.hpp
+++ b/include/natalie/encoding/ibm860_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm861_encoding_object.hpp
+++ b/include/natalie/encoding/ibm861_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm862_encoding_object.hpp
+++ b/include/natalie/encoding/ibm862_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm863_encoding_object.hpp
+++ b/include/natalie/encoding/ibm863_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm864_encoding_object.hpp
+++ b/include/natalie/encoding/ibm864_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm865_encoding_object.hpp
+++ b/include/natalie/encoding/ibm865_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm866_encoding_object.hpp
+++ b/include/natalie/encoding/ibm866_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/ibm869_encoding_object.hpp
+++ b/include/natalie/encoding/ibm869_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885910_encoding_object.hpp
+++ b/include/natalie/encoding/iso885910_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885911_encoding_object.hpp
+++ b/include/natalie/encoding/iso885911_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885912_encoding_object.hpp
+++ b/include/natalie/encoding/iso885912_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885913_encoding_object.hpp
+++ b/include/natalie/encoding/iso885913_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885914_encoding_object.hpp
+++ b/include/natalie/encoding/iso885914_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885915_encoding_object.hpp
+++ b/include/natalie/encoding/iso885915_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso885916_encoding_object.hpp
+++ b/include/natalie/encoding/iso885916_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88591_encoding_object.hpp
+++ b/include/natalie/encoding/iso88591_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88592_encoding_object.hpp
+++ b/include/natalie/encoding/iso88592_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88593_encoding_object.hpp
+++ b/include/natalie/encoding/iso88593_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88594_encoding_object.hpp
+++ b/include/natalie/encoding/iso88594_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88595_encoding_object.hpp
+++ b/include/natalie/encoding/iso88595_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88596_encoding_object.hpp
+++ b/include/natalie/encoding/iso88596_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88597_encoding_object.hpp
+++ b/include/natalie/encoding/iso88597_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88598_encoding_object.hpp
+++ b/include/natalie/encoding/iso88598_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/iso88599_encoding_object.hpp
+++ b/include/natalie/encoding/iso88599_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/shiftjis_encoding_object.hpp
+++ b/include/natalie/encoding/shiftjis_encoding_object.hpp
@@ -32,7 +32,7 @@ public:
         return true; // ok single byte
     }
     // NATFIXME : incorrect implementation
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
 

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint <= 127;
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint < 128;
     }
 

--- a/include/natalie/encoding/utf16be_encoding_object.hpp
+++ b/include/natalie/encoding/utf16be_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf16le_encoding_object.hpp
+++ b/include/natalie/encoding/utf16le_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf32be_encoding_object.hpp
+++ b/include/natalie/encoding/utf32be_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf32le_encoding_object.hpp
+++ b/include/natalie/encoding/utf32le_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         // it's positive and takes 1-4 bytes
         return codepoint >= 0 && codepoint < 0x10000000000;
     }

--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -19,7 +19,7 @@ public:
         // from RFC3629: 0x0..0x10FFFF are valid, with exception of 0xD800-0xDFFF
         return (codepoint >= 0 && codepoint < 0xD800) || (codepoint > 0xDFFF && codepoint <= 0x10FFFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return codepoint >= 0 && codepoint < 0x110000;
     }
 

--- a/include/natalie/encoding/windows1250_encoding_object.hpp
+++ b/include/natalie/encoding/windows1250_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/windows1251_encoding_object.hpp
+++ b/include/natalie/encoding/windows1251_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding/windows1252_encoding_object.hpp
+++ b/include/natalie/encoding/windows1252_encoding_object.hpp
@@ -18,7 +18,7 @@ public:
     virtual bool valid_codepoint(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) override {
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const override {
         return (codepoint >= 0 && codepoint <= 0xFF);
     }
     virtual bool is_ascii_compatible() const override { return true; };

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -42,7 +42,7 @@ public:
 
     Value inspect(Env *) const;
 
-    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) { NAT_UNREACHABLE(); }
+    virtual bool in_encoding_codepoint_range(nat_int_t codepoint) const { NAT_UNREACHABLE(); }
     virtual bool is_ascii_compatible() const { return false; } // default
     virtual bool is_dummy() const { return false; }
 

--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -124,8 +124,7 @@ describe "IO#write on a file" do
     end
   end
 
-  # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "writes binary data if no encoding is given" do
+  it "writes binary data if no encoding is given" do
     File.open(@filename, "w") do |file|
       file.write('Hëllö'.encode('ISO-8859-1'))
     end
@@ -210,8 +209,7 @@ describe "IO.write" do
     end
   end
 
-  # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "writes binary data if no encoding is given" do
+  it "writes binary data if no encoding is given" do
     IO.write(@filename, 'Hëllö'.encode('ISO-8859-1'))
     xEB = [235].pack('C*')
     xF6 = [246].pack('C*')

--- a/spec/core/regexp/union_spec.rb
+++ b/spec/core/regexp/union_spec.rb
@@ -25,9 +25,10 @@ describe "Regexp.union" do
     end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "returns a Regexp with the encoding of a String containing non-ASCII-compatible characters" do
-    Regexp.union("\u00A9".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
+  it "returns a Regexp with the encoding of a String containing non-ASCII-compatible characters" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Regexp.union("\u00A9".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
+    end
   end
 
   it "returns a Regexp with US-ASCII encoding if all arguments are ASCII-only" do
@@ -42,14 +43,16 @@ describe "Regexp.union" do
     end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "returns a Regexp with the encoding of multiple non-conflicting Strings containing non-ASCII-compatible characters" do
-    Regexp.union("\u00A9".encode("ISO-8859-1"), "\u00B0".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
+  it "returns a Regexp with the encoding of multiple non-conflicting Strings containing non-ASCII-compatible characters" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Regexp.union("\u00A9".encode("ISO-8859-1"), "\u00B0".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
+    end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "returns a Regexp with the encoding of a String containing non-ASCII-compatible characters and another ASCII-only String" do
-    Regexp.union("\u00A9".encode("ISO-8859-1"), "a".encode("UTF-8")).encoding.should == Encoding::ISO_8859_1
+  it "returns a Regexp with the encoding of a String containing non-ASCII-compatible characters and another ASCII-only String" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      Regexp.union("\u00A9".encode("ISO-8859-1"), "a".encode("UTF-8")).encoding.should == Encoding::ISO_8859_1
+    end
   end
 
   it "returns ASCII-8BIT if the regexp encodings are ASCII-8BIT and at least one has non-ASCII characters" do
@@ -111,20 +114,22 @@ describe "Regexp.union" do
     end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include a fixed encoding Regexp and a String containing non-ASCII-compatible characters in a different encoding" do
-    -> {
-      Regexp.union(Regexp.new("a".encode("UTF-8"), Regexp::FIXEDENCODING),
-                   "\u00A9".encode("ISO-8859-1"))
-    }.should raise_error(ArgumentError, 'incompatible encodings: UTF-8 and ISO-8859-1')
+  it "raises ArgumentError if the arguments include a fixed encoding Regexp and a String containing non-ASCII-compatible characters in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union(Regexp.new("a".encode("UTF-8"), Regexp::FIXEDENCODING),
+                     "\u00A9".encode("ISO-8859-1"))
+      }.should raise_error(ArgumentError, 'incompatible encodings: UTF-8 and ISO-8859-1')
+    end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include a String containing non-ASCII-compatible characters and a fixed encoding Regexp in a different encoding" do
-    -> {
-      Regexp.union("\u00A9".encode("ISO-8859-1"),
-                   Regexp.new("a".encode("UTF-8"), Regexp::FIXEDENCODING))
-    }.should raise_error(ArgumentError, 'incompatible encodings: ISO-8859-1 and UTF-8')
+  it "raises ArgumentError if the arguments include a String containing non-ASCII-compatible characters and a fixed encoding Regexp in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union("\u00A9".encode("ISO-8859-1"),
+                     Regexp.new("a".encode("UTF-8"), Regexp::FIXEDENCODING))
+      }.should raise_error(ArgumentError, 'incompatible encodings: ISO-8859-1 and UTF-8')
+    end
   end
 
   it "raises ArgumentError if the arguments include an ASCII-incompatible String and an ASCII-only String" do
@@ -159,32 +164,36 @@ describe "Regexp.union" do
     end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include an ASCII-incompatible String and a String containing non-ASCII-compatible characters in a different encoding" do
-    -> {
-      Regexp.union("a".encode("UTF-16LE"), "\u00A9".encode("ISO-8859-1"))
-    }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+  it "raises ArgumentError if the arguments include an ASCII-incompatible String and a String containing non-ASCII-compatible characters in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union("a".encode("UTF-16LE"), "\u00A9".encode("ISO-8859-1"))
+      }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+    end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include an ASCII-incompatible Regexp and a String containing non-ASCII-compatible characters in a different encoding" do
-    -> {
-      Regexp.union(Regexp.new("a".encode("UTF-16LE")), "\u00A9".encode("ISO-8859-1"))
-    }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+  it "raises ArgumentError if the arguments include an ASCII-incompatible Regexp and a String containing non-ASCII-compatible characters in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union(Regexp.new("a".encode("UTF-16LE")), "\u00A9".encode("ISO-8859-1"))
+      }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+    end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include an ASCII-incompatible String and a Regexp containing non-ASCII-compatible characters in a different encoding" do
-    -> {
-      Regexp.union("a".encode("UTF-16LE"), Regexp.new("\u00A9".encode("ISO-8859-1")))
-    }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+  it "raises ArgumentError if the arguments include an ASCII-incompatible String and a Regexp containing non-ASCII-compatible characters in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union("a".encode("UTF-16LE"), Regexp.new("\u00A9".encode("ISO-8859-1")))
+      }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+    end
   end
 
-  # NATFIXME NOT YET IMPLEMENTED: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises ArgumentError if the arguments include an ASCII-incompatible Regexp and a Regexp containing non-ASCII-compatible characters in a different encoding" do
-    -> {
-      Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("\u00A9".encode("ISO-8859-1")))
-    }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+  it "raises ArgumentError if the arguments include an ASCII-incompatible Regexp and a Regexp containing non-ASCII-compatible characters in a different encoding" do
+    NATFIXME 'Encodings', exception: SpecFailedException do
+      -> {
+        Regexp.union(Regexp.new("a".encode("UTF-16LE")), Regexp.new("\u00A9".encode("ISO-8859-1")))
+      }.should raise_error(ArgumentError, 'incompatible encodings: UTF-16LE and ISO-8859-1')
+    end
   end
 
   it "uses to_str to convert arguments (if not Regexp)" do

--- a/spec/core/string/chars_spec.rb
+++ b/spec/core/string/chars_spec.rb
@@ -1,10 +1,16 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
-require_relative 'shared/each_char_without_block'
 
 describe "String#chars" do
   it_behaves_like :string_chars, :chars
 
   it "returns an array when no block given" do
     "hello".chars.should == ['h', 'e', 'l', 'l', 'o']
+  end
+
+  it "returns Strings in the same encoding as self" do
+    "hello".encode("US-ASCII").chars.each do |c|
+      c.encoding.should == Encoding::US_ASCII
+    end
   end
 end

--- a/spec/core/string/each_char_spec.rb
+++ b/spec/core/string/each_char_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
 require_relative 'shared/each_char_without_block'
 

--- a/spec/core/string/rindex_spec.rb
+++ b/spec/core/string/rindex_spec.rb
@@ -415,11 +415,12 @@ describe "String#rindex with Regexp" do
      end
   end
 
-  # NATFIXME: Conversion above Unicode Basic Latin (0x00..0x7F) not implemented
-  xit "raises an Encoding::CompatibilityError if the encodings are incompatible" do
+  it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
     re = Regexp.new "れ".encode(Encoding::EUC_JP)
-    -> do
-      "あれ".rindex re
-    end.should raise_error(Encoding::CompatibilityError, "incompatible encoding regexp match (EUC-JP regexp with UTF-8 string)")
+    NATFIXME 'Support Regexp argument', exception: SpecFailedException do
+      -> do
+        "あれ".rindex re
+      end.should raise_error(Encoding::CompatibilityError, "incompatible encoding regexp match (EUC-JP regexp with UTF-8 string)")
+    end
   end
 end

--- a/spec/core/string/shared/chars.rb
+++ b/spec/core/string/shared/chars.rb
@@ -21,7 +21,7 @@ describe :string_chars, shared: true do
   end
 
   it "returns characters in the same encoding as self" do
-    "&%".force_encoding('ASCII-8BIT').send(@method).to_a.all? {|c| c.encoding.name.should == 'ASCII-8BIT'}
+    "&%".force_encoding('Shift_JIS').send(@method).to_a.all? {|c| c.encoding.name.should == 'Shift_JIS'}
     "&%".encode('BINARY').send(@method).to_a.all? {|c| c.encoding.should == Encoding::BINARY }
   end
 
@@ -57,10 +57,12 @@ describe :string_chars, shared: true do
       [0xAD].pack('C').force_encoding('BINARY'),
       [0xA2].pack('C').force_encoding('BINARY')
     ]
-    #s.force_encoding('SJIS').send(@method).to_a.should == [
-      #[0xF0,0xA4].pack('CC').force_encoding('SJIS'),
-      #[0xAD].pack('C').force_encoding('SJIS'),
-      #[0xA2].pack('C').force_encoding('SJIS')
-    #]
+    NATFIXME 'Implement SJIS encoding', exception: ArgumentError, message: 'unknown encoding name - "SJIS"' do
+      s.force_encoding('SJIS').send(@method).to_a.should == [
+        [0xF0,0xA4].pack('CC').force_encoding('SJIS'),
+        [0xAD].pack('C').force_encoding('SJIS'),
+        [0xA2].pack('C').force_encoding('SJIS')
+      ]
+    end
   end
 end

--- a/src/encoding/eucjp_encoding_object.cpp
+++ b/src/encoding/eucjp_encoding_object.cpp
@@ -3,7 +3,7 @@
 
 namespace Natalie {
 
-const long JIS0208[] = {
+static const long JIS0208[] = {
     0x3000, 0x3001, 0x3002, 0xFF0C, 0xFF0E, 0x30FB, 0xFF1A, 0xFF1B, 0xFF1F, 0xFF01,
     0x309B, 0x309C, 0xB4, 0xFF40, 0xA8, 0xFF3E, 0xFFE3, 0xFF3F, 0x30FD, 0x30FE,
     0x309D, 0x309E, 0x3003, 0x4EDD, 0x3005, 0x3006, 0x3007, 0x30FC, 0x2015, 0x2010,
@@ -1116,9 +1116,9 @@ const long JIS0208[] = {
     0x9A4E, 0x9AD9, 0x9ADC, 0x9B75, 0x9B72, 0x9B8F, 0x9BB1, 0x9BBB, 0x9C00, 0x9D70,
     0x9D6B, 0xFA2D, 0x9E19, 0x9ED1
 };
-long JIS0208_max = 11103;
+static const long JIS0208_max = 11103;
 
-const long JIS0212[] = {
+static const long JIS0212[] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -1842,7 +1842,7 @@ const long JIS0212[] = {
     0x9F90, 0x9F91, 0x9F92, 0x9F94, 0x9F96, 0x9F97, 0x9F9E, 0x9FA1, 0x9FA2, 0x9FA3,
     0x9FA5
 };
-long JIS0212_max = 7210;
+static const long JIS0212_max = 7210;
 
 bool EucJpEncodingObject::valid_codepoint(nat_int_t codepoint) const {
     if (codepoint < 0 || codepoint > 0x8ffefe)

--- a/test/encodings/eucjp_tables.rb
+++ b/test/encodings/eucjp_tables.rb
@@ -14,7 +14,7 @@ TABLES.each do |table_name, url|
     hash[idx.to_i] = value
   end
 
-  print "const long #{table_name}[] = {"
+  print "static const long #{table_name}[] = {"
 
   0.upto(index.keys.max).each do |i|
     value = index[i]
@@ -31,6 +31,6 @@ TABLES.each do |table_name, url|
   end
 
   puts '};'
-  puts "long #{table_name}_max = #{index.keys.max};"
+  puts "static const long #{table_name}_max = #{index.keys.max};"
   puts
 end

--- a/test/natalie/encoding_test.rb
+++ b/test/natalie/encoding_test.rb
@@ -38,7 +38,7 @@ describe 'encodings' do
       end
     end
 
-    it 'can chop a character (this uses EncdoingObject::prev_char)' do
+    it 'can chop a character (this uses EncodingObject::prev_char)' do
       [
         0x61,
         0xA1A1,
@@ -84,7 +84,7 @@ describe 'encodings' do
       end
     end
 
-    it 'can chop a character (this uses EncdoingObject::prev_char)' do
+    it 'can chop a character (this uses EncodingObject::prev_char)' do
       [
         0x61,
         0x8E,

--- a/test/natalie/encoding_test.rb
+++ b/test/natalie/encoding_test.rb
@@ -80,7 +80,7 @@ describe 'encodings' do
         0x8E => 0x8E,
         0xFF => 0xFF,
       }.each do |codepoint, expected|
-        codepoint.chr(Encoding::ISO_8859_1).encode(Encoding::ISO_8859_1).ord.to_s(16).should == expected.to_s(16)
+        codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_1).ord.to_s(16).should == expected.to_s(16)
       end
     end
 


### PR DESCRIPTION
It turned out every "Conversion above Unicode Basic Latin" comment in the specs folder was outdated, and a lot of our own tests included small mistakes.