### PR TITLE
Update Array#rassoc to call #to_ary

### DIFF
--- a/spec/core/array/rassoc_spec.rb
+++ b/spec/core/array/rassoc_spec.rb
@@ -42,13 +42,11 @@ describe "Array#rassoc" do
       s2 = ArraySpecs::ArrayConvertible.new(2, 3)
       a = [s1, s2]
 
-      NATFIXME 'calls to_ary on non-array elements', exception: SpecFailedException do
-        s1.should_not_receive(:to_ary)
-        a.rassoc(2).should equal(s1)
+      s1.should_not_receive(:to_ary)
+      a.rassoc(2).should equal(s1)
 
-        a.rassoc(3).should == [2, 3]
-        s2.called.should equal(:to_ary)
-      end
+      a.rassoc(3).should == [2, 3]
+      s2.called.should equal(:to_ary)
     end
   end
 end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1497,10 +1497,10 @@ Value ArrayObject::bsearch_index(Env *env, Block *block) {
 
 Value ArrayObject::rassoc(Env *env, Value needle) {
     for (auto &item : *this) {
-        if (!item->is_array())
+        if (!item->is_array() && !item->respond_to(env, "to_ary"_s))
             continue;
 
-        ArrayObject *sub_array = item->as_array();
+        ArrayObject *sub_array = item->to_ary(env);
         if (sub_array->size() < 2)
             continue;
 


### PR DESCRIPTION
This fixes a Ruby 3.3 compatibility issue