### PR TITLE
Guard rescue

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -410,6 +410,8 @@ end
 
 def guard(proc)
   yield if proc.call
+rescue
+  nil
 end
 
 def guard_not(proc)


### PR DESCRIPTION
This fixes things like https://github.com/ruby/spec/blob/18b9174287940c5c7bdab3f33889fc4640582cb1/core/kernel/caller_spec.rb#L59, which now results in a crash in the nightly specs.