### PR TITLE
Sweep unreachable cells after we wake up the world

### DIFF
--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -139,9 +139,9 @@ void Heap::collect() {
     if (is_profiled)
         mark_profiler_event->end_now();
 
-    sweep();
-
     ThreadObject::wake_up_the_world();
+
+    sweep();
 }
 
 void Heap::sweep() {


### PR DESCRIPTION
This should reduce the surface area of free()/delete calls that can deadlock. There might still be some more I need to track down though...