### PR TITLE
Remove path on nodes

### DIFF
--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -127,12 +127,14 @@ module Natalie
     def transform
       @context = build_context
 
+      main_file = LoadedFile.new(path: @path, encoding: @encoding)
+
       keep_final_value_on_stack = options[:interpret]
       instructions = Pass1.new(
         ast,
         compiler_context: @context,
         macro_expander:   macro_expander,
-        encoding:         @encoding,
+        loaded_file:      main_file,
       ).transform(
         used: keep_final_value_on_stack
       )
@@ -141,7 +143,7 @@ module Natalie
         exit
       end
 
-      main_file = LoadedFile.new(path: @path, instructions: instructions, encoding: @encoding)
+      main_file.instructions = instructions
       files = [main_file] + @context[:required_ruby_files].values
       files.each do |file_info|
         {
@@ -165,7 +167,6 @@ module Natalie
 
     def macro_expander
       @macro_expander ||= MacroExpander.new(
-        path:             @path,
         load_path:        load_path,
         interpret:        interpret?,
         log_load_error:   options[:log_load_error],

--- a/lib/natalie/compiler/comptime_values.rb
+++ b/lib/natalie/compiler/comptime_values.rb
@@ -34,7 +34,7 @@ module Natalie
       end
 
       def raise_comptime_value_error(expected, node)
-        raise ArgumentError, "expected #{expected} at compile time, but got: #{node.inspect} (#{node.location.path}##{node.location.start_line})"
+        raise ArgumentError, "expected #{expected} at compile time, but got: #{node.inspect} (##{node.location.start_line})"
       end
     end
   end

--- a/lib/natalie/compiler/const_prepper.rb
+++ b/lib/natalie/compiler/const_prepper.rb
@@ -17,7 +17,7 @@ module Natalie
             @namespace = PushObjectClassInstruction.new
           end
         else
-          raise "Unknown constant name type #{node.inspect} #{node.location.path}##{node.location.start_line}"
+          raise "Unknown constant name type #{node.inspect}"
         end
       end
 

--- a/lib/natalie/compiler/loaded_file.rb
+++ b/lib/natalie/compiler/loaded_file.rb
@@ -8,9 +8,11 @@ module Natalie
         @encoding = encoding
       end
 
-      attr_accessor :ast,
-                    :instructions,
-                    :encoding
+      attr_reader :path,
+                  :ast,
+                  :encoding
+
+      attr_accessor :instructions
     end
   end
 end

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -1194,9 +1194,7 @@ describe "The predefined standard object nil" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    NATFIXME 'raises a SyntaxError if assigned to', exception: SpecFailedException do
-      -> { eval("nil = true") }.should raise_error(SyntaxError)
-    end
+    -> { eval("nil = true") }.should raise_error(SyntaxError)
   end
 end
 
@@ -1206,9 +1204,7 @@ describe "The predefined standard object true" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    NATFIXME 'raises a SyntaxError if assigned to', exception: SpecFailedException do
-      -> { eval("true = false") }.should raise_error(SyntaxError)
-    end
+    -> { eval("true = false") }.should raise_error(SyntaxError)
   end
 end
 
@@ -1218,17 +1214,13 @@ describe "The predefined standard object false" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    NATFIXME 'raises a SyntaxError if assigned to', exception: SpecFailedException do
-      -> { eval("false = nil") }.should raise_error(SyntaxError)
-    end
+    -> { eval("false = nil") }.should raise_error(SyntaxError)
   end
 end
 
 describe "The self pseudo-variable" do
   it "raises a SyntaxError if assigned to" do
-    NATFIXME 'raises a SyntaxError if assigned to', exception: SpecFailedException do
-      -> { eval("self = 1") }.should raise_error(SyntaxError)
-    end
+    -> { eval("self = 1") }.should raise_error(SyntaxError)
   end
 end
 


### PR DESCRIPTION
We don't need to attach the file path on every Prism node any longer. In the process of doing this work I also fixed the Parser class so it raises an error if there is bad syntax, which fixed some specs.