### PR TITLE
Thread abort_on_exception settings

### DIFF
--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -131,6 +131,16 @@ public:
     Value fiber_scheduler() const { return m_fiber_scheduler; }
     void set_fiber_scheduler(Value scheduler) { m_fiber_scheduler = scheduler; }
 
+    bool abort_on_exception() const { return m_abort_on_exception; }
+    bool set_abort_on_exception(bool abrt) {
+        m_abort_on_exception = abrt;
+        return abrt;
+    }
+    bool set_abort_on_exception(Value abrt) {
+        m_abort_on_exception = abrt->is_truthy();
+        return abrt;
+    }
+
     bool report_on_exception() const { return m_report_on_exception; }
     bool set_report_on_exception(bool report) {
         m_report_on_exception = report;
@@ -179,6 +189,16 @@ public:
         return report;
     }
 
+    static bool global_abort_on_exception() { return s_abort_on_exception; }
+    static bool set_global_abort_on_exception(bool abrt) {
+        s_abort_on_exception = abrt;
+        return abrt;
+    }
+    static bool set_global_abort_on_exception(Value abrt) {
+        s_abort_on_exception = abrt->is_truthy();
+        return abrt;
+    }
+
     static void cancelation_checkpoint(Env *env);
 
 private:
@@ -209,6 +229,7 @@ private:
     TM::Optional<TM::String> m_file {};
     TM::Optional<size_t> m_line {};
 
+    bool m_abort_on_exception { false };
     bool m_report_on_exception { true };
 
     bool m_sleeping { false };
@@ -222,6 +243,7 @@ private:
     inline static pthread_t s_main_id = 0;
     inline static ThreadObject *s_main = nullptr;
     inline static TM::Vector<ThreadObject *> s_list {};
+    inline static bool s_abort_on_exception { false };
     inline static bool s_report_on_exception { true };
 };
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1309,6 +1309,8 @@ gen.binding('Symbol', 'to_s', 'SymbolObject', 'to_s', argc: 0, pass_env: true, p
 gen.binding('Symbol', 'to_sym', 'SymbolObject', 'to_sym', argc: 0, pass_env: true, pass_block: false, aliases: ['intern'], return_type: :Object)
 gen.binding('Symbol', 'upcase', 'SymbolObject', 'upcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
+gen.static_binding('Thread', 'abort_on_exception', 'ThreadObject', 'global_abort_on_exception', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.static_binding('Thread', 'abort_on_exception=', 'ThreadObject', 'set_global_abort_on_exception', argc: 1, pass_env: false, pass_block: false, return_type: :bool)
 gen.static_binding('Thread', 'current', 'ThreadObject', 'current', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.static_binding('Thread', 'exit', 'ThreadObject', 'exit', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Thread', 'list', 'ThreadObject', 'list', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
@@ -1319,6 +1321,8 @@ gen.static_binding('Thread', 'report_on_exception=', 'ThreadObject', 'set_defaul
 gen.static_binding('Thread', 'stop', 'ThreadObject', 'stop', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', '[]', 'ThreadObject', 'ref', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', '[]=', 'ThreadObject', 'refeq', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Thread', 'abort_on_exception', 'ThreadObject', 'abort_on_exception', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Thread', 'abort_on_exception=', 'ThreadObject', 'set_abort_on_exception', argc: 1, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'alive?', 'ThreadObject', 'is_alive', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'fetch', 'ThreadObject', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Thread', 'initialize', 'ThreadObject', 'initialize', argc: :any, pass_env: true, pass_block: true, return_type: :Object)

--- a/spec/core/thread/abort_on_exception_spec.rb
+++ b/spec/core/thread/abort_on_exception_spec.rb
@@ -1,0 +1,106 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Thread#abort_on_exception" do
+  before do
+    ThreadSpecs.clear_state
+    @thread = Thread.new { Thread.pass until ThreadSpecs.state == :exit }
+  end
+
+  after do
+    ThreadSpecs.state = :exit
+    @thread.join
+  end
+
+  it "is false by default" do
+    @thread.abort_on_exception.should be_false
+  end
+
+  it "returns true when #abort_on_exception= is passed true" do
+    @thread.abort_on_exception = true
+    @thread.abort_on_exception.should be_true
+  end
+end
+
+describe :thread_abort_on_exception, shared: true do
+  before do
+    @thread = Thread.new do
+      Thread.pass until ThreadSpecs.state == :run
+      raise RuntimeError, "Thread#abort_on_exception= specs"
+    end
+  end
+
+  it "causes the main thread to raise the exception raised in the thread" do
+    begin
+      ScratchPad << :before
+
+      @thread.abort_on_exception = true if @object
+      -> do
+        ThreadSpecs.state = :run
+        # Wait for the main thread to be interrupted
+        sleep
+      end.should raise_error(RuntimeError, "Thread#abort_on_exception= specs")
+
+      ScratchPad << :after
+    rescue Exception => e
+      ScratchPad << [:rescue, e]
+    end
+
+    ScratchPad.recorded.should == [:before, :after]
+  end
+end
+
+describe "Thread#abort_on_exception=" do
+  describe "when enabled and the thread dies due to an exception" do
+    before do
+      ScratchPad.record []
+      ThreadSpecs.clear_state
+      @stderr, $stderr = $stderr, IOStub.new
+    end
+
+    after do
+      $stderr = @stderr
+    end
+
+    it_behaves_like :thread_abort_on_exception, nil, true
+  end
+end
+
+describe "Thread.abort_on_exception" do
+  before do
+    @abort_on_exception = Thread.abort_on_exception
+  end
+
+  after do
+     Thread.abort_on_exception = @abort_on_exception
+  end
+
+  it "is false by default" do
+    Thread.abort_on_exception.should == false
+  end
+
+  it "returns true when .abort_on_exception= is passed true" do
+    Thread.abort_on_exception = true
+    Thread.abort_on_exception.should be_true
+  end
+end
+
+describe "Thread.abort_on_exception=" do
+  describe "when enabled and a non-main thread dies due to an exception" do
+    before :each do
+      ScratchPad.record []
+      ThreadSpecs.clear_state
+      @stderr, $stderr = $stderr, IOStub.new
+
+      @abort_on_exception = Thread.abort_on_exception
+      Thread.abort_on_exception = true
+    end
+
+    after :each do
+      Thread.abort_on_exception = @abort_on_exception
+      $stderr = @stderr
+    end
+
+    it_behaves_like :thread_abort_on_exception, nil, false
+  end
+end

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -140,6 +140,8 @@ ThreadObject *ThreadObject::initialize(Env *env, Args args, Block *block) {
 
     m_thread = std::thread { nat_create_thread, (void *)this };
 
+    m_report_on_exception = s_report_on_exception;
+
     return this;
 }
 

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -130,4 +130,26 @@ describe 'Thread' do
       end
     end
   end
+
+  describe 'Thread#report_on_exception' do
+    before do
+      @report_setting = Thread.report_on_exception
+    end
+
+    after do
+      Thread.report_on_exception = @report_setting
+    end
+
+    it 'defaults to Thread.report_on_exception' do
+      Thread.report_on_exception = false
+      t1 = Thread.new {}
+      t1.report_on_exception.should == false
+
+      Thread.report_on_exception = true
+      t2 = Thread.new {}
+      t2.report_on_exception.should == true
+
+      t1.report_on_exception.should == false
+    end
+  end
 end

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -86,4 +86,48 @@ describe 'Thread' do
       Thread.list.should == [Thread.current]
     end
   end
+
+  describe 'abort_on_exception' do
+    before do
+      @report_setting = Thread.report_on_exception
+      @abort_setting = Thread.abort_on_exception
+    end
+
+    after do
+      Thread.report_on_exception = @report_setting
+      Thread.abort_on_exception = @abort_setting
+    end
+
+    it 'raises an error in the main thread if either Thread.abort_on_exception or Thread#abort_on_exception is true' do
+      [
+        [false, false],
+        [true, false],
+        [false, true],
+        [true, true],
+      ].each do |global, local|
+        Thread.abort_on_exception = global
+
+        t = Thread.new do
+          Thread.current.report_on_exception = false
+          Thread.pass until Thread.main.stop?
+          Thread.current.abort_on_exception = local
+          raise 'foo'
+        end
+
+        # this is always false by default
+        t.abort_on_exception.should == false
+
+        if global || local
+          begin
+            sleep
+          rescue StandardError => e
+            e.message.should == 'foo'
+          end
+        else
+          sleep 0.1
+          # should not raise
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
There is scarce documentation about this, but my observation is that `Thread.abort_on_exception` is not a "default" setting for new threads, but rather a sort of "global" setting. If *either* the global or the local setting is true, then the thread causes the main thread to abort when there is an unhandled exception.

...at least, that's how it appears to work.

This is in contrast to `Thread.report_on_exception` and `Thread#report_on_exception`, which seem to behave like a "default" and a "local" as I would expect. Changing `Thread.report_on_exception` affects any threads created after that, and you can override the setting with `Thread#report_on_exception`.

Weirdly inconsistent!