### PR TITLE
Use mach thread interface for suspending/resuming threads on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We have a very quiet [Discord server](https://discord.gg/hnHp2tdQyn) -- come and
 
 ## Building
 
-Natalie is tested on macOS, OpenBSD, and Ubuntu Linux. Windows is not yet supported.
+Natalie is tested on macOS and Ubuntu Linux. Windows is not yet supported.
 
 Natalie requires a system Ruby (MRI) to host the compiler, for now.
 

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <float.h>
 #include <inttypes.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -207,5 +208,12 @@ void dbg(const char *fmt, Args... args) {
 }
 
 int pipe2(int pipefd[2], int flags);
+
+void trap_signal(int signal, void (*handler)(int, siginfo_t *, void *));
+
+void gc_signal_handler(int signal, siginfo_t *, void *ucontext);
+
+void sigint_handler(int, siginfo_t *, void *);
+void sigpipe_handler(int, siginfo_t *, void *);
 
 }

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -40,6 +40,7 @@ public:
     };
 
     enum class SuspendStatus {
+        Launching,
         Running,
         Suspended,
     };
@@ -186,8 +187,6 @@ public:
     SuspendStatus suspend_status() const { return m_suspend_status; }
     void set_suspend_status(SuspendStatus status) { m_suspend_status = status; }
 
-    void set_launched(bool launched) { m_launched = launched; }
-
     virtual void visit_children(Visitor &) override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -289,10 +288,7 @@ private:
 #endif
     ucontext_t *m_context { nullptr };
 
-    std::atomic<SuspendStatus> m_suspend_status { SuspendStatus::Running };
-
-    // TODO: move this into the SuspendStatus enum
-    std::atomic<bool> m_launched { false };
+    std::atomic<SuspendStatus> m_suspend_status { SuspendStatus::Launching };
 
     bool m_abort_on_exception { false };
     bool m_report_on_exception { true };

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -39,6 +39,11 @@ public:
         Dead,
     };
 
+    enum class SuspendStatus {
+        Running,
+        Suspended,
+    };
+
     ThreadObject()
         : Object { Object::Type::Thread, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->as_class() } { }
 
@@ -178,8 +183,8 @@ public:
     void check_exception(Env *);
 
     ucontext_t *get_context() const { return m_context; }
-    bool context_saved() const { return m_context_saved; }
-    void set_context_saved(bool saved) { m_context_saved = saved; }
+    SuspendStatus suspend_status() const { return m_suspend_status; }
+    void set_suspend_status(SuspendStatus status) { m_suspend_status = status; }
 
     void set_launched(bool launched) { m_launched = launched; }
 
@@ -283,7 +288,10 @@ private:
     void *m_asan_fake_stack { nullptr };
 #endif
     ucontext_t *m_context { nullptr };
-    std::atomic<bool> m_context_saved { false };
+
+    std::atomic<SuspendStatus> m_suspend_status { SuspendStatus::Running };
+
+    // TODO: move this into the SuspendStatus enum
     std::atomic<bool> m_launched { false };
 
     bool m_abort_on_exception { false };

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -762,7 +762,7 @@ void ThreadObject::wake_up_the_world() {
     }
 }
 
-void ThreadObject::suspend() {
+void ThreadObject::suspend() { // NOLINT "can be made const" warning only for Linux
 #ifdef __APPLE__
     assert(m_mach_thread_port != MACH_PORT_NULL);
     int result;
@@ -778,7 +778,7 @@ void ThreadObject::suspend() {
 #endif
 }
 
-void ThreadObject::resume() {
+void ThreadObject::resume() { // NOLINT "can be made const" warning only for Linux
 #ifdef __APPLE__
     assert(m_mach_thread_port != MACH_PORT_NULL);
     int result;

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -735,8 +735,6 @@ void ThreadObject::stop_the_world_and_save_context() {
             handle = thread->native_thread_handle();
         }
 
-        thread->set_context_saved(false);
-
         pthread_kill(handle, SIGUSR1);
         NAT_THREAD_DEBUG("sent halt signal to thread %p", thread);
     }
@@ -747,7 +745,7 @@ void ThreadObject::stop_the_world_and_save_context() {
         ready = true;
         for (auto thread : ThreadObject::list()) {
             if (thread->is_main()) continue;
-            if (thread->context_saved()) {
+            if (thread->suspend_status() == SuspendStatus::Suspended) {
                 continue;
             } else {
                 ready = false;


### PR DESCRIPTION
macOS was dropping some of our signals, and the mach interface is actually pretty slick, so let's use that!

This will hopefully make the GC stop-the-world flow more stable on macOS. 🤞 