### PR TITLE
Mark results of Socket.pack_sockaddr_* as binary strings

### DIFF
--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -67,7 +67,7 @@ public:
 #else
         arc4random_buf(buffer, length);
 #endif
-        return new StringObject { buffer, length, EncodingObject::get(Encoding::ASCII_8BIT) };
+        return new StringObject { buffer, length, Encoding::ASCII_8BIT };
     }
 
 private:

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -64,6 +64,13 @@ public:
         set_str(str);
     }
 
+    StringObject(const char *str, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
+        assert(m_encoding);
+        set_str(str);
+    }
+
     StringObject(const char *str, size_t length)
         : Object { Object::Type::String, GlobalEnv::the()->String() }
         , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
@@ -74,6 +81,13 @@ public:
     StringObject(const char *str, size_t length, EncodingObject *encoding)
         : Object { Object::Type::String, GlobalEnv::the()->String() }
         , m_encoding { encoding } {
+        assert(m_encoding);
+        set_str(str, length);
+    }
+
+    StringObject(const char *str, size_t length, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
         assert(m_encoding);
         set_str(str, length);
     }

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -338,7 +338,7 @@ class Date
       int maxsize = 32;
       char buffer[maxsize];
       auto length = ::strftime(buffer, maxsize, format_var->as_string()->c_str(), &time);
-      return new StringObject { buffer, length, EncodingObject::get(Encoding::US_ASCII) };
+      return new StringObject { buffer, length, Encoding::US_ASCII };
     END
   end
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -125,7 +125,7 @@ Value OpenSSL_Cipher_final(Env *env, Value self, Args args, Block *) {
     if (!EVP_CipherFinal_ex(ctx, reinterpret_cast<unsigned char *>(&buf[0]), &size))
         OpenSSL_Cipher_raise_error(env, "EVP_CipherFinal_ex");
     buf.truncate(size);
-    return new StringObject { std::move(buf), EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { std::move(buf), Encoding::ASCII_8BIT };
 }
 
 Value OpenSSL_Cipher_iv_set(Env *env, Value self, Args args, Block *) {
@@ -180,7 +180,7 @@ Value OpenSSL_Cipher_update(Env *env, Value self, Args args, Block *) {
     if (!EVP_CipherUpdate(ctx, reinterpret_cast<unsigned char *>(&buf[0]), &size, reinterpret_cast<const unsigned char *>(data->c_str()), data->bytesize()))
         OpenSSL_Cipher_raise_error(env, "EVP_CipherUpdate");
     buf.truncate(size);
-    return new StringObject { std::move(buf), EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { std::move(buf), Encoding::ASCII_8BIT };
 }
 
 Value OpenSSL_Cipher_ciphers(Env *env, Value self, Args args, Block *) {
@@ -263,7 +263,7 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args args, Block *) {
 
     OpenSSL_Digest_reset(env, self, {}, nullptr);
 
-    return new StringObject { reinterpret_cast<const char *>(buf), md_len, EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { reinterpret_cast<const char *>(buf), md_len, Encoding::ASCII_8BIT };
 }
 
 Value OpenSSL_Digest_digest_length(Env *env, Value self, Args args, Block *) {
@@ -395,7 +395,7 @@ Value OpenSSL_KDF_pbkdf2_hmac(Env *env, Value self, Args args, Block *) {
         OpenSSL_raise_error(env, "PKCS5_PBKDF2_HMAC", KDFError->as_class());
     }
 
-    return new StringObject { reinterpret_cast<char *>(out), out_size, EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { reinterpret_cast<char *>(out), out_size, Encoding::ASCII_8BIT };
 }
 
 Value OpenSSL_KDF_scrypt(Env *env, Value self, Args args, Block *) {
@@ -525,7 +525,7 @@ Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
     if (RAND_bytes(buf, num) != 1)
         OpenSSL_raise_error(env, "RAND_bytes");
 
-    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), Encoding::ASCII_8BIT };
 }
 
 Value OpenSSL_X509_Name_add_entry(Env *env, Value self, Args args, Block *) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -804,12 +804,12 @@ Value Socket_pack_sockaddr_in(Env *env, Value self, Args args, Block *block) {
     switch (addr->ai_family) {
     case AF_INET: {
         auto in = (struct sockaddr_in *)addr->ai_addr;
-        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in) };
+        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in), Encoding::ASCII_8BIT };
         break;
     }
     case AF_INET6: {
         auto in = (struct sockaddr_in6 *)addr->ai_addr;
-        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in6) };
+        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in6), Encoding::ASCII_8BIT };
         break;
     }
     default:
@@ -835,7 +835,7 @@ Value Socket_pack_sockaddr_un(Env *env, Value self, Args args, Block *block) {
 
     un.sun_family = AF_UNIX;
     memcpy(un.sun_path, path_string->c_str(), path_string->length());
-    return new StringObject { (const char *)&un, sizeof(un) };
+    return new StringObject { (const char *)&un, sizeof(un), Encoding::ASCII_8BIT };
 }
 
 Value Socket_unpack_sockaddr_in(Env *env, Value self, Args args, Block *block) {

--- a/spec/library/socket/shared/pack_sockaddr.rb
+++ b/spec/library/socket/shared/pack_sockaddr.rb
@@ -19,9 +19,11 @@ describe :socket_pack_sockaddr_in, shared: true do
     Socket.unpack_sockaddr_in(sockaddr_in).should == [0, '127.0.0.1']
   end
 
-  it 'resolves the service name to a port' do
-    sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
-    Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
+  platform_is_not :solaris do
+    it 'resolves the service name to a port' do
+      sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
+      Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
+    end
   end
 
   describe 'using an IPv4 address' do

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -347,7 +347,7 @@ Value IoObject::read(Env *env, Value count_value, Value buffer) {
         if (count > std::numeric_limits<off_t>::max())
             env->raise("RangeError", "bignum too big to convert into `long'");
         if (m_read_buffer.size() >= static_cast<size_t>(count)) {
-            auto result = new StringObject { m_read_buffer.c_str(), static_cast<size_t>(count), EncodingObject::get(Encoding::ASCII_8BIT) };
+            auto result = new StringObject { m_read_buffer.c_str(), static_cast<size_t>(count), Encoding::ASCII_8BIT };
             m_read_buffer = String { m_read_buffer.c_str() + count, m_read_buffer.size() - count };
             return result;
         }
@@ -364,14 +364,14 @@ Value IoObject::read(Env *env, Value count_value, Value buffer) {
             if (count == 0) {
                 if (buffer != nullptr)
                     return buffer;
-                return new StringObject { "", 0, EncodingObject::get(Encoding::ASCII_8BIT) };
+                return new StringObject { "", 0, Encoding::ASCII_8BIT };
             }
             return NilObject::the();
         } else if (buffer != nullptr) {
             buffer->as_string()->set_str(buf.c_str(), static_cast<size_t>(bytes_read));
             return buffer;
         } else {
-            return new StringObject { std::move(buf), EncodingObject::get(Encoding::ASCII_8BIT) };
+            return new StringObject { std::move(buf), Encoding::ASCII_8BIT };
         }
     }
     char buf[NAT_READ_BYTES + 1];

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -32,7 +32,7 @@ Value RandomObject::bytes(Env *env, Value size) {
     for (size_t i = 0; i < blocks; i++)
         output[i] = random_number(*m_generator);
 
-    return new StringObject { reinterpret_cast<char *>(output), static_cast<size_t>(isize), EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { reinterpret_cast<char *>(output), static_cast<size_t>(isize), Encoding::ASCII_8BIT };
 }
 
 Value RandomObject::rand(Env *env, Value arg) {

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -251,7 +251,7 @@ Value ThreadObject::to_s(Env *env) {
         location,
         status());
 
-    return new StringObject { formatted, EncodingObject::get(Encoding::ASCII_8BIT) };
+    return new StringObject { formatted, Encoding::ASCII_8BIT };
 }
 
 Value ThreadObject::status(Env *env) {

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -535,7 +535,7 @@ Value TimeObject::build_string(Env *, const char *format) {
     int maxsize = 32;
     char buffer[maxsize];
     auto length = ::strftime(buffer, maxsize, format, &m_time);
-    return new StringObject { buffer, length, EncodingObject::get(Encoding::US_ASCII) };
+    return new StringObject { buffer, length, Encoding::US_ASCII };
 }
 
 Value TimeObject::strip_zeroes(StringObject *string) {


### PR DESCRIPTION
This does include an addition to the constructors of `StringObject` to make it easier to pass the encoding.