### PR TITLE
Fix raise with an exception where the first argument of the constructor is not the message

### DIFF
--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -479,7 +479,8 @@ Value KernelModule::raise(Env *env, Value klass, Value message) {
             env->raise("TypeError", "exception klass/object expected");
         }
     }
-    env->raise(klass->as_class(), message->as_string());
+    Value to_be_raised = _new(env, klass->as_class(), { message }, nullptr);
+    env->raise_exception(to_be_raised->as_exception());
 }
 
 Value KernelModule::Rational(Env *env, Value x, Value y, Value exception) {

--- a/test/natalie/raise_test.rb
+++ b/test/natalie/raise_test.rb
@@ -1,0 +1,11 @@
+require_relative '../spec_helper'
+
+describe 'raise' do
+  it 'constructs an exception without a call to new' do
+    begin
+      raise SystemExit, 123
+    rescue SystemExit => e
+      e.status.should == 123
+    end
+  end
+end


### PR DESCRIPTION
This is one of the issues found in  #1625