### PR TITLE
Support UNIX sockets in BasicSocket#getsockname

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -969,6 +969,7 @@ Value Socket_unpack_sockaddr_un(Env *env, Value self, Args args, Block *block) {
     memcpy(&addr, sockaddr->as_string()->c_str(), std::min(sizeof(addr), sockaddr->as_string()->bytesize()));
     if (addr.sun_family != AF_UNIX)
         env->raise("ArgumentError", "not an AF_UNIX sockaddr");
+    // NATFIXME: Change to ASCII_8BIT, but this currently breaks the specs due to a missing String#encode with 2 arguments
     return new StringObject { addr.sun_path };
 }
 

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -88,7 +88,7 @@ static String Socket_reverse_lookup_address(Env *env, struct sockaddr *addr) {
 }
 
 static int Addrinfo_sockaddr_family(Env *env, StringObject *sockaddr) {
-    if (sockaddr->bytesize() < sizeof(struct sockaddr))
+    if (sockaddr->bytesize() < offsetof(struct sockaddr, sa_family) + sizeof(sa_family_t))
         env->raise("ArgumentError", "bad sockaddr");
     return ((struct sockaddr *)(sockaddr->c_str()))->sa_family;
 }

--- a/spec/library/socket/basicsocket/connect_address_spec.rb
+++ b/spec/library/socket/basicsocket/connect_address_spec.rb
@@ -1,0 +1,154 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe 'Socket#connect_address' do
+  describe 'using an unbound socket' do
+    after do
+      @sock.close
+    end
+
+    it 'raises SocketError' do
+      @sock = Socket.new(:INET, :STREAM)
+
+      -> { @sock.connect_address }.should raise_error(SocketError)
+    end
+  end
+
+  describe 'using a socket bound to 0.0.0.0' do
+    before do
+      @sock = Socket.new(:INET, :STREAM)
+      @sock.bind(Socket.sockaddr_in(0, '0.0.0.0'))
+    end
+
+    after do
+      @sock.close
+    end
+
+    it 'returns an Addrinfo' do
+      @sock.connect_address.should be_an_instance_of(Addrinfo)
+    end
+
+    it 'uses 127.0.0.1 as the IP address' do
+      @sock.connect_address.ip_address.should == '127.0.0.1'
+    end
+
+    it 'uses the correct port number' do
+      @sock.connect_address.ip_port.should > 0
+    end
+
+    it 'uses AF_INET as the address family' do
+      @sock.connect_address.afamily.should == Socket::AF_INET
+    end
+
+    it 'uses PF_INET as the address family' do
+      @sock.connect_address.pfamily.should == Socket::PF_INET
+    end
+
+    it 'uses SOCK_STREAM as the socket type' do
+      @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+    end
+
+    it 'uses 0 as the protocol' do
+      @sock.connect_address.protocol.should == 0
+    end
+  end
+
+  guard -> { SocketSpecs.ipv6_available? } do
+    describe 'using a socket bound to ::' do
+      before do
+        @sock = Socket.new(:INET6, :STREAM)
+        @sock.bind(Socket.sockaddr_in(0, '::'))
+      end
+
+      after do
+        @sock.close
+      end
+
+      it 'returns an Addrinfo' do
+        @sock.connect_address.should be_an_instance_of(Addrinfo)
+      end
+
+      it 'uses ::1 as the IP address' do
+        @sock.connect_address.ip_address.should == '::1'
+      end
+
+      it 'uses the correct port number' do
+        @sock.connect_address.ip_port.should > 0
+      end
+
+      it 'uses AF_INET6 as the address family' do
+        @sock.connect_address.afamily.should == Socket::AF_INET6
+      end
+
+      it 'uses PF_INET6 as the address family' do
+        @sock.connect_address.pfamily.should == Socket::PF_INET6
+      end
+
+      it 'uses SOCK_STREAM as the socket type' do
+        @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+      end
+
+      it 'uses 0 as the protocol' do
+        @sock.connect_address.protocol.should == 0
+      end
+    end
+  end
+
+  with_feature :unix_socket do
+    platform_is_not :aix do
+      describe 'using an unbound UNIX socket' do
+        before do
+          @path = SocketSpecs.socket_path
+          @server = UNIXServer.new(@path)
+          @client = UNIXSocket.new(@path)
+        end
+
+        after do
+          @client.close
+          @server.close
+          rm_r(@path)
+        end
+
+        it 'raises SocketError' do
+          -> { @client.connect_address }.should raise_error(SocketError)
+        end
+      end
+    end
+
+    describe 'using a bound UNIX socket' do
+      before do
+        @path = SocketSpecs.socket_path
+        @sock = UNIXServer.new(@path)
+      end
+
+      after do
+        @sock.close
+        rm_r(@path)
+      end
+
+      it 'returns an Addrinfo' do
+        @sock.connect_address.should be_an_instance_of(Addrinfo)
+      end
+
+      it 'uses the correct socket path' do
+        @sock.connect_address.unix_path.should == @path
+      end
+
+      it 'uses AF_UNIX as the address family' do
+        @sock.connect_address.afamily.should == Socket::AF_UNIX
+      end
+
+      it 'uses PF_UNIX as the protocol family' do
+        @sock.connect_address.pfamily.should == Socket::PF_UNIX
+      end
+
+      it 'uses SOCK_STREAM as the socket type' do
+        @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+      end
+
+      it 'uses 0 as the protocol' do
+        @sock.connect_address.protocol.should == 0
+      end
+    end
+  end
+end

--- a/spec/library/socket/basicsocket/connect_address_spec.rb
+++ b/spec/library/socket/basicsocket/connect_address_spec.rb
@@ -10,7 +10,9 @@ describe 'Socket#connect_address' do
     it 'raises SocketError' do
       @sock = Socket.new(:INET, :STREAM)
 
-      -> { @sock.connect_address }.should raise_error(SocketError)
+      NATFIXME 'using an unbound socket raises SocketError', exception: SpecFailedException do
+        -> { @sock.connect_address }.should raise_error(SocketError)
+      end
     end
   end
 
@@ -29,7 +31,9 @@ describe 'Socket#connect_address' do
     end
 
     it 'uses 127.0.0.1 as the IP address' do
-      @sock.connect_address.ip_address.should == '127.0.0.1'
+      NATFIXME 'uses 127.0.0.1 as the IP address', exception: SpecFailedException do
+        @sock.connect_address.ip_address.should == '127.0.0.1'
+      end
     end
 
     it 'uses the correct port number' do
@@ -41,11 +45,15 @@ describe 'Socket#connect_address' do
     end
 
     it 'uses PF_INET as the address family' do
-      @sock.connect_address.pfamily.should == Socket::PF_INET
+      NATFIXME 'uses PF_INET as the address family', exception: SpecFailedException do
+        @sock.connect_address.pfamily.should == Socket::PF_INET
+      end
     end
 
     it 'uses SOCK_STREAM as the socket type' do
-      @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+      NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+        @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+      end
     end
 
     it 'uses 0 as the protocol' do
@@ -69,7 +77,9 @@ describe 'Socket#connect_address' do
       end
 
       it 'uses ::1 as the IP address' do
-        @sock.connect_address.ip_address.should == '::1'
+        NATFIXME 'uses ::1 as the IP address', exception: SpecFailedException do
+          @sock.connect_address.ip_address.should == '::1'
+        end
       end
 
       it 'uses the correct port number' do
@@ -81,11 +91,15 @@ describe 'Socket#connect_address' do
       end
 
       it 'uses PF_INET6 as the address family' do
-        @sock.connect_address.pfamily.should == Socket::PF_INET6
+        NATFIXME 'uses PF_INET6 as the address family', exception: SpecFailedException do
+          @sock.connect_address.pfamily.should == Socket::PF_INET6
+        end
       end
 
       it 'uses SOCK_STREAM as the socket type' do
-        @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+        NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+          @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+        end
       end
 
       it 'uses 0 as the protocol' do
@@ -110,7 +124,9 @@ describe 'Socket#connect_address' do
         end
 
         it 'raises SocketError' do
-          -> { @client.connect_address }.should raise_error(SocketError)
+          NATFIXME 'using an unbound UNIX socket raises SocketError', exception: SpecFailedException do
+            -> { @client.connect_address }.should raise_error(SocketError)
+          end
         end
       end
     end
@@ -139,11 +155,15 @@ describe 'Socket#connect_address' do
       end
 
       it 'uses PF_UNIX as the protocol family' do
-        @sock.connect_address.pfamily.should == Socket::PF_UNIX
+        NATFIXME 'uses PF_UNIX as the protocol family', exception: SpecFailedException do
+          @sock.connect_address.pfamily.should == Socket::PF_UNIX
+        end
       end
 
       it 'uses SOCK_STREAM as the socket type' do
-        @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+        NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+          @sock.connect_address.socktype.should == Socket::SOCK_STREAM
+        end
       end
 
       it 'uses 0 as the protocol' do

--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -15,6 +15,11 @@ describe 'Addrinfo' do
       addrinfo = Addrinfo.new(Socket.pack_sockaddr_un('socket'))
       addrinfo.afamily.should == Socket::AF_UNIX
     end
+
+    it 'works with the result of BasicSocket#getsockname (which is often smaller than sizeof(struct sockaddr))' do
+      addrinfo = Addrinfo.new("\x01\x00/tmp/sock\x00".b)
+      addrinfo.afamily.should == Socket::AF_UNIX
+    end
   end
 end
 

--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -16,9 +16,12 @@ describe 'Addrinfo' do
       addrinfo.afamily.should == Socket::AF_UNIX
     end
 
-    it 'works with the result of BasicSocket#getsockname (which is often smaller than sizeof(struct sockaddr))' do
-      addrinfo = Addrinfo.new("\x01\x00/tmp/sock\x00".b)
-      addrinfo.afamily.should == Socket::AF_UNIX
+    # This test uses a binary dump of struct sockaddr, which may differ between platforms.
+    platform_is :linux do
+      it 'works with the result of BasicSocket#getsockname (which is often smaller than sizeof(struct sockaddr))' do
+        addrinfo = Addrinfo.new("\x01\x00/tmp/sock\x00".b)
+        addrinfo.afamily.should == Socket::AF_UNIX
+      end
     end
   end
 end

--- a/test/natalie/socket_test.rb
+++ b/test/natalie/socket_test.rb
@@ -50,6 +50,23 @@ describe 'Socket' do
 
     t.join
   end
+
+  describe 'Socket.unpack_sockaddr_un' do
+    before :each do
+      @path = SocketSpecs.socket_path
+      @server = UNIXServer.new(@path)
+    end
+
+    after :each do
+      @server.close if @server
+      rm_r @path
+    end
+
+    it 'can unpack the result of BasicSocket#getsockname (which is often smaller than sizeof(struct sockaddr_un))' do
+      packed = @server.getsockname
+      Socket.unpack_sockaddr_un(packed).should == @path
+    end
+  end
 end
 
 describe 'UNIXServer' do


### PR DESCRIPTION
The method still skips some information, but this resolves the "NOT YET IMPLEMENTED" panic in the specs of `BasicSocket#connect_address`.
It does include some additional fixes regarding UNIX sockets.