### PR TITLE
Implement Thread#name and Thread#name=

### DIFF
--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -95,6 +95,9 @@ public:
     void set_value(Value value) { m_value = value; }
     Value value(Env *);
 
+    Value name(Env *);
+    Value set_name(Env *, Value);
+
     Value fetch(Env *, Value, Value = nullptr, Block * = nullptr);
     bool has_key(Env *, Value);
     Value keys(Env *);
@@ -179,6 +182,7 @@ private:
 #endif
     std::atomic<Status> m_status { Status::Created };
     std::atomic<bool> m_joined { false };
+    TM::Optional<TM::String> m_name {};
     TM::Optional<TM::String> m_file {};
     TM::Optional<size_t> m_line {};
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1316,6 +1316,8 @@ gen.binding('Thread', 'join', 'ThreadObject', 'join', argc: 0, pass_env: true, p
 gen.binding('Thread', 'key?', 'ThreadObject', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'keys', 'ThreadObject', 'keys', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'kill', 'ThreadObject', 'kill', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Thread', 'name', 'ThreadObject', 'name', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Thread', 'name=', 'ThreadObject', 'set_name', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'raise', 'ThreadObject', 'raise', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'run', 'ThreadObject', 'run', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'status', 'ThreadObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/thread/name_spec.rb
+++ b/spec/core/thread/name_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../../spec_helper'
+
+describe "Thread#name" do
+  before :each do
+    @thread = Thread.new {}
+  end
+
+  after :each do
+    @thread.join
+  end
+
+  it "is nil initially" do
+    @thread.name.should == nil
+  end
+
+  it "returns the thread name" do
+    @thread.name = "thread_name"
+    @thread.name.should == "thread_name"
+  end
+end
+
+describe "Thread#name=" do
+  before :each do
+    @thread = Thread.new {}
+  end
+
+  after :each do
+    @thread.join
+  end
+
+  it "can be set to a String" do
+    @thread.name = "new thread name"
+    @thread.name.should == "new thread name"
+  end
+
+  it "raises an ArgumentError if the name includes a null byte" do
+    -> {
+      @thread.name = "new thread\0name"
+    }.should raise_error(ArgumentError)
+  end
+
+  it "can be reset to nil" do
+    @thread.name = nil
+    @thread.name.should == nil
+  end
+
+  it "calls #to_str to convert name to String" do
+    name = mock("Thread#name")
+    name.should_receive(:to_str).and_return("a thread name")
+
+    @thread.name = name
+    @thread.name.should == "a thread name"
+  end
+end

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -321,6 +321,25 @@ Value ThreadObject::value(Env *env) {
     return m_value;
 }
 
+Value ThreadObject::name(Env *env) {
+    if (!m_name)
+        return NilObject::the();
+    return new StringObject { *m_name };
+}
+
+Value ThreadObject::set_name(Env *env, Value name) {
+    if (!name || name->is_nil()) {
+        m_name.clear();
+        return NilObject::the();
+    }
+
+    auto name_str = name->to_str(env);
+    if (strlen(name_str->c_str()) != name_str->bytesize())
+        env->raise("ArgumentError", "string contains null byte");
+    m_name = name_str->string();
+    return name;
+}
+
 Value ThreadObject::fetch(Env *env, Value key, Value default_value, Block *block) {
     key = validate_key(env, key);
     HashObject *hash = m_storage;


### PR DESCRIPTION
I tried using `pthread_getname_np(3)` and `pthread_setname_np(3)`, but inspection of MRI with `strace` showed they didn't use it either. This also removes the limit of 16 characters on the name.