### PR TITLE
Import specs for BasicSocket#local_address and subclasses

### DIFF
--- a/spec/library/socket/basicsocket/local_address_spec.rb
+++ b/spec/library/socket/basicsocket/local_address_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../spec_helper'
+require_relative '../shared/address'
+
+describe 'BasicSocket#local_address' do
+  it_behaves_like :socket_local_remote_address, :local_address, -> socket {
+    a2 = BasicSocket.for_fd(socket.fileno)
+    a2.autoclose = false
+    a2.local_address
+  }
+end

--- a/spec/library/socket/shared/address.rb
+++ b/spec/library/socket/shared/address.rb
@@ -60,15 +60,13 @@ describe :socket_local_remote_address, shared: true do
     end
 
     it 'can be used to connect to the server' do
-      NATFIXME 'Fix `skip` without arguments', condition: @method == :local_address, exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-        skip if @method == :local_address
-          NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
-          b = @addr.connect
-          begin
-            b.remote_address.to_s.should == @addr.to_s
-          ensure
-            b.close
-          end
+      skip if @method == :local_address
+      NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
+        b = @addr.connect
+        begin
+          b.remote_address.to_s.should == @addr.to_s
+        ensure
+          b.close
         end
       end
     end
@@ -198,15 +196,13 @@ describe :socket_local_remote_address, shared: true do
       end
 
       it 'can be used to connect to the server' do
-        NATFIXME 'Fix `skip` without arguments', condition: @method == :local_address, exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
-          skip if @method == :local_address
-          NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
-            b = @addr.connect
-            begin
-              b.remote_address.to_s.should == @addr.to_s
-            ensure
-              b.close
-            end
+        skip if @method == :local_address
+        NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
+          b = @addr.connect
+          begin
+            b.remote_address.to_s.should == @addr.to_s
+          ensure
+            b.close
           end
         end
       end

--- a/spec/library/socket/shared/address.rb
+++ b/spec/library/socket/shared/address.rb
@@ -42,10 +42,10 @@ describe :socket_local_remote_address, shared: true do
     end
 
     it 'equals address of peer socket' do
-      if @method == :local_address
-        @addr.to_s.should == @b.remote_address.to_s
-      else
-        NATFIXME 'Implement Addrinfo#to_s', exception: SpecFailedException do
+      NATFIXME 'Implement Addrinfo#to_s', exception: SpecFailedException do
+        if @method == :local_address
+          @addr.to_s.should == @b.remote_address.to_s
+        else
           @addr.to_s.should == @b.local_address.to_s
         end
       end
@@ -60,13 +60,15 @@ describe :socket_local_remote_address, shared: true do
     end
 
     it 'can be used to connect to the server' do
-      skip if @method == :local_address
-        NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
-        b = @addr.connect
-        begin
-          b.remote_address.to_s.should == @addr.to_s
-        ensure
-          b.close
+      NATFIXME 'Fix `skip` without arguments', condition: @method == :local_address, exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+        skip if @method == :local_address
+          NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
+          b = @addr.connect
+          begin
+            b.remote_address.to_s.should == @addr.to_s
+          ensure
+            b.close
+          end
         end
       end
     end
@@ -178,10 +180,10 @@ describe :socket_local_remote_address, shared: true do
       end
 
       it 'equals address of peer socket' do
-        if @method == :local_address
-          @addr.to_s.should == @b.remote_address.to_s
-        else
-          NATFIXME 'Implement Addrinfo#to_s', exception: SpecFailedException do
+        NATFIXME 'Implement Addrinfo#to_s', exception: SpecFailedException do
+          if @method == :local_address
+            @addr.to_s.should == @b.remote_address.to_s
+          else
             @addr.to_s.should == @b.local_address.to_s
           end
         end
@@ -196,13 +198,15 @@ describe :socket_local_remote_address, shared: true do
       end
 
       it 'can be used to connect to the server' do
-        skip if @method == :local_address
-        NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
-          b = @addr.connect
-          begin
-            b.remote_address.to_s.should == @addr.to_s
-          ensure
-            b.close
+        NATFIXME 'Fix `skip` without arguments', condition: @method == :local_address, exception: ArgumentError, message: 'wrong number of arguments (given 0, expected 1)' do
+          skip if @method == :local_address
+          NATFIXME 'Implement Addrinfo#connect', exception: NoMethodError, message: "undefined method `connect' for an instance of Addrinfo" do
+            b = @addr.connect
+            begin
+              b.remote_address.to_s.should == @addr.to_s
+            ensure
+              b.close
+            end
           end
         end
       end

--- a/spec/library/socket/socket/local_address_spec.rb
+++ b/spec/library/socket/socket/local_address_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../spec_helper'
+
+describe 'Socket#local_address' do
+  before do
+    @sock = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, Socket::IPPROTO_TCP)
+  end
+
+  after do
+    @sock.close
+  end
+
+  it 'returns an Addrinfo' do
+    @sock.local_address.should be_an_instance_of(Addrinfo)
+  end
+
+  describe 'the returned Addrinfo' do
+    it 'uses AF_INET as the address family' do
+      @sock.local_address.afamily.should == Socket::AF_INET
+    end
+
+    it 'uses PF_INET as the protocol family' do
+      NATFIXME 'uses PF_INET as the protocol family', exception: SpecFailedException do
+        @sock.local_address.pfamily.should == Socket::PF_INET
+      end
+    end
+
+    it 'uses SOCK_STREAM as the socket type' do
+      NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+        @sock.local_address.socktype.should == Socket::SOCK_STREAM
+      end
+    end
+
+    it 'uses 0.0.0.0 as the IP address' do
+      @sock.local_address.ip_address.should == '0.0.0.0'
+    end
+
+    platform_is_not :windows do
+      it 'uses 0 as the port' do
+        @sock.local_address.ip_port.should == 0
+      end
+    end
+
+    it 'uses 0 as the protocol' do
+      @sock.local_address.protocol.should == 0
+    end
+  end
+end

--- a/spec/library/socket/tcpsocket/local_address_spec.rb
+++ b/spec/library/socket/tcpsocket/local_address_spec.rb
@@ -1,0 +1,77 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe 'TCPSocket#local_address' do
+  SocketSpecs.each_ip_protocol do |family, ip_address|
+    before do
+      @server = TCPServer.new(ip_address, 0)
+      @host   = @server.connect_address.ip_address
+      @port   = @server.connect_address.ip_port
+    end
+
+    after do
+      @server.close
+    end
+
+    describe 'using an explicit hostname' do
+      before do
+        @sock = TCPSocket.new(@host, @port)
+      end
+
+      after do
+        @sock.close
+      end
+
+      it 'returns an Addrinfo' do
+        @sock.local_address.should be_an_instance_of(Addrinfo)
+      end
+
+      describe 'the returned Addrinfo' do
+        it 'uses AF_INET as the address family' do
+          @sock.local_address.afamily.should == family
+        end
+
+        it 'uses PF_INET as the protocol family' do
+          NATFIXME 'uses PF_INET as the protocol family', exception: SpecFailedException do
+            @sock.local_address.pfamily.should == family
+          end
+        end
+
+        it 'uses SOCK_STREAM as the socket type' do
+          NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+            @sock.local_address.socktype.should == Socket::SOCK_STREAM
+          end
+        end
+
+        it 'uses the correct IP address' do
+          @sock.local_address.ip_address.should == @host
+        end
+
+        it 'uses a randomly assigned local port' do
+          @sock.local_address.ip_port.should > 0
+          @sock.local_address.ip_port.should_not == @port
+        end
+
+        it 'uses 0 as the protocol' do
+          @sock.local_address.protocol.should == 0
+        end
+      end
+    end
+
+    describe 'using an implicit hostname' do
+      before do
+        @sock = TCPSocket.new(nil, @port)
+      end
+
+      after do
+        @sock.close
+      end
+
+      describe 'the returned Addrinfo' do
+        it 'uses the correct IP address' do
+          @sock.local_address.ip_address.should == @host
+        end
+      end
+    end
+  end
+end

--- a/spec/library/socket/unixsocket/local_address_spec.rb
+++ b/spec/library/socket/unixsocket/local_address_spec.rb
@@ -1,0 +1,102 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+with_feature :unix_socket do
+  describe 'UNIXSocket#local_address' do
+    before do
+      @path   = SocketSpecs.socket_path
+      @server = UNIXServer.new(@path)
+      @client = UNIXSocket.new(@path)
+    end
+
+    after do
+      @client.close
+      @server.close
+
+      rm_r(@path)
+    end
+
+    it 'returns an Addrinfo' do
+      @client.local_address.should be_an_instance_of(Addrinfo)
+    end
+
+    describe 'the returned Addrinfo' do
+      platform_is_not :aix do
+        it 'uses AF_UNIX as the address family' do
+          @client.local_address.afamily.should == Socket::AF_UNIX
+        end
+
+        it 'uses PF_UNIX as the protocol family' do
+          NATFIXME 'uses PF_UNIX as the protocol family', exception: SpecFailedException do
+            @client.local_address.pfamily.should == Socket::PF_UNIX
+          end
+        end
+      end
+
+      it 'uses SOCK_STREAM as the socket type' do
+        NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+          @client.local_address.socktype.should == Socket::SOCK_STREAM
+        end
+      end
+
+      platform_is_not :aix do
+        it 'uses an empty socket path' do
+          @client.local_address.unix_path.should == ''
+        end
+      end
+
+      it 'uses 0 as the protocol' do
+        @client.local_address.protocol.should == 0
+      end
+    end
+  end
+
+  describe 'UNIXSocket#local_address with a UNIX socket pair' do
+    before :each do
+      @sock, @sock2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+    end
+
+    after :each do
+      @sock.close
+      @sock2.close
+    end
+
+    it 'returns an Addrinfo' do
+      @sock.local_address.should be_an_instance_of(Addrinfo)
+    end
+
+    describe 'the returned Addrinfo' do
+      it 'uses AF_UNIX as the address family' do
+        @sock.local_address.afamily.should == Socket::AF_UNIX
+      end
+
+      it 'uses PF_UNIX as the protocol family' do
+        NATFIXME 'uses PF_UNIX as the protocol family', exception: SpecFailedException do
+          @sock.local_address.pfamily.should == Socket::PF_UNIX
+        end
+      end
+
+      it 'uses SOCK_STREAM as the socket type' do
+        NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+          @sock.local_address.socktype.should == Socket::SOCK_STREAM
+        end
+      end
+
+      it 'raises SocketError for #ip_address' do
+        -> {
+          @sock.local_address.ip_address
+        }.should raise_error(SocketError, "need IPv4 or IPv6 address")
+      end
+
+      it 'raises SocketError for #ip_port' do
+        -> {
+          @sock.local_address.ip_port
+        }.should raise_error(SocketError, "need IPv4 or IPv6 address")
+      end
+
+      it 'uses 0 as the protocol' do
+        @sock.local_address.protocol.should == 0
+      end
+    end
+  end
+end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -152,7 +152,9 @@ def xit(test, &block)
   @specs << [$context.dup, test, nil]
 end
 
-alias skip xit
+def skip(test = nil, &block)
+  xit(test, &block)
+end
 
 def it_behaves_like(behavior, method, obj = nil)
   before :all do


### PR DESCRIPTION
We should really fix those issues with `Addrinfo#pfamily` and `Addrinfo#socktype`