### PR TITLE
Add optional condition keyword to NATFIXME

### DIFF
--- a/test/natalie/natfixme_test.rb
+++ b/test/natalie/natfixme_test.rb
@@ -54,4 +54,16 @@ describe "NATFIXME" do
       end
     }.should raise_error(NatalieFixMeException)
   end
+
+  it "can be skipped with a condition" do
+    x = 0
+    NATFIXME 'Division by 0', exception: ZeroDivisionError, condition: x == 0 do
+      1 / x
+    end
+
+    x = 1
+    NATFIXME 'Division by 0', exception: ZeroDivisionError, condition: x == 0 do
+      1 / x
+    end
+  end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1565,9 +1565,11 @@ at_exit { run_specs }
 # If the code inside the block does not cause the error or the error it causes does
 # not match the exception (or exception/message) then NatalieFixMeException will be raised.
 #
-def NATFIXME(description, exception: nil, message: nil)
+def NATFIXME(description, exception: nil, condition: true, message: nil)
   raise SpecFailedException, "NATFIXME requires a block" unless block_given?
   exception ||= StandardError
+
+  return yield unless condition
 
   $natfixme_depth += 1
 


### PR DESCRIPTION
My suggestion from #1633, this makes it possible to selectively disable tests for shared specs.