### PR TITLE
wip: signal threads and waiting IO

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -206,4 +206,6 @@ void dbg(const char *fmt, Args... args) {
     puts(out->c_str());
 }
 
+int pipe2(int pipefd[2], int flags);
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
     setvbuf(stdout, nullptr, _IOLBF, 1024);
 
     Env *env = ::build_top_env();
-    ThreadObject::build_main_thread(__builtin_frame_address(0));
+    ThreadObject::build_main_thread(env, __builtin_frame_address(0));
 
     trap_signal(SIGINT, sigint_handler);
     trap_signal(SIGPIPE, sigpipe_handler);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -832,4 +832,35 @@ int hex_char_to_decimal_value(char c) {
     }
 };
 
+int pipe2(int pipefd[2], int flags) {
+    // printf("flags = %d, O_NONBLOCK = %d, FD_CLOEXEC = %d, O_CLOEXEC = %d\n", flags, O_NONBLOCK, FD_CLOEXEC, O_CLOEXEC);
+    if (flags & (~O_NONBLOCK & ~O_CLOEXEC))
+        NAT_NOT_YET_IMPLEMENTED("Extra flags passed to our pipe2 that aren't supported.");
+
+#ifdef __APPLE__
+    if (pipe(pipefd) == -1)
+        return -1;
+
+    if (flags & O_NONBLOCK) {
+        if (fcntl(pipefd[0], F_SETFL, O_NONBLOCK) == -1 || fcntl(pipefd[1], F_SETFL, O_NONBLOCK) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+
+    if (flags & O_CLOEXEC) {
+        if (fcntl(pipefd[0], F_SETFD, O_CLOEXEC) == -1 || fcntl(pipefd[1], F_SETFD, O_CLOEXEC) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+
+    return 0;
+#else
+    return ::pipe2(pipefd, flags);
+#endif
+}
+
 }


### PR DESCRIPTION
We need a better way to interrupt blocking IO. Currently the solution has been to do a tight loop with a 100 nanosecond select(2), checking if the thread should interrupt each time.

But it seems the current state of the art is to set up a pipe that we can add to the select() and then write a byte to that pipe, waking up the blocking call.

This is my first naive attempt, which naturally has problems. It sets up a pipe for every file descriptor and another pipe for every thread. This worked ok for small processes, but for a few tests with lots of IO, we hit the per-process open files limit.

This work will be redone, but I wanted to record this attempt, for future reference. :-)