### PR TITLE
Allow hyphens in regexp group names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -405,12 +405,14 @@ end
 
 file 'build/onigmo/lib/libonigmo.a' do
   build_dir = File.expand_path('build/onigmo', __dir__)
+  patch_path = File.expand_path('ext/onigmo.patch', __dir__)
   rm_rf build_dir
   cp_r 'ext/onigmo', build_dir
   sh <<-SH
     cd #{build_dir} && \
     sh autogen.sh && \
     ./configure --with-pic --prefix #{build_dir} && \
+    git apply #{patch_path} && \
     make -j 4 && \
     make install
   SH

--- a/ext/onigmo.patch
+++ b/ext/onigmo.patch
@@ -1,0 +1,13 @@
+diff --git a/regparse.c b/regparse.c
+index dd41be0..57e3d77 100644
+--- a/regparse.c
++++ b/regparse.c
+@@ -2506,7 +2506,7 @@ get_name_end_code_point(OnigCodePoint start)
+ }
+ 
+ #ifdef USE_NAMED_GROUP
+-# ifdef RUBY
++# if 1
+ #  define ONIGENC_IS_CODE_NAME(enc, c)  TRUE
+ # else
+ #  define ONIGENC_IS_CODE_NAME(enc, c)  ONIGENC_IS_CODE_WORD(enc, c)

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -285,6 +285,12 @@ describe 'regexp' do
       age.should == '21'
     end
 
+    it 'works with hyphenated name' do
+      m = /(?<name-and-age>\w+ is \d+)/.match('Joe is 21 years old')
+      m.named_captures['name-and-age'].should == 'Joe is 21'
+    end
+
+
     it 'sets variables to nil when there is no match' do
       /(?<name>\w+) is (?'age'\d+) years/ =~ 'Joe is not yet 21 years old'
       name.should == nil


### PR DESCRIPTION
This enables a more relaxed group name support in Onigmo by patching the `#ifdef RUBY` line to be true. I tried defining RUBY, but that breaks a bunch of other stuff and tries to include Ruby headers, which I'd like to try to avoid.