### PR TITLE
Fix Array#* memory problem

### DIFF
--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1022,7 +1022,7 @@ void ArrayObject::push_splat(Env *env, Value val) {
         val = val.send(env, "to_a"_s);
     }
     if (val->is_array()) {
-        m_vector.set_capacity(m_vector.capacity() + val->as_array()->size());
+        m_vector.set_capacity(m_vector.size() + val->as_array()->size());
         for (Value v : *val->as_array()) {
             push(v);
         }

--- a/test/natalie/array_test.rb
+++ b/test/natalie/array_test.rb
@@ -1990,4 +1990,12 @@ describe 'array' do
       [].bsearch { true }.should == nil
     end
   end
+
+  describe '#*' do
+    it 'returns a new array with self repeated n times' do
+      expected = []
+      100.times { expected.push(1, 2, 3) }
+      ([1, 2, 3] * 100).should == expected
+    end
+  end
 end


### PR DESCRIPTION
Memory growth was exponential because we were effectively doubling the *capacity* of the vector on each push.

Fixes #1578 