### PR TITLE
Some fixes for loading libraries on macOS

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -261,7 +261,8 @@ class Runner
 
   def run_temp_and_wait(path)
     build_dir = File.expand_path('../build', __dir__)
-    env = { 'LD_LIBRARY_PATH' => "#{build_dir}:#{build_dir}/onigmo/lib" }
+    var_name = RUBY_PLATFORM =~ /darwin/ ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH'
+    env = { var_name => Natalie::Compiler::CppBackend::LIB_PATHS.join(':') }
     pid = spawn(env, path, *ARGV)
     Process.wait(pid)
     @run_result = $?

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -47,7 +47,7 @@ module Natalie
         File.join(BUILD_DIR, 'zlib'),
       ].freeze
 
-      PACKAGES_REQUIRING_PKG_CONFIG = %w[openssl libffi].freeze
+      PACKAGES_REQUIRING_PKG_CONFIG = %w[openssl libffi yaml-0.1].freeze
 
       def initialize(instructions, compiler:, compiler_context:)
         @instructions = instructions

--- a/test/setup_pkgconfig_with_homebrew.sh
+++ b/test/setup_pkgconfig_with_homebrew.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Homebrew does not put the .pc files in a common place that pkg-config can find.
+# This script sets up the PKG_CONFIG_PATH so that the packages can be found by Natalie.
+# You can run this prior to running `bin/natalie` or `rake test` or whatever.
+#
+# Usage:
+#
+#     eval(test/setup_pkgconfig_with_homebrew.sh)
+
+set -e
+
+packages=("libyaml")
+
+if ! type -P brew &>/dev/null; then
+  echo "Could not find $(brew) command. This script assumes you have Homebrew installed."
+  exit 1
+fi
+
+for package in ${packages[@]}; do
+  PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix $package)/lib/pkgconfig"
+done
+
+echo "export PKG_CONFIG_PATH=\"$PKG_CONFIG_PATH\""


### PR DESCRIPTION
I've noticed this on my mac for awhile but I just ignored it. I don't know how it worked in CI honestly, but both libyaml and zlib would not load on my mac.

This seems to fix it for me.

I added a hacky little script for Homebrew, which I'll consider if we want to pull that logic into Natalie proper. But for now, I don't love that Natalie would "know" how Homebrew works.