### PR TITLE
Update C++ standard to C++20

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -366,7 +366,7 @@ end
 
 # # # # Internal Tasks and Rules # # # #
 
-STANDARD = 'c++17'.freeze
+STANDARD = 'c++20'.freeze
 HEADERS = Rake::FileList['include/**/{*.h,*.hpp}']
 
 PRIMARY_SOURCES = Rake::FileList['src/**/*.{c,cpp}'].exclude('src/main.cpp')

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -77,6 +77,8 @@ module Natalie
         File.write(@compiler.write_obj_path, cpp)
       end
 
+      CPP_STANDARD = 'c++20'.freeze
+
       def compiler_command
         [
           cc,
@@ -84,8 +86,8 @@ module Natalie
           (shared? ? '-fPIC -shared' : ''),
           inc_paths.map { |path| "-I #{path}" }.join(' '),
           "-o #{@compiler.out_path}",
-          '-x c++ -std=c++17',
-          (cpp_path || 'code.cpp'),
+          "-x c++ -std=#{CPP_STANDARD}",
+          cpp_path || 'code.cpp',
           lib_paths.map { |path| "-L #{path}" }.join(' '),
           libraries.join(' '),
           link_flags,

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -54,6 +54,8 @@ TEMPLATE_TYPES = {
   'ManagedVector<T>' => { canonical_name: 'Natalie::ManagedVector', superclass: 'Natalie::Cell' },
 }
 
+CPP_STANDARD = 'c++20'.freeze
+
 require 'bundler/inline'
 
 gemfile do
@@ -87,7 +89,7 @@ def get_class_details_for_path(path)
   code = File.read(path)
   code_lines = code.split(/\n/)
   index = FFI::Clang::Index.new
-  translation_unit = index.parse_translation_unit(path, ['-I', 'include', '-std=c++17'])
+  translation_unit = index.parse_translation_unit(path, ['-I', 'include', "-std=#{CPP_STANDARD}"])
   cursor = translation_unit.cursor
 
   cursor.visit_children do |cursor, parent|


### PR DESCRIPTION
I'm going to make this PR and then promptly close it. I'm disappointed to see that using C++20 increases compile time of individual rb files by up to 25%, sheesh. 😢 

```
| compiler | standard | test suite run time |                                                                                                                                                                
|----------|----------|---------------------|                                                                                                                                                                
| gcc      | c++17    | 10:42               |                                                                                                                                                                
| gcc      | c++20    | 13:03               |                                                                                                                                                                
| clang    | c++17    | 7:55                |                                                                                                                                                                
| clang    | c++20    | 9:54                | 
```

These are times it takes to run the entire test suite on my 12-core machine with Ubuntu 23.10.