### PR TITLE
More self-hosted tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,12 +81,14 @@ task :watch do
 end
 
 desc 'Test that the self-hosted compiler builds and runs'
-task test_self_hosted: :bootstrap do
+task test_self_hosted: %i[bootstrap build_test_support] do
   sh 'bin/nat --version'
-  # Until our test runner works with the self-hosted compiler, let's run the examples...
-  sh 'bin/nat examples/hello.rb'
-  sh 'bin/nat examples/fib.rb'
-  sh 'bin/nat examples/boardslam.rb 3 5 1'
+  # The self-hosted compiler is a bit slow yet, so let's run a core subset of the tests.
+  env = {
+    'NAT_BINARY' => 'bin/nat',
+    'GLOB'       => 'spec/language/*_spec.rb'
+  }
+  sh env, 'bundle exec ruby test/all.rb'
 end
 
 desc 'Test that some representatitve code runs with the AddressSanitizer enabled'

--- a/test/ruby/repl_test.rb
+++ b/test/ruby/repl_test.rb
@@ -22,7 +22,11 @@ class ReplWrapper
 end
 
 describe 'REPL' do
-  describe 'MRI-hosted' do
+  if NAT_BINARY == 'bin/nat'
+    it 'can execute expressions and affect the environment' do
+      skip
+    end
+  else
     it 'can execute expressions and affect the environment' do
       execute(NAT_BINARY)
     end

--- a/test/ruby/ruby_specs_test.rb
+++ b/test/ruby/ruby_specs_test.rb
@@ -16,6 +16,12 @@ describe 'ruby/spec' do
            # I use this when I'm working on the compiler,
            # as it catches 99% of bugs and finishes a lot quicker.
            Dir['spec/language/*_spec.rb']
+         elsif (glob = ENV['GLOB'])
+           # GLOB="spec/core/io/*_spec.rb,spec/core/thread/*_spec.rb" rake test
+           Dir[*glob.split(',')].tap do |files|
+             puts "Matched files:"
+             puts files.to_a
+           end
          else
            Dir['spec/**/*_spec.rb']
          end


### PR DESCRIPTION
These are some specs that were already passing with the self-hosted compiler, so let's add them to CI.

I'd like to get all the specs in `spec/core/*` running, but the Onigmo issue @herwinw mentioned in 7904b894c017faf7d9e63e24f360beb8fedb4822 is also an issue for some of those. I really hate the idea that I have to import the forked Onigmo files into this repo, but I will look into it further...