### PR TITLE
Make Thread#inspect and Thread#to_s spec-compliant

### DIFF
--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -67,7 +67,7 @@ public:
 
     ThreadObject *initialize(Env *env, Args args, Block *block);
 
-    Value inspect(Env *);
+    Value to_s(Env *);
 
     void set_start_of_stack(void *ptr) { m_start_of_stack = ptr; }
     void *start_of_stack() { return m_start_of_stack; }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1322,6 +1322,7 @@ gen.binding('Thread', '[]=', 'ThreadObject', 'refeq', argc: 2, pass_env: true, p
 gen.binding('Thread', 'alive?', 'ThreadObject', 'is_alive', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'fetch', 'ThreadObject', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Thread', 'initialize', 'ThreadObject', 'initialize', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('Thread', 'inspect', 'ThreadObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'join', 'ThreadObject', 'join', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'key?', 'ThreadObject', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'keys', 'ThreadObject', 'keys', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1322,7 +1322,6 @@ gen.binding('Thread', '[]=', 'ThreadObject', 'refeq', argc: 2, pass_env: true, p
 gen.binding('Thread', 'alive?', 'ThreadObject', 'is_alive', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'fetch', 'ThreadObject', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Thread', 'initialize', 'ThreadObject', 'initialize', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
-gen.binding('Thread', 'inspect', 'ThreadObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'join', 'ThreadObject', 'join', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'key?', 'ThreadObject', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'keys', 'ThreadObject', 'keys', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
@@ -1335,6 +1334,7 @@ gen.binding('Thread', 'report_on_exception=', 'ThreadObject', 'set_report_on_exc
 gen.binding('Thread', 'run', 'ThreadObject', 'run', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'status', 'ThreadObject', 'status', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'stop?', 'ThreadObject', 'is_stopped', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Thread', 'to_s', 'ThreadObject', 'to_s', argc: 0, pass_env: true, pass_block: false, aliases: ['inspect'], return_type: :Object)
 gen.binding('Thread', 'value', 'ThreadObject', 'value', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Thread', 'wakeup', 'ThreadObject', 'wakeup', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 

--- a/spec/core/thread/inspect_spec.rb
+++ b/spec/core/thread/inspect_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/to_s'
+
+describe "Thread#inspect" do
+  it_behaves_like :thread_to_s, :inspect
+end

--- a/spec/core/thread/shared/to_s.rb
+++ b/spec/core/thread/shared/to_s.rb
@@ -40,7 +40,9 @@ describe :thread_to_s, shared: true do
   end
 
   it "describes a dying sleeping thread" do
-    ThreadSpecs.status_of_dying_sleeping_thread.send(@method).should include('sleep')
+    NATFIXME 'Bug with sleeping a thread after it is killed', exception: ThreadError do
+      ThreadSpecs.status_of_dying_sleeping_thread.send(@method).should include('sleep')
+    end
   end
 
   it "reports aborting on a killed thread" do
@@ -48,6 +50,8 @@ describe :thread_to_s, shared: true do
   end
 
   it "reports aborting on a killed thread after sleep" do
-    ThreadSpecs.status_of_dying_thread_after_sleep.send(@method).should include('aborting')
+    NATFIXME 'Bug with stopping a thread after it is killed', exception: ThreadError do
+      ThreadSpecs.status_of_dying_thread_after_sleep.send(@method).should include('aborting')
+    end
   end
 end

--- a/spec/core/thread/to_s_spec.rb
+++ b/spec/core/thread/to_s_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/to_s'
+
+describe "Thread#to_s" do
+  it_behaves_like :thread_to_s, :to_s
+end

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -141,7 +141,7 @@ ThreadObject *ThreadObject::initialize(Env *env, Args args, Block *block) {
     return this;
 }
 
-Value ThreadObject::inspect(Env *env) {
+Value ThreadObject::to_s(Env *env) {
     String location;
 
     if (m_file && m_line)

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -141,16 +141,42 @@ ThreadObject *ThreadObject::initialize(Env *env, Args args, Block *block) {
     return this;
 }
 
+Value ThreadObject::inspect(Env *env) {
+    String location;
+
+    if (m_file && m_line)
+        location = String::format(" {}:{}", *m_file, *m_line);
+
+    auto formatted = String::format(
+        "#<{}:{}{} {}>",
+        m_klass->inspect_str(),
+        String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed),
+        location,
+        status());
+
+    return new StringObject { formatted, EncodingObject::get(Encoding::ASCII_8BIT) };
+}
+
 Value ThreadObject::status(Env *env) {
-    switch (m_status) {
-    case Status::Created:
-        return new StringObject { "run" };
-    case Status::Active:
-        return new StringObject { m_sleeping ? "sleep" : "run" };
-    case Status::Dead:
+    auto status_string = status();
+    if (m_status == Status::Dead) {
         if (m_exception)
             return NilObject::the();
         return FalseObject::the();
+    }
+    return new StringObject { status_string };
+}
+
+String ThreadObject::status() {
+    switch (m_status) {
+    case Status::Created:
+        return "run";
+    case Status::Active:
+        return m_sleeping ? "sleep" : "run";
+    case Status::Aborting:
+        return "aborting";
+    case Status::Dead:
+        return "dead";
     }
     NAT_UNREACHABLE();
 }
@@ -187,11 +213,13 @@ Value ThreadObject::join(Env *env) {
     return this;
 }
 
-Value ThreadObject::kill(Env *env) const {
+Value ThreadObject::kill(Env *env) {
     if (is_main())
         exit(0);
 
     wait_until_running();
+
+    m_status = Status::Aborting;
 
     std::lock_guard<std::recursive_mutex> lock(g_thread_recursive_mutex);
     pthread_cancel(m_thread_id);


### PR DESCRIPTION
There are a couple of specs I had to disable because of another bug with `Thread#sleep` and `Thread#stop` being called after `Thread#kill`. I can handle that bug in another PR.