### PR TITLE
Change implementation of Addrinfo.unix

### DIFF
--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -224,7 +224,7 @@ class Addrinfo
     end
 
     def unix(path)
-      Addrinfo.new(Socket.pack_sockaddr_un(path))
+      Addrinfo.new([:UNIX, path])
     end
   end
 

--- a/spec/library/socket/addrinfo/unix_spec.rb
+++ b/spec/library/socket/addrinfo/unix_spec.rb
@@ -15,9 +15,7 @@ with_feature :unix_socket do
     end
 
     it 'sets the protocol family' do
-      NATFIXME 'sets the protocol family', exception: SpecFailedException do
-        Addrinfo.unix('socket').pfamily.should == Socket::PF_UNIX
-      end
+      Addrinfo.unix('socket').pfamily.should == Socket::PF_UNIX
     end
 
     it 'sets the socket type' do


### PR DESCRIPTION
Replace the pack with an array. This looks to me like the more straightforward implementation (the old one packs the path into a binary string just to immediately unpack it again), and it accidentally fixes an issue in the specs.