### PR TITLE
Use NAT_BINARY env var for 'test' directory

### DIFF
--- a/test/support/compare_rubies.rb
+++ b/test/support/compare_rubies.rb
@@ -2,9 +2,10 @@ require 'timeout'
 
 module CompareRubies
   SPEC_TIMEOUT = (ENV['SPEC_TIMEOUT'] || 120).to_i
+  NAT_BINARY = ENV['NAT_BINARY'] || 'bin/natalie'
 
   def run_nat(path, *args)
-    out_nat = sh("bin/natalie -I test/support #{path} #{args.join(' ')} 2>&1")
+    out_nat = sh("#{NAT_BINARY} -I test/support #{path} #{args.join(' ')} 2>&1")
     puts out_nat unless $?.success?
     expect($?).must_be :success?
     out_nat


### PR DESCRIPTION
This fixes the `test_self_hosted` rake task which is supposed to run tests with the self-hosted compiler but wasn't honoring the env variable.