### PR TITLE
Fix behaviour with range in MatchData#[] when first result is nil

### DIFF
--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -368,12 +368,11 @@ Value MatchDataObject::ref(Env *env, Value index_value, Value size_value) {
             last--;
         if (last < first)
             return new ArrayObject {};
-        auto first_result = group(first);
-        if (first_result->is_nil())
+        if (first + static_cast<nat_int_t>(size()) <= 0)
             return NilObject::the();
-        auto result = new ArrayObject { first_result };
+        auto result = new ArrayObject {};
         if (last >= static_cast<nat_int_t>(size())) last = size() - 1;
-        for (auto i = first + 1; i <= last; i++) {
+        for (auto i = first; i <= last; i++) {
             auto next_result = group(i);
             result->push(next_result);
         }

--- a/test/natalie/matchdata_test.rb
+++ b/test/natalie/matchdata_test.rb
@@ -78,5 +78,10 @@ describe 'MatchData' do
       match[0...3].should == ['foo bar', 'foo', nil]
       match[0..-1].should == ['foo bar', 'foo', nil]
     end
+
+    it 'support ranges when using optional capture groups' do
+      md = /(foo)?(bar)/.match('bar')
+      md[1..-1].should == [nil, 'bar']
+    end
   end
 end


### PR DESCRIPTION
Just one more yak remaining for the uri gem, and that one is not related to matchdata.