### PR TITLE
Support magic comment to set encoding

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -149,7 +149,7 @@ class Runner
       repl.go(options)
     elsif options[:ast]
       require 'pp'
-      pp ast
+      pp parser.ast
     elsif options[:compile] && options[:bytecode]
       compiler.out_path = options[:compile]
       compiler.compile_to_bytecode
@@ -312,7 +312,11 @@ class Runner
   end
 
   def compiler
-    @compiler ||= Natalie::Compiler.new(ast, source_path, options).tap do |c|
+    return @compiler if @compiler
+
+    ast = parser.ast
+    encoding = parser.encoding
+    @compiler = Natalie::Compiler.new(ast: ast, path: source_path, encoding: encoding, options: options).tap do |c|
       c.load_path = options[:load_path]
       c.write_obj_path = options[:write_obj_path]
     end
@@ -320,10 +324,6 @@ class Runner
 
   def parser
     @parser ||= Natalie::Parser.new(code, source_path)
-  end
-
-  def ast
-    @ast ||= parser.ast
   end
 
   def print_cpp_source(path)

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -43,6 +43,13 @@ public:
     StringObject()
         : StringObject { "" } { }
 
+    StringObject(EncodingObject *encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        set_str("", 0);
+    }
+
     StringObject(const char *str)
         : Object { Object::Type::String, GlobalEnv::the()->String() }
         , m_encoding { EncodingObject::get(Encoding::UTF_8) } {

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -19,10 +19,11 @@ module Natalie
     class CompileError < StandardError
     end
 
-    def initialize(ast, path, options = {})
+    def initialize(ast:, path:, encoding: Encoding::UTF_8, options: {})
       @ast = ast
       @var_num = 0
       @path = path
+      @encoding = encoding
       @options = options
       @inline_cpp_enabled = {}
     end
@@ -130,7 +131,8 @@ module Natalie
       instructions = Pass1.new(
         ast,
         compiler_context: @context,
-        macro_expander:   macro_expander
+        macro_expander:   macro_expander,
+        encoding:         @encoding,
       ).transform(
         used: keep_final_value_on_stack
       )
@@ -139,7 +141,7 @@ module Natalie
         exit
       end
 
-      main_file = LoadedFile.new(path: @path, instructions: instructions)
+      main_file = LoadedFile.new(path: @path, instructions: instructions, encoding: @encoding)
       files = [main_file] + @context[:required_ruby_files].values
       files.each do |file_info|
         {

--- a/lib/natalie/compiler/backends/cpp_backend/transform.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/transform.rb
@@ -212,7 +212,6 @@ module Natalie
           end
           out.join("\n")
         end
-
       end
     end
   end

--- a/lib/natalie/compiler/instructions/push_string_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_string_instruction.rb
@@ -6,20 +6,27 @@ module Natalie
     class PushStringInstruction < BaseInstruction
       include StringToCpp
 
-      def initialize(string, bytesize: string.bytesize)
+      def initialize(string, bytesize: string.bytesize, encoding: Encoding::UTF_8)
+        super()
         @string = string
         @bytesize = bytesize
+        @encoding = encoding
       end
 
       def to_s
-        "push_string #{@string.inspect}, #{@bytesize}"
+        "push_string #{@string.inspect}, #{@bytesize}, #{@encoding.name}"
       end
 
       def generate(transform)
+        enum = @encoding.name.tr('-', '_').upcase
+        encoding_object = "EncodingObject::get(Encoding::#{enum})"
         if @string.empty?
-          transform.exec_and_push(:string, "Value(new StringObject)")
+          transform.exec_and_push(:string, "Value(new StringObject(#{encoding_object}))")
         else
-          transform.exec_and_push(:string, "Value(new StringObject(#{string_to_cpp(@string)}, (size_t)#{@bytesize}))")
+          transform.exec_and_push(
+            :string,
+            "Value(new StringObject(#{string_to_cpp(@string)}, (size_t)#{@bytesize}, #{encoding_object}))"
+          )
         end
       end
 

--- a/lib/natalie/compiler/loaded_file.rb
+++ b/lib/natalie/compiler/loaded_file.rb
@@ -1,14 +1,16 @@
 module Natalie
   class Compiler
     class LoadedFile
-      def initialize(path:, ast: nil, instructions: nil)
+      def initialize(path:, ast: nil, instructions: nil, encoding: Encoding::UTF_8)
         @path = path
         @ast = ast
         @instructions = instructions
+        @encoding = encoding
       end
 
       attr_accessor :ast,
-                    :instructions
+                    :instructions,
+                    :encoding
     end
   end
 end

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -226,8 +226,8 @@ module Natalie
 
         unless (loaded_file = @required_ruby_files[path])
           code = File.read(path)
-          ast = Natalie::Parser.new(code, path).ast
-          @required_ruby_files[path] = LoadedFile.new(path: path, ast: ast)
+          parser = Natalie::Parser.new(code, path)
+          @required_ruby_files[path] = LoadedFile.new(path: path, ast: parser.ast, encoding: parser.encoding)
         end
 
         [:load_file, path, require_once]

--- a/lib/natalie/repl/main.rb
+++ b/lib/natalie/repl/main.rb
@@ -38,7 +38,7 @@ module Natalie
           )
           ast.statements.body << puts_and_set_underscore_variable
           temp = Tempfile.create('natalie.so')
-          compiler = Compiler.new(ast, '(repl)')
+          compiler = Compiler.new(ast: ast, path: '(repl)')
           compiler.repl = true
           compiler.repl_num = (repl_num += 1)
           compiler.vars = vars

--- a/lib/natalie/vm.rb
+++ b/lib/natalie/vm.rb
@@ -122,7 +122,7 @@ module Natalie
     end
 
     def self.compile_and_run(ast, path:)
-      compiler = Compiler.new(ast, path, interpret: true)
+      compiler = Compiler.new(ast: ast, path: path, options: { interpret: true })
       VM.new(compiler.instructions, path: path).run
     end
 

--- a/spec/core/io/shared/gets_ascii.rb
+++ b/spec/core/io/shared/gets_ascii.rb
@@ -5,7 +5,7 @@ describe :io_gets_ascii, shared: true do
       @name = tmp("gets_specs.txt")
       touch(@name, "wb") { |f| f.print "this is a test\xFFtesty\ntestier" }
 
-      NATFIXME 'Encoding issues', exception: ArgumentError, message: 'invalid byte sequence in UTF-8' do
+      NATFIXME 'Encoding issues', exception: Encoding::CompatibilityError do
         File.open(@name, "rb") { |f| @data = f.send(@method, "\xFF") }
       end
     end

--- a/spec/core/string/count_spec.rb
+++ b/spec/core/string/count_spec.rb
@@ -81,9 +81,11 @@ describe "String#count" do
   end
 
   it 'returns the number of occurrences of a multi-byte character' do
-    str = "\u{2605}"
-    str.count(str).should == 1
-    "asd#{str}zzz#{str}ggg".count(str).should == 2
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      str = "\u{2605}"
+      str.count(str).should == 1
+      "asd#{str}zzz#{str}ggg".count(str).should == 2
+    end
   end
 
   it "calls #to_str to convert each set arg to a String" do

--- a/spec/core/string/shared/codepoints.rb
+++ b/spec/core/string/shared/codepoints.rb
@@ -38,20 +38,26 @@ describe :string_codepoints, shared: true do
   end
 
   it "works for multibyte characters" do
-    s = "\u{9819}"
-    s.bytesize.should == 3
-    s.send(@method).to_a.should == [38937]
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      s = "\u{9819}"
+      s.bytesize.should == 3
+      s.send(@method).to_a.should == [38937]
+    end
   end
 
   it "yields the codepoints corresponding to the character's position in the String's encoding" do
-    "\u{787}".send(@method).to_a.should == [1927]
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      "\u{787}".send(@method).to_a.should == [1927]
+    end
   end
 
   it "round-trips to the original String using Integer#chr" do
-    s = "\u{13}\u{7711}\u{1010}"
-    s2 = ""
-    s.send(@method) {|n| s2 << n.chr(Encoding::UTF_8)}
-    s.should == s2
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      s = "\u{13}\u{7711}\u{1010}"
+      s2 = ""
+      s.send(@method) {|n| s2 << n.chr(Encoding::UTF_8)}
+      s.should == s2
+    end
   end
 
   it "is synonymous with #bytes for Strings which are single-byte optimizable" do

--- a/spec/core/string/unpack/u_spec.rb
+++ b/spec/core/string/unpack/u_spec.rb
@@ -12,11 +12,15 @@ describe "String#unpack with format 'U'" do
   it_behaves_like :string_unpack_taint, 'U'
 
   it "raises ArgumentError on a malformed byte sequence" do
-    -> { "\xE3".unpack('U') }.should raise_error(ArgumentError)
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      -> { "\xE3".unpack('U') }.should raise_error(ArgumentError)
+    end
   end
 
   it "raises ArgumentError on a malformed byte sequence and doesn't continue when used with the * modifier" do
-    -> { "\xE3".unpack('U*') }.should raise_error(ArgumentError)
+    NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+      -> { "\xE3".unpack('U*') }.should raise_error(ArgumentError)
+    end
   end
 end
 

--- a/spec/language/string_spec.rb
+++ b/spec/language/string_spec.rb
@@ -164,41 +164,45 @@ describe "Ruby character strings" do
 
   describe "Unicode escaping" do
     it "can be done with \\u and four hex digits" do
-      [ ["\u0000", 0x0000],
-        ["\u2020", 0x2020]
-      ].should be_computed_by(:ord)
+      NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+        [ ["\u0000", 0x0000],
+          ["\u2020", 0x2020]
+        ].should be_computed_by(:ord)
+      end
     end
 
     it "can be done with \\u{} and one to six hex digits" do
-      [ ["\u{a}", 0xa],
-        ["\u{ab}", 0xab],
-        ["\u{abc}", 0xabc],
-        ["\u{1abc}", 0x1abc],
-        ["\u{12abc}", 0x12abc],
-        ["\u{100000}", 0x100000]
-      ].should be_computed_by(:ord)
+      NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+        [ ["\u{a}", 0xa],
+          ["\u{ab}", 0xab],
+          ["\u{abc}", 0xabc],
+          ["\u{1abc}", 0x1abc],
+          ["\u{12abc}", 0x12abc],
+          ["\u{100000}", 0x100000]
+        ].should be_computed_by(:ord)
+      end
     end
 
     # TODO: spec other source encodings
     describe "with ASCII_8BIT source encoding" do
       it "produces an ASCII string when escaping ASCII characters via \\u" do
-        NATFIXME 'Encoding magic comment', exception: SpecFailedException do
-          "\u0000".encoding.should == Encoding::BINARY
-        end
+        "\u0000".encoding.should == Encoding::BINARY
       end
 
       it "produces an ASCII string when escaping ASCII characters via \\u{}" do
-        NATFIXME 'Encoding magic comment', exception: SpecFailedException do
-          "\u{0000}".encoding.should == Encoding::BINARY
-        end
+        "\u{0000}".encoding.should == Encoding::BINARY
       end
 
       it "produces a UTF-8-encoded string when escaping non-ASCII characters via \\u" do
-        "\u1234".encoding.should == Encoding::UTF_8
+        NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+          "\u1234".encoding.should == Encoding::UTF_8
+        end
       end
 
       it "produces a UTF-8-encoded string when escaping non-ASCII characters via \\u{}" do
-        "\u{1234}".encoding.should == Encoding::UTF_8
+        NATFIXME 'Need to change encoding of string based on escapes', exception: SpecFailedException do
+          "\u{1234}".encoding.should == Encoding::UTF_8
+        end
       end
     end
   end

--- a/spec/library/socket/basicsocket/recv_spec.rb
+++ b/spec/library/socket/basicsocket/recv_spec.rb
@@ -63,7 +63,7 @@ describe "BasicSocket#recv" do
   it "gets lines delimited with a custom separator"  do
     t = Thread.new do
       client = @server.accept
-      NATFIXME 'invalid utf-8', exception: ArgumentError do
+      NATFIXME 'invalid utf-8', exception: Encoding::CompatibilityError do
         ScratchPad.record client.gets("\377")
       end
 

--- a/test/natalie/encoding_magic_comment_test.rb
+++ b/test/natalie/encoding_magic_comment_test.rb
@@ -1,0 +1,14 @@
+# encoding: US-ASCII
+
+require_relative '../spec_helper'
+require_relative '../support/encoding_magic_comment_eucjp'
+
+describe 'encoding magic comment' do
+  it 'sets the encoding for new strings' do
+    'foo'.encoding.should == Encoding::US_ASCII
+  end
+
+  it 'can be changed per file' do
+    encoding_magic_comment_eucjp.should == Encoding::EUC_JP
+  end
+end

--- a/test/natalie/encoding_test.rb
+++ b/test/natalie/encoding_test.rb
@@ -122,8 +122,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x104 => 0xA1,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_2).ord.to_s(16).should == expected.to_s(16)
@@ -168,8 +168,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x126 => 0xA1,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_3).ord.to_s(16).should == expected.to_s(16)
@@ -214,8 +214,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x101 => 0xE0,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_4).ord.to_s(16).should == expected.to_s(16)
@@ -260,8 +260,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x440 => 0xE0,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_5).ord.to_s(16).should == expected.to_s(16)
@@ -306,8 +306,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x640 => 0xE0,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_6).ord.to_s(16).should == expected.to_s(16)
@@ -353,9 +353,9 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
-        0xA8 => 0xA8,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
+        0xA8  => 0xA8,
         0x3B0 => 0xE0,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_7).ord.to_s(16).should == expected.to_s(16)
@@ -401,9 +401,9 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
-        0xA8 => 0xA8,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
+        0xA8  => 0xA8,
         0x5D0 => 0xE0,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_8).ord.to_s(16).should == expected.to_s(16)
@@ -500,8 +500,8 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x13B => 0xA8,
         0x138 => 0xFF,
       }.each do |codepoint, expected|
@@ -548,7 +548,9 @@ describe 'encodings' do
       end
 
       @unmapped.each do |codepoint|
-        -> { codepoint.chr(Encoding::ISO_8859_11).encode(Encoding::UTF_8) }.should raise_error(Encoding::UndefinedConversionError)
+        -> { codepoint.chr(Encoding::ISO_8859_11).encode(Encoding::UTF_8) }.should raise_error(
+          Encoding::UndefinedConversionError
+        )
       end
     end
 
@@ -600,9 +602,9 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
-        0xD8 => 0xA8,
+        0x61   => 0x61,
+        0x8E   => 0x8E,
+        0xD8   => 0xA8,
         0x2019 => 0xFF,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_13).ord.to_s(16).should == expected.to_s(16)
@@ -648,10 +650,10 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61   => 0x61,
+        0x8E   => 0x8E,
         0x1E80 => 0xA8,
-        0xFF => 0xFF,
+        0xFF   => 0xFF,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_14).ord.to_s(16).should == expected.to_s(16)
       end
@@ -696,10 +698,10 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x161 => 0xA8,
-        0xFF => 0xFF,
+        0xFF  => 0xFF,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_15).ord.to_s(16).should == expected.to_s(16)
       end
@@ -744,10 +746,10 @@ describe 'encodings' do
 
     it 'can convert from UTF-8' do
       {
-        0x61 => 0x61,
-        0x8E => 0x8E,
+        0x61  => 0x61,
+        0x8E  => 0x8E,
         0x161 => 0xA8,
-        0xFF => 0xFF,
+        0xFF  => 0xFF,
       }.each do |codepoint, expected|
         codepoint.chr(Encoding::UTF_8).encode(Encoding::ISO_8859_16).ord.to_s(16).should == expected.to_s(16)
       end

--- a/test/support/encoding_magic_comment_eucjp.rb
+++ b/test/support/encoding_magic_comment_eucjp.rb
@@ -1,0 +1,5 @@
+# encoding: euc-jp
+
+def encoding_magic_comment_eucjp
+  'foo'.encoding
+end


### PR DESCRIPTION
This honors the magic comment at the top of a file like this:

```ruby
# encoding: binary

p 'foo'.encoding # => #<Encoding:ASCII-8BIT>
```

Unfortunately this PR breaks some specs that were accidentally passing before since we don't change the encoding of individual strings based on escape sequences. The next version of Prism will help us do that. 🎉  (See ruby/prism#1990)