### PR TITLE
Support File arguments in rm_r of specs

### DIFF
--- a/test/support/spec_helpers/fs.rb
+++ b/test/support/spec_helpers/fs.rb
@@ -58,7 +58,7 @@ end
 # a file.
 def rm_r(*paths)
   paths.each do |path|
-    path = File.expand_path path
+    path = path.is_a?(File) ? path.to_path : File.expand_path(path)
 
     prefix = SPEC_TEMP_DIR
     unless path[0, prefix.size] == prefix


### PR DESCRIPTION
This resolves the crash in the specs of Kernel.test