### PR TITLE
Remove type assertion in Regexp.compile

### DIFF
--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -50,7 +50,6 @@ public:
     }
 
     static Value compile(Env *env, Value pattern, Value flags = nullptr, ClassObject *klass = nullptr) {
-        pattern->assert_type(env, Object::Type::String, "String");
         if (!klass)
             klass = GlobalEnv::the()->Regexp();
         RegexpObject *regexp = new RegexpObject { klass };

--- a/spec/core/regexp/compile_spec.rb
+++ b/spec/core/regexp/compile_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'shared/new'
+
+describe "Regexp.compile" do
+  it_behaves_like :regexp_new, :compile
+end
+
+describe "Regexp.compile given a String" do
+  it_behaves_like :regexp_new_string, :compile
+  it_behaves_like :regexp_new_string_binary, :compile
+end
+
+describe "Regexp.compile given a Regexp" do
+  it_behaves_like :regexp_new_regexp, :compile
+end
+
+describe "Regexp.compile given a non-String/Regexp" do
+  it_behaves_like :regexp_new_non_string_or_regexp, :compile
+end


### PR DESCRIPTION
This is just an alias for `Regexp.new`, no extra checks are required. This fixes 9 issues in the specs, which I think is a pretty good score for removing code :D