### PR TITLE
Fix bug with IO#gets

### DIFF
--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -320,11 +320,11 @@ Value IoObject::write_file(Env *env, Args args) {
 
 #define NAT_READ_BYTES 1024
 
-static ssize_t blocking_read(int fileno, void *buf, int offset) {
+static ssize_t blocking_read(int fileno, void *buf, int count) {
     Defer done_sleeping([] { ThreadObject::set_current_sleeping(false); });
     ThreadObject::set_current_sleeping(true);
 
-    auto ret = ::read(fileno, buf, offset);
+    auto ret = ::read(fileno, buf, count);
     while (ret == -1 && errno == EAGAIN) {
         sched_yield();
 
@@ -339,7 +339,7 @@ static ssize_t blocking_read(int fileno, void *buf, int offset) {
         ret = select(1, &rfds, nullptr, nullptr, &tv);
         if (ret < 0) return ret;
 
-        ret = ::read(fileno, buf, offset);
+        ret = ::read(fileno, buf, count);
     }
 
     return ret;

--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -28,7 +28,7 @@ describe 'Socket' do
     @socket.read.should =~ /this page left intentionally blank/
   end
 
-  it 'can respond to curl' do
+  it 'reads from buffer even if other end of socket has stopped writing' do
     server = TCPServer.new(0)
     port = server.addr[1]
     t = Thread.new do
@@ -41,8 +41,11 @@ describe 'Socket' do
       conn.close
     end
 
-    out = `curl -s -v http://127.0.0.1:#{port} 2>&1`
-    out.should =~ /hello world/
+    client = TCPSocket.new('127.0.0.1', port)
+    client.write "GET / HTTP/1.1\r\n" \
+                 "Host: localhost:#{port}\r\n" \
+                 "User-Agent: ruby\r\n" \
+                 "\r\n"
 
     t.join
   end

--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -27,4 +27,23 @@ describe 'Socket' do
     @socket.write("GET / HTTP/1.0\r\nHost: 71m.us\r\n\r\n")
     @socket.read.should =~ /this page left intentionally blank/
   end
+
+  it 'can respond to curl' do
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    t = Thread.new do
+      conn = server.accept
+      conn.gets.should == "GET / HTTP/1.1\r\n"
+      line = conn.gets until line == "\r\n"
+      conn.write "HTTP/1.1 200\r\n"
+      conn.write "\r\n"
+      conn.write "hello world\r\n"
+      conn.close
+    end
+
+    out = `curl -s -v http://127.0.0.1:#{port} 2>&1`
+    out.should =~ /hello world/
+
+    t.join
+  end
 end


### PR DESCRIPTION
If there is data in the read buffer, we should continue to consume from it rather than block with another read(2).

I found this when trying to update [the server](https://github.com/natalie-lang/natalie-lang.org/blob/master/server.rb) for natalie-lang.org.