### PR TITLE
Set file/line information when creating a lambda/proc

### DIFF
--- a/lib/natalie/compiler/instructions/create_lambda_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_lambda_instruction.rb
@@ -3,15 +3,28 @@ require_relative './base_instruction'
 module Natalie
   class Compiler
     class CreateLambdaInstruction < BaseInstruction
+      def initialize(file:, line:)
+        super()
+
+        # source location info
+        @file = file
+        @line = line
+      end
+
       def to_s
         s = 'create_lambda'
         s << " (break point: #{break_point})" if break_point
         s
       end
 
+      attr_reader :file, :line
+
       attr_accessor :break_point
 
       def generate(transform)
+        transform.set_file(@file)
+        transform.set_line(@line)
+
         block = transform.pop
         block_temp = transform.temp('block')
         transform.exec_and_push(:lambda, [

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1650,7 +1650,7 @@ module Natalie
         instructions = track_scope(node) do
           transform_block_node(node, used: true, is_lambda: true)
         end
-        instructions << CreateLambdaInstruction.new
+        instructions << CreateLambdaInstruction.new(file: @file.path, line: node.location.start_line)
         instructions << PopInstruction.new unless used
         instructions
       end

--- a/spec/core/proc/source_location_spec.rb
+++ b/spec/core/proc/source_location_spec.rb
@@ -27,9 +27,7 @@ describe "Proc#source_location" do
 
     file = @lambda.source_location.first
     file.should be_an_instance_of(String)
-    NATFIXME 'It currently uses a relative path for lambda', exception: SpecFailedException do
-      file.should == File.realpath('fixtures/source_location.rb', __dir__)
-    end
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
 
     file = @method.source_location.first
     file.should be_an_instance_of(String)
@@ -47,9 +45,7 @@ describe "Proc#source_location" do
 
     line = @lambda.source_location.last
     line.should be_an_instance_of(Integer)
-    NATFIXME 'Fix line in Env', exception: SpecFailedException do
-      line.should == 8
-    end
+    line.should == 8
 
     line = @method.source_location.last
     line.should be_an_instance_of(Integer)
@@ -61,17 +57,13 @@ describe "Proc#source_location" do
   it "works even if the proc was created on the same line" do
     proc { true }.source_location.should == [__FILE__, __LINE__]
     Proc.new { true }.source_location.should == [__FILE__, __LINE__]
-    NATFIXME 'Fix line in Env', exception: SpecFailedException do
-      -> { true }.source_location.should == [__FILE__, __LINE__]
-    end
+    -> { true }.source_location.should == [__FILE__, __LINE__]
   end
 
   it "returns the first line of a multi-line proc (i.e. the line containing 'proc do')" do
     ProcSpecs::SourceLocation.my_multiline_proc.source_location.last.should == 20
     ProcSpecs::SourceLocation.my_multiline_proc_new.source_location.last.should == 34
-    NATFIXME "returns the first line of a multi-line proc (i.e. the line containing 'proc do'", exception: SpecFailedException do
-      ProcSpecs::SourceLocation.my_multiline_lambda.source_location.last.should == 27
-    end
+    ProcSpecs::SourceLocation.my_multiline_lambda.source_location.last.should == 27
   end
 
   it "returns the location of the proc's body; not necessarily the proc itself" do


### PR DESCRIPTION
This resolves some issues with the source location specs.

Just for fun, try this script on the current master branch:
```ruby
x = -> {}
p x.source_location
```
Because we never set the environment info before creating this lambda, the last info is used, so this is shown as if it were defined in `src/warning.rb`