### PR TITLE
Update natalie tests for compatibility with Ruby 3.3

### DIFF
--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -546,17 +546,34 @@ describe 'method with keyword args' do
     -> { method_with_kwargs14(1, b: 2, c: 3) }.should_not raise_error
   end
 
-  it 'raises an error when the method is not defined' do
-    class Foo
+  ruby_version_is ''...'3.3' do
+    it 'raises an error when the method is not defined' do
+      class Foo
+      end
+      -> { Foo.new.not_a_method }.should raise_error(NoMethodError, /undefined method `not_a_method' for #<Foo:0x.+>/)
     end
-    -> { Foo.new.not_a_method }.should raise_error(NoMethodError, /undefined method `not_a_method' for #<Foo:0x.+>/)
+
+    it 'does not loop infinitely when trying to call inspect on BasicObject' do
+      -> { BasicObject.new.inspect }.should raise_error(
+                                              NoMethodError,
+                                              /undefined method `inspect' for #<BasicObject:0x.+>/,
+                                            )
+    end
   end
 
-  it 'does not loop infinitely when trying to call inspect on BasicObject' do
-    -> { BasicObject.new.inspect }.should raise_error(
-                                            NoMethodError,
-                                            /undefined method `inspect' for #<BasicObject:0x.+>/,
-                                          )
+  ruby_version_is '3.3' do
+    it 'raises an error when the method is not defined' do
+      class Foo
+      end
+      -> { Foo.new.not_a_method }.should raise_error(NoMethodError, "undefined method `not_a_method' for an instance of Foo")
+    end
+
+    it 'does not loop infinitely when trying to call inspect on BasicObject' do
+      -> { BasicObject.new.inspect }.should raise_error(
+                                              NoMethodError,
+                                              "undefined method `inspect' for an instance of BasicObject",
+                                            )
+    end
   end
 end
 

--- a/test/natalie/method_visibility_test.rb
+++ b/test/natalie/method_visibility_test.rb
@@ -83,15 +83,30 @@ describe 'method visibility' do
   end
 
   describe 'explicit private' do
-    it 'is not visible outside the class' do
-      -> { Foo.new.private_foo }.should raise_error(
-                                          NoMethodError,
-                                          /^private method `private_foo' called for #<Foo:0x\X+>/,
-                                        )
-      -> { Foo.new.private_foo2 }.should raise_error(
-                                           NoMethodError,
-                                           /^private method `private_foo2' called for #<Foo:0x\X+>/,
-                                         )
+    ruby_version_is ''...'3.3' do
+      it 'is not visible outside the class' do
+        -> { Foo.new.private_foo }.should raise_error(
+                                            NoMethodError,
+                                            /^private method `private_foo' called for #<Foo:0x\X+>/,
+                                          )
+        -> { Foo.new.private_foo2 }.should raise_error(
+                                             NoMethodError,
+                                             /^private method `private_foo2' called for #<Foo:0x\X+>/,
+                                           )
+      end
+    end
+
+    ruby_version_is '3.3' do
+      it 'is not visible outside the class' do
+        -> { Foo.new.private_foo }.should raise_error(
+                                            NoMethodError,
+                                            "private method `private_foo' called for an instance of Foo",
+                                          )
+        -> { Foo.new.private_foo2 }.should raise_error(
+                                             NoMethodError,
+                                             "private method `private_foo2' called for an instance of Foo",
+                                           )
+      end
     end
 
     it 'is visible inside the class' do
@@ -112,11 +127,22 @@ describe 'method visibility' do
   end
 
   describe 'explicit protected' do
-    it 'is not visible outside the class' do
-      -> { Foo.new.protected_foo }.should raise_error(
-                                            NoMethodError,
-                                            /^protected method `protected_foo' called for #<Foo:0x\X+>/,
-                                          )
+    ruby_version_is ''...'3.3' do
+      it 'is not visible outside the class' do
+        -> { Foo.new.protected_foo }.should raise_error(
+                                              NoMethodError,
+                                              /^protected method `protected_foo' called for #<Foo:0x\X+>/,
+                                            )
+      end
+    end
+
+    ruby_version_is '3.3' do
+      it 'is not visible outside the class' do
+        -> { Foo.new.protected_foo }.should raise_error(
+                                              NoMethodError,
+                                              "protected method `protected_foo' called for an instance of Foo",
+                                            )
+      end
     end
 
     it 'is visible inside the class' do

--- a/test/natalie/proc_test.rb
+++ b/test/natalie/proc_test.rb
@@ -21,14 +21,25 @@ describe 'Proc' do
       p.should be_kind_of(Proc)
     end
 
-    it 'creates a new Proc object from a block argument' do
-      def create_lambda(&block)
-        lambda(&block)
+    ruby_version_is ''...'3.3' do
+      it 'creates a new Proc object from a block argument' do
+        def create_lambda(&block)
+          lambda(&block)
+        end
+        result = suppress_warning do
+          create_lambda { 1 }
+        end
+        result.should be_kind_of(Proc)
       end
-      result = suppress_warning do
-        create_lambda { 1 }
+    end
+
+    ruby_version_is '3.3' do
+      it 'cannot create a new Proc object from a block argument' do
+        def create_lambda(&block)
+          lambda(&block)
+        end
+        -> { create_lambda { 1 } }.should raise_error(ArgumentError, 'the lambda method requires a literal block')
       end
-      result.should be_kind_of(Proc)
     end
   end
 

--- a/test/natalie/struct_test.rb
+++ b/test/natalie/struct_test.rb
@@ -14,12 +14,24 @@ describe 'Struct' do
     s.new(1, 2)
   end
 
-  it 'cannot be initialized without arguments' do
-    -> { Struct.new }.should raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1+)')
+  ruby_version_is ''...'3.3' do
+    it 'cannot be initialized without arguments' do
+      -> { Struct.new }.should raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1+)')
 
-    # But this is accepted in MRI, which feels like a bug
-    named_struct = Struct.new('NamedStruct')
-    named_struct.should == Struct::NamedStruct
+      # But this is accepted in MRI, which feels like a bug
+      named_struct = Struct.new('NamedStruct')
+      named_struct.should == Struct::NamedStruct
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it 'can be initialized without arguments' do
+      -> { Struct.new }.should_not raise_error(ArgumentError)
+
+      # But this is accepted in MRI, which feels like a bug
+      named_struct = Struct.new('NamedStruct')
+      named_struct.should == Struct::NamedStruct
+    end
   end
 
   context 'keyword_init' do


### PR DESCRIPTION
I don't think we can add the preview to the build matrix yet, but it works* on my local system.


 \* It actually means it works using 3.3.0-preview2. When trying preview3 I ran into some issues with differences in the Prism gem, because it tried to use the default gems instead of our local version. This might be something to look into.