### PR TITLE
Refresh specs for syntax error

### DIFF
--- a/spec/command_line/syntax_error_spec.rb
+++ b/spec/command_line/syntax_error_spec.rb
@@ -3,11 +3,17 @@ require_relative '../spec_helper'
 describe "The interpreter" do
   it "prints an error when given a file with invalid syntax" do
     out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), args: "2>&1", exit_status: 1)
-    out.should include "syntax error"
+
+    # it's tempting not to rely on error message and rely only on exception class name,
+    # but CRuby before 3.2 doesn't print class name for syntax error
+    out.should include_any_of("syntax error", "SyntaxError")
   end
 
   it "prints an error when given code via -e with invalid syntax" do
     out = ruby_exe(nil, args: "-e 'a{' 2>&1", exit_status: 1)
-    out.should include "syntax error"
+
+    # it's tempting not to rely on error message and rely only on exception class name,
+    # but CRuby before 3.2 doesn't print class name for syntax error
+    out.should include_any_of("syntax error", "SyntaxError")
   end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1157,6 +1157,24 @@ class IncludeExpectation
   end
 end
 
+class IncludeAnyExpectation
+  def initialize(values)
+    @values = values
+  end
+
+  def match(subject)
+    if @values.none? { |value| subject.include?(value) }
+      raise SpecFailedException, "#{subject.inspect} should include any of #{@values}"
+    end
+  end
+
+  def inverted_match(subject)
+    if @values.any? { |value| subject.include?(value) }
+      raise SpecFailedException, "#{subject.inspect} should not include any of #{@values}"
+    end
+  end
+end
+
 class HaveConstantExpectation
   def initialize(constant)
     @constant = constant.to_sym
@@ -1402,6 +1420,10 @@ class Object
 
   def include(*values)
     IncludeExpectation.new(values)
+  end
+
+  def include_any_of(*values)
+    IncludeAnyExpectation.new(values)
   end
 
   # FIXME: the above method is visible to tests in **Natalie** but not MRI, and I don't know why.


### PR DESCRIPTION
This includes the new `include_any_of` in the spec runner.