### PR TITLE
Fix streaming interface for Zlib

### DIFF
--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -86,7 +86,7 @@ Value Zlib_deflate_append(Env *env, Value self, Args args, Block *) {
 
     Zlib_do_deflate(env, self, string->string(), Z_NO_FLUSH);
 
-    return string;
+    return self;
 }
 
 Value Zlib_deflate_close(Env *env, Value self, Args args, Block *) {
@@ -171,7 +171,7 @@ Value Zlib_inflate_append(Env *env, Value self, Args args, Block *) {
 
     Zlib_do_inflate(env, self, string->string(), Z_NO_FLUSH);
 
-    return string;
+    return self;
 }
 
 Value Zlib_inflate_finish(Env *env, Value self, Args args, Block *) {

--- a/test/natalie/zlib_test.rb
+++ b/test/natalie/zlib_test.rb
@@ -32,6 +32,12 @@ describe 'Zlib' do
       deflated.bytes.should == "x\x9C\xAB\xA8\xAC\xAA\x18E\xC4!\x00a\xAF\x8D\xCD".force_encoding('ASCII-8BIT').bytes
     end
 
+    it 'returns itself in the streaming interface' do
+      zstream = Zlib::Deflate.new
+      zstream << 'foo' << 'bar'
+      zstream.finish.should == Zlib.deflate('foobar')
+    end
+
     it 'raises an error after the stream is closed' do
       zstream = Zlib::Deflate.new
       zstream.close
@@ -63,6 +69,17 @@ describe 'Zlib' do
       end
       inflated = zstream.finish                                                                                                                                                               
       zstream.close                                                                                                                                                                           
+      inflated.should == 'hello world'
+    end
+
+    it 'returns itself in the streaming interface' do
+      deflated = "x\x9C\xCBH\xCD\xC9\xC9W(\xCF/\xCAI\x01\x00\x1A\v\x04]".force_encoding('ASCII-8BIT')
+      zstream = Zlib::Inflate.new
+      deflated.chars.each_slice(5) do |chunk|
+        (zstream << chunk.join).should == zstream
+      end
+      inflated = zstream.finish
+      zstream.close
       inflated.should == 'hello world'
     end
 

--- a/test/natalie/zlib_test.rb
+++ b/test/natalie/zlib_test.rb
@@ -23,12 +23,12 @@ describe 'Zlib' do
 
     it 'deflates in chunks' do
       inflated = 'xyz' * 100
-      zstream = Zlib::Deflate.new                                                                                                                                                             
+      zstream = Zlib::Deflate.new
       inflated.chars.each_slice(50) do |chunk|
         zstream << chunk.join
       end
-      deflated = zstream.finish                                                                                                                                                               
-      zstream.close                                                                                                                                                                           
+      deflated = zstream.finish
+      zstream.close
       deflated.bytes.should == "x\x9C\xAB\xA8\xAC\xAA\x18E\xC4!\x00a\xAF\x8D\xCD".force_encoding('ASCII-8BIT').bytes
     end
 


### PR DESCRIPTION
The general idea for the method `<<` is to return itself, so they can be chained.
This PR includes two new tests, the test for deflate explicitly tests for the return value, the test for deflate adds an implicit test by chaining two appends. This is done because the chaining makes sense for plaintext input, but would feel very much out of place for the binary input of deflate.