### PR TITLE
Update specs for Mutex#sleep

### DIFF
--- a/spec/core/mutex/sleep_spec.rb
+++ b/spec/core/mutex/sleep_spec.rb
@@ -54,65 +54,64 @@ describe "Mutex#sleep" do
     end
   end
 
-  #it "relocks the mutex when woken" do
-    #m = Mutex.new
-    #m.lock
-    #m.sleep(0.001)
-    #m.locked?.should be_true
-  #end
+  it "relocks the mutex when woken" do
+    m = Mutex.new
+    m.lock
+    m.sleep(0.001)
+    m.locked?.should be_true
+  end
 
-  #it "relocks the mutex when woken by an exception being raised" do
-    #NATFIXME 'Thread exceptions do not raise at the proper point in the call stack yet', exception: SpecFailedException do
-      #m = Mutex.new
-      #locked = false
-      #th = Thread.new do
-        #m.lock
-        #locked = true
-        #begin
-          #m.sleep
-        #rescue Exception
-          #m.locked?
-        #end
-      #end
-      #Thread.pass until locked
-      #Thread.pass until th.stop?
-      #th.raise(Exception)
-      #th.value.should be_true
-    #end
-  #end
+  # NATFIXME: Thread exceptions do not raise at the proper point in the call stack yet
+  xit "relocks the mutex when woken by an exception being raised" do
+    m = Mutex.new
+    locked = false
+    th = Thread.new do
+      m.lock
+      locked = true
+      begin
+        m.sleep
+      rescue Exception
+        m.locked?
+      end
+    end
+    Thread.pass until locked
+    Thread.pass until th.stop?
+    th.raise(Exception)
+    th.value.should be_true
+  end
 
-  #it "returns the rounded number of seconds asleep" do
-    #NATFIXME 'Implement Thread#start and fix Thread#wakeup', exception: NoMethodError do
-      #m = Mutex.new
-      #locked = false
-      #th = Thread.start do
-        #m.lock
-        #locked = true
-        #m.sleep
-      #end
-      #Thread.pass until locked
-      #Thread.pass until th.stop?
-      #th.wakeup
-      #th.value.should be_kind_of(Integer)
-    #end
-  #end
+  it "returns the rounded number of seconds asleep" do
+    NATFIXME 'Implement Thread.start and fix Thread#wakeup', exception: NoMethodError, message: "undefined method `start' for class Thread" do
+      m = Mutex.new
+      locked = false
+      th = Thread.start do
+        m.lock
+        locked = true
+        m.sleep
+      end
+      Thread.pass until locked
+      Thread.pass until th.stop?
+      th.wakeup
+      th.value.should be_kind_of(Integer)
+    end
+  end
 
-  #it "wakes up when requesting sleep times near or equal to zero" do
-    #times = []
-    #val = 1
+  it "wakes up when requesting sleep times near or equal to zero" do
+    times = []
+    val = 1
 
-    ## power of two divisor so we eventually get near zero
-    #loop do
-      #val = val / 16.0
-      #times << val
-      #break if val == 0.0
-    #end
+    # power of two divisor so we eventually get near zero
+    loop do
+      val = val / 16.0
+      times << val
+      break if val == 0.0
+    end
 
-    #m = Mutex.new
-    #m.lock
-    #times.each do |time|
-      ## just testing that sleep completes
-      #-> {m.sleep(time)}.should_not raise_error
-    #end
-  #end
+    m = Mutex.new
+    m.lock
+    times.each do |time|
+      # just testing that sleep completes
+      -> {m.sleep(time)}.should_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Enable passing specs, use `xit` instead of commenting out everything for specs that hit a timeout.