### PR TITLE
Use Ruby 3.3 in macos tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           brew uninstall -f ruby
           brew uninstall -f ruby@3.0
-          brew install ruby@3.2
+          brew install ruby@3.3
       - name: check ruby
         env:
           PATH: "/usr/local/opt/ruby/bin:/usr/local/bin/:/usr/bin"


### PR DESCRIPTION
According to https://formulae.brew.sh/formula/ruby Ruby 3.3 is now available.