### PR TITLE
Fix calls to _error in Zlib_do_inflate

### DIFF
--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -143,7 +143,6 @@ void Zlib_do_inflate(Env *env, Value self, const String &string, int flush) {
 
             switch (ret) {
             case Z_NEED_DICT:
-                ret = Z_DATA_ERROR;
                 inflateEnd(strm);
                 self->klass()->send(env, "_error"_s, { Value::integer(ret) });
                 break;

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -142,12 +142,9 @@ void Zlib_do_inflate(Env *env, Value self, const String &string, int flush) {
             ret = inflate(strm, Z_NO_FLUSH);
 
             switch (ret) {
-            case Z_NEED_DICT:
-                inflateEnd(strm);
-                self->klass()->send(env, "_error"_s, { Value::integer(ret) });
-                break;
             case Z_DATA_ERROR:
             case Z_MEM_ERROR:
+            case Z_NEED_DICT:
                 inflateEnd(strm);
                 self->klass()->send(env, "_error"_s, { Value::integer(ret) });
                 break;

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -145,12 +145,12 @@ void Zlib_do_inflate(Env *env, Value self, const String &string, int flush) {
             case Z_NEED_DICT:
                 ret = Z_DATA_ERROR;
                 inflateEnd(strm);
-                self->send(env, "_error"_s, { Value::integer(ret) });
+                self->klass()->send(env, "_error"_s, { Value::integer(ret) });
                 break;
             case Z_DATA_ERROR:
             case Z_MEM_ERROR:
                 inflateEnd(strm);
-                self->send(env, "_error"_s, { Value::integer(ret) });
+                self->klass()->send(env, "_error"_s, { Value::integer(ret) });
                 break;
             case Z_STREAM_ERROR: {
                 auto Error = fetch_nested_const({ "Zlib"_s, "Error"_s })->as_class_or_raise(env);


### PR DESCRIPTION
This is a class method, not an instance method.
The current isuse is visible in the nightly specs of `library/zlib/inflate/set_dictionary_spec.rb`:
```
undefined method `_error' for an instance of Zlib::Inflate
```
With this change, we still raise the wrong exception, but at least the first step is fixed.