### PR TITLE
Thread interrupt

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -206,4 +206,6 @@ void dbg(const char *fmt, Args... args) {
     puts(out->c_str());
 }
 
+int pipe2(int pipefd[2], int flags);
+
 }

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <assert.h>
-
 #include "natalie/class_object.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/macros.hpp"
 #include "natalie/object.hpp"
 #include "natalie/symbol_object.hpp"
+
+#include <atomic>
 
 #ifdef fileno
 #undef fileno
@@ -132,7 +132,7 @@ private:
     EncodingObject *m_internal_encoding { nullptr };
     int m_fileno { -1 };
     int m_lineno { 0 };
-    bool m_closed { false };
+    std::atomic<bool> m_closed { false };
     bool m_autoclose { true };
     bool m_sync { false };
     StringObject *m_path { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -25,13 +25,15 @@ public:
 
     IoObject(int fileno)
         : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s)->as_class() }
-        , m_fileno { fileno }
-        , m_sync { fileno == STDERR_FILENO } { }
+        , m_sync { fileno == STDERR_FILENO } {
+        set_fileno(fileno);
+    }
 
     virtual ~IoObject() override {
         if (m_fileno == STDIN_FILENO || m_fileno == STDOUT_FILENO || m_fileno == STDERR_FILENO)
             return;
         if (m_autoclose && !m_closed && m_fileno != -1) {
+            // TODO: actually ::close() the fd :-)
             m_closed = true;
             m_fileno = -1;
         }
@@ -102,6 +104,7 @@ public:
     int rewind(Env *);
     int set_pos(Env *, Value);
     static Value select(Env *, Value, Value = nullptr, Value = nullptr, Value = nullptr);
+    void select_read(Env *env, timeval *timeout = nullptr) const;
     bool sync(Env *) const;
     Value sysread(Env *, Value, Value = nullptr);
     Value sysseek(Env *, Value, Value = nullptr);
@@ -123,6 +126,8 @@ protected:
     int write(Env *, Value);
 
 private:
+    ssize_t blocking_read(Env *env, void *buf, int count) const;
+
     EncodingObject *m_external_encoding { nullptr };
     EncodingObject *m_internal_encoding { nullptr };
     int m_fileno { -1 };
@@ -133,5 +138,4 @@ private:
     StringObject *m_path { nullptr };
     TM::String m_read_buffer {};
 };
-
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
     setvbuf(stdout, nullptr, _IOLBF, 1024);
 
     Env *env = ::build_top_env();
-    ThreadObject::build_main_thread(__builtin_frame_address(0));
+    ThreadObject::build_main_thread(env, __builtin_frame_address(0));
 
     trap_signal(SIGINT, sigint_handler);
     trap_signal(SIGPIPE, sigpipe_handler);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -832,4 +832,34 @@ int hex_char_to_decimal_value(char c) {
     }
 };
 
+int pipe2(int pipefd[2], int flags) {
+    if (flags & (~O_NONBLOCK & ~O_CLOEXEC))
+        NAT_NOT_YET_IMPLEMENTED("Extra flags passed to our pipe2 that aren't supported.");
+
+#ifdef __APPLE__
+    if (pipe(pipefd) == -1)
+        return -1;
+
+    if (flags & O_NONBLOCK) {
+        if (fcntl(pipefd[0], F_SETFL, O_NONBLOCK) == -1 || fcntl(pipefd[1], F_SETFL, O_NONBLOCK) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+
+    if (flags & O_CLOEXEC) {
+        if (fcntl(pipefd[0], F_SETFD, O_CLOEXEC) == -1 || fcntl(pipefd[1], F_SETFD, O_CLOEXEC) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+
+    return 0;
+#else
+    return ::pipe2(pipefd, flags);
+#endif
+}
+
 }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -109,7 +109,7 @@ bool ThreadObject::is_stopped() const {
     return m_sleeping || m_status == Status::Dead;
 }
 
-void ThreadObject::build_main_thread(void *start_of_stack) {
+void ThreadObject::build_main_thread(Env *env, void *start_of_stack) {
     assert(!s_main && !s_main_id); // can only be built once
     auto thread = new ThreadObject;
     assert(start_of_stack);
@@ -121,6 +121,7 @@ void ThreadObject::build_main_thread(void *start_of_stack) {
     s_main = thread;
     s_main_id = thread->m_thread_id;
     tl_current_thread = thread;
+    setup_interrupt_pipe(env);
 }
 
 void ThreadObject::build_main_fiber() {
@@ -246,7 +247,13 @@ Value ThreadObject::raise(Env *env, Args args) {
         env->raise_exception(exception);
 
     m_exception = exception;
+
+    // Wake up the thread in case it is sleeping.
     wakeup(env);
+
+    // In case this thread is blocking on read/select/whatever,
+    // we may need to interrupt it (and all other threads, incidentally).
+    ThreadObject::interrupt();
 
     return NilObject::the();
 }
@@ -476,14 +483,39 @@ void ThreadObject::wait_until_running() const {
         sched_yield();
 }
 
+void ThreadObject::setup_interrupt_pipe(Env *env) {
+    int pipefd[2];
+    if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) < 0)
+        env->raise_errno();
+    s_interrupt_read_fileno = pipefd[0];
+    s_interrupt_write_fileno = pipefd[1];
+}
+
+void ThreadObject::interrupt() {
+    ::write(s_interrupt_write_fileno, "!", 1);
+}
+
+void ThreadObject::clear_interrupt() {
+    // arbitrarily-chosen buffer size just to avoid several single-byte reads
+    constexpr int BUF_SIZE = 8;
+    char buf[BUF_SIZE];
+    ssize_t bytes;
+    do {
+        // This fd is non-blocking, so this can set errno to EAGAIN,
+        // but we don't care -- we just want the buffer to be empty.
+        bytes = ::read(s_interrupt_read_fileno, buf, BUF_SIZE);
+    } while (bytes > 0);
+}
+
 void ThreadObject::cancelation_checkpoint(Env *env) {
+    auto thread = current();
+
     // This call gives us a cancelation point that works with pthread_cancel(3).
     ::usleep(0);
 
-    auto t = current();
-    if (t->m_exception) {
-        auto exception = Value(t->m_exception).send(env, "exception"_s, {})->as_exception_or_raise(env);
-        t->set_exception(nullptr);
+    if (thread->m_exception) {
+        auto exception = Value(thread->m_exception).send(env, "exception"_s, {})->as_exception_or_raise(env);
+        thread->set_exception(nullptr);
         env->raise_exception(exception);
     }
 }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -59,7 +59,9 @@ static void *nat_create_thread(void *thread_object) {
     try {
         thread->set_status(Natalie::ThreadObject::Status::Active);
         auto return_value = NAT_RUN_BLOCK_WITHOUT_BREAK((&e), block, args, nullptr);
-        thread->cancelation_checkpoint(&e);
+        auto exception = thread->exception();
+        if (exception)
+            e.raise_exception(exception);
         thread->set_value(return_value);
         pthread_exit(return_value.object());
     } catch (Natalie::ExceptionObject *exception) {


### PR DESCRIPTION
This is v2 of my work from #1663. This fixes a few things:

- Prior to this PR, we were doing `select()`/`read()` in a tight loop in order to allow `Thread#raise` to work. This PR teaches those select() calls to watch for a special interrupt file descriptor so they can be interrupted.
- Prior to this PR, we were not handling closed file descriptors properly. On Linux, it is undefined behavior to continue select() or read() on a closed file, so we need a way to interrupt those too.
- I also found a bug with `Thread#raise` called on a dying thread -- it was accidentally raising the exception in the main thread.

This work also sets us up to fix some issues with `Thread#kill`, but I'll save that for the next PR.