### PR TITLE
Implement stop-the-world for GC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE=ruby:3.3
 FROM $IMAGE
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov clang-tidy libclang-dev lldb python3 python3-pip ccache
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential autoconf libtool clang lcov clang-tidy libclang-dev lldb gdb python3 python3-pip ccache
 
 # PIP externally-managed-environment now forces you
 # to be explicit when installing system-wide package

--- a/Rakefile
+++ b/Rakefile
@@ -290,12 +290,26 @@ task docker_bash: :docker_build_clang do
   sh "docker run -it --rm --entrypoint bash natalie_clang_#{ruby_version_string}"
 end
 
+task docker_bash_gcc: :docker_build_gcc do
+  sh "docker run -it --rm --entrypoint bash natalie_gcc_#{ruby_version_string}"
+end
+
 task docker_bash_lldb: :docker_build_clang do
   sh 'docker run -it --rm ' \
      '--entrypoint bash ' \
      '--cap-add=SYS_PTRACE ' \
      '--security-opt seccomp=unconfined ' \
      "natalie_clang_#{ruby_version_string}"
+end
+
+task docker_bash_gdb: :docker_build_gcc do
+  sh 'docker run -it --rm ' \
+     '--entrypoint bash ' \
+     '--cap-add=SYS_PTRACE ' \
+     '--security-opt seccomp=unconfined ' \
+     '-m 2g ' \
+     '--cpus=2 ' \
+     "natalie_gcc_#{ruby_version_string}"
 end
 
 task docker_test: %i[docker_test_gcc docker_test_clang docker_test_self_hosted docker_test_asan]

--- a/include/natalie/args.hpp
+++ b/include/natalie/args.hpp
@@ -65,6 +65,8 @@ public:
     size_t size() const { return m_data.size(); }
     const Value *data() const { return m_data.data(); }
 
+    Vector<Value> &vector() { return m_data; }
+
     bool has_keyword_hash() const { return m_has_keyword_hash; }
     HashObject *keyword_hash() const;
     HashObject *pop_keyword_hash();

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -15,6 +15,8 @@ namespace Natalie {
 
 using namespace TM;
 
+extern thread_local ExceptionObject *tl_current_exception;
+
 class Env : public Cell {
 public:
     Env() { }

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -104,6 +104,7 @@ private:
                 return *allocator;
             }
         }
+        fprintf(stderr, "No allocator found for size %zu\n", size);
         NAT_UNREACHABLE();
     }
 

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -14,7 +14,7 @@
 
 namespace Natalie {
 
-extern std::mutex g_gc_mutex;
+extern std::recursive_mutex g_gc_recursive_mutex;
 
 using namespace TM;
 

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -41,7 +41,7 @@ public:
 
     void *allocate(size_t size);
 
-    void collect(bool);
+    void collect();
 
     void return_cell_to_free_list(Cell *cell);
 
@@ -81,6 +81,8 @@ public:
     void set_collect_all_at_exit(bool collect) { m_collect_all_at_exit = collect; }
 
 private:
+    void collect_dangerously_without_mutex();
+
     inline static Heap *s_instance = nullptr;
 
     Heap() {

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -81,8 +81,6 @@ public:
     void set_collect_all_at_exit(bool collect) { m_collect_all_at_exit = collect; }
 
 private:
-    void collect_dangerously_without_mutex();
-
     inline static Heap *s_instance = nullptr;
 
     Heap() {

--- a/include/natalie/gc_module.hpp
+++ b/include/natalie/gc_module.hpp
@@ -19,7 +19,7 @@ public:
     }
 
     static Value start(Env *env) {
-        Heap::the().collect(false);
+        Heap::the().collect();
         return NilObject::the();
     }
 

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -14,6 +14,7 @@ namespace Natalie {
 
 extern std::mutex g_backtrace_mutex;
 extern std::mutex g_thread_mutex;
+extern std::recursive_mutex g_thread_recursive_mutex;
 
 extern "C" {
 #include "onigmo.h"

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -12,8 +12,6 @@
 
 namespace Natalie {
 
-extern std::mutex g_backtrace_mutex;
-
 extern "C" {
 #include "onigmo.h"
 }

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -13,8 +13,6 @@
 namespace Natalie {
 
 extern std::mutex g_backtrace_mutex;
-extern std::mutex g_thread_mutex;
-extern std::recursive_mutex g_thread_recursive_mutex;
 
 extern "C" {
 #include "onigmo.h"

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -224,7 +224,6 @@ private:
         } while (key != first_key);
     }
 
-    std::mutex m_hash_mutex;
     Key *m_key_list { nullptr };
     TM::Hashmap<Key *, Value> m_hashmap { hash, compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -4,11 +4,10 @@
         abort();                                                              \
     }
 
-#define NAT_NOT_YET_IMPLEMENTED(msg, ...)                                                         \
-    {                                                                                             \
-        fprintf(stderr, "NOT YET IMPLEMENTED in %s#%d: " msg, __FILE__, __LINE__, ##__VA_ARGS__); \
-        fprintf(stderr, "\n");                                                                    \
-        abort();                                                                                  \
+#define NAT_NOT_YET_IMPLEMENTED(msg, ...)                                                              \
+    {                                                                                                  \
+        fprintf(stderr, "NOT YET IMPLEMENTED in %s#%d: " msg "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+        abort();                                                                                       \
     }
 
 #define NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, on_break_flag) ({ \
@@ -75,3 +74,10 @@
 #endif
 
 #define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
+
+#ifdef NAT_DEBUG_THREADS
+#define NAT_THREAD_DEBUG(msg, ...) \
+    fprintf(stderr, "THREAD DEBUG: " msg "\n", ##__VA_ARGS__)
+#else
+#define NAT_THREAD_DEBUG(msg, ...)
+#endif

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -52,7 +52,7 @@
 #ifdef NAT_GC_GUARD
 #define NAT_GC_GUARD_VALUE(val)                                                               \
     {                                                                                         \
-        std::lock_guard<std::mutex> gc_lock(Natalie::g_gc_mutex);                             \
+        std::lock_guard<std::recursive_mutex> gc_lock(Natalie::g_gc_recursive_mutex);         \
         Object *ptr;                                                                          \
         if ((ptr = val.object_or_null()) && Heap::the().gc_enabled()) {                       \
             void *dummy;                                                                      \

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -52,9 +52,9 @@
 #ifdef NAT_GC_GUARD
 #define NAT_GC_GUARD_VALUE(val)                                                               \
     {                                                                                         \
-        std::lock_guard<std::recursive_mutex> gc_lock(Natalie::g_gc_recursive_mutex);         \
         Object *ptr;                                                                          \
         if ((ptr = val.object_or_null()) && Heap::the().gc_enabled()) {                       \
+            std::lock_guard<std::recursive_mutex> gc_lock(Natalie::g_gc_recursive_mutex);     \
             void *dummy;                                                                      \
             auto end_of_stack = (uintptr_t)(&dummy);                                          \
             auto start_of_stack = (uintptr_t)(ThreadObject::current()->start_of_stack());     \

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -52,7 +52,7 @@
 #ifdef NAT_GC_GUARD
 #define NAT_GC_GUARD_VALUE(val)                                                               \
     {                                                                                         \
-        NAT_GC_LOCK_GUARD();                                                                  \
+        std::lock_guard<std::mutex> gc_lock(Natalie::g_gc_mutex);                             \
         Object *ptr;                                                                          \
         if ((ptr = val.object_or_null()) && Heap::the().gc_enabled()) {                       \
             void *dummy;                                                                      \
@@ -75,5 +75,3 @@
 #endif
 
 #define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
-
-#define NAT_GC_LOCK_GUARD() std::lock_guard<std::mutex> gc_lock(g_gc_mutex);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -3,14 +3,15 @@
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"
 #include "natalie/hash_object.hpp"
-#include "natalie/nil_object.hpp"
 #include "natalie/object.hpp"
 #include "natalie/symbol_object.hpp"
 
+#ifdef __APPLE__
+#define _XOPEN_SOURCE
+#endif
 #include <atomic>
 #include <sys/ucontext.h>
 #include <thread>
-#include <ucontext.h>
 
 namespace Natalie {
 

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -173,6 +173,8 @@ public:
         return report;
     }
 
+    void check_exception(Env *);
+
     virtual void visit_children(Visitor &) override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -234,8 +236,6 @@ public:
             s_thread_kill_class = GlobalEnv::the()->Object()->subclass(env, "ThreadKillError");
         return s_thread_kill_class;
     }
-
-    void check_exception(Env *);
 
 private:
     void wait_until_running() const;

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -90,7 +90,7 @@ public:
     Block *block() { return m_block; }
 
     bool is_alive() const {
-        return m_status == Status::Active || m_status == Status::Created;
+        return m_status == Status::Active || m_status == Status::Created || m_status == Status::Aborting;
     }
 
     bool is_main() const {

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -228,6 +228,15 @@ public:
     static void interrupt();
     static void clear_interrupt();
 
+    static ClassObject *thread_kill_class() { return s_thread_kill_class; }
+    static ClassObject *thread_kill_class(Env *env) {
+        if (!s_thread_kill_class)
+            s_thread_kill_class = GlobalEnv::the()->Object()->subclass(env, "ThreadKillError");
+        return s_thread_kill_class;
+    }
+
+    void check_exception(Env *);
+
 private:
     void wait_until_running() const;
 
@@ -286,6 +295,12 @@ private:
     // TODO: we'll need to rebuild these after a fork :-/
     inline static int s_interrupt_read_fileno { -1 };
     inline static int s_interrupt_write_fileno { -1 };
+
+    // We use this special class as an off-the-books exception class
+    // for killing threads. It cannot be rescued in user code, but it
+    // does trigger `ensure` blocks.
+    // We only build this class once it is needed.
+    inline static ClassObject *s_thread_kill_class { nullptr };
 };
 
 }

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -36,17 +36,17 @@ public:
 
     ThreadObject()
         : Object { Object::Type::Thread, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->as_class() } {
-        s_list.push(this);
+        add_to_list(this);
     }
 
     ThreadObject(ClassObject *klass)
         : Object { Object::Type::Thread, klass } {
-        s_list.push(this);
+        add_to_list(this);
     }
 
     ThreadObject(ClassObject *klass, Block *block)
         : Object { Object::Type::Thread, klass } {
-        s_list.push(this);
+        add_to_list(this);
     }
 
     virtual ~ThreadObject() {
@@ -146,8 +146,6 @@ public:
     FiberObject *main_fiber() { return m_main_fiber; }
     FiberObject *current_fiber() { return m_current_fiber; }
 
-    void remove_from_list() const;
-
     virtual bool is_collectible() override {
         return m_status == Status::Dead && !m_thread.joinable();
     }
@@ -198,6 +196,9 @@ public:
 
     static ThreadObject *current();
     static ThreadObject *main() { return s_main; }
+
+    static void add_to_list(ThreadObject *);
+    static void remove_from_list(ThreadObject *);
 
     static Value exit(Env *env) { return current()->kill(env); }
     static Value stop(Env *);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -131,8 +131,16 @@ public:
 
     bool is_stopped() const;
 
-    void set_thread_id(pthread_t thread_id) { m_thread_id = thread_id; }
-    pthread_t thread_id() const { return m_thread_id; }
+    void set_thread_id(pthread_t thread_id) {
+        assert(!m_thread_id);
+        m_thread_id = thread_id;
+    }
+
+    pthread_t thread_id() const {
+        while (!m_thread_id)
+            sched_yield();
+        return m_thread_id;
+    }
 
     void build_main_fiber();
     FiberObject *main_fiber() { return m_main_fiber; }

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -221,7 +221,7 @@ public:
         return abrt;
     }
 
-    static void cancelation_checkpoint(Env *env);
+    static void check_current_exception(Env *env);
 
     static void setup_interrupt_pipe(Env *env);
     static int interrupt_read_fileno() { return s_interrupt_read_fileno; }

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -88,7 +88,7 @@ public:
     void set_exception(ExceptionObject *exception) { m_exception = exception; }
     ExceptionObject *exception() { return m_exception; }
 
-    ArrayObject *args() { return m_args; }
+    ArrayObject *args() { return m_args.to_array(); }
     Block *block() { return m_block; }
 
     bool is_alive() const {
@@ -261,7 +261,7 @@ private:
 
     friend FiberObject;
 
-    ArrayObject *m_args { nullptr };
+    Args m_args {};
     Block *m_block { nullptr };
     std::thread m_thread {};
     std::thread::native_handle_type m_native_thread_handle { 0 };

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -233,7 +233,7 @@ public:
     static ClassObject *thread_kill_class() { return s_thread_kill_class; }
     static ClassObject *thread_kill_class(Env *env) {
         if (!s_thread_kill_class)
-            s_thread_kill_class = GlobalEnv::the()->Object()->subclass(env, "ThreadKillError");
+            s_thread_kill_class = GlobalEnv::the()->BasicObject()->subclass(env, "ThreadKillError");
         return s_thread_kill_class;
     }
 

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -274,7 +274,7 @@ private:
     Value m_fiber_scheduler { nullptr };
 
     // This condition variable is used to wake a sleeping thread,
-    // i.e. a thread where Kernel#sleep or Thread#sleep has been called.
+    // i.e. a thread where Kernel#sleep has been called.
     pthread_cond_t m_sleep_cond = PTHREAD_COND_INITIALIZER;
     pthread_mutex_t m_sleep_lock = PTHREAD_MUTEX_INITIALIZER;
 

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -65,6 +65,10 @@ public:
         return m_native_thread_handle;
     }
 
+    void set_native_thread_handle(std::thread::native_handle_type handle) {
+        m_native_thread_handle = handle;
+    }
+
     Value to_s(Env *);
 
     void set_start_of_stack(void *ptr) { m_start_of_stack = ptr; }

--- a/spec/core/thread/kill_spec.rb
+++ b/spec/core/thread/kill_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/exit'
+
+# This spec randomly kills mspec worker like: https://ci.appveyor.com/project/ruby/ruby/builds/19473223/job/f69derxnlo09xhuj
+# TODO: Investigate the cause or at least print helpful logs, and remove this `platform_is_not` guard.
+platform_is_not :mingw do
+  describe "Thread#kill" do
+    it_behaves_like :thread_exit, :kill
+  end
+
+  describe "Thread.kill" do
+    it "causes the given thread to exit" do
+      NATFIXME 'Implement Thread.kill', exception: NoMethodError do
+        thread = Thread.new { sleep }
+        Thread.pass while thread.status and thread.status != "sleep"
+        Thread.kill(thread).should == thread
+        thread.join
+        thread.status.should be_false
+      end
+    end
+  end
+end

--- a/spec/core/thread/report_on_exception_spec.rb
+++ b/spec/core/thread/report_on_exception_spec.rb
@@ -92,26 +92,24 @@ describe "Thread#report_on_exception=" do
     end
 
     it "prints the backtrace even if the thread was killed just after Thread#raise" do
-      NATFIXME 'Thread#kill should still print backtrace', exception: SpecFailedException do
-        t = nil
-        ready = false
-        -> {
-          t = Thread.new {
-            Thread.current.report_on_exception = true
-            ready = true
-            sleep
-          }
+      t = nil
+      ready = false
+      -> {
+        t = Thread.new {
+          Thread.current.report_on_exception = true
+          ready = true
+          sleep
+        }
 
-          Thread.pass until ready and t.stop?
-          t.raise RuntimeError, "Thread#report_on_exception before kill spec"
-          t.kill
-          Thread.pass while t.alive?
-        }.should output("", /Thread.+terminated with exception.+Thread#report_on_exception before kill spec/m)
+        Thread.pass until ready and t.stop?
+        t.raise RuntimeError, "Thread#report_on_exception before kill spec"
+        t.kill
+        Thread.pass while t.alive?
+      }.should output("", /Thread.+terminated with exception.+Thread#report_on_exception before kill spec/m)
 
-        -> {
-          t.join
-        }.should raise_error(RuntimeError, "Thread#report_on_exception before kill spec")
-      end
+      -> {
+        t.join
+      }.should raise_error(RuntimeError, "Thread#report_on_exception before kill spec")
     end
   end
 
@@ -134,28 +132,28 @@ describe "Thread#report_on_exception=" do
 
   describe "when used in conjunction with Thread#abort_on_exception" do
     it "first reports then send the exception back to the main Thread" do
-      NATFIXME 'Implement Thread abort_on_exception', exception: SpecFailedException do
-        t = nil
-        mutex = Mutex.new
-        mutex.lock
-        -> {
-          t = Thread.new {
-            Thread.current.abort_on_exception = true
-            Thread.current.report_on_exception = true
-            mutex.lock
-            mutex.unlock
-            raise RuntimeError, "Thread#report_on_exception specs"
-          }
+      t = nil
+      mutex = Mutex.new
+      mutex.lock
+      -> {
+        t = Thread.new {
+          Thread.current.abort_on_exception = true
+          Thread.current.report_on_exception = true
+          mutex.lock
+          mutex.unlock
+          raise RuntimeError, "Thread#report_on_exception specs"
+        }
 
+        NATFIXME 'Mutex#sleep re-raises the thread exception', exception: SpecFailedException, message: /but instead raised nothing/ do
           -> {
             mutex.sleep(5)
           }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
-        }.should output("", /Thread.+terminated with exception.+Thread#report_on_exception specs/m)
+        end
+      }.should output(/^\*?/, /Thread.+terminated with exception.+Thread#report_on_exception specs/m)
 
-        -> {
-          t.join
-        }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
-      end
+      -> {
+        t.join
+      }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
     end
   end
 end

--- a/spec/core/thread/shared/to_s.rb
+++ b/spec/core/thread/shared/to_s.rb
@@ -40,9 +40,7 @@ describe :thread_to_s, shared: true do
   end
 
   it "describes a dying sleeping thread" do
-    NATFIXME 'Bug with sleeping a thread after it is killed', exception: ThreadError do
-      ThreadSpecs.status_of_dying_sleeping_thread.send(@method).should include('sleep')
-    end
+    ThreadSpecs.status_of_dying_sleeping_thread.send(@method).should include('sleep')
   end
 
   it "reports aborting on a killed thread" do
@@ -50,8 +48,6 @@ describe :thread_to_s, shared: true do
   end
 
   it "reports aborting on a killed thread after sleep" do
-    NATFIXME 'Bug with stopping a thread after it is killed', exception: ThreadError do
-      ThreadSpecs.status_of_dying_thread_after_sleep.send(@method).should include('aborting')
-    end
+    ThreadSpecs.status_of_dying_thread_after_sleep.send(@method).should include('aborting')
   end
 end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -12,8 +12,6 @@
 
 namespace Natalie {
 
-std::mutex g_array_mutex;
-
 ArrayObject::ArrayObject(std::initializer_list<Value> list)
     : ArrayObject {} {
     m_vector.set_capacity(list.size());
@@ -88,13 +86,13 @@ Value ArrayObject::initialize_copy(Env *env, Value other) {
 
 void ArrayObject::push(Value val) {
     NAT_GC_GUARD_VALUE(val);
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     m_vector.push(val);
 }
 
 Value ArrayObject::first() {
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (m_vector.is_empty())
         return NilObject::the();
@@ -102,7 +100,7 @@ Value ArrayObject::first() {
 }
 
 Value ArrayObject::last() {
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (m_vector.is_empty())
         return NilObject::the();
@@ -110,7 +108,7 @@ Value ArrayObject::last() {
 }
 
 Value ArrayObject::pop() {
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (m_vector.is_empty())
         return NilObject::the();
@@ -118,7 +116,7 @@ Value ArrayObject::pop() {
 }
 
 Value ArrayObject::shift() {
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (m_vector.is_empty())
         return NilObject::the();
@@ -127,7 +125,7 @@ Value ArrayObject::shift() {
 
 void ArrayObject::set(size_t index, Value value) {
     NAT_GC_GUARD_VALUE(value);
-    std::lock_guard<std::mutex> lock(g_array_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (index == m_vector.size()) {
         m_vector.push(value);

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -2,8 +2,6 @@
 
 namespace Natalie {
 
-std::mutex g_class_mutex;
-
 Value ClassObject::initialize(Env *env, Value superclass, Block *block) {
     if (!superclass)
         superclass = GlobalEnv::the()->Object();
@@ -15,7 +13,7 @@ Value ClassObject::initialize(Env *env, Value superclass, Block *block) {
 }
 
 ClassObject *ClassObject::subclass(Env *env, String name, Type object_type) {
-    std::lock_guard<std::mutex> lock(g_class_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ClassObject *subclass = new ClassObject { klass() };
     initialize_subclass(subclass, env, name, object_type);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -4,8 +4,6 @@
 
 namespace Natalie {
 
-std::mutex g_var_mutex;
-
 using namespace TM;
 
 void Env::build_vars(size_t size) {
@@ -316,7 +314,7 @@ Backtrace *Env::backtrace() {
 }
 
 Value Env::var_get(const char *name, size_t index) {
-    std::lock_guard<std::mutex> lock(g_var_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!m_vars || index >= m_vars->size())
         return NilObject::the();
@@ -330,7 +328,7 @@ Value Env::var_get(const char *name, size_t index) {
 
 Value Env::var_set(const char *name, size_t index, bool allocate, Value val) {
     NAT_GC_GUARD_VALUE(val);
-    std::lock_guard<std::mutex> lock(g_var_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     size_t needed = index + 1;
     size_t current_size = m_vars ? m_vars->size() : 0;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -6,6 +6,8 @@ namespace Natalie {
 
 using namespace TM;
 
+thread_local ExceptionObject *tl_current_exception = nullptr;
+
 void Env::build_vars(size_t size) {
     m_vars = new ManagedVector<Value>(size, NilObject::the());
 }
@@ -99,6 +101,8 @@ void Env::raise(const char *class_name, String message) {
 }
 
 void Env::raise_exception(ExceptionObject *exception) {
+    tl_current_exception = exception;
+
     if (!exception->backtrace()) {
         // only build a backtrace the first time the exception is raised (not on a re-raise)
         exception->build_backtrace(this);

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -116,19 +116,21 @@ Value FiberObject::resume(Env *env, Args args) {
         env->raise("FiberError", "attempt to resume the current fiber");
 
     auto suspending_fiber = m_previous_fiber = current();
-    ThreadObject::current()->m_current_fiber = this;
-    ThreadObject::current()->set_start_of_stack(m_start_of_stack);
-
-    set_args(args);
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        ThreadObject::current()->m_current_fiber = this;
+        ThreadObject::current()->set_start_of_stack(m_start_of_stack);
+        set_args(args);
 
 #ifdef __SANITIZE_ADDRESS__
-    auto fake_stack = __asan_get_current_fake_stack();
-    void *real_stack = __asan_addr_is_in_fake_stack(fake_stack, &args, nullptr, nullptr);
-    suspending_fiber->m_end_of_stack = real_stack ? real_stack : &args;
-    suspending_fiber->m_asan_fake_stack = __asan_get_current_fake_stack();
+        auto fake_stack = __asan_get_current_fake_stack();
+        void *real_stack = __asan_addr_is_in_fake_stack(fake_stack, &args, nullptr, nullptr);
+        suspending_fiber->m_end_of_stack = real_stack ? real_stack : &args;
+        suspending_fiber->m_asan_fake_stack = __asan_get_current_fake_stack();
 #else
-    suspending_fiber->m_end_of_stack = &args;
+        suspending_fiber->m_end_of_stack = &args;
 #endif
+    }
 
     auto res = mco_resume(m_coroutine);
     assert(res == MCO_SUCCESS);
@@ -209,9 +211,13 @@ Value FiberObject::yield(Env *env, Args args) {
     auto current_fiber = FiberObject::current();
     if (!current_fiber->m_previous_fiber)
         env->raise("FiberError", "can't yield from root fiber");
-    current_fiber->set_status(Status::Suspended);
-    current_fiber->m_end_of_stack = &args;
-    current_fiber->swap_to_previous(env, args);
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        current_fiber->set_status(Status::Suspended);
+        current_fiber->m_end_of_stack = &args;
+        current_fiber->swap_to_previous(env, args);
+    }
 
     mco_yield(mco_running());
 
@@ -228,9 +234,12 @@ Value FiberObject::yield(Env *env, Args args) {
 void FiberObject::swap_to_previous(Env *env, Args args) {
     assert(m_previous_fiber);
     auto new_current = m_previous_fiber;
-    ThreadObject::current()->m_current_fiber = new_current;
-    ThreadObject::current()->set_start_of_stack(new_current->start_of_stack());
-    new_current->set_args(args);
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        ThreadObject::current()->m_current_fiber = new_current;
+        ThreadObject::current()->set_start_of_stack(new_current->start_of_stack());
+        new_current->set_args(args);
+    }
     m_previous_fiber = nullptr;
 }
 
@@ -311,8 +320,13 @@ void fiber_wrapper_func(mco_coro *co) {
     auto user_data = (coroutine_user_data *)co->user_data;
     auto env = user_data->env;
     auto fiber = user_data->fiber;
-    Natalie::ThreadObject::current()->set_start_of_stack(fiber->start_of_stack());
-    fiber->set_status(Natalie::FiberObject::Status::Resumed);
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(Natalie::g_gc_recursive_mutex);
+        Natalie::ThreadObject::current()->set_start_of_stack(fiber->start_of_stack());
+        fiber->set_status(Natalie::FiberObject::Status::Resumed);
+    }
+
     assert(fiber->block());
     Natalie::Value return_arg = nullptr;
     bool reraise = false;
@@ -331,8 +345,11 @@ void fiber_wrapper_func(mco_coro *co) {
         reraise = true;
     }
 
-    fiber->set_status(Natalie::FiberObject::Status::Terminated);
-    fiber->set_end_of_stack(&fiber);
+    {
+        std::lock_guard<std::recursive_mutex> lock(Natalie::g_gc_recursive_mutex);
+        fiber->set_status(Natalie::FiberObject::Status::Terminated);
+        fiber->set_end_of_stack(&fiber);
+    }
 
     if (reraise)
         fiber->swap_to_previous(env, {});

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -260,7 +260,7 @@ NO_SANITIZE_ADDRESS void FiberObject::visit_children_from_stack(Visitor &visitor
     // If this Fiber is the currently active Fiber for its parent Thread,
     // then the Thread#visit_children_from_stack method will walk this Fiber's stack,
     // and we can bail out here.
-    if (this == m_thread->current_fiber())
+    if (m_thread && this == m_thread->current_fiber())
         return;
 
     if (!m_end_of_stack) {

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -257,8 +257,12 @@ void FiberObject::visit_children(Visitor &visitor) {
 }
 
 NO_SANITIZE_ADDRESS void FiberObject::visit_children_from_stack(Visitor &visitor) const {
-    if (m_start_of_stack == ThreadObject::current()->start_of_stack())
-        return; // this is the currently active fiber, so don't walk its stack a second time
+    // If this Fiber is the currently active Fiber for its parent Thread,
+    // then the Thread#visit_children_from_stack method will walk this Fiber's stack,
+    // and we can bail out here.
+    if (this == m_thread->current_fiber())
+        return;
+
     if (!m_end_of_stack) {
         assert(m_status == Status::Created);
         return; // this fiber hasn't been started yet, so the stack shouldn't have anything on it

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -8,7 +8,7 @@ extern "C" void GC_disable() {
 
 namespace Natalie {
 
-std::mutex g_gc_mutex;
+std::recursive_mutex g_gc_recursive_mutex;
 
 void *Cell::operator new(size_t size) {
     auto *cell = Heap::the().allocate(size);
@@ -88,7 +88,7 @@ NO_SANITIZE_ADDRESS TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
 }
 
 void Heap::collect() {
-    std::lock_guard<std::mutex> gc_lock(g_gc_mutex);
+    std::lock_guard<std::recursive_mutex> gc_lock(g_gc_recursive_mutex);
 
     collect_dangerously_without_mutex();
 }
@@ -170,7 +170,7 @@ void Heap::sweep() {
 }
 
 void *Heap::allocate(size_t size) {
-    std::lock_guard<std::mutex> gc_lock(g_gc_mutex);
+    std::lock_guard<std::recursive_mutex> gc_lock(g_gc_recursive_mutex);
 
     static auto is_profiled = NativeProfiler::the()->enabled();
     NativeProfilerEvent *profiler_event;

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -129,6 +129,7 @@ void Heap::collect() {
     visitor.visit(NilObject::the());
     visitor.visit(TrueObject::the());
     visitor.visit(FalseObject::the());
+    visitor.visit(tl_current_exception);
     for (auto thread : ThreadObject::list())
         visitor.visit(thread);
 

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -78,7 +78,7 @@ NO_SANITIZE_ADDRESS TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
     setjmp(jump_buf);
     for (char *i = (char *)jump_buf; i < (char *)jump_buf + sizeof(jump_buf); ++i) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(i);
-        if (roots.get(potential_cell))
+        if (!potential_cell || roots.get(potential_cell))
             continue;
         if (is_a_heap_cell_in_use(potential_cell)) {
             roots.set(potential_cell);

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -90,10 +90,6 @@ NO_SANITIZE_ADDRESS TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
 void Heap::collect() {
     std::lock_guard<std::recursive_mutex> gc_lock(g_gc_recursive_mutex);
 
-    collect_dangerously_without_mutex();
-}
-
-void Heap::collect_dangerously_without_mutex() {
     // Only collect on the main thread for now.
     if (ThreadObject::current() != ThreadObject::main()) return;
 
@@ -190,7 +186,7 @@ void *Heap::allocate(size_t size) {
         if (allocator.total_cells() == 0) {
             allocator.add_multiple_blocks(initial_blocks_per_allocator);
         } else if (allocator.free_cells_percentage() < min_percent_free_triggers_collection) {
-            collect_dangerously_without_mutex();
+            collect();
             allocator.add_blocks_until_percent_free_reached(min_percent_free_after_collection);
         }
 #endif

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -3,11 +3,8 @@
 
 namespace Natalie {
 
-std::mutex g_gvar_mutex;
-std::mutex g_gvar_alias_mutex;
-
 bool GlobalEnv::global_defined(Env *env, SymbolObject *name) {
-    std::lock_guard<std::mutex> lock(g_gvar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!name->is_global_name())
         env->raise_name_error(name, "`{}' is not allowed as a global variable name", name->string());
@@ -20,7 +17,7 @@ bool GlobalEnv::global_defined(Env *env, SymbolObject *name) {
 }
 
 Value GlobalEnv::global_get(Env *env, SymbolObject *name) {
-    std::lock_guard<std::mutex> lock(g_gvar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!name->is_global_name())
         env->raise_name_error(name, "`{}' is not allowed as a global variable name", name->string());
@@ -33,7 +30,7 @@ Value GlobalEnv::global_get(Env *env, SymbolObject *name) {
 }
 
 Value GlobalEnv::global_set(Env *env, SymbolObject *name, Value val) {
-    std::lock_guard<std::mutex> lock(g_gvar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!name->is_global_name())
         env->raise_name_error(name, "`{}' is not allowed as a global variable name", name->string());
@@ -49,7 +46,7 @@ Value GlobalEnv::global_set(Env *env, SymbolObject *name, Value val) {
 }
 
 Value GlobalEnv::global_alias(Env *env, SymbolObject *new_name, SymbolObject *old_name) {
-    std::lock_guard<std::mutex> lock(g_gvar_alias_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!new_name->is_global_name())
         env->raise_name_error(new_name, "`{}' is not allowed as a global variable name", new_name->string());
@@ -66,7 +63,8 @@ Value GlobalEnv::global_alias(Env *env, SymbolObject *new_name, SymbolObject *ol
 }
 
 ArrayObject *GlobalEnv::global_list(Env *env) {
-    std::lock_guard<std::mutex> lock(g_gvar_alias_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+
     auto result = new ArrayObject { m_global_variables.size() + 2 };
     for (const auto &[key, _] : m_global_variables) {
         result->push(key);

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -35,7 +35,7 @@ bool HashObject::is_comparing_by_identity() const {
 }
 
 Value HashObject::get(Env *env, Value key) {
-    std::lock_guard<std::mutex> lock(m_hash_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     Key key_container;
     key_container.key = key;
@@ -72,7 +72,7 @@ Value HashObject::set_default(Env *env, Value value) {
 void HashObject::put(Env *env, Value key, Value val) {
     NAT_GC_GUARD_VALUE(key);
     NAT_GC_GUARD_VALUE(val);
-    std::lock_guard<std::mutex> lock(m_hash_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     assert_not_frozen(env);
     Key key_container;
@@ -97,7 +97,7 @@ void HashObject::put(Env *env, Value key, Value val) {
 }
 
 Value HashObject::remove(Env *env, Value key) {
-    std::lock_guard<std::mutex> lock(m_hash_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     Key key_container;
     key_container.key = key;
@@ -115,7 +115,7 @@ Value HashObject::remove(Env *env, Value key) {
 }
 
 Value HashObject::clear(Env *env) {
-    std::lock_guard<std::mutex> lock(m_hash_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     assert_not_frozen(env);
     m_hashmap.clear();

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -955,15 +955,22 @@ Value IoObject::select(Env *env, Value read_ios, Value write_ios, Value error_io
     int result;
     for (;;) {
         result = ::select(nfds, &read_fds, &write_fds, &error_fds, timeout_ptr);
-        if (result == -1)
+        if (result == -1 && errno == EINTR) {
+            // Interrupted by a signal -- probably the GC stopping the world.
+            // Try again.
+        } else if (result == -1) {
+            // An error the user needs to handle.
             break;
-
-        if (FD_ISSET(interrupt_fileno, &read_fds)) {
+        } else if (FD_ISSET(interrupt_fileno, &read_fds)) {
+            // Interrupted by our thread file descriptor.
+            // This thread may need to raise or exit.
             ThreadObject::clear_interrupt();
             ThreadObject::check_current_exception(env);
             if (any_closed(read_ios_ary) || any_closed(write_ios_ary) || any_closed(error_ios_ary))
                 env->raise("IOError", "closed stream");
         } else {
+            // Only thing left is one of the file descriptors
+            // we were waiting on got an update.
             break;
         }
 
@@ -1003,15 +1010,21 @@ void IoObject::select_read(Env *env, timeval *timeout) const {
     for (;;) {
         ret = ::select(nfds, &readfds, nullptr, nullptr, timeout);
 
-        if (ret == -1 && errno == EBADF && m_closed) {
-            // On macOS, the blocking select() call returns an error
-            // when the file is closed. This can also happen on Linux
-            // if the file was closed just prior to our select() call.
-            env->raise("IOError", "closed stream");
+        if (ret == -1) {
+            if (errno == EINTR) {
+                // Interrupted by a signal -- probably the GC stopping the world.
+                // Try again.
+                readfds = readfds_copy;
+                continue;
+            } else if (errno == EBADF && m_closed) {
+                // On macOS, the blocking select() call returns an error
+                // when the file is closed. This can also happen on Linux
+                // if the file was closed just prior to our select() call.
+                env->raise("IOError", "closed stream");
+            } else {
+                env->raise_errno();
+            }
         }
-
-        if (ret == -1)
-            break;
 
         if (FD_ISSET(interrupt_fileno, &readfds)) {
             ThreadObject::clear_interrupt();
@@ -1022,11 +1035,11 @@ void IoObject::select_read(Env *env, timeval *timeout) const {
 
         if (FD_ISSET(m_fileno, &readfds))
             break;
+
         readfds = readfds_copy;
     }
 
-    if (ret == -1)
-        env->raise_errno();
+    assert(ret != -1);
 }
 
 Value IoObject::pipe(Env *env, Value external_encoding, Value internal_encoding, Block *block, ClassObject *klass) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -960,7 +960,7 @@ Value IoObject::select(Env *env, Value read_ios, Value write_ios, Value error_io
 
         if (FD_ISSET(interrupt_fileno, &read_fds)) {
             ThreadObject::clear_interrupt();
-            ThreadObject::cancelation_checkpoint(env);
+            ThreadObject::check_current_exception(env);
             if (any_closed(read_ios_ary) || any_closed(write_ios_ary) || any_closed(error_ios_ary))
                 env->raise("IOError", "closed stream");
         } else {
@@ -1015,7 +1015,7 @@ void IoObject::select_read(Env *env, timeval *timeout) const {
 
         if (FD_ISSET(interrupt_fileno, &readfds)) {
             ThreadObject::clear_interrupt();
-            ThreadObject::cancelation_checkpoint(env);
+            ThreadObject::check_current_exception(env);
             if (m_closed)
                 env->raise("IOError", "closed stream");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,22 +43,48 @@ extern "C" Object *EVAL(Env *env) {
     }
 }
 
-void sigint_handler(int sig) {
+void sigint_handler(int, siginfo_t *, void *) {
     const char *msg = "Interrupt\n";
     auto bytes_written = write(STDOUT_FILENO, msg, strlen(msg));
     if (bytes_written == -1) abort();
     exit(128 + SIGINT);
 }
 
-void sigpipe_handler(int unused) {
+void sigpipe_handler(int, siginfo_t *, void *) {
     // TODO: do something here?
 }
 
-void trap_signal(int signal, void (*handler)(int)) {
+void gc_signal_handler(int signal, siginfo_t *, void *ucontext) {
+    switch (signal) {
+    case SIGUSR1: {
+        auto thread = ThreadObject::current();
+        if (!thread || thread->is_main()) return;
+
+        auto ctx = thread->get_context();
+        assert(ctx);
+        memcpy(ctx, ucontext, sizeof(ucontext_t));
+        thread->set_context_saved(true);
+#ifdef NAT_DEBUG_THREADS
+        char msg[] = "THREAD DEBUG: Thread paused\n";
+        ::write(STDERR_FILENO, msg, sizeof(msg));
+#endif
+        pause();
+        break;
+    }
+    case SIGUSR2:
+#ifdef NAT_DEBUG_THREADS
+        char msg2[] = "THREAD DEBUG: Thread woke up\n";
+        ::write(STDERR_FILENO, msg2, sizeof(msg2));
+#endif
+        break;
+    }
+}
+
+void trap_signal(int signal, void (*handler)(int, siginfo_t *, void *)) {
     struct sigaction sa;
-    sa.sa_handler = handler;
+    sa.sa_sigaction = handler;
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
+    sa.sa_flags = SA_SIGINFO;
 
     if (sigaction(signal, &sa, nullptr) == -1) {
         printf("Failed to trap %d\n", signal);
@@ -78,6 +104,8 @@ int main(int argc, char *argv[]) {
 
     trap_signal(SIGINT, sigint_handler);
     trap_signal(SIGPIPE, sigpipe_handler);
+    trap_signal(SIGUSR1, gc_signal_handler);
+    trap_signal(SIGUSR2, gc_signal_handler);
 
 #ifndef NAT_GC_DISABLE
     Heap::the().gc_enable();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,14 +44,10 @@ extern "C" Object *EVAL(Env *env) {
 }
 
 void sigint_handler(int sig) {
-    if (ThreadObject::i_am_main()) {
-        const char *msg = "Interrupt\n";
-        auto bytes_written = write(STDOUT_FILENO, msg, strlen(msg));
-        if (bytes_written == -1) abort();
-        exit(128 + SIGINT);
-    } else {
-        pthread_cancel(pthread_self());
-    }
+    const char *msg = "Interrupt\n";
+    auto bytes_written = write(STDOUT_FILENO, msg, strlen(msg));
+    if (bytes_written == -1) abort();
+    exit(128 + SIGINT);
 }
 
 void sigpipe_handler(int unused) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,11 @@ void gc_signal_handler(int signal, siginfo_t *, void *ucontext) {
         if (!thread || thread->is_main()) return;
 
         auto ctx = thread->get_context();
-        assert(ctx);
+        if (!ctx) {
+            char msg[] = "Fatal: Could not get pointer for thread context.";
+            ::write(STDERR_FILENO, msg, sizeof(msg));
+            abort();
+        }
         memcpy(ctx, ucontext, sizeof(ucontext_t));
         thread->set_context_saved(true);
 #ifdef NAT_DEBUG_THREADS

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -494,17 +494,19 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception, Thread
         out.send(env, "puts"_s, { formatted });
     }
 
-    ArrayObject *backtrace = exception->backtrace()->to_ruby_array();
-    if (backtrace && backtrace->size() > 0) {
-        out.send(env, "puts"_s, { new StringObject { "Traceback (most recent call last):" } });
-        for (int i = backtrace->size() - 1; i > 0; i--) {
-            auto line = backtrace->at(i)->as_string_or_raise(env);
-            auto formatted = StringObject::format("        {}: from {}", i, line->string());
-            out.send(env, "puts"_s, { formatted });
+    if (exception->backtrace()) {
+        ArrayObject *backtrace = exception->backtrace()->to_ruby_array();
+        if (backtrace->size() > 0) {
+            out.send(env, "puts"_s, { new StringObject { "Traceback (most recent call last):" } });
+            for (int i = backtrace->size() - 1; i > 0; i--) {
+                auto line = backtrace->at(i)->as_string_or_raise(env);
+                auto formatted = StringObject::format("        {}: from {}", i, line->string());
+                out.send(env, "puts"_s, { formatted });
+            }
+            auto line = backtrace->at(0)->as_string_or_raise(env);
+            auto formatted = StringObject::format("{}: ", line->string());
+            out.send(env, "print"_s, { formatted });
         }
-        auto line = backtrace->at(0)->as_string_or_raise(env);
-        auto formatted = StringObject::format("{}: ", line->string());
-        out.send(env, "print"_s, { formatted });
     }
 
     auto formatted = StringObject::format(

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -808,6 +808,7 @@ Value super(Env *env, Value self, Args args, Block *block) {
 }
 
 void clean_up_and_exit(int status) {
+    ThreadObject::detach_all();
     if (Heap::the().collect_all_at_exit()) {
         delete &Heap::the();
         delete NativeProfiler::the();

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -8,8 +8,6 @@
 
 namespace Natalie {
 
-std::mutex g_backtrace_mutex;
-
 Env *build_top_env() {
     auto *global_env = GlobalEnv::the();
     auto *env = new Env {};
@@ -485,7 +483,7 @@ void run_at_exit_handlers(Env *env) {
 }
 
 void print_exception_with_backtrace(Env *env, ExceptionObject *exception, ThreadObject *thread) {
-    std::lock_guard<std::mutex> lock(g_backtrace_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     auto out = env->global_get("$stderr"_s);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -5,9 +5,6 @@
 
 namespace Natalie {
 
-std::mutex g_define_method_mutex;
-std::mutex g_ivar_mutex;
-
 Object::Object(const Object &other)
     : m_klass { other.m_klass }
     , m_type { other.m_type }
@@ -688,7 +685,7 @@ bool Object::ivar_defined(Env *env, SymbolObject *name) {
 }
 
 Value Object::ivar_get(Env *env, SymbolObject *name) {
-    std::lock_guard<std::mutex> lock(g_ivar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!name->is_ivar_name())
         env->raise_name_error(name, "`{}' is not allowed as an instance variable name", name->string());
@@ -704,7 +701,7 @@ Value Object::ivar_get(Env *env, SymbolObject *name) {
 }
 
 Value Object::ivar_remove(Env *env, SymbolObject *name) {
-    std::lock_guard<std::mutex> lock(g_ivar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!name->is_ivar_name())
         env->raise("NameError", "`{}' is not allowed as an instance variable name", name->string());
@@ -721,7 +718,7 @@ Value Object::ivar_remove(Env *env, SymbolObject *name) {
 
 Value Object::ivar_set(Env *env, SymbolObject *name, Value val) {
     NAT_GC_GUARD_VALUE(val);
-    std::lock_guard<std::mutex> lock(g_ivar_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     assert_not_frozen(env);
 
@@ -810,7 +807,7 @@ nat_int_t Object::object_id() const {
 }
 
 SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
-    std::lock_guard<std::mutex> lock(g_define_method_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ClassObject *klass = singleton_class(env);
     if (klass->is_frozen())
@@ -820,7 +817,7 @@ SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, Meth
 }
 
 SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, Block *block) {
-    std::lock_guard<std::mutex> lock(g_define_method_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ClassObject *klass = singleton_class(env);
     if (klass->is_frozen())
@@ -830,7 +827,7 @@ SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, Bloc
 }
 
 SymbolObject *Object::undefine_singleton_method(Env *env, SymbolObject *name) {
-    std::lock_guard<std::mutex> lock(g_define_method_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ClassObject *klass = singleton_class(env);
     klass->undefine_method(env, name);

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -2,8 +2,6 @@
 
 namespace Natalie::Thread {
 
-std::mutex g_mutex_mutex; // That's a funny name. :-)
-
 Value MutexObject::lock(Env *env) {
     auto locked = m_mutex.try_lock();
 
@@ -21,7 +19,7 @@ Value MutexObject::lock(Env *env) {
         }
     }
 
-    std::lock_guard<std::mutex> lock(g_mutex_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
     m_thread = ThreadObject::current();
     m_thread->add_mutex(this);
     m_fiber = FiberObject::current();
@@ -64,7 +62,7 @@ bool MutexObject::try_lock() {
 }
 
 Value MutexObject::unlock(Env *env) {
-    std::lock_guard<std::mutex> lock(g_mutex_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!is_locked())
         env->raise("ThreadError", "Attempt to unlock a mutex which is not locked");
@@ -94,7 +92,7 @@ bool MutexObject::is_locked() {
 }
 
 bool MutexObject::is_owned() {
-    std::lock_guard<std::mutex> lock(g_mutex_mutex);
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     if (!is_locked()) return false;
 

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -15,7 +15,7 @@ Value MutexObject::lock(Env *env) {
             ThreadObject::set_current_sleeping(true);
             struct timespec request = { 0, 100000 };
             while (!m_mutex.try_lock()) {
-                ThreadObject::cancelation_checkpoint(env);
+                ThreadObject::check_current_exception(env);
                 nanosleep(&request, nullptr);
             }
         }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -754,7 +754,7 @@ NO_SANITIZE_ADDRESS void ThreadObject::visit_children_from_stack(Visitor &visito
     // If this thread is still in the state of being setup, the stack might not
     // be known yet. Plus, there shouldn't be any GC-managed variables on the
     // stack prior to it being set as Status::Active.
-    if (m_status == Status::Created)
+    if (!m_launched)
         return;
 
     // Walk the stack looking for variables...

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -666,6 +666,12 @@ NO_SANITIZE_ADDRESS void ThreadObject::visit_children_from_stack(Visitor &visito
     if (m_status == Status::Created)
         return;
 
+    // If this thread is Dead, then it's possible the OS has already reclaimed
+    // the stack space. We shouldn't have any remaining variables on the stack
+    // that we need to keep anyway.
+    if (m_status == Status::Dead)
+        return;
+
     for (char *ptr = reinterpret_cast<char *>(m_end_of_stack); ptr < m_start_of_stack; ptr += sizeof(intptr_t)) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(ptr);
         if (Heap::the().is_a_heap_cell_in_use(potential_cell))

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -275,7 +275,6 @@ Value ThreadObject::join(Env *env) {
     }
 
     m_joined = true;
-    remove_from_list();
 
     if (m_exception)
         env->raise_exception(m_exception);
@@ -312,8 +311,6 @@ Value ThreadObject::kill(Env *env) {
         wakeup(env);
         ThreadObject::interrupt();
     }
-
-    remove_from_list();
 
     return this;
 }
@@ -565,10 +562,8 @@ void ThreadObject::remove_from_list() const {
             break;
         }
     }
-    // We call remove_from_list() from a few different places,
-    // so it's possible it was already removed.
-    if (found)
-        s_list.remove(i);
+    assert(found);
+    s_list.remove(i);
 }
 
 void ThreadObject::add_mutex(Thread::MutexObject *mutex) {

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -792,6 +792,8 @@ void ThreadObject::visit_children_from_asan_fake_stack(Visitor &visitor, Cell *p
 NO_SANITIZE_ADDRESS void ThreadObject::visit_children_from_context(Visitor &visitor) const {
     for (char *i = (char *)m_context; i < (char *)m_context + sizeof(ucontext_t); ++i) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(i);
+        if (!potential_cell)
+            continue;
         if (Heap::the().is_a_heap_cell_in_use(potential_cell))
             visitor.visit(potential_cell);
     }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -347,7 +347,7 @@ Value ThreadObject::wakeup(Env *env) {
     pthread_cond_signal(&m_sleep_cond);
     pthread_mutex_unlock(&m_sleep_lock);
 
-    return NilObject::the();
+    return this;
 }
 
 Value ThreadObject::sleep(Env *env, float timeout) {

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -204,9 +204,9 @@ ThreadObject *ThreadObject::initialize(Env *env, Args args, Block *block) {
     m_file = env->file();
     m_line = env->line();
 
-    m_thread = std::thread { nat_create_thread, (void *)this };
-
     m_report_on_exception = s_report_on_exception;
+
+    m_thread = std::thread { nat_create_thread, (void *)this };
 
     return this;
 }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -117,8 +117,8 @@ static void *nat_create_thread(void *thread_object) {
             // so we need to store it on the thread for later use.
             thread->set_exception(exception);
 
-            // This is a regular Ruby Exception. We need to potentially print it,
-            // handle SystemExit, and/or abort if necessary.
+            // This is a regular Ruby Exception.
+            // We need to potentially print it and/or handle SystemExit.
             Natalie::handle_top_level_exception(&e, exception, false);
 
             // The user might have said we should abort the whole program

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -327,7 +327,9 @@ Value ThreadObject::raise(Env *env, Args args) {
     m_exception = exception;
 
     // Wake up the thread in case it is sleeping.
-    wakeup(env);
+    pthread_mutex_lock(&m_sleep_lock);
+    pthread_cond_signal(&m_sleep_cond);
+    pthread_mutex_unlock(&m_sleep_lock);
 
     // In case this thread is blocking on read/select/whatever,
     // we may need to interrupt it (and all other threads, incidentally).

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -656,6 +656,15 @@ void ThreadObject::check_exception(Env *env) {
     env->raise_exception(exception);
 }
 
+void ThreadObject::detach_all() {
+    std::lock_guard<std::recursive_mutex> lock(g_thread_recursive_mutex);
+    for (auto thread : s_list) {
+        if (thread->is_main())
+            continue;
+        thread->detach();
+    }
+}
+
 NO_SANITIZE_ADDRESS void ThreadObject::visit_children_from_stack(Visitor &visitor) const {
     // If this is the currently active thread,
     // we don't need walk its stack a second time.

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -205,11 +205,11 @@ ThreadObject *ThreadObject::initialize(Env *env, Args args, Block *block) {
 
     m_report_on_exception = s_report_on_exception;
 
+    add_to_list(this);
+
     NAT_THREAD_DEBUG("Creating thread %p", this);
     m_thread = std::thread { nat_create_thread, (void *)this };
     m_native_thread_handle = m_thread.native_handle();
-
-    add_to_list(this);
 
     return this;
 }

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -95,7 +95,7 @@ std::mutex g_thread_mutex;
 std::recursive_mutex g_thread_recursive_mutex;
 
 Value ThreadObject::pass(Env *env) {
-    cancelation_checkpoint(env);
+    check_current_exception(env);
 
     sched_yield();
 
@@ -329,7 +329,7 @@ Value ThreadObject::sleep(Env *env, float timeout) {
         handle_error(pthread_cond_wait(&m_sleep_cond, &m_sleep_lock));
         pthread_mutex_unlock(&m_sleep_lock);
 
-        cancelation_checkpoint(env);
+        check_exception(env);
 
         return calculate_elapsed();
     }
@@ -358,7 +358,7 @@ Value ThreadObject::sleep(Env *env, float timeout) {
     handle_error(pthread_cond_timedwait(&m_sleep_cond, &m_sleep_lock, &wait));
     pthread_mutex_unlock(&m_sleep_lock);
 
-    cancelation_checkpoint(env);
+    check_exception(env);
 
     return calculate_elapsed();
 }
@@ -572,10 +572,7 @@ void ThreadObject::clear_interrupt() {
     } while (bytes > 0);
 }
 
-void ThreadObject::cancelation_checkpoint(Env *env) {
-    // This call gives us a cancelation point that works with pthread_cancel(3).
-    ::usleep(0);
-
+void ThreadObject::check_current_exception(Env *env) {
     current()->check_exception(env);
 }
 

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -26,9 +26,7 @@ describe 'Thread' do
 
   it 'works' do
     threads = create_threads
-    1_000_000.times do
-      'trigger gc'
-    end
+    GC.start
     threads.each(&:join)
     $results.size.should == 10
   end

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -20,6 +20,7 @@ describe 'Thread' do
   end
 
   after do
+    GC.start # Trigger GC bugs here ;-)
     Thread.report_on_exception = @report_setting
     Thread.abort_on_exception = @abort_setting
   end

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -50,7 +50,7 @@ describe 'Thread' do
       t.join.should == t
 
       # make sure thread id reuse doesn't cause later join to block
-      other_threads = 1.upto(100).map { Thread.new { sleep } }
+      other_threads = 1.upto(10).map { Thread.new { sleep } }
       sleep 0.1
 
       # if the thread id gets reused and we are using pthread_join with that id,

--- a/test/support/compare_rubies.rb
+++ b/test/support/compare_rubies.rb
@@ -1,7 +1,7 @@
 require 'timeout'
 
 module CompareRubies
-  SPEC_TIMEOUT = (ENV['SPEC_TIMEOUT'] || 120).to_i
+  SPEC_TIMEOUT = (ENV['SPEC_TIMEOUT'] || 240).to_i
   NAT_BINARY = ENV['NAT_BINARY'] || 'bin/natalie'
 
   def run_nat(path, *args)


### PR DESCRIPTION
Originally I intended to just fix `ensure` blocks in threads. From there my life spiraled and I learned more about Linux signals and processor state than I ever wanted to know. 😆 

This PR does a lot of things -- too many actually -- but the headline feature is a stop-the-world workflow for our GC so that thread state is always in a stable place when we do our conservative stack and context scan.

I found and fixed lots of edge cases around thread birth and death, too.

The secondary feature is that `Thread#raise` now works as expected, by raising an exception at the point in the stack where the thread is running.