### PR TITLE
Support nil argument in Mutex#sleep

### DIFF
--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -28,7 +28,7 @@ Value MutexObject::lock(Env *env) {
 }
 
 Value MutexObject::sleep(Env *env, Value timeout) {
-    if (!timeout) {
+    if (!timeout || timeout->is_nil()) {
         unlock(env);
         while (true)
             ::sleep(1000);


### PR DESCRIPTION
This is supported in MRI as well. Since we're having issues with waking up mutexes, no test has been added.