### PR TITLE
Import net-http gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | `prettyprint.rb` | Yukihiro Matsumoto                | BSD               |
 | `shellwords.rb`  | Akinori MUSHA                     | BSD               |
 | `spec/*`         | Engine Yard, Inc.                 | MIT               |
+| `timeout.rb`     | Network Applied Communication Laboratory, Inc. and Information-technology Promotion Agency, Japan | BSD |
 | `uri.rb`         | Akira Yamada                      | BSD               |
 | `uri/*`          | Akira Yamada                      | BSD               |
 | `version.rb`     | Engine Yard, Inc.                 | MIT               |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | `find.rb`        | Kazuki Tsujimoto                  | BSD               |
 | `linenoise`      | S. Sanfilippo and P. Noordhuis    | BSD               |
 | `minicoro.h`     | Eduardo Bart                      | MIT               |
+| `net/*`          | Yukihiro Matsumoto, Minero Aoki   | BSD               |
 | `pp.rb`          | Yukihiro Matsumoto                | BSD               |
 | `prettyprint.rb` | Yukihiro Matsumoto                | BSD               |
 | `shellwords.rb`  | Akinori MUSHA                     | BSD               |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | `net/*`          | Yukihiro Matsumoto, Minero Aoki   | BSD               |
 | `pp.rb`          | Yukihiro Matsumoto                | BSD               |
 | `prettyprint.rb` | Yukihiro Matsumoto                | BSD               |
+| `resolv.rb`      | Yukihiro Matsumoto                | BSD               |
 | `shellwords.rb`  | Akinori MUSHA                     | BSD               |
 | `spec/*`         | Engine Yard, Inc.                 | MIT               |
 | `timeout.rb`     | Network Applied Communication Laboratory, Inc. and Information-technology Promotion Agency, Japan | BSD |

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1,0 +1,2496 @@
+# frozen_string_literal: true
+#
+# = net/http.rb
+#
+# Copyright (c) 1999-2007 Yukihiro Matsumoto
+# Copyright (c) 1999-2007 Minero Aoki
+# Copyright (c) 2001 GOTOU Yuuzou
+#
+# Written and maintained by Minero Aoki <aamine@loveruby.net>.
+# HTTPS support added by GOTOU Yuuzou <gotoyuzo@notwork.org>.
+#
+# This file is derived from "http-access.rb".
+#
+# Documented by Minero Aoki; converted to RDoc by William Webber.
+#
+# This program is free software. You can re-distribute and/or
+# modify this program under the same terms of ruby itself ---
+# Ruby Distribution License or GNU General Public License.
+#
+# See Net::HTTP for an overview and examples.
+#
+
+require 'net/protocol'
+require 'uri'
+require 'resolv'
+autoload :OpenSSL, 'openssl'
+
+module Net   #:nodoc:
+
+  # :stopdoc:
+  class HTTPBadResponse < StandardError; end
+  class HTTPHeaderSyntaxError < StandardError; end
+  # :startdoc:
+
+  # \Class \Net::HTTP provides a rich library that implements the client
+  # in a client-server model that uses the \HTTP request-response protocol.
+  # For information about \HTTP, see:
+  #
+  # - {Hypertext Transfer Protocol}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol].
+  # - {Technical overview}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Technical_overview].
+  #
+  # == About the Examples
+  #
+  # :include: doc/net-http/examples.rdoc
+  #
+  # == Strategies
+  #
+  # - If you will make only a few GET requests,
+  #   consider using {OpenURI}[rdoc-ref:OpenURI].
+  # - If you will make only a few requests of all kinds,
+  #   consider using the various singleton convenience methods in this class.
+  #   Each of the following methods automatically starts and finishes
+  #   a {session}[rdoc-ref:Net::HTTP@Sessions] that sends a single request:
+  #
+  #     # Return string response body.
+  #     Net::HTTP.get(hostname, path)
+  #     Net::HTTP.get(uri)
+  #
+  #     # Write string response body to $stdout.
+  #     Net::HTTP.get_print(hostname, path)
+  #     Net::HTTP.get_print(uri)
+  #
+  #     # Return response as Net::HTTPResponse object.
+  #     Net::HTTP.get_response(hostname, path)
+  #     Net::HTTP.get_response(uri)
+  #     data = '{"title": "foo", "body": "bar", "userId": 1}'
+  #     Net::HTTP.post(uri, data)
+  #     params = {title: 'foo', body: 'bar', userId: 1}
+  #     Net::HTTP.post_form(uri, params)
+  #
+  # - If performance is important, consider using sessions, which lower request overhead.
+  #   This {session}[rdoc-ref:Net::HTTP@Sessions] has multiple requests for
+  #   {HTTP methods}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods]
+  #   and {WebDAV methods}[https://en.wikipedia.org/wiki/WebDAV#Implementation]:
+  #
+  #     Net::HTTP.start(hostname) do |http|
+  #       # Session started automatically before block execution.
+  #       http.get(path)
+  #       http.head(path)
+  #       body = 'Some text'
+  #       http.post(path, body)  # Can also have a block.
+  #       http.put(path, body)
+  #       http.delete(path)
+  #       http.options(path)
+  #       http.trace(path)
+  #       http.patch(path, body) # Can also have a block.
+  #       http.copy(path)
+  #       http.lock(path, body)
+  #       http.mkcol(path, body)
+  #       http.move(path)
+  #       http.propfind(path, body)
+  #       http.proppatch(path, body)
+  #       http.unlock(path, body)
+  #       # Session finished automatically at block exit.
+  #     end
+  #
+  # The methods cited above are convenience methods that, via their few arguments,
+  # allow minimal control over the requests.
+  # For greater control, consider using {request objects}[rdoc-ref:Net::HTTPRequest].
+  #
+  # == URIs
+  #
+  # On the internet, a URI
+  # ({Universal Resource Identifier}[https://en.wikipedia.org/wiki/Uniform_Resource_Identifier])
+  # is a string that identifies a particular resource.
+  # It consists of some or all of: scheme, hostname, path, query, and fragment;
+  # see {URI syntax}[https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax].
+  #
+  # A Ruby {URI::Generic}[rdoc-ref:URI::Generic] object
+  # represents an internet URI.
+  # It provides, among others, methods
+  # +scheme+, +hostname+, +path+, +query+, and +fragment+.
+  #
+  # === Schemes
+  #
+  # An internet \URI has
+  # a {scheme}[https://en.wikipedia.org/wiki/List_of_URI_schemes].
+  #
+  # The two schemes supported in \Net::HTTP are <tt>'https'</tt> and <tt>'http'</tt>:
+  #
+  #   uri.scheme                       # => "https"
+  #   URI('http://example.com').scheme # => "http"
+  #
+  # === Hostnames
+  #
+  # A hostname identifies a server (host) to which requests may be sent:
+  #
+  #   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+  #   Net::HTTP.start(hostname) do |http|
+  #     # Some HTTP stuff.
+  #   end
+  #
+  # === Paths
+  #
+  # A host-specific path identifies a resource on the host:
+  #
+  #   _uri = uri.dup
+  #   _uri.path = '/todos/1'
+  #   hostname = _uri.hostname
+  #   path = _uri.path
+  #   Net::HTTP.get(hostname, path)
+  #
+  # === Queries
+  #
+  # A host-specific query adds name/value pairs to the URI:
+  #
+  #   _uri = uri.dup
+  #   params = {userId: 1, completed: false}
+  #   _uri.query = URI.encode_www_form(params)
+  #   _uri # => #<URI::HTTPS https://jsonplaceholder.typicode.com?userId=1&completed=false>
+  #   Net::HTTP.get(_uri)
+  #
+  # === Fragments
+  #
+  # A {URI fragment}[https://en.wikipedia.org/wiki/URI_fragment] has no effect
+  # in \Net::HTTP;
+  # the same data is returned, regardless of whether a fragment is included.
+  #
+  # == Request Headers
+  #
+  # Request headers may be used to pass additional information to the host,
+  # similar to arguments passed in a method call;
+  # each header is a name/value pair.
+  #
+  # Each of the \Net::HTTP methods that sends a request to the host
+  # has optional argument +headers+,
+  # where the headers are expressed as a hash of field-name/value pairs:
+  #
+  #   headers = {Accept: 'application/json', Connection: 'Keep-Alive'}
+  #   Net::HTTP.get(uri, headers)
+  #
+  # See lists of both standard request fields and common request fields at
+  # {Request Fields}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields].
+  # A host may also accept other custom fields.
+  #
+  # == \HTTP Sessions
+  #
+  # A _session_ is a connection between a server (host) and a client that:
+  #
+  # - Is begun by instance method Net::HTTP#start.
+  # - May contain any number of requests.
+  # - Is ended by instance method Net::HTTP#finish.
+  #
+  # See example sessions at {Strategies}[rdoc-ref:Net::HTTP@Strategies].
+  #
+  # === Session Using \Net::HTTP.start
+  #
+  # If you have many requests to make to a single host (and port),
+  # consider using singleton method Net::HTTP.start with a block;
+  # the method handles the session automatically by:
+  #
+  # - Calling #start before block execution.
+  # - Executing the block.
+  # - Calling #finish after block execution.
+  #
+  # In the block, you can use these instance methods,
+  # each of which that sends a single request:
+  #
+  # - {HTTP methods}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods]:
+  #
+  #   - #get, #request_get: GET.
+  #   - #head, #request_head: HEAD.
+  #   - #post, #request_post: POST.
+  #   - #delete: DELETE.
+  #   - #options: OPTIONS.
+  #   - #trace: TRACE.
+  #   - #patch: PATCH.
+  #
+  # - {WebDAV methods}[https://en.wikipedia.org/wiki/WebDAV#Implementation]:
+  #
+  #   - #copy: COPY.
+  #   - #lock: LOCK.
+  #   - #mkcol: MKCOL.
+  #   - #move: MOVE.
+  #   - #propfind: PROPFIND.
+  #   - #proppatch: PROPPATCH.
+  #   - #unlock: UNLOCK.
+  #
+  # === Session Using \Net::HTTP.start and \Net::HTTP.finish
+  #
+  # You can manage a session manually using methods #start and #finish:
+  #
+  #   http = Net::HTTP.new(hostname)
+  #   http.start
+  #   http.get('/todos/1')
+  #   http.get('/todos/2')
+  #   http.delete('/posts/1')
+  #   http.finish # Needed to free resources.
+  #
+  # === Single-Request Session
+  #
+  # Certain convenience methods automatically handle a session by:
+  #
+  # - Creating an \HTTP object
+  # - Starting a session.
+  # - Sending a single request.
+  # - Finishing the session.
+  # - Destroying the object.
+  #
+  # Such methods that send GET requests:
+  #
+  # - ::get: Returns the string response body.
+  # - ::get_print: Writes the string response body to $stdout.
+  # - ::get_response: Returns a Net::HTTPResponse object.
+  #
+  # Such methods that send POST requests:
+  #
+  # - ::post: Posts data to the host.
+  # - ::post_form: Posts form data to the host.
+  #
+  # == \HTTP Requests and Responses
+  #
+  # Many of the methods above are convenience methods,
+  # each of which sends a request and returns a string
+  # without directly using \Net::HTTPRequest and \Net::HTTPResponse objects.
+  #
+  # You can, however, directly create a request object, send the request,
+  # and retrieve the response object; see:
+  #
+  # - Net::HTTPRequest.
+  # - Net::HTTPResponse.
+  #
+  # == Following Redirection
+  #
+  # Each returned response is an instance of a subclass of Net::HTTPResponse.
+  # See the {response class hierarchy}[rdoc-ref:Net::HTTPResponse@Response+Subclasses].
+  #
+  # In particular, class Net::HTTPRedirection is the parent
+  # of all redirection classes.
+  # This allows you to craft a case statement to handle redirections properly:
+  #
+  #   def fetch(uri, limit = 10)
+  #     # You should choose a better exception.
+  #     raise ArgumentError, 'Too many HTTP redirects' if limit == 0
+  #
+  #     res = Net::HTTP.get_response(URI(uri))
+  #     case res
+  #     when Net::HTTPSuccess     # Any success class.
+  #       res
+  #     when Net::HTTPRedirection # Any redirection class.
+  #       location = res['Location']
+  #       warn "Redirected to #{location}"
+  #       fetch(location, limit - 1)
+  #     else                      # Any other class.
+  #       res.value
+  #     end
+  #   end
+  #
+  #   fetch(uri)
+  #
+  # == Basic Authentication
+  #
+  # Basic authentication is performed according to
+  # {RFC2617}[http://www.ietf.org/rfc/rfc2617.txt]:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.basic_auth('user', 'pass')
+  #   res = Net::HTTP.start(hostname) do |http|
+  #     http.request(req)
+  #   end
+  #
+  # == Streaming Response Bodies
+  #
+  # By default \Net::HTTP reads an entire response into memory.  If you are
+  # handling large files or wish to implement a progress bar you can instead
+  # stream the body directly to an IO.
+  #
+  #   Net::HTTP.start(hostname) do |http|
+  #     req = Net::HTTP::Get.new(uri)
+  #     http.request(req) do |res|
+  #       open('t.tmp', 'w') do |f|
+  #         res.read_body do |chunk|
+  #           f.write chunk
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  # == HTTPS
+  #
+  # HTTPS is enabled for an \HTTP connection by Net::HTTP#use_ssl=:
+  #
+  #   Net::HTTP.start(hostname, :use_ssl => true) do |http|
+  #     req = Net::HTTP::Get.new(uri)
+  #     res = http.request(req)
+  #   end
+  #
+  # Or if you simply want to make a GET request, you may pass in a URI
+  # object that has an \HTTPS URL. \Net::HTTP automatically turns on TLS
+  # verification if the URI object has a 'https' URI scheme:
+  #
+  #   uri # => #<URI::HTTPS https://jsonplaceholder.typicode.com/>
+  #   Net::HTTP.get(uri)
+  #
+  # == Proxy Server
+  #
+  # An \HTTP object can have
+  # a {proxy server}[https://en.wikipedia.org/wiki/Proxy_server].
+  #
+  # You can create an \HTTP object with a proxy server
+  # using method Net::HTTP.new or method Net::HTTP.start.
+  #
+  # The proxy may be defined either by argument +p_addr+
+  # or by environment variable <tt>'http_proxy'</tt>.
+  #
+  # === Proxy Using Argument +p_addr+ as a \String
+  #
+  # When argument +p_addr+ is a string hostname,
+  # the returned +http+ has the given host as its proxy:
+  #
+  #   http = Net::HTTP.new(hostname, nil, 'proxy.example')
+  #   http.proxy?          # => true
+  #   http.proxy_from_env? # => false
+  #   http.proxy_address   # => "proxy.example"
+  #   # These use default values.
+  #   http.proxy_port      # => 80
+  #   http.proxy_user      # => nil
+  #   http.proxy_pass      # => nil
+  #
+  # The port, username, and password for the proxy may also be given:
+  #
+  #   http = Net::HTTP.new(hostname, nil, 'proxy.example', 8000, 'pname', 'ppass')
+  #   # => #<Net::HTTP jsonplaceholder.typicode.com:80 open=false>
+  #   http.proxy?          # => true
+  #   http.proxy_from_env? # => false
+  #   http.proxy_address   # => "proxy.example"
+  #   http.proxy_port      # => 8000
+  #   http.proxy_user      # => "pname"
+  #   http.proxy_pass      # => "ppass"
+  #
+  # === Proxy Using '<tt>ENV['http_proxy']</tt>'
+  #
+  # When environment variable <tt>'http_proxy'</tt>
+  # is set to a \URI string,
+  # the returned +http+ will have the server at that URI as its proxy;
+  # note that the \URI string must have a protocol
+  # such as <tt>'http'</tt> or <tt>'https'</tt>:
+  #
+  #   ENV['http_proxy'] = 'http://example.com'
+  #   http = Net::HTTP.new(hostname)
+  #   http.proxy?          # => true
+  #   http.proxy_from_env? # => true
+  #   http.proxy_address   # => "example.com"
+  #   # These use default values.
+  #   http.proxy_port      # => 80
+  #   http.proxy_user      # => nil
+  #   http.proxy_pass      # => nil
+  #
+  # The \URI string may include proxy username, password, and port number:
+  #
+  #   ENV['http_proxy'] = 'http://pname:ppass@example.com:8000'
+  #   http = Net::HTTP.new(hostname)
+  #   http.proxy?          # => true
+  #   http.proxy_from_env? # => true
+  #   http.proxy_address   # => "example.com"
+  #   http.proxy_port      # => 8000
+  #   http.proxy_user      # => "pname"
+  #   http.proxy_pass      # => "ppass"
+  #
+  # === Filtering Proxies
+  #
+  # With method Net::HTTP.new (but not Net::HTTP.start),
+  # you can use argument +p_no_proxy+ to filter proxies:
+  #
+  # - Reject a certain address:
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'proxy.example', 8000, 'pname', 'ppass', 'proxy.example')
+  #     http.proxy_address # => nil
+  #
+  # - Reject certain domains or subdomains:
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'my.proxy.example', 8000, 'pname', 'ppass', 'proxy.example')
+  #     http.proxy_address # => nil
+  #
+  # - Reject certain addresses and port combinations:
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'proxy.example', 8000, 'pname', 'ppass', 'proxy.example:1234')
+  #     http.proxy_address # => "proxy.example"
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'proxy.example', 8000, 'pname', 'ppass', 'proxy.example:8000')
+  #     http.proxy_address # => nil
+  #
+  # - Reject a list of the types above delimited using a comma:
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'proxy.example', 8000, 'pname', 'ppass', 'my.proxy,proxy.example:8000')
+  #     http.proxy_address # => nil
+  #
+  #     http = Net::HTTP.new('example.com', nil, 'my.proxy', 8000, 'pname', 'ppass', 'my.proxy,proxy.example:8000')
+  #     http.proxy_address # => nil
+  #
+  # == Compression and Decompression
+  #
+  # \Net::HTTP does not compress the body of a request before sending.
+  #
+  # By default, \Net::HTTP adds header <tt>'Accept-Encoding'</tt>
+  # to a new {request object}[rdoc-ref:Net::HTTPRequest]:
+  #
+  #   Net::HTTP::Get.new(uri)['Accept-Encoding']
+  #   # => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+  #
+  # This requests the server to zip-encode the response body if there is one;
+  # the server is not required to do so.
+  #
+  # \Net::HTTP does not automatically decompress a response body
+  # if the response has header <tt>'Content-Range'</tt>.
+  #
+  # Otherwise decompression (or not) depends on the value of header
+  # {Content-Encoding}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-encoding-response-header]:
+  #
+  # - <tt>'deflate'</tt>, <tt>'gzip'</tt>, or <tt>'x-gzip'</tt>:
+  #   decompresses the body and deletes the header.
+  # - <tt>'none'</tt> or <tt>'identity'</tt>:
+  #   does not decompress the body, but deletes the header.
+  # - Any other value:
+  #   leaves the body and header unchanged.
+  #
+  # == What's Here
+  #
+  # This is a categorized summary of methods and attributes.
+  #
+  # === \Net::HTTP Objects
+  #
+  # - {::new}[rdoc-ref:Net::HTTP.new]:
+  #   Creates a new instance.
+  # - {#inspect}[rdoc-ref:Net::HTTP#inspect]:
+  #   Returns a string representation of +self+.
+  #
+  # === Sessions
+  #
+  # - {::start}[rdoc-ref:Net::HTTP.start]:
+  #   Begins a new session in a new \Net::HTTP object.
+  # - {#started?}[rdoc-ref:Net::HTTP#started?]
+  #   (aliased as {#active?}[rdoc-ref:Net::HTTP#active?]):
+  #   Returns whether in a session.
+  # - {#finish}[rdoc-ref:Net::HTTP#finish]:
+  #   Ends an active session.
+  # - {#start}[rdoc-ref:Net::HTTP#start]:
+  #   Begins a new session in an existing \Net::HTTP object (+self+).
+  #
+  # === Connections
+  #
+  # - {:continue_timeout}[rdoc-ref:Net::HTTP#continue_timeout]:
+  #   Returns the continue timeout.
+  # - {#continue_timeout=}[rdoc-ref:Net::HTTP#continue_timeout=]:
+  #   Sets the continue timeout seconds.
+  # - {:keep_alive_timeout}[rdoc-ref:Net::HTTP#keep_alive_timeout]:
+  #   Returns the keep-alive timeout.
+  # - {:keep_alive_timeout=}[rdoc-ref:Net::HTTP#keep_alive_timeout=]:
+  #   Sets the keep-alive timeout.
+  # - {:max_retries}[rdoc-ref:Net::HTTP#max_retries]:
+  #   Returns the maximum retries.
+  # - {#max_retries=}[rdoc-ref:Net::HTTP#max_retries=]:
+  #   Sets the maximum retries.
+  # - {:open_timeout}[rdoc-ref:Net::HTTP#open_timeout]:
+  #   Returns the open timeout.
+  # - {:open_timeout=}[rdoc-ref:Net::HTTP#open_timeout=]:
+  #   Sets the open timeout.
+  # - {:read_timeout}[rdoc-ref:Net::HTTP#read_timeout]:
+  #   Returns the open timeout.
+  # - {:read_timeout=}[rdoc-ref:Net::HTTP#read_timeout=]:
+  #   Sets the read timeout.
+  # - {:ssl_timeout}[rdoc-ref:Net::HTTP#ssl_timeout]:
+  #   Returns the ssl timeout.
+  # - {:ssl_timeout=}[rdoc-ref:Net::HTTP#ssl_timeout=]:
+  #   Sets the ssl timeout.
+  # - {:write_timeout}[rdoc-ref:Net::HTTP#write_timeout]:
+  #   Returns the write timeout.
+  # - {write_timeout=}[rdoc-ref:Net::HTTP#write_timeout=]:
+  #   Sets the write timeout.
+  #
+  # === Requests
+  #
+  # - {::get}[rdoc-ref:Net::HTTP.get]:
+  #   Sends a GET request and returns the string response body.
+  # - {::get_print}[rdoc-ref:Net::HTTP.get_print]:
+  #   Sends a GET request and write the string response body to $stdout.
+  # - {::get_response}[rdoc-ref:Net::HTTP.get_response]:
+  #   Sends a GET request and returns a response object.
+  # - {::post_form}[rdoc-ref:Net::HTTP.post_form]:
+  #   Sends a POST request with form data and returns a response object.
+  # - {::post}[rdoc-ref:Net::HTTP.post]:
+  #   Sends a POST request with data and returns a response object.
+  # - {#copy}[rdoc-ref:Net::HTTP#copy]:
+  #   Sends a COPY request and returns a response object.
+  # - {#delete}[rdoc-ref:Net::HTTP#delete]:
+  #   Sends a DELETE request and returns a response object.
+  # - {#get}[rdoc-ref:Net::HTTP#get]:
+  #   Sends a GET request and returns a response object.
+  # - {#head}[rdoc-ref:Net::HTTP#head]:
+  #   Sends a HEAD request and returns a response object.
+  # - {#lock}[rdoc-ref:Net::HTTP#lock]:
+  #   Sends a LOCK request and returns a response object.
+  # - {#mkcol}[rdoc-ref:Net::HTTP#mkcol]:
+  #   Sends a MKCOL request and returns a response object.
+  # - {#move}[rdoc-ref:Net::HTTP#move]:
+  #   Sends a MOVE request and returns a response object.
+  # - {#options}[rdoc-ref:Net::HTTP#options]:
+  #   Sends a OPTIONS request and returns a response object.
+  # - {#patch}[rdoc-ref:Net::HTTP#patch]:
+  #   Sends a PATCH request and returns a response object.
+  # - {#post}[rdoc-ref:Net::HTTP#post]:
+  #   Sends a POST request and returns a response object.
+  # - {#propfind}[rdoc-ref:Net::HTTP#propfind]:
+  #   Sends a PROPFIND request and returns a response object.
+  # - {#proppatch}[rdoc-ref:Net::HTTP#proppatch]:
+  #   Sends a PROPPATCH request and returns a response object.
+  # - {#put}[rdoc-ref:Net::HTTP#put]:
+  #   Sends a PUT request and returns a response object.
+  # - {#request}[rdoc-ref:Net::HTTP#request]:
+  #   Sends a request and returns a response object.
+  # - {#request_get}[rdoc-ref:Net::HTTP#request_get]
+  #   (aliased as {#get2}[rdoc-ref:Net::HTTP#get2]):
+  #   Sends a GET request and forms a response object;
+  #   if a block given, calls the block with the object,
+  #   otherwise returns the object.
+  # - {#request_head}[rdoc-ref:Net::HTTP#request_head]
+  #   (aliased as {#head2}[rdoc-ref:Net::HTTP#head2]):
+  #   Sends a HEAD request and forms a response object;
+  #   if a block given, calls the block with the object,
+  #   otherwise returns the object.
+  # - {#request_post}[rdoc-ref:Net::HTTP#request_post]
+  #   (aliased as {#post2}[rdoc-ref:Net::HTTP#post2]):
+  #   Sends a POST request and forms a response object;
+  #   if a block given, calls the block with the object,
+  #   otherwise returns the object.
+  # - {#send_request}[rdoc-ref:Net::HTTP#send_request]:
+  #   Sends a request and returns a response object.
+  # - {#trace}[rdoc-ref:Net::HTTP#trace]:
+  #   Sends a TRACE request and returns a response object.
+  # - {#unlock}[rdoc-ref:Net::HTTP#unlock]:
+  #   Sends an UNLOCK request and returns a response object.
+  #
+  # === Responses
+  #
+  # - {:close_on_empty_response}[rdoc-ref:Net::HTTP#close_on_empty_response]:
+  #   Returns whether to close connection on empty response.
+  # - {:close_on_empty_response=}[rdoc-ref:Net::HTTP#close_on_empty_response=]:
+  #   Sets whether to close connection on empty response.
+  # - {:ignore_eof}[rdoc-ref:Net::HTTP#ignore_eof]:
+  #   Returns whether to ignore end-of-file when reading a response body
+  #   with <tt>Content-Length</tt> headers.
+  # - {:ignore_eof=}[rdoc-ref:Net::HTTP#ignore_eof=]:
+  #   Sets whether to ignore end-of-file when reading a response body
+  #   with <tt>Content-Length</tt> headers.
+  # - {:response_body_encoding}[rdoc-ref:Net::HTTP#response_body_encoding]:
+  #   Returns the encoding to use for the response body.
+  # - {#response_body_encoding=}[rdoc-ref:Net::HTTP#response_body_encoding=]:
+  #   Sets the response body encoding.
+  #
+  # === Proxies
+  #
+  # - {:proxy_address}[rdoc-ref:Net::HTTP#proxy_address]:
+  #   Returns the proxy address.
+  # - {:proxy_address=}[rdoc-ref:Net::HTTP#proxy_address=]:
+  #   Sets the proxy address.
+  # - {::proxy_class?}[rdoc-ref:Net::HTTP.proxy_class?]:
+  #   Returns whether +self+ is a proxy class.
+  # - {#proxy?}[rdoc-ref:Net::HTTP#proxy?]:
+  #   Returns whether +self+ has a proxy.
+  # - {#proxy_address}[rdoc-ref:Net::HTTP#proxy_address]
+  #   (aliased as {#proxyaddr}[rdoc-ref:Net::HTTP#proxyaddr]):
+  #   Returns the proxy address.
+  # - {#proxy_from_env?}[rdoc-ref:Net::HTTP#proxy_from_env?]:
+  #   Returns whether the proxy is taken from an environment variable.
+  # - {:proxy_from_env=}[rdoc-ref:Net::HTTP#proxy_from_env=]:
+  #   Sets whether the proxy is to be taken from an environment variable.
+  # - {:proxy_pass}[rdoc-ref:Net::HTTP#proxy_pass]:
+  #   Returns the proxy password.
+  # - {:proxy_pass=}[rdoc-ref:Net::HTTP#proxy_pass=]:
+  #   Sets the proxy password.
+  # - {:proxy_port}[rdoc-ref:Net::HTTP#proxy_port]:
+  #   Returns the proxy port.
+  # - {:proxy_port=}[rdoc-ref:Net::HTTP#proxy_port=]:
+  #   Sets the proxy port.
+  # - {#proxy_user}[rdoc-ref:Net::HTTP#proxy_user]:
+  #   Returns the proxy user name.
+  # - {:proxy_user=}[rdoc-ref:Net::HTTP#proxy_user=]:
+  #   Sets the proxy user.
+  #
+  # === Security
+  #
+  # - {:ca_file}[rdoc-ref:Net::HTTP#ca_file]:
+  #   Returns the path to a CA certification file.
+  # - {:ca_file=}[rdoc-ref:Net::HTTP#ca_file=]:
+  #   Sets the path to a CA certification file.
+  # - {:ca_path}[rdoc-ref:Net::HTTP#ca_path]:
+  #   Returns the path of to CA directory containing certification files.
+  # - {:ca_path=}[rdoc-ref:Net::HTTP#ca_path=]:
+  #   Sets the path of to CA directory containing certification files.
+  # - {:cert}[rdoc-ref:Net::HTTP#cert]:
+  #   Returns the OpenSSL::X509::Certificate object to be used for client certification.
+  # - {:cert=}[rdoc-ref:Net::HTTP#cert=]:
+  #   Sets the OpenSSL::X509::Certificate object to be used for client certification.
+  # - {:cert_store}[rdoc-ref:Net::HTTP#cert_store]:
+  #   Returns the X509::Store to be used for verifying peer certificate.
+  # - {:cert_store=}[rdoc-ref:Net::HTTP#cert_store=]:
+  #   Sets the X509::Store to be used for verifying peer certificate.
+  # - {:ciphers}[rdoc-ref:Net::HTTP#ciphers]:
+  #   Returns the available SSL ciphers.
+  # - {:ciphers=}[rdoc-ref:Net::HTTP#ciphers=]:
+  #   Sets the available SSL ciphers.
+  # - {:extra_chain_cert}[rdoc-ref:Net::HTTP#extra_chain_cert]:
+  #   Returns the extra X509 certificates to be added to the certificate chain.
+  # - {:extra_chain_cert=}[rdoc-ref:Net::HTTP#extra_chain_cert=]:
+  #   Sets the extra X509 certificates to be added to the certificate chain.
+  # - {:key}[rdoc-ref:Net::HTTP#key]:
+  #   Returns the OpenSSL::PKey::RSA or OpenSSL::PKey::DSA object.
+  # - {:key=}[rdoc-ref:Net::HTTP#key=]:
+  #   Sets the OpenSSL::PKey::RSA or OpenSSL::PKey::DSA object.
+  # - {:max_version}[rdoc-ref:Net::HTTP#max_version]:
+  #   Returns the maximum SSL version.
+  # - {:max_version=}[rdoc-ref:Net::HTTP#max_version=]:
+  #   Sets the maximum SSL version.
+  # - {:min_version}[rdoc-ref:Net::HTTP#min_version]:
+  #   Returns the minimum SSL version.
+  # - {:min_version=}[rdoc-ref:Net::HTTP#min_version=]:
+  #   Sets the minimum SSL version.
+  # - {#peer_cert}[rdoc-ref:Net::HTTP#peer_cert]:
+  #   Returns the X509 certificate chain for the session's socket peer.
+  # - {:ssl_version}[rdoc-ref:Net::HTTP#ssl_version]:
+  #   Returns the SSL version.
+  # - {:ssl_version=}[rdoc-ref:Net::HTTP#ssl_version=]:
+  #   Sets the SSL version.
+  # - {#use_ssl=}[rdoc-ref:Net::HTTP#use_ssl=]:
+  #   Sets whether a new session is to use Transport Layer Security.
+  # - {#use_ssl?}[rdoc-ref:Net::HTTP#use_ssl?]:
+  #   Returns whether +self+ uses SSL.
+  # - {:verify_callback}[rdoc-ref:Net::HTTP#verify_callback]:
+  #   Returns the callback for the server certification verification.
+  # - {:verify_callback=}[rdoc-ref:Net::HTTP#verify_callback=]:
+  #   Sets the callback for the server certification verification.
+  # - {:verify_depth}[rdoc-ref:Net::HTTP#verify_depth]:
+  #   Returns the maximum depth for the certificate chain verification.
+  # - {:verify_depth=}[rdoc-ref:Net::HTTP#verify_depth=]:
+  #   Sets the maximum depth for the certificate chain verification.
+  # - {:verify_hostname}[rdoc-ref:Net::HTTP#verify_hostname]:
+  #   Returns the flags for server the certification verification at the beginning of the SSL/TLS session.
+  # - {:verify_hostname=}[rdoc-ref:Net::HTTP#verify_hostname=]:
+  #   Sets he flags for server the certification verification at the beginning of the SSL/TLS session.
+  # - {:verify_mode}[rdoc-ref:Net::HTTP#verify_mode]:
+  #   Returns the flags for server the certification verification at the beginning of the SSL/TLS session.
+  # - {:verify_mode=}[rdoc-ref:Net::HTTP#verify_mode=]:
+  #   Sets the flags for server the certification verification at the beginning of the SSL/TLS session.
+  #
+  # === Addresses and Ports
+  #
+  # - {:address}[rdoc-ref:Net::HTTP#address]:
+  #   Returns the string host name or host IP.
+  # - {::default_port}[rdoc-ref:Net::HTTP.default_port]:
+  #   Returns integer 80, the default port to use for HTTP requests.
+  # - {::http_default_port}[rdoc-ref:Net::HTTP.http_default_port]:
+  #   Returns integer 80, the default port to use for HTTP requests.
+  # - {::https_default_port}[rdoc-ref:Net::HTTP.https_default_port]:
+  #   Returns integer 443, the default port to use for HTTPS requests.
+  # - {#ipaddr}[rdoc-ref:Net::HTTP#ipaddr]:
+  #   Returns the IP address for the connection.
+  # - {#ipaddr=}[rdoc-ref:Net::HTTP#ipaddr=]:
+  #   Sets the IP address for the connection.
+  # - {:local_host}[rdoc-ref:Net::HTTP#local_host]:
+  #   Returns the string local host used to establish the connection.
+  # - {:local_host=}[rdoc-ref:Net::HTTP#local_host=]:
+  #   Sets the string local host used to establish the connection.
+  # - {:local_port}[rdoc-ref:Net::HTTP#local_port]:
+  #   Returns the integer local port used to establish the connection.
+  # - {:local_port=}[rdoc-ref:Net::HTTP#local_port=]:
+  #   Sets the integer local port used to establish the connection.
+  # - {:port}[rdoc-ref:Net::HTTP#port]:
+  #   Returns the integer port number.
+  #
+  # === \HTTP Version
+  #
+  # - {::version_1_2?}[rdoc-ref:Net::HTTP.version_1_2?]
+  #   (aliased as {::is_version_1_2?}[rdoc-ref:Net::HTTP.is_version_1_2?]
+  #   and {::version_1_2}[rdoc-ref:Net::HTTP.version_1_2]):
+  #   Returns true; retained for compatibility.
+  #
+  # === Debugging
+  #
+  # - {#set_debug_output}[rdoc-ref:Net::HTTP#set_debug_output]:
+  #   Sets the output stream for debugging.
+  #
+  class HTTP < Protocol
+
+    # :stopdoc:
+    VERSION = "0.4.0"
+    HTTPVersion = '1.1'
+    begin
+      require 'zlib'
+      HAVE_ZLIB=true
+    rescue LoadError
+      HAVE_ZLIB=false
+    end
+    # :startdoc:
+
+    # Returns +true+; retained for compatibility.
+    def HTTP.version_1_2
+      true
+    end
+
+    # Returns +true+; retained for compatibility.
+    def HTTP.version_1_2?
+      true
+    end
+
+    # Returns +false+; retained for compatibility.
+    def HTTP.version_1_1?  #:nodoc:
+      false
+    end
+
+    class << HTTP
+      alias is_version_1_1? version_1_1?   #:nodoc:
+      alias is_version_1_2? version_1_2?   #:nodoc:
+    end
+
+    # :call-seq:
+    #   Net::HTTP.get_print(hostname, path, port = 80) -> nil
+    #   Net::HTTP:get_print(uri, headers = {}, port = uri.port) -> nil
+    #
+    # Like Net::HTTP.get, but writes the returned body to $stdout;
+    # returns +nil+.
+    def HTTP.get_print(uri_or_host, path_or_headers = nil, port = nil)
+      get_response(uri_or_host, path_or_headers, port) {|res|
+        res.read_body do |chunk|
+          $stdout.print chunk
+        end
+      }
+      nil
+    end
+
+    # :call-seq:
+    #   Net::HTTP.get(hostname, path, port = 80) -> body
+    #   Net::HTTP:get(uri, headers = {}, port = uri.port) -> body
+    #
+    # Sends a GET request and returns the \HTTP response body as a string.
+    #
+    # With string arguments +hostname+ and +path+:
+    #
+    #   hostname = 'jsonplaceholder.typicode.com'
+    #   path = '/todos/1'
+    #   puts Net::HTTP.get(hostname, path)
+    #
+    # Output:
+    #
+    #   {
+    #     "userId": 1,
+    #     "id": 1,
+    #     "title": "delectus aut autem",
+    #     "completed": false
+    #   }
+    #
+    # With URI object +uri+ and optional hash argument +headers+:
+    #
+    #   uri = URI('https://jsonplaceholder.typicode.com/todos/1')
+    #   headers = {'Content-type' => 'application/json; charset=UTF-8'}
+    #   Net::HTTP.get(uri, headers)
+    #
+    # Related:
+    #
+    # - Net::HTTP::Get: request class for \HTTP method +GET+.
+    # - Net::HTTP#get: convenience method for \HTTP method +GET+.
+    #
+    def HTTP.get(uri_or_host, path_or_headers = nil, port = nil)
+      get_response(uri_or_host, path_or_headers, port).body
+    end
+
+    # :call-seq:
+    #   Net::HTTP.get_response(hostname, path, port = 80) -> http_response
+    #   Net::HTTP:get_response(uri, headers = {}, port = uri.port) -> http_response
+    #
+    # Like Net::HTTP.get, but returns a Net::HTTPResponse object
+    # instead of the body string.
+    def HTTP.get_response(uri_or_host, path_or_headers = nil, port = nil, &block)
+      if path_or_headers && !path_or_headers.is_a?(Hash)
+        host = uri_or_host
+        path = path_or_headers
+        new(host, port || HTTP.default_port).start {|http|
+          return http.request_get(path, &block)
+        }
+      else
+        uri = uri_or_host
+        headers = path_or_headers
+        start(uri.hostname, uri.port,
+              :use_ssl => uri.scheme == 'https') {|http|
+          return http.request_get(uri, headers, &block)
+        }
+      end
+    end
+
+    # Posts data to a host; returns a Net::HTTPResponse object.
+    #
+    # Argument +url+ must be a URL;
+    # argument +data+ must be a string:
+    #
+    #   _uri = uri.dup
+    #   _uri.path = '/posts'
+    #   data = '{"title": "foo", "body": "bar", "userId": 1}'
+    #   headers = {'content-type': 'application/json'}
+    #   res = Net::HTTP.post(_uri, data, headers) # => #<Net::HTTPCreated 201 Created readbody=true>
+    #   puts res.body
+    #
+    # Output:
+    #
+    #   {
+    #     "title": "foo",
+    #     "body": "bar",
+    #     "userId": 1,
+    #     "id": 101
+    #   }
+    #
+    # Related:
+    #
+    # - Net::HTTP::Post: request class for \HTTP method +POST+.
+    # - Net::HTTP#post: convenience method for \HTTP method +POST+.
+    #
+    def HTTP.post(url, data, header = nil)
+      start(url.hostname, url.port,
+            :use_ssl => url.scheme == 'https' ) {|http|
+        http.post(url, data, header)
+      }
+    end
+
+    # Posts data to a host; returns a Net::HTTPResponse object.
+    #
+    # Argument +url+ must be a URI;
+    # argument +data+ must be a hash:
+    #
+    #   _uri = uri.dup
+    #   _uri.path = '/posts'
+    #   data = {title: 'foo', body: 'bar', userId: 1}
+    #   res = Net::HTTP.post_form(_uri, data) # => #<Net::HTTPCreated 201 Created readbody=true>
+    #   puts res.body
+    #
+    # Output:
+    #
+    #   {
+    #     "title": "foo",
+    #     "body": "bar",
+    #     "userId": "1",
+    #     "id": 101
+    #   }
+    #
+    def HTTP.post_form(url, params)
+      req = Post.new(url)
+      req.form_data = params
+      req.basic_auth url.user, url.password if url.user
+      start(url.hostname, url.port,
+            :use_ssl => url.scheme == 'https' ) {|http|
+        http.request(req)
+      }
+    end
+
+    #
+    # \HTTP session management
+    #
+
+    # Returns integer +80+, the default port to use for \HTTP requests:
+    #
+    #   Net::HTTP.default_port # => 80
+    #
+    def HTTP.default_port
+      http_default_port()
+    end
+
+    # Returns integer +80+, the default port to use for \HTTP requests:
+    #
+    #   Net::HTTP.http_default_port # => 80
+    #
+    def HTTP.http_default_port
+      80
+    end
+
+    # Returns integer +443+, the default port to use for HTTPS requests:
+    #
+    #   Net::HTTP.https_default_port # => 443
+    #
+    def HTTP.https_default_port
+      443
+    end
+
+    def HTTP.socket_type   #:nodoc: obsolete
+      BufferedIO
+    end
+
+    # :call-seq:
+    #   HTTP.start(address, port = nil, p_addr = :ENV, p_port = nil, p_user = nil, p_pass = nil, opts) -> http
+    #   HTTP.start(address, port = nil, p_addr = :ENV, p_port = nil, p_user = nil, p_pass = nil, opts) {|http| ... } -> object
+    #
+    # Creates a new \Net::HTTP object, +http+, via \Net::HTTP.new:
+    #
+    # - For arguments +address+ and +port+, see Net::HTTP.new.
+    # - For proxy-defining arguments +p_addr+ through +p_pass+,
+    #   see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    # - For argument +opts+, see below.
+    #
+    # With no block given:
+    #
+    # - Calls <tt>http.start</tt> with no block (see #start),
+    #   which opens a TCP connection and \HTTP session.
+    # - Returns +http+.
+    # - The caller should call #finish to close the session:
+    #
+    #     http = Net::HTTP.start(hostname)
+    #     http.started? # => true
+    #     http.finish
+    #     http.started? # => false
+    #
+    # With a block given:
+    #
+    # - Calls <tt>http.start</tt> with the block (see #start), which:
+    #
+    #   - Opens a TCP connection and \HTTP session.
+    #   - Calls the block,
+    #     which may make any number of requests to the host.
+    #   - Closes the \HTTP session and TCP connection on block exit.
+    #   - Returns the block's value +object+.
+    #
+    # - Returns +object+.
+    #
+    # Example:
+    #
+    #   hostname = 'jsonplaceholder.typicode.com'
+    #   Net::HTTP.start(hostname) do |http|
+    #     puts http.get('/todos/1').body
+    #     puts http.get('/todos/2').body
+    #   end
+    #
+    # Output:
+    #
+    #   {
+    #     "userId": 1,
+    #     "id": 1,
+    #     "title": "delectus aut autem",
+    #     "completed": false
+    #   }
+    #   {
+    #     "userId": 1,
+    #     "id": 2,
+    #     "title": "quis ut nam facilis et officia qui",
+    #     "completed": false
+    #   }
+    #
+    # If the last argument given is a hash, it is the +opts+ hash,
+    # where each key is a method or accessor to be called,
+    # and its value is the value to be set.
+    #
+    # The keys may include:
+    #
+    # - #ca_file
+    # - #ca_path
+    # - #cert
+    # - #cert_store
+    # - #ciphers
+    # - #close_on_empty_response
+    # - +ipaddr+ (calls #ipaddr=)
+    # - #keep_alive_timeout
+    # - #key
+    # - #open_timeout
+    # - #read_timeout
+    # - #ssl_timeout
+    # - #ssl_version
+    # - +use_ssl+ (calls #use_ssl=)
+    # - #verify_callback
+    # - #verify_depth
+    # - #verify_mode
+    # - #write_timeout
+    #
+    # Note: If +port+ is +nil+ and <tt>opts[:use_ssl]</tt> is a truthy value,
+    # the value passed to +new+ is Net::HTTP.https_default_port, not +port+.
+    #
+    def HTTP.start(address, *arg, &block) # :yield: +http+
+      arg.pop if opt = Hash.try_convert(arg[-1])
+      port, p_addr, p_port, p_user, p_pass = *arg
+      p_addr = :ENV if arg.size < 2
+      port = https_default_port if !port && opt && opt[:use_ssl]
+      http = new(address, port, p_addr, p_port, p_user, p_pass)
+      http.ipaddr = opt[:ipaddr] if opt && opt[:ipaddr]
+
+      if opt
+        if opt[:use_ssl]
+          opt = {verify_mode: OpenSSL::SSL::VERIFY_PEER}.update(opt)
+        end
+        http.methods.grep(/\A(\w+)=\z/) do |meth|
+          key = $1.to_sym
+          opt.key?(key) or next
+          http.__send__(meth, opt[key])
+        end
+      end
+
+      http.start(&block)
+    end
+
+    class << HTTP
+      alias newobj new # :nodoc:
+    end
+
+    # Returns a new \Net::HTTP object +http+
+    # (but does not open a TCP connection or \HTTP session).
+    #
+    # With only string argument +address+ given
+    # (and <tt>ENV['http_proxy']</tt> undefined or +nil+),
+    # the returned +http+:
+    #
+    # - Has the given address.
+    # - Has the default port number, Net::HTTP.default_port (80).
+    # - Has no proxy.
+    #
+    # Example:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   # => #<Net::HTTP jsonplaceholder.typicode.com:80 open=false>
+    #   http.address # => "jsonplaceholder.typicode.com"
+    #   http.port    # => 80
+    #   http.proxy?  # => false
+    #
+    # With integer argument +port+ also given,
+    # the returned +http+ has the given port:
+    #
+    #   http = Net::HTTP.new(hostname, 8000)
+    #   # => #<Net::HTTP jsonplaceholder.typicode.com:8000 open=false>
+    #   http.port # => 8000
+    #
+    # For proxy-defining arguments +p_addr+ through +p_no_proxy+,
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    #
+    def HTTP.new(address, port = nil, p_addr = :ENV, p_port = nil, p_user = nil, p_pass = nil, p_no_proxy = nil)
+      http = super address, port
+
+      if proxy_class? then # from Net::HTTP::Proxy()
+        http.proxy_from_env = @proxy_from_env
+        http.proxy_address  = @proxy_address
+        http.proxy_port     = @proxy_port
+        http.proxy_user     = @proxy_user
+        http.proxy_pass     = @proxy_pass
+      elsif p_addr == :ENV then
+        http.proxy_from_env = true
+      else
+        if p_addr && p_no_proxy && !URI::Generic.use_proxy?(address, address, port, p_no_proxy)
+          p_addr = nil
+          p_port = nil
+        end
+        http.proxy_address = p_addr
+        http.proxy_port    = p_port || default_port
+        http.proxy_user    = p_user
+        http.proxy_pass    = p_pass
+      end
+
+      http
+    end
+
+    # Creates a new \Net::HTTP object for the specified server address,
+    # without opening the TCP connection or initializing the \HTTP session.
+    # The +address+ should be a DNS hostname or IP address.
+    def initialize(address, port = nil) # :nodoc:
+      @address = address
+      @port    = (port || HTTP.default_port)
+      @ipaddr = nil
+      @local_host = nil
+      @local_port = nil
+      @curr_http_version = HTTPVersion
+      @keep_alive_timeout = 2
+      @last_communicated = nil
+      @close_on_empty_response = false
+      @socket  = nil
+      @started = false
+      @open_timeout = 60
+      @read_timeout = 60
+      @write_timeout = 60
+      @continue_timeout = nil
+      @max_retries = 1
+      @debug_output = nil
+      @response_body_encoding = false
+      @ignore_eof = true
+
+      @proxy_from_env = false
+      @proxy_uri      = nil
+      @proxy_address  = nil
+      @proxy_port     = nil
+      @proxy_user     = nil
+      @proxy_pass     = nil
+
+      @use_ssl = false
+      @ssl_context = nil
+      @ssl_session = nil
+      @sspi_enabled = false
+      SSL_IVNAMES.each do |ivname|
+        instance_variable_set ivname, nil
+      end
+    end
+
+    # Returns a string representation of +self+:
+    #
+    #   Net::HTTP.new(hostname).inspect
+    #   # => "#<Net::HTTP jsonplaceholder.typicode.com:80 open=false>"
+    #
+    def inspect
+      "#<#{self.class} #{@address}:#{@port} open=#{started?}>"
+    end
+
+    # *WARNING* This method opens a serious security hole.
+    # Never use this method in production code.
+    #
+    # Sets the output stream for debugging:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   File.open('t.tmp', 'w') do |file|
+    #     http.set_debug_output(file)
+    #     http.start
+    #     http.get('/nosuch/1')
+    #     http.finish
+    #   end
+    #   puts File.read('t.tmp')
+    #
+    # Output:
+    #
+    #   opening connection to jsonplaceholder.typicode.com:80...
+    #   opened
+    #   <- "GET /nosuch/1 HTTP/1.1\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: jsonplaceholder.typicode.com\r\n\r\n"
+    #   -> "HTTP/1.1 404 Not Found\r\n"
+    #   -> "Date: Mon, 12 Dec 2022 21:14:11 GMT\r\n"
+    #   -> "Content-Type: application/json; charset=utf-8\r\n"
+    #   -> "Content-Length: 2\r\n"
+    #   -> "Connection: keep-alive\r\n"
+    #   -> "X-Powered-By: Express\r\n"
+    #   -> "X-Ratelimit-Limit: 1000\r\n"
+    #   -> "X-Ratelimit-Remaining: 999\r\n"
+    #   -> "X-Ratelimit-Reset: 1670879660\r\n"
+    #   -> "Vary: Origin, Accept-Encoding\r\n"
+    #   -> "Access-Control-Allow-Credentials: true\r\n"
+    #   -> "Cache-Control: max-age=43200\r\n"
+    #   -> "Pragma: no-cache\r\n"
+    #   -> "Expires: -1\r\n"
+    #   -> "X-Content-Type-Options: nosniff\r\n"
+    #   -> "Etag: W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\"\r\n"
+    #   -> "Via: 1.1 vegur\r\n"
+    #   -> "CF-Cache-Status: MISS\r\n"
+    #   -> "Server-Timing: cf-q-config;dur=1.3000000762986e-05\r\n"
+    #   -> "Report-To: {\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=yOr40jo%2BwS1KHzhTlVpl54beJ5Wx2FcG4gGV0XVrh3X9OlR5q4drUn2dkt5DGO4GDcE%2BVXT7CNgJvGs%2BZleIyMu8CLieFiDIvOviOY3EhHg94m0ZNZgrEdpKD0S85S507l1vsEwEHkoTm%2Ff19SiO\"}],\"group\":\"cf-nel\",\"max_age\":604800}\r\n"
+    #   -> "NEL: {\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}\r\n"
+    #   -> "Server: cloudflare\r\n"
+    #   -> "CF-RAY: 778977dc484ce591-DFW\r\n"
+    #   -> "alt-svc: h3=\":443\"; ma=86400, h3-29=\":443\"; ma=86400\r\n"
+    #   -> "\r\n"
+    #   reading 2 bytes...
+    #   -> "{}"
+    #   read 2 bytes
+    #   Conn keep-alive
+    #
+    def set_debug_output(output)
+      warn 'Net::HTTP#set_debug_output called after HTTP started', uplevel: 1 if started?
+      @debug_output = output
+    end
+
+    # Returns the string host name or host IP given as argument +address+ in ::new.
+    attr_reader :address
+
+    # Returns the integer port number given as argument +port+ in ::new.
+    attr_reader :port
+
+    # Sets or returns the string local host used to establish the connection;
+    # initially +nil+.
+    attr_accessor :local_host
+
+    # Sets or returns the integer local port used to establish the connection;
+    # initially +nil+.
+    attr_accessor :local_port
+
+    # Returns the encoding to use for the response body;
+    # see #response_body_encoding=.
+    attr_reader :response_body_encoding
+
+    # Sets the encoding to be used for the response body;
+    # returns the encoding.
+    #
+    # The given +value+ may be:
+    #
+    # - An Encoding object.
+    # - The name of an encoding.
+    # - An alias for an encoding name.
+    #
+    # See {Encoding}[rdoc-ref:Encoding].
+    #
+    # Examples:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.response_body_encoding = Encoding::US_ASCII # => #<Encoding:US-ASCII>
+    #   http.response_body_encoding = 'US-ASCII'         # => "US-ASCII"
+    #   http.response_body_encoding = 'ASCII'            # => "ASCII"
+    #
+    def response_body_encoding=(value)
+      value = Encoding.find(value) if value.is_a?(String)
+      @response_body_encoding = value
+    end
+
+    # Sets whether to determine the proxy from environment variable
+    # '<tt>ENV['http_proxy']</tt>';
+    # see {Proxy Using ENV['http_proxy']}[rdoc-ref:Net::HTTP@Proxy+Using+-27ENV-5B-27http_proxy-27-5D-27].
+    attr_writer :proxy_from_env
+
+    # Sets the proxy address;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    attr_writer :proxy_address
+
+    # Sets the proxy port;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    attr_writer :proxy_port
+
+    # Sets the proxy user;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    attr_writer :proxy_user
+
+    # Sets the proxy password;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    attr_writer :proxy_pass
+
+    # Returns the IP address for the connection.
+    #
+    # If the session has not been started,
+    # returns the value set by #ipaddr=,
+    # or +nil+ if it has not been set:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.ipaddr # => nil
+    #   http.ipaddr = '172.67.155.76'
+    #   http.ipaddr # => "172.67.155.76"
+    #
+    # If the session has been started,
+    # returns the IP address from the socket:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.start
+    #   http.ipaddr # => "172.67.155.76"
+    #   http.finish
+    #
+    def ipaddr
+      started? ?  @socket.io.peeraddr[3] : @ipaddr
+    end
+
+    # Sets the IP address for the connection:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.ipaddr # => nil
+    #   http.ipaddr = '172.67.155.76'
+    #   http.ipaddr # => "172.67.155.76"
+    #
+    # The IP address may not be set if the session has been started.
+    def ipaddr=(addr)
+      raise IOError, "ipaddr value changed, but session already started" if started?
+      @ipaddr = addr
+    end
+
+    # Sets or returns the numeric (\Integer or \Float) number of seconds
+    # to wait for a connection to open;
+    # initially 60.
+    # If the connection is not made in the given interval,
+    # an exception is raised.
+    attr_accessor :open_timeout
+
+    # Returns the numeric (\Integer or \Float) number of seconds
+    # to wait for one block to be read (via one read(2) call);
+    # see #read_timeout=.
+    attr_reader :read_timeout
+
+    # Returns the numeric (\Integer or \Float) number of seconds
+    # to wait for one block to be written (via one write(2) call);
+    # see #write_timeout=.
+    attr_reader :write_timeout
+
+    # Sets the maximum number of times to retry an idempotent request in case of
+    # \Net::ReadTimeout, IOError, EOFError, Errno::ECONNRESET,
+    # Errno::ECONNABORTED, Errno::EPIPE, OpenSSL::SSL::SSLError,
+    # Timeout::Error.
+    # The initial value is 1.
+    #
+    # Argument +retries+ must be a non-negative numeric value:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.max_retries = 2   # => 2
+    #   http.max_retries       # => 2
+    #
+    def max_retries=(retries)
+      retries = retries.to_int
+      if retries < 0
+        raise ArgumentError, 'max_retries should be non-negative integer number'
+      end
+      @max_retries = retries
+    end
+
+    # Returns the maximum number of times to retry an idempotent request;
+    # see #max_retries=.
+    attr_reader :max_retries
+
+    # Sets the read timeout, in seconds, for +self+ to integer +sec+;
+    # the initial value is 60.
+    #
+    # Argument +sec+ must be a non-negative numeric value:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.read_timeout # => 60
+    #   http.get('/todos/1') # => #<Net::HTTPOK 200 OK readbody=true>
+    #   http.read_timeout = 0
+    #   http.get('/todos/1') # Raises Net::ReadTimeout.
+    #
+    def read_timeout=(sec)
+      @socket.read_timeout = sec if @socket
+      @read_timeout = sec
+    end
+
+    # Sets the write timeout, in seconds, for +self+ to integer +sec+;
+    # the initial value is 60.
+    #
+    # Argument +sec+ must be a non-negative numeric value:
+    #
+    #   _uri = uri.dup
+    #   _uri.path = '/posts'
+    #   body = 'bar' * 200000
+    #   data = <<EOF
+    #   {"title": "foo", "body": "#{body}", "userId": "1"}
+    #   EOF
+    #   headers = {'content-type': 'application/json'}
+    #   http = Net::HTTP.new(hostname)
+    #   http.write_timeout # => 60
+    #   http.post(_uri.path, data, headers)
+    #   # => #<Net::HTTPCreated 201 Created readbody=true>
+    #   http.write_timeout = 0
+    #   http.post(_uri.path, data, headers) # Raises Net::WriteTimeout.
+    #
+    def write_timeout=(sec)
+      @socket.write_timeout = sec if @socket
+      @write_timeout = sec
+    end
+
+    # Returns the continue timeout value;
+    # see continue_timeout=.
+    attr_reader :continue_timeout
+
+    # Sets the continue timeout value,
+    # which is the number of seconds to wait for an expected 100 Continue response.
+    # If the \HTTP object does not receive a response in this many seconds
+    # it sends the request body.
+    def continue_timeout=(sec)
+      @socket.continue_timeout = sec if @socket
+      @continue_timeout = sec
+    end
+
+    # Sets or returns the numeric (\Integer or \Float) number of seconds
+    # to keep the connection open after a request is sent;
+    # initially 2.
+    # If a new request is made during the given interval,
+    # the still-open connection is used;
+    # otherwise the connection will have been closed
+    # and a new connection is opened.
+    attr_accessor :keep_alive_timeout
+
+    # Sets or returns whether to ignore end-of-file when reading a response body
+    # with <tt>Content-Length</tt> headers;
+    # initially +true+.
+    attr_accessor :ignore_eof
+
+    # Returns +true+ if the \HTTP session has been started:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.started? # => false
+    #   http.start
+    #   http.started? # => true
+    #   http.finish # => nil
+    #   http.started? # => false
+    #
+    #   Net::HTTP.start(hostname) do |http|
+    #     http.started?
+    #   end # => true
+    #   http.started? # => false
+    #
+    def started?
+      @started
+    end
+
+    alias active? started?   #:nodoc: obsolete
+
+    # Sets or returns whether to close the connection when the response is empty;
+    # initially +false+.
+    attr_accessor :close_on_empty_response
+
+    # Returns +true+ if +self+ uses SSL, +false+ otherwise.
+    # See Net::HTTP#use_ssl=.
+    def use_ssl?
+      @use_ssl
+    end
+
+    # Sets whether a new session is to use
+    # {Transport Layer Security}[https://en.wikipedia.org/wiki/Transport_Layer_Security]:
+    #
+    # Raises IOError if attempting to change during a session.
+    #
+    # Raises OpenSSL::SSL::SSLError if the port is not an HTTPS port.
+    def use_ssl=(flag)
+      flag = flag ? true : false
+      if started? and @use_ssl != flag
+        raise IOError, "use_ssl value changed, but session already started"
+      end
+      @use_ssl = flag
+    end
+
+    SSL_IVNAMES = [
+      :@ca_file,
+      :@ca_path,
+      :@cert,
+      :@cert_store,
+      :@ciphers,
+      :@extra_chain_cert,
+      :@key,
+      :@ssl_timeout,
+      :@ssl_version,
+      :@min_version,
+      :@max_version,
+      :@verify_callback,
+      :@verify_depth,
+      :@verify_mode,
+      :@verify_hostname,
+    ] # :nodoc:
+    SSL_ATTRIBUTES = [
+      :ca_file,
+      :ca_path,
+      :cert,
+      :cert_store,
+      :ciphers,
+      :extra_chain_cert,
+      :key,
+      :ssl_timeout,
+      :ssl_version,
+      :min_version,
+      :max_version,
+      :verify_callback,
+      :verify_depth,
+      :verify_mode,
+      :verify_hostname,
+    ] # :nodoc:
+
+    # Sets or returns the path to a CA certification file in PEM format.
+    attr_accessor :ca_file
+
+    # Sets or returns the path of to CA directory
+    # containing certification files in PEM format.
+    attr_accessor :ca_path
+
+    # Sets or returns the OpenSSL::X509::Certificate object
+    # to be used for client certification.
+    attr_accessor :cert
+
+    # Sets or returns the X509::Store to be used for verifying peer certificate.
+    attr_accessor :cert_store
+
+    # Sets or returns the available SSL ciphers.
+    # See {OpenSSL::SSL::SSLContext#ciphers=}[rdoc-ref:OpenSSL::SSL::SSLContext#ciphers-3D].
+    attr_accessor :ciphers
+
+    # Sets or returns the extra X509 certificates to be added to the certificate chain.
+    # See {OpenSSL::SSL::SSLContext#add_certificate}[rdoc-ref:OpenSSL::SSL::SSLContext#add_certificate].
+    attr_accessor :extra_chain_cert
+
+    # Sets or returns the OpenSSL::PKey::RSA or OpenSSL::PKey::DSA object.
+    attr_accessor :key
+
+    # Sets or returns the SSL timeout seconds.
+    attr_accessor :ssl_timeout
+
+    # Sets or returns the SSL version.
+    # See {OpenSSL::SSL::SSLContext#ssl_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#ssl_version-3D].
+    attr_accessor :ssl_version
+
+    # Sets or returns the minimum SSL version.
+    # See {OpenSSL::SSL::SSLContext#min_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#min_version-3D].
+    attr_accessor :min_version
+
+    # Sets or returns the maximum SSL version.
+    # See {OpenSSL::SSL::SSLContext#max_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#max_version-3D].
+    attr_accessor :max_version
+
+    # Sets or returns the callback for the server certification verification.
+    attr_accessor :verify_callback
+
+    # Sets or returns the maximum depth for the certificate chain verification.
+    attr_accessor :verify_depth
+
+    # Sets or returns the flags for server the certification verification
+    # at the beginning of the SSL/TLS session.
+    # OpenSSL::SSL::VERIFY_NONE or OpenSSL::SSL::VERIFY_PEER are acceptable.
+    attr_accessor :verify_mode
+
+    # Sets or returns whether to verify that the server certificate is valid
+    # for the hostname.
+    # See {OpenSSL::SSL::SSLContext#verify_hostname=}[rdoc-ref:OpenSSL::SSL::SSLContext#attribute-i-verify_mode].
+    attr_accessor :verify_hostname
+
+    # Returns the X509 certificate chain (an array of strings)
+    # for the session's socket peer,
+    # or +nil+ if none.
+    def peer_cert
+      if not use_ssl? or not @socket
+        return nil
+      end
+      @socket.io.peer_cert
+    end
+
+    # Starts an \HTTP session.
+    #
+    # Without a block, returns +self+:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   # => #<Net::HTTP jsonplaceholder.typicode.com:80 open=false>
+    #   http.start
+    #   # => #<Net::HTTP jsonplaceholder.typicode.com:80 open=true>
+    #   http.started? # => true
+    #   http.finish
+    #
+    # With a block, calls the block with +self+,
+    # finishes the session when the block exits,
+    # and returns the block's value:
+    #
+    #   http.start do |http|
+    #     http
+    #   end
+    #   # => #<Net::HTTP jsonplaceholder.typicode.com:80 open=false>
+    #   http.started? # => false
+    #
+    def start  # :yield: http
+      raise IOError, 'HTTP session already opened' if @started
+      if block_given?
+        begin
+          do_start
+          return yield(self)
+        ensure
+          do_finish
+        end
+      end
+      do_start
+      self
+    end
+
+    def do_start
+      connect
+      @started = true
+    end
+    private :do_start
+
+    def connect
+      if use_ssl?
+        # reference early to load OpenSSL before connecting,
+        # as OpenSSL may take time to load.
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+      end
+
+      if proxy? then
+        conn_addr = proxy_address
+        conn_port = proxy_port
+      else
+        conn_addr = conn_address
+        conn_port = port
+      end
+
+      debug "opening connection to #{conn_addr}:#{conn_port}..."
+      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
+        begin
+          TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
+        rescue => e
+          raise e, "Failed to open TCP connection to " +
+            "#{conn_addr}:#{conn_port} (#{e.message})"
+        end
+      }
+      s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+      debug "opened"
+      if use_ssl?
+        if proxy?
+          plain_sock = BufferedIO.new(s, read_timeout: @read_timeout,
+                                      write_timeout: @write_timeout,
+                                      continue_timeout: @continue_timeout,
+                                      debug_output: @debug_output)
+          buf = +"CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n" \
+            "Host: #{@address}:#{@port}\r\n"
+          if proxy_user
+            credential = ["#{proxy_user}:#{proxy_pass}"].pack('m0')
+            buf << "Proxy-Authorization: Basic #{credential}\r\n"
+          end
+          buf << "\r\n"
+          plain_sock.write(buf)
+          HTTPResponse.read_new(plain_sock).value
+          # assuming nothing left in buffers after successful CONNECT response
+        end
+
+        ssl_parameters = Hash.new
+        iv_list = instance_variables
+        SSL_IVNAMES.each_with_index do |ivname, i|
+          if iv_list.include?(ivname)
+            value = instance_variable_get(ivname)
+            unless value.nil?
+              ssl_parameters[SSL_ATTRIBUTES[i]] = value
+            end
+          end
+        end
+        @ssl_context.set_params(ssl_parameters)
+        unless @ssl_context.session_cache_mode.nil? # a dummy method on JRuby
+          @ssl_context.session_cache_mode =
+              OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
+                  OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
+        end
+        if @ssl_context.respond_to?(:session_new_cb) # not implemented under JRuby
+          @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
+        end
+
+        # Still do the post_connection_check below even if connecting
+        # to IP address
+        verify_hostname = @ssl_context.verify_hostname
+
+        # Server Name Indication (SNI) RFC 3546/6066
+        case @address
+        when Resolv::IPv4::Regex, Resolv::IPv6::Regex
+          # don't set SNI, as IP addresses in SNI is not valid
+          # per RFC 6066, section 3.
+
+          # Avoid openssl warning
+          @ssl_context.verify_hostname = false
+        else
+          ssl_host_address = @address
+        end
+
+        debug "starting SSL for #{conn_addr}:#{conn_port}..."
+        s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
+        s.sync_close = true
+        s.hostname = ssl_host_address if s.respond_to?(:hostname=) && ssl_host_address
+
+        if @ssl_session and
+           Process.clock_gettime(Process::CLOCK_REALTIME) < @ssl_session.time.to_f + @ssl_session.timeout
+          s.session = @ssl_session
+        end
+        ssl_socket_connect(s, @open_timeout)
+        if (@ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE) && verify_hostname
+          s.post_connection_check(@address)
+        end
+        debug "SSL established, protocol: #{s.ssl_version}, cipher: #{s.cipher[0]}"
+      end
+      @socket = BufferedIO.new(s, read_timeout: @read_timeout,
+                               write_timeout: @write_timeout,
+                               continue_timeout: @continue_timeout,
+                               debug_output: @debug_output)
+      @last_communicated = nil
+      on_connect
+    rescue => exception
+      if s
+        debug "Conn close because of connect error #{exception}"
+        s.close
+      end
+      raise
+    end
+    private :connect
+
+    def on_connect
+    end
+    private :on_connect
+
+    # Finishes the \HTTP session:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.start
+    #   http.started? # => true
+    #   http.finish   # => nil
+    #   http.started? # => false
+    #
+    # Raises IOError if not in a session.
+    def finish
+      raise IOError, 'HTTP session not yet started' unless started?
+      do_finish
+    end
+
+    def do_finish
+      @started = false
+      @socket.close if @socket
+      @socket = nil
+    end
+    private :do_finish
+
+    #
+    # proxy
+    #
+
+    public
+
+    # no proxy
+    @is_proxy_class = false
+    @proxy_from_env = false
+    @proxy_addr = nil
+    @proxy_port = nil
+    @proxy_user = nil
+    @proxy_pass = nil
+
+    # Creates an \HTTP proxy class which behaves like \Net::HTTP, but
+    # performs all access via the specified proxy.
+    #
+    # This class is obsolete.  You may pass these same parameters directly to
+    # \Net::HTTP.new.  See Net::HTTP.new for details of the arguments.
+    def HTTP.Proxy(p_addr = :ENV, p_port = nil, p_user = nil, p_pass = nil) #:nodoc:
+      return self unless p_addr
+
+      Class.new(self) {
+        @is_proxy_class = true
+
+        if p_addr == :ENV then
+          @proxy_from_env = true
+          @proxy_address = nil
+          @proxy_port    = nil
+        else
+          @proxy_from_env = false
+          @proxy_address = p_addr
+          @proxy_port    = p_port || default_port
+        end
+
+        @proxy_user = p_user
+        @proxy_pass = p_pass
+      }
+    end
+
+    class << HTTP
+      # Returns true if self is a class which was created by HTTP::Proxy.
+      def proxy_class?
+        defined?(@is_proxy_class) ? @is_proxy_class : false
+      end
+
+      # Returns the address of the proxy host, or +nil+ if none;
+      # see Net::HTTP@Proxy+Server.
+      attr_reader :proxy_address
+
+      # Returns the port number of the proxy host, or +nil+ if none;
+      # see Net::HTTP@Proxy+Server.
+      attr_reader :proxy_port
+
+      # Returns the user name for accessing the proxy, or +nil+ if none;
+      # see Net::HTTP@Proxy+Server.
+      attr_reader :proxy_user
+
+      # Returns the password for accessing the proxy, or +nil+ if none;
+      # see Net::HTTP@Proxy+Server.
+      attr_reader :proxy_pass
+    end
+
+    # Returns +true+ if a proxy server is defined, +false+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy?
+      !!(@proxy_from_env ? proxy_uri : @proxy_address)
+    end
+
+    # Returns +true+ if the proxy server is defined in the environment,
+    # +false+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy_from_env?
+      @proxy_from_env
+    end
+
+    # The proxy URI determined from the environment for this connection.
+    def proxy_uri # :nodoc:
+      return if @proxy_uri == false
+      @proxy_uri ||= URI::HTTP.new(
+        "http", nil, address, port, nil, nil, nil, nil, nil
+      ).find_proxy || false
+      @proxy_uri || nil
+    end
+
+    # Returns the address of the proxy server, if defined, +nil+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy_address
+      if @proxy_from_env then
+        proxy_uri&.hostname
+      else
+        @proxy_address
+      end
+    end
+
+    # Returns the port number of the proxy server, if defined, +nil+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy_port
+      if @proxy_from_env then
+        proxy_uri&.port
+      else
+        @proxy_port
+      end
+    end
+
+    # Returns the user name of the proxy server, if defined, +nil+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy_user
+      if @proxy_from_env
+        user = proxy_uri&.user
+        unescape(user) if user
+      else
+        @proxy_user
+      end
+    end
+
+    # Returns the password of the proxy server, if defined, +nil+ otherwise;
+    # see {Proxy Server}[rdoc-ref:Net::HTTP@Proxy+Server].
+    def proxy_pass
+      if @proxy_from_env
+        pass = proxy_uri&.password
+        unescape(pass) if pass
+      else
+        @proxy_pass
+      end
+    end
+
+    alias proxyaddr proxy_address   #:nodoc: obsolete
+    alias proxyport proxy_port      #:nodoc: obsolete
+
+    private
+
+    def unescape(value)
+      require 'cgi/util'
+      CGI.unescape(value)
+    end
+
+    # without proxy, obsolete
+
+    def conn_address # :nodoc:
+      @ipaddr || address()
+    end
+
+    def conn_port # :nodoc:
+      port()
+    end
+
+    def edit_path(path)
+      if proxy?
+        if path.start_with?("ftp://") || use_ssl?
+          path
+        else
+          "http://#{addr_port}#{path}"
+        end
+      else
+        path
+      end
+    end
+
+    #
+    # HTTP operations
+    #
+
+    public
+
+    # :call-seq:
+    #    get(path, initheader = nil) {|res| ... }
+    #
+    # Sends a GET request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Get object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    # With a block given, calls the block with the response body:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.get('/todos/1') do |res|
+    #     p res
+    #   end # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # Output:
+    #
+    #   "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false\n}"
+    #
+    # With no block given, simply returns the response object:
+    #
+    #   http.get('/') # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # Related:
+    #
+    # - Net::HTTP::Get: request class for \HTTP method GET.
+    # - Net::HTTP.get: sends GET request, returns response body.
+    #
+    def get(path, initheader = nil, dest = nil, &block) # :yield: +body_segment+
+      res = nil
+
+      request(Get.new(path, initheader)) {|r|
+        r.read_body dest, &block
+        res = r
+      }
+      res
+    end
+
+    # Sends a HEAD request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Head object
+    # created from string +path+ and initial headers hash +initheader+:
+    #
+    #   res = http.head('/todos/1') # => #<Net::HTTPOK 200 OK readbody=true>
+    #   res.body                    # => nil
+    #   res.to_hash.take(3)
+    #   # =>
+    #   [["date", ["Wed, 15 Feb 2023 15:25:42 GMT"]],
+    #    ["content-type", ["application/json; charset=utf-8"]],
+    #    ["connection", ["close"]]]
+    #
+    def head(path, initheader = nil)
+      request(Head.new(path, initheader))
+    end
+
+    # :call-seq:
+    #    post(path, data, initheader = nil) {|res| ... }
+    #
+    # Sends a POST request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Post object
+    # created from string +path+, string +data+, and initial headers hash +initheader+.
+    #
+    # With a block given, calls the block with the response body:
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.post('/todos', data) do |res|
+    #     p res
+    #   end # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    # Output:
+    #
+    #   "{\n  \"{\\\"userId\\\": 1, \\\"id\\\": 1, \\\"title\\\": \\\"delectus aut autem\\\", \\\"completed\\\": false}\": \"\",\n  \"id\": 201\n}"
+    #
+    # With no block given, simply returns the response object:
+    #
+    #   http.post('/todos', data) # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    # Related:
+    #
+    # - Net::HTTP::Post: request class for \HTTP method POST.
+    # - Net::HTTP.post: sends POST request, returns response body.
+    #
+    def post(path, data, initheader = nil, dest = nil, &block) # :yield: +body_segment+
+      send_entity(path, data, initheader, dest, Post, &block)
+    end
+
+    # :call-seq:
+    #    patch(path, data, initheader = nil) {|res| ... }
+    #
+    # Sends a PATCH request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Patch object
+    # created from string +path+, string +data+, and initial headers hash +initheader+.
+    #
+    # With a block given, calls the block with the response body:
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.patch('/todos/1', data) do |res|
+    #     p res
+    #   end # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # Output:
+    #
+    #   "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false,\n  \"{\\\"userId\\\": 1, \\\"id\\\": 1, \\\"title\\\": \\\"delectus aut autem\\\", \\\"completed\\\": false}\": \"\"\n}"
+    #
+    # With no block given, simply returns the response object:
+    #
+    #   http.patch('/todos/1', data) # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    def patch(path, data, initheader = nil, dest = nil, &block) # :yield: +body_segment+
+      send_entity(path, data, initheader, dest, Patch, &block)
+    end
+
+    # Sends a PUT request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Put object
+    # created from string +path+, string +data+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.put('/todos/1', data) # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    def put(path, data, initheader = nil)
+      request(Put.new(path, initheader), data)
+    end
+
+    # Sends a PROPPATCH request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Proppatch object
+    # created from string +path+, string +body+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.proppatch('/todos/1', data)
+    #
+    def proppatch(path, body, initheader = nil)
+      request(Proppatch.new(path, initheader), body)
+    end
+
+    # Sends a LOCK request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Lock object
+    # created from string +path+, string +body+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.lock('/todos/1', data)
+    #
+    def lock(path, body, initheader = nil)
+      request(Lock.new(path, initheader), body)
+    end
+
+    # Sends an UNLOCK request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Unlock object
+    # created from string +path+, string +body+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.unlock('/todos/1', data)
+    #
+    def unlock(path, body, initheader = nil)
+      request(Unlock.new(path, initheader), body)
+    end
+
+    # Sends an Options request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Options object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.options('/')
+    #
+    def options(path, initheader = nil)
+      request(Options.new(path, initheader))
+    end
+
+    # Sends a PROPFIND request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Propfind object
+    # created from string +path+, string +body+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http = Net::HTTP.new(hostname)
+    #   http.propfind('/todos/1', data)
+    #
+    def propfind(path, body = nil, initheader = {'Depth' => '0'})
+      request(Propfind.new(path, initheader), body)
+    end
+
+    # Sends a DELETE request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Delete object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.delete('/todos/1')
+    #
+    def delete(path, initheader = {'Depth' => 'Infinity'})
+      request(Delete.new(path, initheader))
+    end
+
+    # Sends a MOVE request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Move object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.move('/todos/1')
+    #
+    def move(path, initheader = nil)
+      request(Move.new(path, initheader))
+    end
+
+    # Sends a COPY request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Copy object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.copy('/todos/1')
+    #
+    def copy(path, initheader = nil)
+      request(Copy.new(path, initheader))
+    end
+
+    # Sends a MKCOL request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Mkcol object
+    # created from string +path+, string +body+, and initial headers hash +initheader+.
+    #
+    #   data = '{"userId": 1, "id": 1, "title": "delectus aut autem", "completed": false}'
+    #   http.mkcol('/todos/1', data)
+    #   http = Net::HTTP.new(hostname)
+    #
+    def mkcol(path, body = nil, initheader = nil)
+      request(Mkcol.new(path, initheader), body)
+    end
+
+    # Sends a TRACE request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Trace object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.trace('/todos/1')
+    #
+    def trace(path, initheader = nil)
+      request(Trace.new(path, initheader))
+    end
+
+    # Sends a GET request to the server;
+    # forms the response into a Net::HTTPResponse object.
+    #
+    # The request is based on the Net::HTTP::Get object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    # With no block given, returns the response object:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.request_get('/todos') # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # With a block given, calls the block with the response object
+    # and returns the response object:
+    #
+    #   http.request_get('/todos') do |res|
+    #     p res
+    #   end # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # Output:
+    #
+    #   #<Net::HTTPOK 200 OK readbody=false>
+    #
+    def request_get(path, initheader = nil, &block) # :yield: +response+
+      request(Get.new(path, initheader), &block)
+    end
+
+    # Sends a HEAD request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Head object
+    # created from string +path+ and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.head('/todos/1') # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    def request_head(path, initheader = nil, &block)
+      request(Head.new(path, initheader), &block)
+    end
+
+    # Sends a POST request to the server;
+    # forms the response into a Net::HTTPResponse object.
+    #
+    # The request is based on the Net::HTTP::Post object
+    # created from string +path+, string +data+, and initial headers hash +initheader+.
+    #
+    # With no block given, returns the response object:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.post('/todos', 'xyzzy')
+    #   # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    # With a block given, calls the block with the response body
+    # and returns the response object:
+    #
+    #   http.post('/todos', 'xyzzy') do |res|
+    #     p res
+    #   end # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    # Output:
+    #
+    #   "{\n  \"xyzzy\": \"\",\n  \"id\": 201\n}"
+    #
+    def request_post(path, data, initheader = nil, &block) # :yield: +response+
+      request Post.new(path, initheader), data, &block
+    end
+
+    # Sends a PUT request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTP::Put object
+    # created from string +path+, string +data+, and initial headers hash +initheader+.
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.put('/todos/1', 'xyzzy')
+    #   # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    def request_put(path, data, initheader = nil, &block)   #:nodoc:
+      request Put.new(path, initheader), data, &block
+    end
+
+    alias get2   request_get    #:nodoc: obsolete
+    alias head2  request_head   #:nodoc: obsolete
+    alias post2  request_post   #:nodoc: obsolete
+    alias put2   request_put    #:nodoc: obsolete
+
+    # Sends an \HTTP request to the server;
+    # returns an instance of a subclass of Net::HTTPResponse.
+    #
+    # The request is based on the Net::HTTPRequest object
+    # created from string +path+, string +data+, and initial headers hash +header+.
+    # That object is an instance of the
+    # {subclass of Net::HTTPRequest}[rdoc-ref:Net::HTTPRequest@Request+Subclasses],
+    # that corresponds to the given uppercase string +name+,
+    # which must be
+    # an {HTTP request method}[https://en.wikipedia.org/wiki/HTTP#Request_methods]
+    # or a {WebDAV request method}[https://en.wikipedia.org/wiki/WebDAV#Implementation].
+    #
+    # Examples:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #   http.send_request('GET', '/todos/1')
+    #   # => #<Net::HTTPOK 200 OK readbody=true>
+    #   http.send_request('POST', '/todos', 'xyzzy')
+    #   # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    def send_request(name, path, data = nil, header = nil)
+      has_response_body = name != 'HEAD'
+      r = HTTPGenericRequest.new(name,(data ? true : false),has_response_body,path,header)
+      request r, data
+    end
+
+    # Sends the given request +req+ to the server;
+    # forms the response into a Net::HTTPResponse object.
+    #
+    # The given +req+ must be an instance of a
+    # {subclass of Net::HTTPRequest}[rdoc-ref:Net::HTTPRequest@Request+Subclasses].
+    # Argument +body+ should be given only if needed for the request.
+    #
+    # With no block given, returns the response object:
+    #
+    #   http = Net::HTTP.new(hostname)
+    #
+    #   req = Net::HTTP::Get.new('/todos/1')
+    #   http.request(req)
+    #   # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    #   req = Net::HTTP::Post.new('/todos')
+    #   http.request(req, 'xyzzy')
+    #   # => #<Net::HTTPCreated 201 Created readbody=true>
+    #
+    # With a block given, calls the block with the response and returns the response:
+    #
+    #   req = Net::HTTP::Get.new('/todos/1')
+    #   http.request(req) do |res|
+    #     p res
+    #   end # => #<Net::HTTPOK 200 OK readbody=true>
+    #
+    # Output:
+    #
+    #   #<Net::HTTPOK 200 OK readbody=false>
+    #
+    def request(req, body = nil, &block)  # :yield: +response+
+      unless started?
+        start {
+          req['connection'] ||= 'close'
+          return request(req, body, &block)
+        }
+      end
+      if proxy_user()
+        req.proxy_basic_auth proxy_user(), proxy_pass() unless use_ssl?
+      end
+      req.set_body_internal body
+      res = transport_request(req, &block)
+      if sspi_auth?(res)
+        sspi_auth(req)
+        res = transport_request(req, &block)
+      end
+      res
+    end
+
+    private
+
+    # Executes a request which uses a representation
+    # and returns its body.
+    def send_entity(path, data, initheader, dest, type, &block)
+      res = nil
+      request(type.new(path, initheader), data) {|r|
+        r.read_body dest, &block
+        res = r
+      }
+      res
+    end
+
+    IDEMPOTENT_METHODS_ = %w/GET HEAD PUT DELETE OPTIONS TRACE/ # :nodoc:
+
+    def transport_request(req)
+      count = 0
+      begin
+        begin_transport req
+        res = catch(:response) {
+          begin
+            req.exec @socket, @curr_http_version, edit_path(req.path)
+          rescue Errno::EPIPE
+            # Failure when writing full request, but we can probably
+            # still read the received response.
+          end
+
+          begin
+            res = HTTPResponse.read_new(@socket)
+            res.decode_content = req.decode_content
+            res.body_encoding = @response_body_encoding
+            res.ignore_eof = @ignore_eof
+          end while res.kind_of?(HTTPInformation)
+
+          res.uri = req.uri
+
+          res
+        }
+        res.reading_body(@socket, req.response_body_permitted?) {
+          yield res if block_given?
+        }
+      rescue Net::OpenTimeout
+        raise
+      rescue Net::ReadTimeout, IOError, EOFError,
+             Errno::ECONNRESET, Errno::ECONNABORTED, Errno::EPIPE, Errno::ETIMEDOUT,
+             # avoid a dependency on OpenSSL
+             defined?(OpenSSL::SSL) ? OpenSSL::SSL::SSLError : IOError,
+             Timeout::Error => exception
+        if count < max_retries && IDEMPOTENT_METHODS_.include?(req.method)
+          count += 1
+          @socket.close if @socket
+          debug "Conn close because of error #{exception}, and retry"
+          retry
+        end
+        debug "Conn close because of error #{exception}"
+        @socket.close if @socket
+        raise
+      end
+
+      end_transport req, res
+      res
+    rescue => exception
+      debug "Conn close because of error #{exception}"
+      @socket.close if @socket
+      raise exception
+    end
+
+    def begin_transport(req)
+      if @socket.closed?
+        connect
+      elsif @last_communicated
+        if @last_communicated + @keep_alive_timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          debug 'Conn close because of keep_alive_timeout'
+          @socket.close
+          connect
+        elsif @socket.io.to_io.wait_readable(0) && @socket.eof?
+          debug "Conn close because of EOF"
+          @socket.close
+          connect
+        end
+      end
+
+      if not req.response_body_permitted? and @close_on_empty_response
+        req['connection'] ||= 'close'
+      end
+
+      req.update_uri address, port, use_ssl?
+      req['host'] ||= addr_port()
+    end
+
+    def end_transport(req, res)
+      @curr_http_version = res.http_version
+      @last_communicated = nil
+      if @socket.closed?
+        debug 'Conn socket closed'
+      elsif not res.body and @close_on_empty_response
+        debug 'Conn close'
+        @socket.close
+      elsif keep_alive?(req, res)
+        debug 'Conn keep-alive'
+        @last_communicated = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      else
+        debug 'Conn close'
+        @socket.close
+      end
+    end
+
+    def keep_alive?(req, res)
+      return false if req.connection_close?
+      if @curr_http_version <= '1.0'
+        res.connection_keep_alive?
+      else   # HTTP/1.1 or later
+        not res.connection_close?
+      end
+    end
+
+    def sspi_auth?(res)
+      return false unless @sspi_enabled
+      if res.kind_of?(HTTPProxyAuthenticationRequired) and
+          proxy? and res["Proxy-Authenticate"].include?("Negotiate")
+        begin
+          require 'win32/sspi'
+          true
+        rescue LoadError
+          false
+        end
+      else
+        false
+      end
+    end
+
+    def sspi_auth(req)
+      n = Win32::SSPI::NegotiateAuth.new
+      req["Proxy-Authorization"] = "Negotiate #{n.get_initial_token}"
+      # Some versions of ISA will close the connection if this isn't present.
+      req["Connection"] = "Keep-Alive"
+      req["Proxy-Connection"] = "Keep-Alive"
+      res = transport_request(req)
+      authphrase = res["Proxy-Authenticate"]  or return res
+      req["Proxy-Authorization"] = "Negotiate #{n.complete_authentication(authphrase)}"
+    rescue => err
+      raise HTTPAuthenticationError.new('HTTP authentication failed', err)
+    end
+
+    #
+    # utils
+    #
+
+    private
+
+    def addr_port
+      addr = address
+      addr = "[#{addr}]" if addr.include?(":")
+      default_port = use_ssl? ? HTTP.https_default_port : HTTP.http_default_port
+      default_port == port ? addr : "#{addr}:#{port}"
+    end
+
+    # Adds a message to debugging output
+    def debug(msg)
+      return unless @debug_output
+      @debug_output << msg
+      @debug_output << "\n"
+    end
+
+    alias_method :D, :debug
+  end
+
+end
+
+require_relative 'http/exceptions'
+
+require_relative 'http/header'
+
+require_relative 'http/generic_request'
+require_relative 'http/request'
+require_relative 'http/requests'
+
+require_relative 'http/response'
+require_relative 'http/responses'
+
+require_relative 'http/proxy_delta'
+
+require_relative 'http/backward'

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1019,8 +1019,8 @@ module Net   #:nodoc:
         if opt[:use_ssl]
           opt = {verify_mode: OpenSSL::SSL::VERIFY_PEER}.update(opt)
         end
-        http.methods.grep(/\A(\w+)=\z/) do |meth|
-          key = $1.to_sym
+        http.methods.grep(/\A\w+=\z/) do |meth|
+          key = meth.to_s.delete_suffix('=').to_sym
           opt.key?(key) or next
           http.__send__(meth, opt[key])
         end

--- a/lib/net/http/backward.rb
+++ b/lib/net/http/backward.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# for backward compatibility
+
+# :enddoc:
+
+class Net::HTTP
+  ProxyMod = ProxyDelta
+  deprecate_constant :ProxyMod
+end
+
+module Net::NetPrivate
+  HTTPRequest = ::Net::HTTPRequest
+  deprecate_constant :HTTPRequest
+end
+
+module Net
+  HTTPSession = HTTP
+
+  HTTPInformationCode  = HTTPInformation
+  HTTPSuccessCode      = HTTPSuccess
+  HTTPRedirectionCode  = HTTPRedirection
+  HTTPRetriableCode    = HTTPRedirection
+  HTTPClientErrorCode  = HTTPClientError
+  HTTPFatalErrorCode   = HTTPClientError
+  HTTPServerErrorCode  = HTTPServerError
+  HTTPResponseReceiver = HTTPResponse
+
+  HTTPResponceReceiver = HTTPResponse # Typo since 2001
+
+  deprecate_constant :HTTPSession,
+                     :HTTPInformationCode,
+                     :HTTPSuccessCode,
+                     :HTTPRedirectionCode,
+                     :HTTPRetriableCode,
+                     :HTTPClientErrorCode,
+                     :HTTPFatalErrorCode,
+                     :HTTPServerErrorCode,
+                     :HTTPResponseReceiver,
+                     :HTTPResponceReceiver
+end

--- a/lib/net/http/exceptions.rb
+++ b/lib/net/http/exceptions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Net
+  # Net::HTTP exception class.
+  # You cannot use Net::HTTPExceptions directly; instead, you must use
+  # its subclasses.
+  module HTTPExceptions
+    def initialize(msg, res)   #:nodoc:
+      super msg
+      @response = res
+    end
+    attr_reader :response
+    alias data response    #:nodoc: obsolete
+  end
+
+  class HTTPError < ProtocolError
+    include HTTPExceptions
+  end
+
+  class HTTPRetriableError < ProtoRetriableError
+    include HTTPExceptions
+  end
+
+  class HTTPClientException < ProtoServerError
+    include HTTPExceptions
+  end
+
+  class HTTPFatalError < ProtoFatalError
+    include HTTPExceptions
+  end
+
+  # We cannot use the name "HTTPServerError", it is the name of the response.
+  HTTPServerException = HTTPClientException # :nodoc:
+  deprecate_constant(:HTTPServerException)
+end

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+#
+# \HTTPGenericRequest is the parent of the Net::HTTPRequest class.
+#
+# Do not use this directly; instead, use a subclass of Net::HTTPRequest.
+#
+# == About the Examples
+#
+# :include: doc/net-http/examples.rdoc
+#
+class Net::HTTPGenericRequest
+
+  include Net::HTTPHeader
+
+  def initialize(m, reqbody, resbody, uri_or_path, initheader = nil) # :nodoc:
+    @method = m
+    @request_has_body = reqbody
+    @response_has_body = resbody
+
+    if URI === uri_or_path then
+      raise ArgumentError, "not an HTTP URI" unless URI::HTTP === uri_or_path
+      hostname = uri_or_path.hostname
+      raise ArgumentError, "no host component for URI" unless (hostname && hostname.length > 0)
+      @uri = uri_or_path.dup
+      host = @uri.hostname.dup
+      host << ":" << @uri.port.to_s if @uri.port != @uri.default_port
+      @path = uri_or_path.request_uri
+      raise ArgumentError, "no HTTP request path given" unless @path
+    else
+      @uri = nil
+      host = nil
+      raise ArgumentError, "no HTTP request path given" unless uri_or_path
+      raise ArgumentError, "HTTP request path is empty" if uri_or_path.empty?
+      @path = uri_or_path.dup
+    end
+
+    @decode_content = false
+
+    if Net::HTTP::HAVE_ZLIB then
+      if !initheader ||
+         !initheader.keys.any? { |k|
+           %w[accept-encoding range].include? k.downcase
+         } then
+        @decode_content = true if @response_has_body
+        initheader = initheader ? initheader.dup : {}
+        initheader["accept-encoding"] =
+          "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      end
+    end
+
+    initialize_http_header initheader
+    self['Accept'] ||= '*/*'
+    self['User-Agent'] ||= 'Ruby'
+    self['Host'] ||= host if host
+    @body = nil
+    @body_stream = nil
+    @body_data = nil
+  end
+
+  # Returns the string method name for the request:
+  #
+  #   Net::HTTP::Get.new(uri).method  # => "GET"
+  #   Net::HTTP::Post.new(uri).method # => "POST"
+  #
+  attr_reader :method
+
+  # Returns the string path for the request:
+  #
+  #   Net::HTTP::Get.new(uri).path # => "/"
+  #   Net::HTTP::Post.new('example.com').path # => "example.com"
+  #
+  attr_reader :path
+
+  # Returns the URI object for the request, or +nil+ if none:
+  #
+  #   Net::HTTP::Get.new(uri).uri
+  #   # => #<URI::HTTPS https://jsonplaceholder.typicode.com/>
+  #   Net::HTTP::Get.new('example.com').uri # => nil
+  #
+  attr_reader :uri
+
+  # Returns +false+ if the request's header <tt>'Accept-Encoding'</tt>
+  # has been set manually or deleted
+  # (indicating that the user intends to handle encoding in the response),
+  # +true+ otherwise:
+  #
+  #   req = Net::HTTP::Get.new(uri) # => #<Net::HTTP::Get GET>
+  #   req['Accept-Encoding']        # => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+  #   req.decode_content            # => true
+  #   req['Accept-Encoding'] = 'foo'
+  #   req.decode_content            # => false
+  #   req.delete('Accept-Encoding')
+  #   req.decode_content            # => false
+  #
+  attr_reader :decode_content
+
+  # Returns a string representation of the request:
+  #
+  #   Net::HTTP::Post.new(uri).inspect # => "#<Net::HTTP::Post POST>"
+  #
+  def inspect
+    "\#<#{self.class} #{@method}>"
+  end
+
+  ##
+  # Don't automatically decode response content-encoding if the user indicates
+  # they want to handle it.
+
+  def []=(key, val) # :nodoc:
+    @decode_content = false if key.downcase == 'accept-encoding'
+
+    super key, val
+  end
+
+  # Returns whether the request may have a body:
+  #
+  #   Net::HTTP::Post.new(uri).request_body_permitted? # => true
+  #   Net::HTTP::Get.new(uri).request_body_permitted?  # => false
+  #
+  def request_body_permitted?
+    @request_has_body
+  end
+
+  # Returns whether the response may have a body:
+  #
+  #   Net::HTTP::Post.new(uri).response_body_permitted? # => true
+  #   Net::HTTP::Head.new(uri).response_body_permitted? # => false
+  #
+  def response_body_permitted?
+    @response_has_body
+  end
+
+  def body_exist? # :nodoc:
+    warn "Net::HTTPRequest#body_exist? is obsolete; use response_body_permitted?", uplevel: 1 if $VERBOSE
+    response_body_permitted?
+  end
+
+  # Returns the string body for the request, or +nil+ if there is none:
+  #
+  #   req = Net::HTTP::Post.new(uri)
+  #   req.body # => nil
+  #   req.body = '{"title": "foo","body": "bar","userId": 1}'
+  #   req.body # => "{\"title\": \"foo\",\"body\": \"bar\",\"userId\": 1}"
+  #
+  attr_reader :body
+
+  # Sets the body for the request:
+  #
+  #   req = Net::HTTP::Post.new(uri)
+  #   req.body # => nil
+  #   req.body = '{"title": "foo","body": "bar","userId": 1}'
+  #   req.body # => "{\"title\": \"foo\",\"body\": \"bar\",\"userId\": 1}"
+  #
+  def body=(str)
+    @body = str
+    @body_stream = nil
+    @body_data = nil
+    str
+  end
+
+  # Returns the body stream object for the request, or +nil+ if there is none:
+  #
+  #   req = Net::HTTP::Post.new(uri)          # => #<Net::HTTP::Post POST>
+  #   req.body_stream                         # => nil
+  #   require 'stringio'
+  #   req.body_stream = StringIO.new('xyzzy') # => #<StringIO:0x0000027d1e5affa8>
+  #   req.body_stream                         # => #<StringIO:0x0000027d1e5affa8>
+  #
+  attr_reader :body_stream
+
+  # Sets the body stream for the request:
+  #
+  #   req = Net::HTTP::Post.new(uri)          # => #<Net::HTTP::Post POST>
+  #   req.body_stream                         # => nil
+  #   require 'stringio'
+  #   req.body_stream = StringIO.new('xyzzy') # => #<StringIO:0x0000027d1e5affa8>
+  #   req.body_stream                         # => #<StringIO:0x0000027d1e5affa8>
+  #
+  def body_stream=(input)
+    @body = nil
+    @body_stream = input
+    @body_data = nil
+    input
+  end
+
+  def set_body_internal(str)   #:nodoc: internal use only
+    raise ArgumentError, "both of body argument and HTTPRequest#body set" if str and (@body or @body_stream)
+    self.body = str if str
+    if @body.nil? && @body_stream.nil? && @body_data.nil? && request_body_permitted?
+      self.body = ''
+    end
+  end
+
+  #
+  # write
+  #
+
+  def exec(sock, ver, path)   #:nodoc: internal use only
+    if @body
+      send_request_with_body sock, ver, path, @body
+    elsif @body_stream
+      send_request_with_body_stream sock, ver, path, @body_stream
+    elsif @body_data
+      send_request_with_body_data sock, ver, path, @body_data
+    else
+      write_header sock, ver, path
+    end
+  end
+
+  def update_uri(addr, port, ssl) # :nodoc: internal use only
+    # reflect the connection and @path to @uri
+    return unless @uri
+
+    if ssl
+      scheme = 'https'
+      klass = URI::HTTPS
+    else
+      scheme = 'http'
+      klass = URI::HTTP
+    end
+
+    if host = self['host']
+      host.sub!(/:.*/m, '')
+    elsif host = @uri.host
+    else
+     host = addr
+    end
+    # convert the class of the URI
+    if @uri.is_a?(klass)
+      @uri.host = host
+      @uri.port = port
+    else
+      @uri = klass.new(
+        scheme, @uri.userinfo,
+        host, port, nil,
+        @uri.path, nil, @uri.query, nil)
+    end
+  end
+
+  private
+
+  class Chunker #:nodoc:
+    def initialize(sock)
+      @sock = sock
+      @prev = nil
+    end
+
+    def write(buf)
+      # avoid memcpy() of buf, buf can huge and eat memory bandwidth
+      rv = buf.bytesize
+      @sock.write("#{rv.to_s(16)}\r\n", buf, "\r\n")
+      rv
+    end
+
+    def finish
+      @sock.write("0\r\n\r\n")
+    end
+  end
+
+  def send_request_with_body(sock, ver, path, body)
+    self.content_length = body.bytesize
+    delete 'Transfer-Encoding'
+    supply_default_content_type
+    write_header sock, ver, path
+    wait_for_continue sock, ver if sock.continue_timeout
+    sock.write body
+  end
+
+  def send_request_with_body_stream(sock, ver, path, f)
+    unless content_length() or chunked?
+      raise ArgumentError,
+          "Content-Length not given and Transfer-Encoding is not `chunked'"
+    end
+    supply_default_content_type
+    write_header sock, ver, path
+    wait_for_continue sock, ver if sock.continue_timeout
+    if chunked?
+      chunker = Chunker.new(sock)
+      IO.copy_stream(f, chunker)
+      chunker.finish
+    else
+      IO.copy_stream(f, sock)
+    end
+  end
+
+  def send_request_with_body_data(sock, ver, path, params)
+    if /\Amultipart\/form-data\z/i !~ self.content_type
+      self.content_type = 'application/x-www-form-urlencoded'
+      return send_request_with_body(sock, ver, path, URI.encode_www_form(params))
+    end
+
+    opt = @form_option.dup
+    require 'securerandom' unless defined?(SecureRandom)
+    opt[:boundary] ||= SecureRandom.urlsafe_base64(40)
+    self.set_content_type(self.content_type, boundary: opt[:boundary])
+    if chunked?
+      write_header sock, ver, path
+      encode_multipart_form_data(sock, params, opt)
+    else
+      require 'tempfile'
+      file = Tempfile.new('multipart')
+      file.binmode
+      encode_multipart_form_data(file, params, opt)
+      file.rewind
+      self.content_length = file.size
+      write_header sock, ver, path
+      IO.copy_stream(file, sock)
+      file.close(true)
+    end
+  end
+
+  def encode_multipart_form_data(out, params, opt)
+    charset = opt[:charset]
+    boundary = opt[:boundary]
+    require 'securerandom' unless defined?(SecureRandom)
+    boundary ||= SecureRandom.urlsafe_base64(40)
+    chunked_p = chunked?
+
+    buf = +''
+    params.each do |key, value, h={}|
+      key = quote_string(key, charset)
+      filename =
+        h.key?(:filename) ? h[:filename] :
+        value.respond_to?(:to_path) ? File.basename(value.to_path) :
+        nil
+
+      buf << "--#{boundary}\r\n"
+      if filename
+        filename = quote_string(filename, charset)
+        type = h[:content_type] || 'application/octet-stream'
+        buf << "Content-Disposition: form-data; " \
+          "name=\"#{key}\"; filename=\"#{filename}\"\r\n" \
+          "Content-Type: #{type}\r\n\r\n"
+        if !out.respond_to?(:write) || !value.respond_to?(:read)
+          # if +out+ is not an IO or +value+ is not an IO
+          buf << (value.respond_to?(:read) ? value.read : value)
+        elsif value.respond_to?(:size) && chunked_p
+          # if +out+ is an IO and +value+ is a File, use IO.copy_stream
+          flush_buffer(out, buf, chunked_p)
+          out << "%x\r\n" % value.size if chunked_p
+          IO.copy_stream(value, out)
+          out << "\r\n" if chunked_p
+        else
+          # +out+ is an IO, and +value+ is not a File but an IO
+          flush_buffer(out, buf, chunked_p)
+          1 while flush_buffer(out, value.read(4096), chunked_p)
+        end
+      else
+        # non-file field:
+        #   HTML5 says, "The parts of the generated multipart/form-data
+        #   resource that correspond to non-file fields must not have a
+        #   Content-Type header specified."
+        buf << "Content-Disposition: form-data; name=\"#{key}\"\r\n\r\n"
+        buf << (value.respond_to?(:read) ? value.read : value)
+      end
+      buf << "\r\n"
+    end
+    buf << "--#{boundary}--\r\n"
+    flush_buffer(out, buf, chunked_p)
+    out << "0\r\n\r\n" if chunked_p
+  end
+
+  def quote_string(str, charset)
+    str = str.encode(charset, fallback:->(c){'&#%d;'%c.encode("UTF-8").ord}) if charset
+    str.gsub(/[\\"]/, '\\\\\&')
+  end
+
+  def flush_buffer(out, buf, chunked_p)
+    return unless buf
+    out << "%x\r\n"%buf.bytesize if chunked_p
+    out << buf
+    out << "\r\n" if chunked_p
+    buf.clear
+  end
+
+  def supply_default_content_type
+    return if content_type()
+    warn 'net/http: Content-Type did not set; using application/x-www-form-urlencoded', uplevel: 1 if $VERBOSE
+    set_content_type 'application/x-www-form-urlencoded'
+  end
+
+  ##
+  # Waits up to the continue timeout for a response from the server provided
+  # we're speaking HTTP 1.1 and are expecting a 100-continue response.
+
+  def wait_for_continue(sock, ver)
+    if ver >= '1.1' and @header['expect'] and
+        @header['expect'].include?('100-continue')
+      if sock.io.to_io.wait_readable(sock.continue_timeout)
+        res = Net::HTTPResponse.read_new(sock)
+        unless res.kind_of?(Net::HTTPContinue)
+          res.decode_content = @decode_content
+          throw :response, res
+        end
+      end
+    end
+  end
+
+  def write_header(sock, ver, path)
+    reqline = "#{@method} #{path} HTTP/#{ver}"
+    if /[\r\n]/ =~ reqline
+      raise ArgumentError, "A Request-Line must not contain CR or LF"
+    end
+    buf = +''
+    buf << reqline << "\r\n"
+    each_capitalized do |k,v|
+      buf << "#{k}: #{v}\r\n"
+    end
+    buf << "\r\n"
+    sock.write buf
+  end
+
+end
+

--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -1,0 +1,981 @@
+# frozen_string_literal: true
+#
+# The \HTTPHeader module provides access to \HTTP headers.
+#
+# The module is included in:
+#
+# - Net::HTTPGenericRequest (and therefore Net::HTTPRequest).
+# - Net::HTTPResponse.
+#
+# The headers are a hash-like collection of key/value pairs called _fields_.
+#
+# == Request and Response Fields
+#
+# Headers may be included in:
+#
+# - A Net::HTTPRequest object:
+#   the object's headers will be sent with the request.
+#   Any fields may be defined in the request;
+#   see {Setters}[rdoc-ref:Net::HTTPHeader@Setters].
+# - A Net::HTTPResponse object:
+#   the objects headers are usually those returned from the host.
+#   Fields may be retrieved from the object;
+#   see {Getters}[rdoc-ref:Net::HTTPHeader@Getters]
+#   and {Iterators}[rdoc-ref:Net::HTTPHeader@Iterators].
+#
+# Exactly which fields should be sent or expected depends on the host;
+# see:
+#
+# - {Request fields}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields].
+# - {Response fields}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Response_fields].
+#
+# == About the Examples
+#
+# :include: doc/net-http/examples.rdoc
+#
+# == Fields
+#
+# A header field is a key/value pair.
+#
+# === Field Keys
+#
+# A field key may be:
+#
+# - A string: Key <tt>'Accept'</tt> is treated as if it were
+#   <tt>'Accept'.downcase</tt>;  i.e., <tt>'accept'</tt>.
+# - A symbol: Key <tt>:Accept</tt> is treated as if it were
+#   <tt>:Accept.to_s.downcase</tt>;  i.e., <tt>'accept'</tt>.
+#
+# Examples:
+#
+#   req = Net::HTTP::Get.new(uri)
+#   req[:accept]  # => "*/*"
+#   req['Accept'] # => "*/*"
+#   req['ACCEPT'] # => "*/*"
+#
+#   req['accept'] = 'text/html'
+#   req[:accept] = 'text/html'
+#   req['ACCEPT'] = 'text/html'
+#
+# === Field Values
+#
+# A field value may be returned as an array of strings or as a string:
+#
+# - These methods return field values as arrays:
+#
+#   - #get_fields: Returns the array value for the given key,
+#     or +nil+ if it does not exist.
+#   - #to_hash: Returns a hash of all header fields:
+#     each key is a field name; its value is the array value for the field.
+#
+# - These methods return field values as string;
+#   the string value for a field is equivalent to
+#   <tt>self[key.downcase.to_s].join(', '))</tt>:
+#
+#   - #[]: Returns the string value for the given key,
+#     or +nil+ if it does not exist.
+#   - #fetch: Like #[], but accepts a default value
+#     to be returned if the key does not exist.
+#
+# The field value may be set:
+#
+# - #[]=: Sets the value for the given key;
+#   the given value may be a string, a symbol, an array, or a hash.
+# - #add_field: Adds a given value to a value for the given key
+#   (not overwriting the existing value).
+# - #delete: Deletes the field for the given key.
+#
+# Example field values:
+#
+# - \String:
+#
+#     req['Accept'] = 'text/html' # => "text/html"
+#     req['Accept']               # => "text/html"
+#     req.get_fields('Accept')    # => ["text/html"]
+#
+# - \Symbol:
+#
+#     req['Accept'] = :text    # => :text
+#     req['Accept']            # => "text"
+#     req.get_fields('Accept') # => ["text"]
+#
+# - Simple array:
+#
+#     req[:foo] = %w[bar baz bat]
+#     req[:foo]            # => "bar, baz, bat"
+#     req.get_fields(:foo) # => ["bar", "baz", "bat"]
+#
+# - Simple hash:
+#
+#     req[:foo] = {bar: 0, baz: 1, bat: 2}
+#     req[:foo]            # => "bar, 0, baz, 1, bat, 2"
+#     req.get_fields(:foo) # => ["bar", "0", "baz", "1", "bat", "2"]
+#
+# - Nested:
+#
+#     req[:foo] = [%w[bar baz], {bat: 0, bam: 1}]
+#     req[:foo]            # => "bar, baz, bat, 0, bam, 1"
+#     req.get_fields(:foo) # => ["bar", "baz", "bat", "0", "bam", "1"]
+#
+#     req[:foo] = {bar: %w[baz bat], bam: {bah: 0, bad: 1}}
+#     req[:foo]            # => "bar, baz, bat, bam, bah, 0, bad, 1"
+#     req.get_fields(:foo) # => ["bar", "baz", "bat", "bam", "bah", "0", "bad", "1"]
+#
+# == Convenience Methods
+#
+# Various convenience methods retrieve values, set values, query values,
+# set form values, or iterate over fields.
+#
+# === Setters
+#
+# \Method #[]= can set any field, but does little to validate the new value;
+# some of the other setter methods provide some validation:
+#
+# - #[]=: Sets the string or array value for the given key.
+# - #add_field: Creates or adds to the array value for the given key.
+# - #basic_auth: Sets the string authorization header for <tt>'Authorization'</tt>.
+# - #content_length=: Sets the integer length for field <tt>'Content-Length</tt>.
+# - #content_type=: Sets the string value for field <tt>'Content-Type'</tt>.
+# - #proxy_basic_auth: Sets the string authorization header for <tt>'Proxy-Authorization'</tt>.
+# - #set_range: Sets the value for field <tt>'Range'</tt>.
+#
+# === Form Setters
+#
+# - #set_form: Sets an HTML form data set.
+# - #set_form_data: Sets header fields and a body from HTML form data.
+#
+# === Getters
+#
+# \Method #[] can retrieve the value of any field that exists,
+# but always as a string;
+# some of the other getter methods return something different
+# from the simple string value:
+#
+# - #[]: Returns the string field value for the given key.
+# - #content_length: Returns the integer value of field <tt>'Content-Length'</tt>.
+# - #content_range: Returns the Range value of field <tt>'Content-Range'</tt>.
+# - #content_type: Returns the string value of field <tt>'Content-Type'</tt>.
+# - #fetch: Returns the string field value for the given key.
+# - #get_fields: Returns the array field value for the given +key+.
+# - #main_type: Returns first part of the string value of field <tt>'Content-Type'</tt>.
+# - #sub_type: Returns second part of the string value of field <tt>'Content-Type'</tt>.
+# - #range: Returns an array of Range objects of field <tt>'Range'</tt>, or +nil+.
+# - #range_length: Returns the integer length of the range given in field <tt>'Content-Range'</tt>.
+# - #type_params: Returns the string parameters for <tt>'Content-Type'</tt>.
+#
+# === Queries
+#
+# - #chunked?: Returns whether field <tt>'Transfer-Encoding'</tt> is set to <tt>'chunked'</tt>.
+# - #connection_close?: Returns whether field <tt>'Connection'</tt> is set to <tt>'close'</tt>.
+# - #connection_keep_alive?: Returns whether field <tt>'Connection'</tt> is set to <tt>'keep-alive'</tt>.
+# - #key?: Returns whether a given key exists.
+#
+# === Iterators
+#
+# - #each_capitalized: Passes each field capitalized-name/value pair to the block.
+# - #each_capitalized_name: Passes each capitalized field name to the block.
+# - #each_header: Passes each field name/value pair to the block.
+# - #each_name: Passes each field name to the block.
+# - #each_value: Passes each string field value to the block.
+#
+module Net::HTTPHeader
+  MAX_KEY_LENGTH = 1024
+  MAX_FIELD_LENGTH = 65536
+
+  def initialize_http_header(initheader) #:nodoc:
+    @header = {}
+    return unless initheader
+    initheader.each do |key, value|
+      warn "net/http: duplicated HTTP header: #{key}", uplevel: 3 if key?(key) and $VERBOSE
+      if value.nil?
+        warn "net/http: nil HTTP header: #{key}", uplevel: 3 if $VERBOSE
+      else
+        value = value.strip # raise error for invalid byte sequences
+        if key.to_s.bytesize > MAX_KEY_LENGTH
+          raise ArgumentError, "too long (#{key.bytesize} bytes) header: #{key[0, 30].inspect}..."
+        end
+        if value.to_s.bytesize > MAX_FIELD_LENGTH
+          raise ArgumentError, "header #{key} has too long field value: #{value.bytesize}"
+        end
+        if value.count("\r\n") > 0
+          raise ArgumentError, "header #{key} has field value #{value.inspect}, this cannot include CR/LF"
+        end
+        @header[key.downcase.to_s] = [value]
+      end
+    end
+  end
+
+  def size   #:nodoc: obsolete
+    @header.size
+  end
+
+  alias length size   #:nodoc: obsolete
+
+  # Returns the string field value for the case-insensitive field +key+,
+  # or +nil+ if there is no such key;
+  # see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['Connection'] # => "keep-alive"
+  #   res['Nosuch']     # => nil
+  #
+  # Note that some field values may be retrieved via convenience methods;
+  # see {Getters}[rdoc-ref:Net::HTTPHeader@Getters].
+  def [](key)
+    a = @header[key.downcase.to_s] or return nil
+    a.join(', ')
+  end
+
+  # Sets the value for the case-insensitive +key+ to +val+,
+  # overwriting the previous value if the field exists;
+  # see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req['Accept'] # => "*/*"
+  #   req['Accept'] = 'text/html'
+  #   req['Accept'] # => "text/html"
+  #
+  # Note that some field values may be set via convenience methods;
+  # see {Setters}[rdoc-ref:Net::HTTPHeader@Setters].
+  def []=(key, val)
+    unless val
+      @header.delete key.downcase.to_s
+      return val
+    end
+    set_field(key, val)
+  end
+
+  # Adds value +val+ to the value array for field +key+ if the field exists;
+  # creates the field with the given +key+ and +val+ if it does not exist.
+  # see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.add_field('Foo', 'bar')
+  #   req['Foo']            # => "bar"
+  #   req.add_field('Foo', 'baz')
+  #   req['Foo']            # => "bar, baz"
+  #   req.add_field('Foo', %w[baz bam])
+  #   req['Foo']            # => "bar, baz, baz, bam"
+  #   req.get_fields('Foo') # => ["bar", "baz", "baz", "bam"]
+  #
+  def add_field(key, val)
+    stringified_downcased_key = key.downcase.to_s
+    if @header.key?(stringified_downcased_key)
+      append_field_value(@header[stringified_downcased_key], val)
+    else
+      set_field(key, val)
+    end
+  end
+
+  private def set_field(key, val)
+    case val
+    when Enumerable
+      ary = []
+      append_field_value(ary, val)
+      @header[key.downcase.to_s] = ary
+    else
+      val = val.to_s # for compatibility use to_s instead of to_str
+      if val.b.count("\r\n") > 0
+        raise ArgumentError, 'header field value cannot include CR/LF'
+      end
+      @header[key.downcase.to_s] = [val]
+    end
+  end
+
+  private def append_field_value(ary, val)
+    case val
+    when Enumerable
+      val.each{|x| append_field_value(ary, x)}
+    else
+      val = val.to_s
+      if /[\r\n]/n.match?(val.b)
+        raise ArgumentError, 'header field value cannot include CR/LF'
+      end
+      ary.push val
+    end
+  end
+
+  # Returns the array field value for the given +key+,
+  # or +nil+ if there is no such field;
+  # see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.get_fields('Connection') # => ["keep-alive"]
+  #   res.get_fields('Nosuch')     # => nil
+  #
+  def get_fields(key)
+    stringified_downcased_key = key.downcase.to_s
+    return nil unless @header[stringified_downcased_key]
+    @header[stringified_downcased_key].dup
+  end
+
+  # call-seq:
+  #   fetch(key, default_val = nil) {|key| ... } -> object
+  #   fetch(key, default_val = nil) -> value or default_val
+  #
+  # With a block, returns the string value for +key+ if it exists;
+  # otherwise returns the value of the block;
+  # ignores the +default_val+;
+  # see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #
+  #   # Field exists; block not called.
+  #   res.fetch('Connection') do |value|
+  #     fail 'Cannot happen'
+  #   end # => "keep-alive"
+  #
+  #   # Field does not exist; block called.
+  #   res.fetch('Nosuch') do |value|
+  #     value.downcase
+  #   end # => "nosuch"
+  #
+  # With no block, returns the string value for +key+ if it exists;
+  # otherwise, returns +default_val+ if it was given;
+  # otherwise raises an exception:
+  #
+  #   res.fetch('Connection', 'Foo') # => "keep-alive"
+  #   res.fetch('Nosuch', 'Foo')     # => "Foo"
+  #   res.fetch('Nosuch')            # Raises KeyError.
+  #
+  def fetch(key, *args, &block)   #:yield: +key+
+    a = @header.fetch(key.downcase.to_s, *args, &block)
+    a.kind_of?(Array) ? a.join(', ') : a
+  end
+
+  # Calls the block with each key/value pair:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.each_header do |key, value|
+  #     p [key, value] if key.start_with?('c')
+  #   end
+  #
+  # Output:
+  #
+  #   ["content-type", "application/json; charset=utf-8"]
+  #   ["connection", "keep-alive"]
+  #   ["cache-control", "max-age=43200"]
+  #   ["cf-cache-status", "HIT"]
+  #   ["cf-ray", "771d17e9bc542cf5-ORD"]
+  #
+  # Returns an enumerator if no block is given.
+  #
+  # Net::HTTPHeader#each is an alias for Net::HTTPHeader#each_header.
+  def each_header   #:yield: +key+, +value+
+    block_given? or return enum_for(__method__) { @header.size }
+    @header.each do |k,va|
+      yield k, va.join(', ')
+    end
+  end
+
+  alias each each_header
+
+  # Calls the block with each field key:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.each_key do |key|
+  #     p key if key.start_with?('c')
+  #   end
+  #
+  # Output:
+  #
+  #   "content-type"
+  #   "connection"
+  #   "cache-control"
+  #   "cf-cache-status"
+  #   "cf-ray"
+  #
+  # Returns an enumerator if no block is given.
+  #
+  # Net::HTTPHeader#each_name is an alias for Net::HTTPHeader#each_key.
+  def each_name(&block)   #:yield: +key+
+    block_given? or return enum_for(__method__) { @header.size }
+    @header.each_key(&block)
+  end
+
+  alias each_key each_name
+
+  # Calls the block with each capitalized field name:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.each_capitalized_name do |key|
+  #     p key if key.start_with?('C')
+  #   end
+  #
+  # Output:
+  #
+  #   "Content-Type"
+  #   "Connection"
+  #   "Cache-Control"
+  #   "Cf-Cache-Status"
+  #   "Cf-Ray"
+  #
+  # The capitalization is system-dependent;
+  # see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
+  #
+  # Returns an enumerator if no block is given.
+  def each_capitalized_name  #:yield: +key+
+    block_given? or return enum_for(__method__) { @header.size }
+    @header.each_key do |k|
+      yield capitalize(k)
+    end
+  end
+
+  # Calls the block with each string field value:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.each_value do |value|
+  #     p value if value.start_with?('c')
+  #   end
+  #
+  # Output:
+  #
+  #   "chunked"
+  #   "cf-q-config;dur=6.0000002122251e-06"
+  #   "cloudflare"
+  #
+  # Returns an enumerator if no block is given.
+  def each_value   #:yield: +value+
+    block_given? or return enum_for(__method__) { @header.size }
+    @header.each_value do |va|
+      yield va.join(', ')
+    end
+  end
+
+  # Removes the header for the given case-insensitive +key+
+  # (see {Fields}[rdoc-ref:Net::HTTPHeader@Fields]);
+  # returns the deleted value, or +nil+ if no such field exists:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.delete('Accept') # => ["*/*"]
+  #   req.delete('Nosuch') # => nil
+  #
+  def delete(key)
+    @header.delete(key.downcase.to_s)
+  end
+
+  # Returns +true+ if the field for the case-insensitive +key+ exists, +false+ otherwise:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.key?('Accept') # => true
+  #   req.key?('Nosuch') # => false
+  #
+  def key?(key)
+    @header.key?(key.downcase.to_s)
+  end
+
+  # Returns a hash of the key/value pairs:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.to_hash
+  #   # =>
+  #   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+  #    "accept"=>["*/*"],
+  #    "user-agent"=>["Ruby"],
+  #    "host"=>["jsonplaceholder.typicode.com"]}
+  #
+  def to_hash
+    @header.dup
+  end
+
+  # Like #each_header, but the keys are returned in capitalized form.
+  #
+  # Net::HTTPHeader#canonical_each is an alias for Net::HTTPHeader#each_capitalized.
+  def each_capitalized
+    block_given? or return enum_for(__method__) { @header.size }
+    @header.each do |k,v|
+      yield capitalize(k), v.join(', ')
+    end
+  end
+
+  alias canonical_each each_capitalized
+
+  def capitalize(name)
+    name.to_s.split(/-/).map {|s| s.capitalize }.join('-')
+  end
+  private :capitalize
+
+  # Returns an array of Range objects that represent
+  # the value of field <tt>'Range'</tt>,
+  # or +nil+ if there is no such field;
+  # see {Range request header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#range-request-header]:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req['Range'] = 'bytes=0-99,200-299,400-499'
+  #   req.range # => [0..99, 200..299, 400..499]
+  #   req.delete('Range')
+  #   req.range # # => nil
+  #
+  def range
+    return nil unless @header['range']
+
+    value = self['Range']
+    # byte-range-set = *( "," OWS ) ( byte-range-spec / suffix-byte-range-spec )
+    #   *( OWS "," [ OWS ( byte-range-spec / suffix-byte-range-spec ) ] )
+    # corrected collected ABNF
+    # http://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#section-5.4.1
+    # http://tools.ietf.org/html/draft-ietf-httpbis-p5-range-19#appendix-C
+    # http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-19#section-3.2.5
+    unless /\Abytes=((?:,[ \t]*)*(?:\d+-\d*|-\d+)(?:[ \t]*,(?:[ \t]*\d+-\d*|-\d+)?)*)\z/ =~ value
+      raise Net::HTTPHeaderSyntaxError, "invalid syntax for byte-ranges-specifier: '#{value}'"
+    end
+
+    byte_range_set = $1
+    result = byte_range_set.split(/,/).map {|spec|
+      m = /(\d+)?\s*-\s*(\d+)?/i.match(spec) or
+              raise Net::HTTPHeaderSyntaxError, "invalid byte-range-spec: '#{spec}'"
+      d1 = m[1].to_i
+      d2 = m[2].to_i
+      if m[1] and m[2]
+        if d1 > d2
+          raise Net::HTTPHeaderSyntaxError, "last-byte-pos MUST greater than or equal to first-byte-pos but '#{spec}'"
+        end
+        d1..d2
+      elsif m[1]
+        d1..-1
+      elsif m[2]
+        -d2..-1
+      else
+        raise Net::HTTPHeaderSyntaxError, 'range is not specified'
+      end
+    }
+    # if result.empty?
+    # byte-range-set must include at least one byte-range-spec or suffix-byte-range-spec
+    # but above regexp already denies it.
+    if result.size == 1 && result[0].begin == 0 && result[0].end == -1
+      raise Net::HTTPHeaderSyntaxError, 'only one suffix-byte-range-spec with zero suffix-length'
+    end
+    result
+  end
+
+  # call-seq:
+  #   set_range(length) -> length
+  #   set_range(offset, length) -> range
+  #   set_range(begin..length) -> range
+  #
+  # Sets the value for field <tt>'Range'</tt>;
+  # see {Range request header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#range-request-header]:
+  #
+  # With argument +length+:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.set_range(100)      # => 100
+  #   req['Range']            # => "bytes=0-99"
+  #
+  # With arguments +offset+ and +length+:
+  #
+  #   req.set_range(100, 100) # => 100...200
+  #   req['Range']            # => "bytes=100-199"
+  #
+  # With argument +range+:
+  #
+  #   req.set_range(100..199) # => 100..199
+  #   req['Range']            # => "bytes=100-199"
+  #
+  # Net::HTTPHeader#range= is an alias for Net::HTTPHeader#set_range.
+  def set_range(r, e = nil)
+    unless r
+      @header.delete 'range'
+      return r
+    end
+    r = (r...r+e) if e
+    case r
+    when Numeric
+      n = r.to_i
+      rangestr = (n > 0 ? "0-#{n-1}" : "-#{-n}")
+    when Range
+      first = r.first
+      last = r.end
+      last -= 1 if r.exclude_end?
+      if last == -1
+        rangestr = (first > 0 ? "#{first}-" : "-#{-first}")
+      else
+        raise Net::HTTPHeaderSyntaxError, 'range.first is negative' if first < 0
+        raise Net::HTTPHeaderSyntaxError, 'range.last is negative' if last < 0
+        raise Net::HTTPHeaderSyntaxError, 'must be .first < .last' if first > last
+        rangestr = "#{first}-#{last}"
+      end
+    else
+      raise TypeError, 'Range/Integer is required'
+    end
+    @header['range'] = ["bytes=#{rangestr}"]
+    r
+  end
+
+  alias range= set_range
+
+  # Returns the value of field <tt>'Content-Length'</tt> as an integer,
+  # or +nil+ if there is no such field;
+  # see {Content-Length request header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-length-request-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/nosuch/1')
+  #   res.content_length # => 2
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res.content_length # => nil
+  #
+  def content_length
+    return nil unless key?('Content-Length')
+    len = self['Content-Length'].slice(/\d+/) or
+        raise Net::HTTPHeaderSyntaxError, 'wrong Content-Length format'
+    len.to_i
+  end
+
+  # Sets the value of field <tt>'Content-Length'</tt> to the given numeric;
+  # see {Content-Length response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-length-response-header]:
+  #
+  #   _uri = uri.dup
+  #   hostname = _uri.hostname           # => "jsonplaceholder.typicode.com"
+  #   _uri.path = '/posts'               # => "/posts"
+  #   req = Net::HTTP::Post.new(_uri)    # => #<Net::HTTP::Post POST>
+  #   req.body = '{"title": "foo","body": "bar","userId": 1}'
+  #   req.content_length = req.body.size # => 42
+  #   req.content_type = 'application/json'
+  #   res = Net::HTTP.start(hostname) do |http|
+  #     http.request(req)
+  #   end # => #<Net::HTTPCreated 201 Created readbody=true>
+  #
+  def content_length=(len)
+    unless len
+      @header.delete 'content-length'
+      return nil
+    end
+    @header['content-length'] = [len.to_i.to_s]
+  end
+
+  # Returns +true+ if field <tt>'Transfer-Encoding'</tt>
+  # exists and has value <tt>'chunked'</tt>,
+  # +false+ otherwise;
+  # see {Transfer-Encoding response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#transfer-encoding-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['Transfer-Encoding'] # => "chunked"
+  #   res.chunked?             # => true
+  #
+  def chunked?
+    return false unless @header['transfer-encoding']
+    field = self['Transfer-Encoding']
+    (/(?:\A|[^\-\w])chunked(?![\-\w])/i =~ field) ? true : false
+  end
+
+  # Returns a Range object representing the value of field
+  # <tt>'Content-Range'</tt>, or +nil+ if no such field exists;
+  # see {Content-Range response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-range-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['Content-Range'] # => nil
+  #   res['Content-Range'] = 'bytes 0-499/1000'
+  #   res['Content-Range'] # => "bytes 0-499/1000"
+  #   res.content_range    # => 0..499
+  #
+  def content_range
+    return nil unless @header['content-range']
+    m = %r<\A\s*(\w+)\s+(\d+)-(\d+)/(\d+|\*)>.match(self['Content-Range']) or
+        raise Net::HTTPHeaderSyntaxError, 'wrong Content-Range format'
+    return unless m[1] == 'bytes'
+    m[2].to_i .. m[3].to_i
+  end
+
+  # Returns the integer representing length of the value of field
+  # <tt>'Content-Range'</tt>, or +nil+ if no such field exists;
+  # see {Content-Range response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-range-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['Content-Range'] # => nil
+  #   res['Content-Range'] = 'bytes 0-499/1000'
+  #   res.range_length     # => 500
+  #
+  def range_length
+    r = content_range() or return nil
+    r.end - r.begin + 1
+  end
+
+  # Returns the {media type}[https://en.wikipedia.org/wiki/Media_type]
+  # from the value of field <tt>'Content-Type'</tt>,
+  # or +nil+ if no such field exists;
+  # see {Content-Type response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-type-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['content-type'] # => "application/json; charset=utf-8"
+  #   res.content_type    # => "application/json"
+  #
+  def content_type
+    main = main_type()
+    return nil unless main
+
+    sub = sub_type()
+    if sub
+      "#{main}/#{sub}"
+    else
+      main
+    end
+  end
+
+  # Returns the leading ('type') part of the
+  # {media type}[https://en.wikipedia.org/wiki/Media_type]
+  # from the value of field <tt>'Content-Type'</tt>,
+  # or +nil+ if no such field exists;
+  # see {Content-Type response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-type-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['content-type'] # => "application/json; charset=utf-8"
+  #   res.main_type       # => "application"
+  #
+  def main_type
+    return nil unless @header['content-type']
+    self['Content-Type'].split(';').first.to_s.split('/')[0].to_s.strip
+  end
+
+  # Returns the trailing ('subtype') part of the
+  # {media type}[https://en.wikipedia.org/wiki/Media_type]
+  # from the value of field <tt>'Content-Type'</tt>,
+  # or +nil+ if no such field exists;
+  # see {Content-Type response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-type-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['content-type'] # => "application/json; charset=utf-8"
+  #   res.sub_type        # => "json"
+  #
+  def sub_type
+    return nil unless @header['content-type']
+    _, sub = *self['Content-Type'].split(';').first.to_s.split('/')
+    return nil unless sub
+    sub.strip
+  end
+
+  # Returns the trailing ('parameters') part of the value of field <tt>'Content-Type'</tt>,
+  # or +nil+ if no such field exists;
+  # see {Content-Type response header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-type-response-header]:
+  #
+  #   res = Net::HTTP.get_response(hostname, '/todos/1')
+  #   res['content-type'] # => "application/json; charset=utf-8"
+  #   res.type_params     # => {"charset"=>"utf-8"}
+  #
+  def type_params
+    result = {}
+    list = self['Content-Type'].to_s.split(';')
+    list.shift
+    list.each do |param|
+      k, v = *param.split('=', 2)
+      result[k.strip] = v.strip
+    end
+    result
+  end
+
+  # Sets the value of field <tt>'Content-Type'</tt>;
+  # returns the new value;
+  # see {Content-Type request header}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#content-type-request-header]:
+  #
+  #   req = Net::HTTP::Get.new(uri)
+  #   req.set_content_type('application/json') # => ["application/json"]
+  #
+  # Net::HTTPHeader#content_type= is an alias for Net::HTTPHeader#set_content_type.
+  def set_content_type(type, params = {})
+    @header['content-type'] = [type + params.map{|k,v|"; #{k}=#{v}"}.join('')]
+  end
+
+  alias content_type= set_content_type
+
+  # Sets the request body to a URL-encoded string derived from argument +params+,
+  # and sets request header field <tt>'Content-Type'</tt>
+  # to <tt>'application/x-www-form-urlencoded'</tt>.
+  #
+  # The resulting request is suitable for HTTP request +POST+ or +PUT+.
+  #
+  # Argument +params+ must be suitable for use as argument +enum+ to
+  # {URI.encode_www_form}[rdoc-ref:URI.encode_www_form].
+  #
+  # With only argument +params+ given,
+  # sets the body to a URL-encoded string with the default separator <tt>'&'</tt>:
+  #
+  #   req = Net::HTTP::Post.new('example.com')
+  #
+  #   req.set_form_data(q: 'ruby', lang: 'en')
+  #   req.body            # => "q=ruby&lang=en"
+  #   req['Content-Type'] # => "application/x-www-form-urlencoded"
+  #
+  #   req.set_form_data([['q', 'ruby'], ['lang', 'en']])
+  #   req.body            # => "q=ruby&lang=en"
+  #
+  #   req.set_form_data(q: ['ruby', 'perl'], lang: 'en')
+  #   req.body            # => "q=ruby&q=perl&lang=en"
+  #
+  #   req.set_form_data([['q', 'ruby'], ['q', 'perl'], ['lang', 'en']])
+  #   req.body            # => "q=ruby&q=perl&lang=en"
+  #
+  # With string argument +sep+ also given,
+  # uses that string as the separator:
+  #
+  #   req.set_form_data({q: 'ruby', lang: 'en'}, '|')
+  #   req.body # => "q=ruby|lang=en"
+  #
+  # Net::HTTPHeader#form_data= is an alias for Net::HTTPHeader#set_form_data.
+  def set_form_data(params, sep = '&')
+    query = URI.encode_www_form(params)
+    query.gsub!(/&/, sep) if sep != '&'
+    self.body = query
+    self.content_type = 'application/x-www-form-urlencoded'
+  end
+
+  alias form_data= set_form_data
+
+  # Stores form data to be used in a +POST+ or +PUT+ request.
+  #
+  # The form data given in +params+ consists of zero or more fields;
+  # each field is:
+  #
+  # - A scalar value.
+  # - A name/value pair.
+  # - An IO stream opened for reading.
+  #
+  # Argument +params+ should be an
+  # {Enumerable}[rdoc-ref:Enumerable@Enumerable+in+Ruby+Classes]
+  # (method <tt>params.map</tt> will be called),
+  # and is often an array or hash.
+  #
+  # First, we set up a request:
+  #
+  #   _uri = uri.dup
+  #   _uri.path ='/posts'
+  #   req = Net::HTTP::Post.new(_uri)
+  #
+  # <b>Argument +params+ As an Array</b>
+  #
+  # When +params+ is an array,
+  # each of its elements is a subarray that defines a field;
+  # the subarray may contain:
+  #
+  # - One string:
+  #
+  #     req.set_form([['foo'], ['bar'], ['baz']])
+  #
+  # - Two strings:
+  #
+  #     req.set_form([%w[foo 0], %w[bar 1], %w[baz 2]])
+  #
+  # - When argument +enctype+ (see below) is given as
+  #   <tt>'multipart/form-data'</tt>:
+  #
+  #   - A string name and an IO stream opened for reading:
+  #
+  #       require 'stringio'
+  #       req.set_form([['file', StringIO.new('Ruby is cool.')]])
+  #
+  #   - A string name, an IO stream opened for reading,
+  #     and an options hash, which may contain these entries:
+  #
+  #     - +:filename+: The name of the file to use.
+  #     - +:content_type+: The content type of the uploaded file.
+  #
+  #     Example:
+  #
+  #       req.set_form([['file', file, {filename: "other-filename.foo"}]]
+  #
+  # The various forms may be mixed:
+  #
+  #   req.set_form(['foo', %w[bar 1], ['file', file]])
+  #
+  # <b>Argument +params+ As a Hash</b>
+  #
+  # When +params+ is a hash,
+  # each of its entries is a name/value pair that defines a field:
+  #
+  # - The name is a string.
+  # - The value may be:
+  #
+  #   - +nil+.
+  #   - Another string.
+  #   - An IO stream opened for reading
+  #     (only when argument +enctype+ -- see below -- is given as
+  #     <tt>'multipart/form-data'</tt>).
+  #
+  # Examples:
+  #
+  #   # Nil-valued fields.
+  #   req.set_form({'foo' => nil, 'bar' => nil, 'baz' => nil})
+  #
+  #   # String-valued fields.
+  #   req.set_form({'foo' => 0, 'bar' => 1, 'baz' => 2})
+  #
+  #   # IO-valued field.
+  #   require 'stringio'
+  #   req.set_form({'file' => StringIO.new('Ruby is cool.')})
+  #
+  #   # Mixture of fields.
+  #   req.set_form({'foo' => nil, 'bar' => 1, 'file' => file})
+  #
+  # Optional argument +enctype+ specifies the value to be given
+  # to field <tt>'Content-Type'</tt>, and must be one of:
+  #
+  # - <tt>'application/x-www-form-urlencoded'</tt> (the default).
+  # - <tt>'multipart/form-data'</tt>;
+  #   see {RFC 7578}[https://www.rfc-editor.org/rfc/rfc7578].
+  #
+  # Optional argument +formopt+ is a hash of options
+  # (applicable only when argument +enctype+
+  # is <tt>'multipart/form-data'</tt>)
+  # that may include the following entries:
+  #
+  # - +:boundary+: The value is the boundary string for the multipart message.
+  #   If not given, the boundary is a random string.
+  #   See {Boundary}[https://www.rfc-editor.org/rfc/rfc7578#section-4.1].
+  # - +:charset+: Value is the character set for the form submission.
+  #   Field names and values of non-file fields should be encoded with this charset.
+  #
+  def set_form(params, enctype='application/x-www-form-urlencoded', formopt={})
+    @body_data = params
+    @body = nil
+    @body_stream = nil
+    @form_option = formopt
+    case enctype
+    when /\Aapplication\/x-www-form-urlencoded\z/i,
+      /\Amultipart\/form-data\z/i
+      self.content_type = enctype
+    else
+      raise ArgumentError, "invalid enctype: #{enctype}"
+    end
+  end
+
+  # Sets header <tt>'Authorization'</tt> using the given
+  # +account+ and +password+ strings:
+  #
+  #   req.basic_auth('my_account', 'my_password')
+  #   req['Authorization']
+  #   # => "Basic bXlfYWNjb3VudDpteV9wYXNzd29yZA=="
+  #
+  def basic_auth(account, password)
+    @header['authorization'] = [basic_encode(account, password)]
+  end
+
+  # Sets header <tt>'Proxy-Authorization'</tt> using the given
+  # +account+ and +password+ strings:
+  #
+  #   req.proxy_basic_auth('my_account', 'my_password')
+  #   req['Proxy-Authorization']
+  #   # => "Basic bXlfYWNjb3VudDpteV9wYXNzd29yZA=="
+  #
+  def proxy_basic_auth(account, password)
+    @header['proxy-authorization'] = [basic_encode(account, password)]
+  end
+
+  def basic_encode(account, password)
+    'Basic ' + ["#{account}:#{password}"].pack('m0')
+  end
+  private :basic_encode
+
+# Returns whether the HTTP session is to be closed.
+  def connection_close?
+    token = /(?:\A|,)\s*close\s*(?:\z|,)/i
+    @header['connection']&.grep(token) {return true}
+    @header['proxy-connection']&.grep(token) {return true}
+    false
+  end
+
+# Returns whether the HTTP session is to be kept alive.
+  def connection_keep_alive?
+    token = /(?:\A|,)\s*keep-alive\s*(?:\z|,)/i
+    @header['connection']&.grep(token) {return true}
+    @header['proxy-connection']&.grep(token) {return true}
+    false
+  end
+
+end

--- a/lib/net/http/net-http.gemspec
+++ b/lib/net/http/net-http.gemspec
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-")+1, "..").join("/")].find do |dir|
+  file = File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")
+  begin
+    break File.foreach(file, mode: "rb") do |line|
+      /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+    end
+  rescue SystemCallError
+    next
+  end
+end
+
+Gem::Specification.new do |spec|
+  spec.name          = name
+  spec.version       = version
+  spec.authors       = ["NARUSE, Yui"]
+  spec.email         = ["naruse@airemix.jp"]
+
+  spec.summary       = %q{HTTP client api for Ruby.}
+  spec.description   = %q{HTTP client api for Ruby.}
+  spec.homepage      = "https://github.com/ruby/net-http"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.licenses      = ["Ruby", "BSD-2-Clause"]
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject { |f| f.match(%r{\A(?:(?:test|spec|features)/|\.git)}) }
+  end
+  spec.bindir        = "exe"
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "uri"
+end

--- a/lib/net/http/proxy_delta.rb
+++ b/lib/net/http/proxy_delta.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Net::HTTP::ProxyDelta   #:nodoc: internal use only
+  private
+
+  def conn_address
+    proxy_address()
+  end
+
+  def conn_port
+    proxy_port()
+  end
+
+  def edit_path(path)
+    use_ssl? ? path : "http://#{addr_port()}#{path}"
+  end
+end
+

--- a/lib/net/http/request.rb
+++ b/lib/net/http/request.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# This class is the base class for \Net::HTTP request classes.
+# The class should not be used directly;
+# instead you should use its subclasses, listed below.
+#
+# == Creating a Request
+#
+# An request object may be created with either a URI or a string hostname:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com/')
+#   req = Net::HTTP::Get.new(uri)          # => #<Net::HTTP::Get GET>
+#   req = Net::HTTP::Get.new(uri.hostname) # => #<Net::HTTP::Get GET>
+#
+# And with any of the subclasses:
+#
+#   req = Net::HTTP::Head.new(uri) # => #<Net::HTTP::Head HEAD>
+#   req = Net::HTTP::Post.new(uri) # => #<Net::HTTP::Post POST>
+#   req = Net::HTTP::Put.new(uri)  # => #<Net::HTTP::Put PUT>
+#   # ...
+#
+# The new instance is suitable for use as the argument to Net::HTTP#request.
+#
+# == Request Headers
+#
+# A new request object has these header fields by default:
+#
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#   "accept"=>["*/*"],
+#   "user-agent"=>["Ruby"],
+#   "host"=>["jsonplaceholder.typicode.com"]}
+#
+# See:
+#
+# - {Request header Accept-Encoding}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Accept-Encoding]
+#   and {Compression and Decompression}[rdoc-ref:Net::HTTP@Compression+and+Decompression].
+# - {Request header Accept}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#accept-request-header].
+# - {Request header User-Agent}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#user-agent-request-header].
+# - {Request header Host}[https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#host-request-header].
+#
+# You can add headers or override default headers:
+#
+#   #   res = Net::HTTP::Get.new(uri, {'foo' => '0', 'bar' => '1'})
+#
+# This class (and therefore its subclasses) also includes (indirectly)
+# module Net::HTTPHeader, which gives access to its
+# {methods for setting headers}[rdoc-ref:Net::HTTPHeader@Setters].
+#
+# == Request Subclasses
+#
+# Subclasses for HTTP requests:
+#
+# - Net::HTTP::Get
+# - Net::HTTP::Head
+# - Net::HTTP::Post
+# - Net::HTTP::Put
+# - Net::HTTP::Delete
+# - Net::HTTP::Options
+# - Net::HTTP::Trace
+# - Net::HTTP::Patch
+#
+# Subclasses for WebDAV requests:
+#
+# - Net::HTTP::Propfind
+# - Net::HTTP::Proppatch
+# - Net::HTTP::Mkcol
+# - Net::HTTP::Copy
+# - Net::HTTP::Move
+# - Net::HTTP::Lock
+# - Net::HTTP::Unlock
+#
+class Net::HTTPRequest < Net::HTTPGenericRequest
+  # Creates an HTTP request object for +path+.
+  #
+  # +initheader+ are the default headers to use.  Net::HTTP adds
+  # Accept-Encoding to enable compression of the response body unless
+  # Accept-Encoding or Range are supplied in +initheader+.
+
+  def initialize(path, initheader = nil)
+    super self.class::METHOD,
+          self.class::REQUEST_HAS_BODY,
+          self.class::RESPONSE_HAS_BODY,
+          path, initheader
+  end
+end

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -1,0 +1,425 @@
+# frozen_string_literal: true
+
+# HTTP/1.1 methods --- RFC2616
+
+# \Class for representing
+# {HTTP method GET}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#GET_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Get.new(uri) # => #<Net::HTTP::Get GET>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP.get: sends +GET+ request, returns response body.
+# - Net::HTTP#get: sends +GET+ request, returns response object.
+#
+class Net::HTTP::Get < Net::HTTPRequest
+  METHOD = 'GET'
+  REQUEST_HAS_BODY  = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method HEAD}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#HEAD_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Head.new(uri) # => #<Net::HTTP::Head HEAD>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: no.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP#head: sends +HEAD+ request, returns response object.
+#
+class Net::HTTP::Head < Net::HTTPRequest
+  METHOD = 'HEAD'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = false
+end
+
+# \Class for representing
+# {HTTP method POST}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#POST_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   uri.path = '/posts'
+#   req = Net::HTTP::Post.new(uri) # => #<Net::HTTP::Post POST>
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: no.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP.post: sends +POST+ request, returns response object.
+# - Net::HTTP#post: sends +POST+ request, returns response object.
+#
+class Net::HTTP::Post < Net::HTTPRequest
+  METHOD = 'POST'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method PUT}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PUT_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   uri.path = '/posts'
+#   req = Net::HTTP::Put.new(uri) # => #<Net::HTTP::Put PUT>
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+class Net::HTTP::Put < Net::HTTPRequest
+  METHOD = 'PUT'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method DELETE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#DELETE_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   uri.path = '/posts/1'
+#   req = Net::HTTP::Delete.new(uri) # => #<Net::HTTP::Delete DELETE>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP#delete: sends +DELETE+ request, returns response object.
+#
+class Net::HTTP::Delete < Net::HTTPRequest
+  METHOD = 'DELETE'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method OPTIONS}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#OPTIONS_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Options.new(uri) # => #<Net::HTTP::Options OPTIONS>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP#options: sends +OPTIONS+ request, returns response object.
+#
+class Net::HTTP::Options < Net::HTTPRequest
+  METHOD = 'OPTIONS'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method TRACE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#TRACE_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Trace.new(uri) # => #<Net::HTTP::Trace TRACE>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: no.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP#trace: sends +TRACE+ request, returns response object.
+#
+class Net::HTTP::Trace < Net::HTTPRequest
+  METHOD = 'TRACE'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {HTTP method PATCH}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PATCH_method]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   uri.path = '/posts'
+#   req = Net::HTTP::Patch.new(uri) # => #<Net::HTTP::Patch PATCH>
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: no.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP#patch: sends +PATCH+ request, returns response object.
+#
+class Net::HTTP::Patch < Net::HTTPRequest
+  METHOD = 'PATCH'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+#
+# WebDAV methods --- RFC2518
+#
+
+# \Class for representing
+# {WebDAV method PROPFIND}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPFIND]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Propfind.new(uri) # => #<Net::HTTP::Propfind PROPFIND>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#propfind: sends +PROPFIND+ request, returns response object.
+#
+class Net::HTTP::Propfind < Net::HTTPRequest
+  METHOD = 'PROPFIND'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method PROPPATCH}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPPATCH]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Proppatch.new(uri) # => #<Net::HTTP::Proppatch PROPPATCH>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#proppatch: sends +PROPPATCH+ request, returns response object.
+#
+class Net::HTTP::Proppatch < Net::HTTPRequest
+  METHOD = 'PROPPATCH'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method MKCOL}[http://www.webdav.org/specs/rfc4918.html#METHOD_MKCOL]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Mkcol.new(uri) # => #<Net::HTTP::Mkcol MKCOL>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#mkcol: sends +MKCOL+ request, returns response object.
+#
+class Net::HTTP::Mkcol < Net::HTTPRequest
+  METHOD = 'MKCOL'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method COPY}[http://www.webdav.org/specs/rfc4918.html#METHOD_COPY]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Copy.new(uri) # => #<Net::HTTP::Copy COPY>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#copy: sends +COPY+ request, returns response object.
+#
+class Net::HTTP::Copy < Net::HTTPRequest
+  METHOD = 'COPY'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method MOVE}[http://www.webdav.org/specs/rfc4918.html#METHOD_MOVE]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Move.new(uri) # => #<Net::HTTP::Move MOVE>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#move: sends +MOVE+ request, returns response object.
+#
+class Net::HTTP::Move < Net::HTTPRequest
+  METHOD = 'MOVE'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method LOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_LOCK]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Lock.new(uri) # => #<Net::HTTP::Lock LOCK>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#lock: sends +LOCK+ request, returns response object.
+#
+class Net::HTTP::Lock < Net::HTTPRequest
+  METHOD = 'LOCK'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+
+# \Class for representing
+# {WebDAV method UNLOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_UNLOCK]:
+#
+#   require 'net/http'
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
+#   req = Net::HTTP::Unlock.new(uri) # => #<Net::HTTP::Unlock UNLOCK>
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# See {Request Headers}[rdoc-ref:Net::HTTPRequest@Request+Headers].
+#
+# Related:
+#
+# - Net::HTTP#unlock: sends +UNLOCK+ request, returns response object.
+#
+class Net::HTTP::Unlock < Net::HTTPRequest
+  METHOD = 'UNLOCK'
+  REQUEST_HAS_BODY = true
+  RESPONSE_HAS_BODY = true
+end
+

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -1,0 +1,738 @@
+# frozen_string_literal: true
+
+# This class is the base class for \Net::HTTP response classes.
+#
+# == About the Examples
+#
+# :include: doc/net-http/examples.rdoc
+#
+# == Returned Responses
+#
+# \Method Net::HTTP.get_response returns
+# an instance of one of the subclasses of \Net::HTTPResponse:
+#
+#   Net::HTTP.get_response(uri)
+#   # => #<Net::HTTPOK 200 OK readbody=true>
+#   Net::HTTP.get_response(hostname, '/nosuch')
+#   # => #<Net::HTTPNotFound 404 Not Found readbody=true>
+#
+# As does method Net::HTTP#request:
+#
+#   req = Net::HTTP::Get.new(uri)
+#   Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end # => #<Net::HTTPOK 200 OK readbody=true>
+#
+# \Class \Net::HTTPResponse includes module Net::HTTPHeader,
+# which provides access to response header values via (among others):
+#
+# - \Hash-like method <tt>[]</tt>.
+# - Specific reader methods, such as +content_type+.
+#
+# Examples:
+#
+#   res = Net::HTTP.get_response(uri) # => #<Net::HTTPOK 200 OK readbody=true>
+#   res['Content-Type']               # => "text/html; charset=UTF-8"
+#   res.content_type                  # => "text/html"
+#
+# == Response Subclasses
+#
+# \Class \Net::HTTPResponse has a subclass for each
+# {HTTP status code}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes].
+# You can look up the response class for a given code:
+#
+#   Net::HTTPResponse::CODE_TO_OBJ['200'] # => Net::HTTPOK
+#   Net::HTTPResponse::CODE_TO_OBJ['400'] # => Net::HTTPBadRequest
+#   Net::HTTPResponse::CODE_TO_OBJ['404'] # => Net::HTTPNotFound
+#
+# And you can retrieve the status code for a response object:
+#
+#   Net::HTTP.get_response(uri).code                 # => "200"
+#   Net::HTTP.get_response(hostname, '/nosuch').code # => "404"
+#
+# The response subclasses (indentation shows class hierarchy):
+#
+# - Net::HTTPUnknownResponse (for unhandled \HTTP extensions).
+#
+# - Net::HTTPInformation:
+#
+#   - Net::HTTPContinue (100)
+#   - Net::HTTPSwitchProtocol (101)
+#   - Net::HTTPProcessing (102)
+#   - Net::HTTPEarlyHints (103)
+#
+# - Net::HTTPSuccess:
+#
+#   - Net::HTTPOK (200)
+#   - Net::HTTPCreated (201)
+#   - Net::HTTPAccepted (202)
+#   - Net::HTTPNonAuthoritativeInformation (203)
+#   - Net::HTTPNoContent (204)
+#   - Net::HTTPResetContent (205)
+#   - Net::HTTPPartialContent (206)
+#   - Net::HTTPMultiStatus (207)
+#   - Net::HTTPAlreadyReported (208)
+#   - Net::HTTPIMUsed (226)
+#
+# - Net::HTTPRedirection:
+#
+#   - Net::HTTPMultipleChoices (300)
+#   - Net::HTTPMovedPermanently (301)
+#   - Net::HTTPFound (302)
+#   - Net::HTTPSeeOther (303)
+#   - Net::HTTPNotModified (304)
+#   - Net::HTTPUseProxy (305)
+#   - Net::HTTPTemporaryRedirect (307)
+#   - Net::HTTPPermanentRedirect (308)
+#
+# - Net::HTTPClientError:
+#
+#   - Net::HTTPBadRequest (400)
+#   - Net::HTTPUnauthorized (401)
+#   - Net::HTTPPaymentRequired (402)
+#   - Net::HTTPForbidden (403)
+#   - Net::HTTPNotFound (404)
+#   - Net::HTTPMethodNotAllowed (405)
+#   - Net::HTTPNotAcceptable (406)
+#   - Net::HTTPProxyAuthenticationRequired (407)
+#   - Net::HTTPRequestTimeOut (408)
+#   - Net::HTTPConflict (409)
+#   - Net::HTTPGone (410)
+#   - Net::HTTPLengthRequired (411)
+#   - Net::HTTPPreconditionFailed (412)
+#   - Net::HTTPRequestEntityTooLarge (413)
+#   - Net::HTTPRequestURITooLong (414)
+#   - Net::HTTPUnsupportedMediaType (415)
+#   - Net::HTTPRequestedRangeNotSatisfiable (416)
+#   - Net::HTTPExpectationFailed (417)
+#   - Net::HTTPMisdirectedRequest (421)
+#   - Net::HTTPUnprocessableEntity (422)
+#   - Net::HTTPLocked (423)
+#   - Net::HTTPFailedDependency (424)
+#   - Net::HTTPUpgradeRequired (426)
+#   - Net::HTTPPreconditionRequired (428)
+#   - Net::HTTPTooManyRequests (429)
+#   - Net::HTTPRequestHeaderFieldsTooLarge (431)
+#   - Net::HTTPUnavailableForLegalReasons (451)
+#
+# - Net::HTTPServerError:
+#
+#   - Net::HTTPInternalServerError (500)
+#   - Net::HTTPNotImplemented (501)
+#   - Net::HTTPBadGateway (502)
+#   - Net::HTTPServiceUnavailable (503)
+#   - Net::HTTPGatewayTimeOut (504)
+#   - Net::HTTPVersionNotSupported (505)
+#   - Net::HTTPVariantAlsoNegotiates (506)
+#   - Net::HTTPInsufficientStorage (507)
+#   - Net::HTTPLoopDetected (508)
+#   - Net::HTTPNotExtended (510)
+#   - Net::HTTPNetworkAuthenticationRequired (511)
+#
+# There is also the Net::HTTPBadResponse exception which is raised when
+# there is a protocol error.
+#
+class Net::HTTPResponse
+  class << self
+    # true if the response has a body.
+    def body_permitted?
+      self::HAS_BODY
+    end
+
+    def exception_type   # :nodoc: internal use only
+      self::EXCEPTION_TYPE
+    end
+
+    def read_new(sock)   #:nodoc: internal use only
+      httpv, code, msg = read_status_line(sock)
+      res = response_class(code).new(httpv, code, msg)
+      each_response_header(sock) do |k,v|
+        res.add_field k, v
+      end
+      res
+    end
+
+    private
+
+    def read_status_line(sock)
+      str = sock.readline
+      m = /\AHTTP(?:\/(\d+\.\d+))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+        raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
+      m.captures
+    end
+
+    def response_class(code)
+      CODE_TO_OBJ[code] or
+      CODE_CLASS_TO_OBJ[code[0,1]] or
+      Net::HTTPUnknownResponse
+    end
+
+    def each_response_header(sock)
+      key = value = nil
+      while true
+        line = sock.readuntil("\n", true).sub(/\s+\z/, '')
+        break if line.empty?
+        if line[0] == ?\s or line[0] == ?\t and value
+          value << ' ' unless value.empty?
+          value << line.strip
+        else
+          yield key, value if key
+          key, value = line.strip.split(/\s*:\s*/, 2)
+          raise Net::HTTPBadResponse, 'wrong header line format' if value.nil?
+        end
+      end
+      yield key, value if key
+    end
+  end
+
+  # next is to fix bug in RDoc, where the private inside class << self
+  # spills out.
+  public
+
+  include Net::HTTPHeader
+
+  def initialize(httpv, code, msg)   #:nodoc: internal use only
+    @http_version = httpv
+    @code         = code
+    @message      = msg
+    initialize_http_header nil
+    @body = nil
+    @read = false
+    @uri  = nil
+    @decode_content = false
+    @body_encoding = false
+    @ignore_eof = true
+  end
+
+  # The HTTP version supported by the server.
+  attr_reader :http_version
+
+  # The HTTP result code string. For example, '302'.  You can also
+  # determine the response type by examining which response subclass
+  # the response object is an instance of.
+  attr_reader :code
+
+  # The HTTP result message sent by the server. For example, 'Not Found'.
+  attr_reader :message
+  alias msg message   # :nodoc: obsolete
+
+  # The URI used to fetch this response.  The response URI is only available
+  # if a URI was used to create the request.
+  attr_reader :uri
+
+  # Set to true automatically when the request did not contain an
+  # Accept-Encoding header from the user.
+  attr_accessor :decode_content
+
+  # Returns the value set by body_encoding=, or +false+ if none;
+  # see #body_encoding=.
+  attr_reader :body_encoding
+
+  # Sets the encoding that should be used when reading the body:
+  #
+  # - If the given value is an Encoding object, that encoding will be used.
+  # - Otherwise if the value is a string, the value of
+  #   {Encoding#find(value)}[rdoc-ref:Encoding.find]
+  #   will be used.
+  # - Otherwise an encoding will be deduced from the body itself.
+  #
+  # Examples:
+  #
+  #   http = Net::HTTP.new(hostname)
+  #   req = Net::HTTP::Get.new('/')
+  #
+  #   http.request(req) do |res|
+  #     p res.body.encoding # => #<Encoding:ASCII-8BIT>
+  #   end
+  #
+  #   http.request(req) do |res|
+  #     res.body_encoding = "UTF-8"
+  #     p res.body.encoding # => #<Encoding:UTF-8>
+  #   end
+  #
+  def body_encoding=(value)
+    value = Encoding.find(value) if value.is_a?(String)
+    @body_encoding = value
+  end
+
+  # Whether to ignore EOF when reading bodies with a specified Content-Length
+  # header.
+  attr_accessor :ignore_eof
+
+  def inspect
+    "#<#{self.class} #{@code} #{@message} readbody=#{@read}>"
+  end
+
+  #
+  # response <-> exception relationship
+  #
+
+  def code_type   #:nodoc:
+    self.class
+  end
+
+  def error!   #:nodoc:
+    message = @code
+    message = "#{message} #{@message.dump}" if @message
+    raise error_type().new(message, self)
+  end
+
+  def error_type   #:nodoc:
+    self.class::EXCEPTION_TYPE
+  end
+
+  # Raises an HTTP error if the response is not 2xx (success).
+  def value
+    error! unless self.kind_of?(Net::HTTPSuccess)
+  end
+
+  def uri= uri # :nodoc:
+    @uri = uri.dup if uri
+  end
+
+  #
+  # header (for backward compatibility only; DO NOT USE)
+  #
+
+  def response   #:nodoc:
+    warn "Net::HTTPResponse#response is obsolete", uplevel: 1 if $VERBOSE
+    self
+  end
+
+  def header   #:nodoc:
+    warn "Net::HTTPResponse#header is obsolete", uplevel: 1 if $VERBOSE
+    self
+  end
+
+  def read_header   #:nodoc:
+    warn "Net::HTTPResponse#read_header is obsolete", uplevel: 1 if $VERBOSE
+    self
+  end
+
+  #
+  # body
+  #
+
+  def reading_body(sock, reqmethodallowbody)  #:nodoc: internal use only
+    @socket = sock
+    @body_exist = reqmethodallowbody && self.class.body_permitted?
+    begin
+      yield
+      self.body   # ensure to read body
+    ensure
+      @socket = nil
+    end
+  end
+
+  # Gets the entity body returned by the remote HTTP server.
+  #
+  # If a block is given, the body is passed to the block, and
+  # the body is provided in fragments, as it is read in from the socket.
+  #
+  # If +dest+ argument is given, response is read into that variable,
+  # with <code>dest#<<</code> method (it could be String or IO, or any
+  # other object responding to <code><<</code>).
+  #
+  # Calling this method a second or subsequent time for the same
+  # HTTPResponse object will return the value already read.
+  #
+  #   http.request_get('/index.html') {|res|
+  #     puts res.read_body
+  #   }
+  #
+  #   http.request_get('/index.html') {|res|
+  #     p res.read_body.object_id   # 538149362
+  #     p res.read_body.object_id   # 538149362
+  #   }
+  #
+  #   # using iterator
+  #   http.request_get('/index.html') {|res|
+  #     res.read_body do |segment|
+  #       print segment
+  #     end
+  #   }
+  #
+  def read_body(dest = nil, &block)
+    if @read
+      raise IOError, "#{self.class}\#read_body called twice" if dest or block
+      return @body
+    end
+    to = procdest(dest, block)
+    stream_check
+    if @body_exist
+      read_body_0 to
+      @body = to
+    else
+      @body = nil
+    end
+    @read = true
+    return if @body.nil?
+
+    case enc = @body_encoding
+    when Encoding, false, nil
+      # Encoding: force given encoding
+      # false/nil: do not force encoding
+    else
+      # other value: detect encoding from body
+      enc = detect_encoding(@body)
+    end
+
+    @body.force_encoding(enc) if enc
+
+    @body
+  end
+
+  # Returns the string response body;
+  # note that repeated calls for the unmodified body return a cached string:
+  #
+  #   path = '/todos/1'
+  #   Net::HTTP.start(hostname) do |http|
+  #     res = http.get(path)
+  #     p res.body
+  #     p http.head(path).body # No body.
+  #   end
+  #
+  # Output:
+  #
+  #   "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false\n}"
+  #   nil
+  #
+  def body
+    read_body()
+  end
+
+  # Sets the body of the response to the given value.
+  def body=(value)
+    @body = value
+  end
+
+  alias entity body   #:nodoc: obsolete
+
+  private
+
+  # :nodoc:
+  def detect_encoding(str, encoding=nil)
+    if encoding
+    elsif encoding = type_params['charset']
+    elsif encoding = check_bom(str)
+    else
+      encoding = case content_type&.downcase
+      when %r{text/x(?:ht)?ml|application/(?:[^+]+\+)?xml}
+        /\A<xml[ \t\r\n]+
+          version[ \t\r\n]*=[ \t\r\n]*(?:"[0-9.]+"|'[0-9.]*')[ \t\r\n]+
+          encoding[ \t\r\n]*=[ \t\r\n]*
+          (?:"([A-Za-z][\-A-Za-z0-9._]*)"|'([A-Za-z][\-A-Za-z0-9._]*)')/x =~ str
+        encoding = $1 || $2 || Encoding::UTF_8
+      when %r{text/html.*}
+        sniff_encoding(str)
+      end
+    end
+    return encoding
+  end
+
+  # :nodoc:
+  def sniff_encoding(str, encoding=nil)
+    # the encoding sniffing algorithm
+    # http://www.w3.org/TR/html5/parsing.html#determining-the-character-encoding
+    if enc = scanning_meta(str)
+      enc
+    # 6. last visited page or something
+    # 7. frequency
+    elsif str.ascii_only?
+      Encoding::US_ASCII
+    elsif str.dup.force_encoding(Encoding::UTF_8).valid_encoding?
+      Encoding::UTF_8
+    end
+    # 8. implementation-defined or user-specified
+  end
+
+  # :nodoc:
+  def check_bom(str)
+    case str.byteslice(0, 2)
+    when "\xFE\xFF"
+      return Encoding::UTF_16BE
+    when "\xFF\xFE"
+      return Encoding::UTF_16LE
+    end
+    if "\xEF\xBB\xBF" == str.byteslice(0, 3)
+      return Encoding::UTF_8
+    end
+    nil
+  end
+
+  # :nodoc:
+  def scanning_meta(str)
+    require 'strscan'
+    ss = StringScanner.new(str)
+    if ss.scan_until(/<meta[\t\n\f\r ]*/)
+      attrs = {} # attribute_list
+      got_pragma = false
+      need_pragma = nil
+      charset = nil
+
+      # step: Attributes
+      while attr = get_attribute(ss)
+        name, value = *attr
+        next if attrs[name]
+        attrs[name] = true
+        case name
+        when 'http-equiv'
+          got_pragma = true if value == 'content-type'
+        when 'content'
+          encoding = extracting_encodings_from_meta_elements(value)
+          unless charset
+            charset = encoding
+          end
+          need_pragma = true
+        when 'charset'
+          need_pragma = false
+          charset = value
+        end
+      end
+
+      # step: Processing
+      return if need_pragma.nil?
+      return if need_pragma && !got_pragma
+
+      charset = Encoding.find(charset) rescue nil
+      return unless charset
+      charset = Encoding::UTF_8 if charset == Encoding::UTF_16
+      return charset # tentative
+    end
+    nil
+  end
+
+  def get_attribute(ss)
+    ss.scan(/[\t\n\f\r \/]*/)
+    if ss.peek(1) == '>'
+      ss.getch
+      return nil
+    end
+    name = ss.scan(/[^=\t\n\f\r \/>]*/)
+    name.downcase!
+    raise if name.empty?
+    ss.skip(/[\t\n\f\r ]*/)
+    if ss.getch != '='
+      value = ''
+      return [name, value]
+    end
+    ss.skip(/[\t\n\f\r ]*/)
+    case ss.peek(1)
+    when '"'
+      ss.getch
+      value = ss.scan(/[^"]+/)
+      value.downcase!
+      ss.getch
+    when "'"
+      ss.getch
+      value = ss.scan(/[^']+/)
+      value.downcase!
+      ss.getch
+    when '>'
+      value = ''
+    else
+      value = ss.scan(/[^\t\n\f\r >]+/)
+      value.downcase!
+    end
+    [name, value]
+  end
+
+  def extracting_encodings_from_meta_elements(value)
+    # http://dev.w3.org/html5/spec/fetching-resources.html#algorithm-for-extracting-an-encoding-from-a-meta-element
+    if /charset[\t\n\f\r ]*=(?:"([^"]*)"|'([^']*)'|["']|\z|([^\t\n\f\r ;]+))/i =~ value
+      return $1 || $2 || $3
+    end
+    return nil
+  end
+
+  ##
+  # Checks for a supported Content-Encoding header and yields an Inflate
+  # wrapper for this response's socket when zlib is present.  If the
+  # Content-Encoding is not supported or zlib is missing, the plain socket is
+  # yielded.
+  #
+  # If a Content-Range header is present, a plain socket is yielded as the
+  # bytes in the range may not be a complete deflate block.
+
+  def inflater # :nodoc:
+    return yield @socket unless Net::HTTP::HAVE_ZLIB
+    return yield @socket unless @decode_content
+    return yield @socket if self['content-range']
+
+    v = self['content-encoding']
+    case v&.downcase
+    when 'deflate', 'gzip', 'x-gzip' then
+      self.delete 'content-encoding'
+
+      inflate_body_io = Inflater.new(@socket)
+
+      begin
+        yield inflate_body_io
+        success = true
+      ensure
+        begin
+          inflate_body_io.finish
+          if self['content-length']
+            self['content-length'] = inflate_body_io.bytes_inflated.to_s
+          end
+        rescue => err
+          # Ignore #finish's error if there is an exception from yield
+          raise err if success
+        end
+      end
+    when 'none', 'identity' then
+      self.delete 'content-encoding'
+
+      yield @socket
+    else
+      yield @socket
+    end
+  end
+
+  def read_body_0(dest)
+    inflater do |inflate_body_io|
+      if chunked?
+        read_chunked dest, inflate_body_io
+        return
+      end
+
+      @socket = inflate_body_io
+
+      clen = content_length()
+      if clen
+        @socket.read clen, dest, @ignore_eof
+        return
+      end
+      clen = range_length()
+      if clen
+        @socket.read clen, dest
+        return
+      end
+      @socket.read_all dest
+    end
+  end
+
+  ##
+  # read_chunked reads from +@socket+ for chunk-size, chunk-extension, CRLF,
+  # etc. and +chunk_data_io+ for chunk-data which may be deflate or gzip
+  # encoded.
+  #
+  # See RFC 2616 section 3.6.1 for definitions
+
+  def read_chunked(dest, chunk_data_io) # :nodoc:
+    total = 0
+    while true
+      line = @socket.readline
+      hexlen = line.slice(/[0-9a-fA-F]+/) or
+          raise Net::HTTPBadResponse, "wrong chunk size line: #{line}"
+      len = hexlen.hex
+      break if len == 0
+      begin
+        chunk_data_io.read len, dest
+      ensure
+        total += len
+        @socket.read 2   # \r\n
+      end
+    end
+    until @socket.readline.empty?
+      # none
+    end
+  end
+
+  def stream_check
+    raise IOError, 'attempt to read body out of block' if @socket.nil? || @socket.closed?
+  end
+
+  def procdest(dest, block)
+    raise ArgumentError, 'both arg and block given for HTTP method' if
+      dest and block
+    if block
+      Net::ReadAdapter.new(block)
+    else
+      dest || +''
+    end
+  end
+
+  ##
+  # Inflater is a wrapper around Net::BufferedIO that transparently inflates
+  # zlib and gzip streams.
+
+  class Inflater # :nodoc:
+
+    ##
+    # Creates a new Inflater wrapping +socket+
+
+    def initialize socket
+      @socket = socket
+      # zlib with automatic gzip detection
+      @inflate = Zlib::Inflate.new(32 + Zlib::MAX_WBITS)
+    end
+
+    ##
+    # Finishes the inflate stream.
+
+    def finish
+      return if @inflate.total_in == 0
+      @inflate.finish
+    end
+
+    ##
+    # The number of bytes inflated, used to update the Content-Length of
+    # the response.
+
+    def bytes_inflated
+      @inflate.total_out
+    end
+
+    ##
+    # Returns a Net::ReadAdapter that inflates each read chunk into +dest+.
+    #
+    # This allows a large response body to be inflated without storing the
+    # entire body in memory.
+
+    def inflate_adapter(dest)
+      if dest.respond_to?(:set_encoding)
+        dest.set_encoding(Encoding::ASCII_8BIT)
+      elsif dest.respond_to?(:force_encoding)
+        dest.force_encoding(Encoding::ASCII_8BIT)
+      end
+      block = proc do |compressed_chunk|
+        @inflate.inflate(compressed_chunk) do |chunk|
+          compressed_chunk.clear
+          dest << chunk
+        end
+      end
+
+      Net::ReadAdapter.new(block)
+    end
+
+    ##
+    # Reads +clen+ bytes from the socket, inflates them, then writes them to
+    # +dest+.  +ignore_eof+ is passed down to Net::BufferedIO#read
+    #
+    # Unlike Net::BufferedIO#read, this method returns more than +clen+ bytes.
+    # At this time there is no way for a user of Net::HTTPResponse to read a
+    # specific number of bytes from the HTTP response body, so this internal
+    # API does not return the same number of bytes as were requested.
+    #
+    # See https://bugs.ruby-lang.org/issues/6492 for further discussion.
+
+    def read clen, dest, ignore_eof = false
+      temp_dest = inflate_adapter(dest)
+
+      @socket.read clen, temp_dest, ignore_eof
+    end
+
+    ##
+    # Reads the rest of the socket, inflates it, then writes it to +dest+.
+
+    def read_all dest
+      temp_dest = inflate_adapter(dest)
+
+      @socket.read_all temp_dest
+    end
+
+  end
+
+end
+

--- a/lib/net/http/responses.rb
+++ b/lib/net/http/responses.rb
@@ -1,0 +1,1174 @@
+# frozen_string_literal: true
+#--
+# https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+
+module Net
+
+  class HTTPUnknownResponse < HTTPResponse
+    HAS_BODY = true
+    EXCEPTION_TYPE = HTTPError                  #
+  end
+
+  # Parent class for informational (1xx) HTTP response classes.
+  #
+  # An informational response indicates that the request was received and understood.
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#status.1xx].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#1xx_informational_response].
+  #
+  class HTTPInformation < HTTPResponse
+    HAS_BODY = false
+    EXCEPTION_TYPE = HTTPError                  #
+  end
+
+  # Parent class for success (2xx) HTTP response classes.
+  #
+  # A success response indicates the action requested by the client
+  # was received, understood, and accepted.
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#status.2xx].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_success].
+  #
+  class HTTPSuccess < HTTPResponse
+    HAS_BODY = true
+    EXCEPTION_TYPE = HTTPError                  #
+  end
+
+  # Parent class for redirection (3xx) HTTP response classes.
+  #
+  # A redirection response indicates the client must take additional action
+  # to complete the request.
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#status.3xx].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_redirection].
+  #
+  class HTTPRedirection < HTTPResponse
+    HAS_BODY = true
+    EXCEPTION_TYPE = HTTPRetriableError         #
+  end
+
+  # Parent class for client error (4xx) HTTP response classes.
+  #
+  # A client error response indicates that the client may have caused an error.
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#status.4xx].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_client_errors].
+  #
+  class HTTPClientError < HTTPResponse
+    HAS_BODY = true
+    EXCEPTION_TYPE = HTTPClientException        #
+  end
+
+  # Parent class for server error (5xx) HTTP response classes.
+  #
+  # A server error response indicates that the server failed to fulfill a request.
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#status.5xx].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors].
+  #
+  class HTTPServerError < HTTPResponse
+    HAS_BODY = true
+    EXCEPTION_TYPE = HTTPFatalError             #
+  end
+
+  # Response class for +Continue+ responses (status code 100).
+  #
+  # A +Continue+ response indicates that the server has received the request headers.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/100].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-100-continue].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#100].
+  #
+  class HTTPContinue < HTTPInformation
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Switching Protocol</tt> responses (status code 101).
+  #
+  # The <tt>Switching Protocol<tt> response indicates that the server has received
+  # a request to switch protocols, and has agreed to do so.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#101].
+  #
+  class HTTPSwitchProtocol < HTTPInformation
+    HAS_BODY = false
+  end
+
+  # Response class for +Processing+ responses (status code 102).
+  #
+  # The +Processing+ response indicates that the server has received
+  # and is processing the request, but no response is available yet.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 2518}[https://www.rfc-editor.org/rfc/rfc2518#section-10.1].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#102].
+  #
+  class HTTPProcessing < HTTPInformation
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Early Hints</tt> responses (status code 103).
+  #
+  # The <tt>Early Hints</tt> indicates that the server has received
+  # and is processing the request, and contains certain headers;
+  # the final response is not available yet.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103].
+  # - {RFC 8297}[https://www.rfc-editor.org/rfc/rfc8297.html#section-2].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#103].
+  #
+  class HTTPEarlyHints < HTTPInformation
+    HAS_BODY = false
+  end
+
+  # Response class for +OK+ responses (status code 200).
+  #
+  # The +OK+ response indicates that the server has received
+  # a request and has responded successfully.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-200-ok].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#200].
+  #
+  class HTTPOK < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for +Created+ responses (status code 201).
+  #
+  # The +Created+ response indicates that the server has received
+  # and has fulfilled a request to create a new resource.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-201-created].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#201].
+  #
+  class HTTPCreated < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for +Accepted+ responses (status code 202).
+  #
+  # The +Accepted+ response indicates that the server has received
+  # and is processing a request, but the processing has not yet been completed.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-202-accepted].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#202].
+  #
+  class HTTPAccepted < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Non-Authoritative Information</tt> responses (status code 203).
+  #
+  # The <tt>Non-Authoritative Information</tt> response indicates that the server
+  # is a transforming proxy (such as a Web accelerator)
+  # that received a 200 OK response from its origin,
+  # and is returning a modified version of the origin's response.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/203].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-203-non-authoritative-infor].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#203].
+  #
+  class HTTPNonAuthoritativeInformation < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>No Content</tt> responses (status code 204).
+  #
+  # The <tt>No Content</tt> response indicates that the server
+  # successfully processed the request, and is not returning any content.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#204].
+  #
+  class HTTPNoContent < HTTPSuccess
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Reset Content</tt> responses (status code 205).
+  #
+  # The <tt>Reset Content</tt> response indicates that the server
+  # successfully processed the request,
+  # asks that the client reset its document view, and is not returning any content.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/205].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-205-reset-content].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#205].
+  #
+  class HTTPResetContent < HTTPSuccess
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Partial Content</tt> responses (status code 206).
+  #
+  # The <tt>Partial Content</tt> response indicates that the server is delivering
+  # only part of the resource (byte serving)
+  # due to a Range header in the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#206].
+  #
+  class HTTPPartialContent < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Multi-Status (WebDAV)</tt> responses (status code 207).
+  #
+  # The <tt>Multi-Status (WebDAV)</tt> response indicates that the server
+  # has received the request,
+  # and that the message body can contain a number of separate response codes.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 4818}[https://www.rfc-editor.org/rfc/rfc4918#section-11.1].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#207].
+  #
+  class HTTPMultiStatus < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Already Reported (WebDAV)</tt> responses (status code 208).
+  #
+  # The <tt>Already Reported (WebDAV)</tt> response indicates that the server
+  # has received the request,
+  # and that the members of a DAV binding have already been enumerated
+  # in a preceding part of the (multi-status) response,
+  # and are not being included again.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 5842}[https://www.rfc-editor.org/rfc/rfc5842.html#section-7.1].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#208].
+  #
+  class HTTPAlreadyReported < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>IM Used</tt> responses (status code 226).
+  #
+  # The <tt>IM Used</tt> response indicates that the server has fulfilled a request
+  # for the resource, and the response is a representation of the result
+  # of one or more instance-manipulations applied to the current instance.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 3229}[https://www.rfc-editor.org/rfc/rfc3229.html#section-10.4.1].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#226].
+  #
+  class HTTPIMUsed < HTTPSuccess
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Multiple Choices</tt> responses (status code 300).
+  #
+  # The <tt>Multiple Choices</tt> response indicates that the server
+  # offers multiple options for the resource from which the client may choose.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/300].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#300].
+  #
+  class HTTPMultipleChoices < HTTPRedirection
+    HAS_BODY = true
+  end
+  HTTPMultipleChoice = HTTPMultipleChoices
+
+  # Response class for <tt>Moved Permanently</tt> responses (status code 301).
+  #
+  # The <tt>Moved Permanently</tt> response indicates that links or records
+  # returning this response should be updated to use the given URL.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#301].
+  #
+  class HTTPMovedPermanently < HTTPRedirection
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Found</tt> responses (status code 302).
+  #
+  # The <tt>Found</tt> response indicates that the client
+  # should look at (browse to) another URL.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#302].
+  #
+  class HTTPFound < HTTPRedirection
+    HAS_BODY = true
+  end
+  HTTPMovedTemporarily = HTTPFound
+
+  # Response class for <tt>See Other</tt> responses (status code 303).
+  #
+  # The response to the request can be found under another URI using the GET method.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-303-see-other].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#303].
+  #
+  class HTTPSeeOther < HTTPRedirection
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Not Modified</tt> responses (status code 304).
+  #
+  # Indicates that the resource has not been modified since the version
+  # specified by the request headers.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#304].
+  #
+  class HTTPNotModified < HTTPRedirection
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Use Proxy</tt> responses (status code 305).
+  #
+  # The requested resource is available only through a proxy,
+  # whose address is provided in the response.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-305-use-proxy].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#305].
+  #
+  class HTTPUseProxy < HTTPRedirection
+    HAS_BODY = false
+  end
+
+  # Response class for <tt>Temporary Redirect</tt> responses (status code 307).
+  #
+  # The request should be repeated with another URI;
+  # however, future requests should still use the original URI.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#307].
+  #
+  class HTTPTemporaryRedirect < HTTPRedirection
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Permanent Redirect</tt> responses (status code 308).
+  #
+  # This and all future requests should be directed to the given URI.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#308].
+  #
+  class HTTPPermanentRedirect < HTTPRedirection
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Bad Request</tt> responses (status code 400).
+  #
+  # The server cannot or will not process the request due to an apparent client error.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#400].
+  #
+  class HTTPBadRequest < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Unauthorized</tt> responses (status code 401).
+  #
+  # Authentication is required, but either was not provided or failed.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#401].
+  #
+  class HTTPUnauthorized < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Payment Required</tt> responses (status code 402).
+  #
+  # Reserved for future use.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-402-payment-required].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#402].
+  #
+  class HTTPPaymentRequired < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Forbidden</tt> responses (status code 403).
+  #
+  # The request contained valid data and was understood by the server,
+  # but the server is refusing action.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#403].
+  #
+  class HTTPForbidden < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Not Found</tt> responses (status code 404).
+  #
+  # The requested resource could not be found but may be available in the future.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#404].
+  #
+  class HTTPNotFound < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Method Not Allowed</tt> responses (status code 405).
+  #
+  # The request method is not supported for the requested resource.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-405-method-not-allowed].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#405].
+  #
+  class HTTPMethodNotAllowed < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Not Acceptable</tt> responses (status code 406).
+  #
+  # The requested resource is capable of generating only content
+  # that not acceptable according to the Accept headers sent in the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#406].
+  #
+  class HTTPNotAcceptable < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Proxy Authentication Required</tt> responses (status code 407).
+  #
+  # The client must first authenticate itself with the proxy.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#407].
+  #
+  class HTTPProxyAuthenticationRequired < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Request Timeout</tt> responses (status code 408).
+  #
+  # The server timed out waiting for the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#408].
+  #
+  class HTTPRequestTimeout < HTTPClientError
+    HAS_BODY = true
+  end
+  HTTPRequestTimeOut = HTTPRequestTimeout
+
+  # Response class for <tt>Conflict</tt> responses (status code 409).
+  #
+  # The request could not be processed because of conflict in the current state of the resource.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#409].
+  #
+  class HTTPConflict < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Gone</tt> responses (status code 410).
+  #
+  # The resource requested was previously in use but is no longer available
+  # and will not be available again.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-410-gone].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#410].
+  #
+  class HTTPGone < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Length Required</tt> responses (status code 411).
+  #
+  # The request did not specify the length of its content,
+  # which is required by the requested resource.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/411].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-411-length-required].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#411].
+  #
+  class HTTPLengthRequired < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Precondition Failed</tt> responses (status code 412).
+  #
+  # The server does not meet one of the preconditions
+  # specified in the request headers.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-412-precondition-failed].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#412].
+  #
+  class HTTPPreconditionFailed < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Payload Too Large</tt> responses (status code 413).
+  #
+  # The request is larger than the server is willing or able to process.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#413].
+  #
+  class HTTPPayloadTooLarge < HTTPClientError
+    HAS_BODY = true
+  end
+  HTTPRequestEntityTooLarge = HTTPPayloadTooLarge
+
+  # Response class for <tt>URI Too Long</tt> responses (status code 414).
+  #
+  # The URI provided was too long for the server to process.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-414-uri-too-long].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#414].
+  #
+  class HTTPURITooLong < HTTPClientError
+    HAS_BODY = true
+  end
+  HTTPRequestURITooLong = HTTPURITooLong
+  HTTPRequestURITooLarge = HTTPRequestURITooLong
+
+  # Response class for <tt>Unsupported Media Type</tt> responses (status code 415).
+  #
+  # The request entity has a media type which the server or resource does not support.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-415-unsupported-media-type].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#415].
+  #
+  class HTTPUnsupportedMediaType < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Range Not Satisfiable</tt> responses (status code 416).
+  #
+  # The request entity has a media type which the server or resource does not support.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#416].
+  #
+  class HTTPRangeNotSatisfiable < HTTPClientError
+    HAS_BODY = true
+  end
+  HTTPRequestedRangeNotSatisfiable = HTTPRangeNotSatisfiable
+
+  # Response class for <tt>Expectation Failed</tt> responses (status code 417).
+  #
+  # The server cannot meet the requirements of the Expect request-header field.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/417].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-417-expectation-failed].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#417].
+  #
+  class HTTPExpectationFailed < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # 418 I'm a teapot - RFC 2324; a joke RFC
+  # See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#418.
+
+  # 420 Enhance Your Calm - Twitter
+
+  # Response class for <tt>Misdirected Request</tt> responses (status code 421).
+  #
+  # The request was directed at a server that is not able to produce a response.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#421].
+  #
+  class HTTPMisdirectedRequest < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Unprocessable Entity</tt> responses (status code 422).
+  #
+  # The request was well-formed but had semantic errors.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#422].
+  #
+  class HTTPUnprocessableEntity < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Locked (WebDAV)</tt> responses (status code 423).
+  #
+  # The requested resource is locked.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 4918}[https://www.rfc-editor.org/rfc/rfc4918#section-11.3].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#423].
+  #
+  class HTTPLocked < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Failed Dependency (WebDAV)</tt> responses (status code 424).
+  #
+  # The request failed because it depended on another request and that request failed.
+  # See {424 Failed Dependency (WebDAV)}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#424].
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {RFC 4918}[https://www.rfc-editor.org/rfc/rfc4918#section-11.4].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#424].
+  #
+  class HTTPFailedDependency < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # 425 Too Early
+  # https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#425.
+
+  # Response class for <tt>Upgrade Required</tt> responses (status code 426).
+  #
+  # The client should switch to the protocol given in the Upgrade header field.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#426].
+  #
+  class HTTPUpgradeRequired < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Precondition Required</tt> responses (status code 428).
+  #
+  # The origin server requires the request to be conditional.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/428].
+  # - {RFC 6585}[https://www.rfc-editor.org/rfc/rfc6585#section-3].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#428].
+  #
+  class HTTPPreconditionRequired < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Too Many Requests</tt> responses (status code 429).
+  #
+  # The user has sent too many requests in a given amount of time.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429].
+  # - {RFC 6585}[https://www.rfc-editor.org/rfc/rfc6585#section-4].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#429].
+  #
+  class HTTPTooManyRequests < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Request Header Fields Too Large</tt> responses (status code 431).
+  #
+  # An individual header field is too large,
+  # or all the header fields collectively, are too large.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431].
+  # - {RFC 6585}[https://www.rfc-editor.org/rfc/rfc6585#section-5].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#431].
+  #
+  class HTTPRequestHeaderFieldsTooLarge < HTTPClientError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Unavailable For Legal Reasons</tt> responses (status code 451).
+  #
+  # A server operator has received a legal demand to deny access to a resource or to a set of resources
+  # that includes the requested resource.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/451].
+  # - {RFC 7725}[https://www.rfc-editor.org/rfc/rfc7725.html#section-3].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#451].
+  #
+  class HTTPUnavailableForLegalReasons < HTTPClientError
+    HAS_BODY = true
+  end
+  # 444 No Response - Nginx
+  # 449 Retry With - Microsoft
+  # 450 Blocked by Windows Parental Controls - Microsoft
+  # 499 Client Closed Request - Nginx
+
+  # Response class for <tt>Internal Server Error</tt> responses (status code 500).
+  #
+  # An unexpected condition was encountered and no more specific message is suitable.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#500].
+  #
+  class HTTPInternalServerError < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Not Implemented</tt> responses (status code 501).
+  #
+  # The server either does not recognize the request method,
+  # or it lacks the ability to fulfil the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-501-not-implemented].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#501].
+  #
+  class HTTPNotImplemented < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Bad Gateway</tt> responses (status code 502).
+  #
+  # The server was acting as a gateway or proxy
+  # and received an invalid response from the upstream server.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-502-bad-gateway].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#502].
+  #
+  class HTTPBadGateway < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Service Unavailable</tt> responses (status code 503).
+  #
+  # The server cannot handle the request
+  # (because it is overloaded or down for maintenance).
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-503-service-unavailable].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#503].
+  #
+  class HTTPServiceUnavailable < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Gateway Timeout</tt> responses (status code 504).
+  #
+  # The server was acting as a gateway or proxy
+  # and did not receive a timely response from the upstream server.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-504-gateway-timeout].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#504].
+  #
+  class HTTPGatewayTimeout < HTTPServerError
+    HAS_BODY = true
+  end
+  HTTPGatewayTimeOut = HTTPGatewayTimeout
+
+  # Response class for <tt>HTTP Version Not Supported</tt> responses (status code 505).
+  #
+  # The server does not support the HTTP version used in the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/505].
+  # - {RFC 9110}[https://www.rfc-editor.org/rfc/rfc9110.html#name-505-http-version-not-suppor].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#505].
+  #
+  class HTTPVersionNotSupported < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Variant Also Negotiates</tt> responses (status code 506).
+  #
+  # Transparent content negotiation for the request results in a circular reference.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/506].
+  # - {RFC 2295}[https://www.rfc-editor.org/rfc/rfc2295#section-8.1].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#506].
+  #
+  class HTTPVariantAlsoNegotiates < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Insufficient Storage (WebDAV)</tt> responses (status code 507).
+  #
+  # The server is unable to store the representation needed to complete the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507].
+  # - {RFC 4918}[https://www.rfc-editor.org/rfc/rfc4918#section-11.5].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#507].
+  #
+  class HTTPInsufficientStorage < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Loop Detected (WebDAV)</tt> responses (status code 508).
+  #
+  # The server detected an infinite loop while processing the request.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/508].
+  # - {RFC 5942}[https://www.rfc-editor.org/rfc/rfc5842.html#section-7.2].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#508].
+  #
+  class HTTPLoopDetected < HTTPServerError
+    HAS_BODY = true
+  end
+  # 509 Bandwidth Limit Exceeded - Apache bw/limited extension
+
+  # Response class for <tt>Not Extended</tt> responses (status code 510).
+  #
+  # Further extensions to the request are required for the server to fulfill it.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/510].
+  # - {RFC 2774}[https://www.rfc-editor.org/rfc/rfc2774.html#section-7].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#510].
+  #
+  class HTTPNotExtended < HTTPServerError
+    HAS_BODY = true
+  end
+
+  # Response class for <tt>Network Authentication Required</tt> responses (status code 511).
+  #
+  # The client needs to authenticate to gain network access.
+  #
+  # :include: doc/net-http/included_getters.rdoc
+  #
+  # References:
+  #
+  # - {Mozilla}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/511].
+  # - {RFC 6585}[https://www.rfc-editor.org/rfc/rfc6585#section-6].
+  # - {Wikipedia}[https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#511].
+  #
+  class HTTPNetworkAuthenticationRequired < HTTPServerError
+    HAS_BODY = true
+  end
+
+end
+
+class Net::HTTPResponse
+  CODE_CLASS_TO_OBJ = {
+    '1' => Net::HTTPInformation,
+    '2' => Net::HTTPSuccess,
+    '3' => Net::HTTPRedirection,
+    '4' => Net::HTTPClientError,
+    '5' => Net::HTTPServerError
+  }
+  CODE_TO_OBJ = {
+    '100' => Net::HTTPContinue,
+    '101' => Net::HTTPSwitchProtocol,
+    '102' => Net::HTTPProcessing,
+    '103' => Net::HTTPEarlyHints,
+
+    '200' => Net::HTTPOK,
+    '201' => Net::HTTPCreated,
+    '202' => Net::HTTPAccepted,
+    '203' => Net::HTTPNonAuthoritativeInformation,
+    '204' => Net::HTTPNoContent,
+    '205' => Net::HTTPResetContent,
+    '206' => Net::HTTPPartialContent,
+    '207' => Net::HTTPMultiStatus,
+    '208' => Net::HTTPAlreadyReported,
+    '226' => Net::HTTPIMUsed,
+
+    '300' => Net::HTTPMultipleChoices,
+    '301' => Net::HTTPMovedPermanently,
+    '302' => Net::HTTPFound,
+    '303' => Net::HTTPSeeOther,
+    '304' => Net::HTTPNotModified,
+    '305' => Net::HTTPUseProxy,
+    '307' => Net::HTTPTemporaryRedirect,
+    '308' => Net::HTTPPermanentRedirect,
+
+    '400' => Net::HTTPBadRequest,
+    '401' => Net::HTTPUnauthorized,
+    '402' => Net::HTTPPaymentRequired,
+    '403' => Net::HTTPForbidden,
+    '404' => Net::HTTPNotFound,
+    '405' => Net::HTTPMethodNotAllowed,
+    '406' => Net::HTTPNotAcceptable,
+    '407' => Net::HTTPProxyAuthenticationRequired,
+    '408' => Net::HTTPRequestTimeout,
+    '409' => Net::HTTPConflict,
+    '410' => Net::HTTPGone,
+    '411' => Net::HTTPLengthRequired,
+    '412' => Net::HTTPPreconditionFailed,
+    '413' => Net::HTTPPayloadTooLarge,
+    '414' => Net::HTTPURITooLong,
+    '415' => Net::HTTPUnsupportedMediaType,
+    '416' => Net::HTTPRangeNotSatisfiable,
+    '417' => Net::HTTPExpectationFailed,
+    '421' => Net::HTTPMisdirectedRequest,
+    '422' => Net::HTTPUnprocessableEntity,
+    '423' => Net::HTTPLocked,
+    '424' => Net::HTTPFailedDependency,
+    '426' => Net::HTTPUpgradeRequired,
+    '428' => Net::HTTPPreconditionRequired,
+    '429' => Net::HTTPTooManyRequests,
+    '431' => Net::HTTPRequestHeaderFieldsTooLarge,
+    '451' => Net::HTTPUnavailableForLegalReasons,
+
+    '500' => Net::HTTPInternalServerError,
+    '501' => Net::HTTPNotImplemented,
+    '502' => Net::HTTPBadGateway,
+    '503' => Net::HTTPServiceUnavailable,
+    '504' => Net::HTTPGatewayTimeout,
+    '505' => Net::HTTPVersionNotSupported,
+    '506' => Net::HTTPVariantAlsoNegotiates,
+    '507' => Net::HTTPInsufficientStorage,
+    '508' => Net::HTTPLoopDetected,
+    '510' => Net::HTTPNotExtended,
+    '511' => Net::HTTPNetworkAuthenticationRequired,
+  }
+end

--- a/lib/net/http/status.rb
+++ b/lib/net/http/status.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative '../http'
+
+if $0 == __FILE__
+  require 'open-uri'
+  File.foreach(__FILE__) do |line|
+    puts line
+    break if line.start_with?('end')
+  end
+  puts
+  puts "Net::HTTP::STATUS_CODES = {"
+  url = "https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv"
+  URI(url).read.each_line do |line|
+    code, mes, = line.split(',')
+    next if ['(Unused)', 'Unassigned', 'Description'].include?(mes)
+    puts "  #{code} => '#{mes}',"
+  end
+  puts "} # :nodoc:"
+end
+
+Net::HTTP::STATUS_CODES = {
+  100 => 'Continue',
+  101 => 'Switching Protocols',
+  102 => 'Processing',
+  103 => 'Early Hints',
+  200 => 'OK',
+  201 => 'Created',
+  202 => 'Accepted',
+  203 => 'Non-Authoritative Information',
+  204 => 'No Content',
+  205 => 'Reset Content',
+  206 => 'Partial Content',
+  207 => 'Multi-Status',
+  208 => 'Already Reported',
+  226 => 'IM Used',
+  300 => 'Multiple Choices',
+  301 => 'Moved Permanently',
+  302 => 'Found',
+  303 => 'See Other',
+  304 => 'Not Modified',
+  305 => 'Use Proxy',
+  307 => 'Temporary Redirect',
+  308 => 'Permanent Redirect',
+  400 => 'Bad Request',
+  401 => 'Unauthorized',
+  402 => 'Payment Required',
+  403 => 'Forbidden',
+  404 => 'Not Found',
+  405 => 'Method Not Allowed',
+  406 => 'Not Acceptable',
+  407 => 'Proxy Authentication Required',
+  408 => 'Request Timeout',
+  409 => 'Conflict',
+  410 => 'Gone',
+  411 => 'Length Required',
+  412 => 'Precondition Failed',
+  413 => 'Content Too Large',
+  414 => 'URI Too Long',
+  415 => 'Unsupported Media Type',
+  416 => 'Range Not Satisfiable',
+  417 => 'Expectation Failed',
+  421 => 'Misdirected Request',
+  422 => 'Unprocessable Content',
+  423 => 'Locked',
+  424 => 'Failed Dependency',
+  425 => 'Too Early',
+  426 => 'Upgrade Required',
+  428 => 'Precondition Required',
+  429 => 'Too Many Requests',
+  431 => 'Request Header Fields Too Large',
+  451 => 'Unavailable For Legal Reasons',
+  500 => 'Internal Server Error',
+  501 => 'Not Implemented',
+  502 => 'Bad Gateway',
+  503 => 'Service Unavailable',
+  504 => 'Gateway Timeout',
+  505 => 'HTTP Version Not Supported',
+  506 => 'Variant Also Negotiates',
+  507 => 'Insufficient Storage',
+  508 => 'Loop Detected',
+  510 => 'Not Extended (OBSOLETED)',
+  511 => 'Network Authentication Required',
+} # :nodoc:

--- a/lib/net/https.rb
+++ b/lib/net/https.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+=begin
+
+= net/https -- SSL/TLS enhancement for Net::HTTP.
+
+  This file has been merged with net/http.  There is no longer any need to
+  require 'net/https' to use HTTPS.
+
+  See Net::HTTP for details on how to make HTTPS connections.
+
+== Info
+  'OpenSSL for Ruby 2' project
+  Copyright (C) 2001 GOTOU Yuuzou <gotoyuzo@notwork.org>
+  All rights reserved.
+
+== Licence
+  This program is licensed under the same licence as Ruby.
+  (See the file 'LICENCE'.)
+
+=end
+
+require_relative 'http'
+require 'openssl'

--- a/lib/net/net-protocol.gemspec
+++ b/lib/net/net-protocol.gemspec
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = ["lib", Array.new(name.count("-"), "..").join("/")].find do |dir|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
+end
+
+Gem::Specification.new do |spec|
+  spec.name          = name
+  spec.version       = version
+  spec.authors = ["Yukihiro Matsumoto"]
+  spec.email = ["matz@ruby-lang.org"]
+
+  spec.summary       = %q{The abstract interface for net-* client.}
+  spec.description   = %q{The abstract interface for net-* client.}
+  spec.homepage      = "https://github.com/ruby/net-protocol"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.licenses      = ["Ruby", "BSD-2-Clause"]
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "timeout"
+end

--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -1,0 +1,544 @@
+# frozen_string_literal: true
+#
+# = net/protocol.rb
+#
+#--
+# Copyright (c) 1999-2004 Yukihiro Matsumoto
+# Copyright (c) 1999-2004 Minero Aoki
+#
+# written and maintained by Minero Aoki <aamine@loveruby.net>
+#
+# This program is free software. You can re-distribute and/or
+# modify this program under the same terms as Ruby itself,
+# Ruby Distribute License or GNU General Public License.
+#
+# $Id$
+#++
+#
+# WARNING: This file is going to remove.
+# Do not rely on the implementation written in this file.
+#
+
+require 'socket'
+require 'timeout'
+require 'io/wait'
+
+module Net # :nodoc:
+
+  class Protocol   #:nodoc: internal use only
+    VERSION = "0.2.2"
+
+    private
+    def Protocol.protocol_param(name, val)
+      module_eval(<<-End, __FILE__, __LINE__ + 1)
+        def #{name}
+          #{val}
+        end
+      End
+    end
+
+    def ssl_socket_connect(s, timeout)
+      if timeout
+        while true
+          raise Net::OpenTimeout if timeout <= 0
+          start = Process.clock_gettime Process::CLOCK_MONOTONIC
+          # to_io is required because SSLSocket doesn't have wait_readable yet
+          case s.connect_nonblock(exception: false)
+          when :wait_readable; s.to_io.wait_readable(timeout)
+          when :wait_writable; s.to_io.wait_writable(timeout)
+          else; break
+          end
+          timeout -= Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        end
+      else
+        s.connect
+      end
+    end
+  end
+
+
+  class ProtocolError          < StandardError; end
+  class ProtoSyntaxError       < ProtocolError; end
+  class ProtoFatalError        < ProtocolError; end
+  class ProtoUnknownError      < ProtocolError; end
+  class ProtoServerError       < ProtocolError; end
+  class ProtoAuthError         < ProtocolError; end
+  class ProtoCommandError      < ProtocolError; end
+  class ProtoRetriableError    < ProtocolError; end
+  ProtocRetryError = ProtoRetriableError
+
+  ##
+  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot
+  # be created within the open_timeout.
+
+  class OpenTimeout            < Timeout::Error; end
+
+  ##
+  # ReadTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be read within the read_timeout.
+
+  class ReadTimeout < Timeout::Error
+    def initialize(io = nil)
+      @io = io
+    end
+    attr_reader :io
+
+    def message
+      msg = super
+      if @io
+        msg = "#{msg} with #{@io.inspect}"
+      end
+      msg
+    end
+  end
+
+  ##
+  # WriteTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be written within the write_timeout.  Not raised on Windows.
+
+  class WriteTimeout < Timeout::Error
+    def initialize(io = nil)
+      @io = io
+    end
+    attr_reader :io
+
+    def message
+      msg = super
+      if @io
+        msg = "#{msg} with #{@io.inspect}"
+      end
+      msg
+    end
+  end
+
+
+  class BufferedIO   #:nodoc: internal use only
+    def initialize(io, read_timeout: 60, write_timeout: 60, continue_timeout: nil, debug_output: nil)
+      @io = io
+      @read_timeout = read_timeout
+      @write_timeout = write_timeout
+      @continue_timeout = continue_timeout
+      @debug_output = debug_output
+      @rbuf = ''.b
+      @rbuf_empty = true
+      @rbuf_offset = 0
+    end
+
+    attr_reader :io
+    attr_accessor :read_timeout
+    attr_accessor :write_timeout
+    attr_accessor :continue_timeout
+    attr_accessor :debug_output
+
+    def inspect
+      "#<#{self.class} io=#{@io}>"
+    end
+
+    def eof?
+      @io.eof?
+    end
+
+    def closed?
+      @io.closed?
+    end
+
+    def close
+      @io.close
+    end
+
+    #
+    # Read
+    #
+
+    public
+
+    def read(len, dest = ''.b, ignore_eof = false)
+      LOG "reading #{len} bytes..."
+      read_bytes = 0
+      begin
+        while read_bytes + rbuf_size < len
+          if s = rbuf_consume_all
+            read_bytes += s.bytesize
+            dest << s
+          end
+          rbuf_fill
+        end
+        s = rbuf_consume(len - read_bytes)
+        read_bytes += s.bytesize
+        dest << s
+      rescue EOFError
+        raise unless ignore_eof
+      end
+      LOG "read #{read_bytes} bytes"
+      dest
+    end
+
+    def read_all(dest = ''.b)
+      LOG 'reading all...'
+      read_bytes = 0
+      begin
+        while true
+          if s = rbuf_consume_all
+            read_bytes += s.bytesize
+            dest << s
+          end
+          rbuf_fill
+        end
+      rescue EOFError
+        ;
+      end
+      LOG "read #{read_bytes} bytes"
+      dest
+    end
+
+    def readuntil(terminator, ignore_eof = false)
+      offset = @rbuf_offset
+      begin
+        until idx = @rbuf.index(terminator, offset)
+          offset = @rbuf.bytesize
+          rbuf_fill
+        end
+        return rbuf_consume(idx + terminator.bytesize - @rbuf_offset)
+      rescue EOFError
+        raise unless ignore_eof
+        return rbuf_consume
+      end
+    end
+
+    def readline
+      readuntil("\n").chop
+    end
+
+    private
+
+    BUFSIZE = 1024 * 16
+
+    def rbuf_fill
+      tmp = @rbuf_empty ? @rbuf : nil
+      case rv = @io.read_nonblock(BUFSIZE, tmp, exception: false)
+      when String
+        @rbuf_empty = false
+        if rv.equal?(tmp)
+          @rbuf_offset = 0
+        else
+          @rbuf << rv
+          rv.clear
+        end
+        return
+      when :wait_readable
+        (io = @io.to_io).wait_readable(@read_timeout) or raise Net::ReadTimeout.new(io)
+        # continue looping
+      when :wait_writable
+        # OpenSSL::Buffering#read_nonblock may fail with IO::WaitWritable.
+        # http://www.openssl.org/support/faq.html#PROG10
+        (io = @io.to_io).wait_writable(@read_timeout) or raise Net::ReadTimeout.new(io)
+        # continue looping
+      when nil
+        raise EOFError, 'end of file reached'
+      end while true
+    end
+
+    def rbuf_flush
+      if @rbuf_empty
+        @rbuf.clear
+        @rbuf_offset = 0
+      end
+      nil
+    end
+
+    def rbuf_size
+      @rbuf.bytesize - @rbuf_offset
+    end
+
+    def rbuf_consume_all
+      rbuf_consume if rbuf_size > 0
+    end
+
+    def rbuf_consume(len = nil)
+      if @rbuf_offset == 0 && (len.nil? || len == @rbuf.bytesize)
+        s = @rbuf
+        @rbuf = ''.b
+        @rbuf_offset = 0
+        @rbuf_empty = true
+      elsif len.nil?
+        s = @rbuf.byteslice(@rbuf_offset..-1)
+        @rbuf = ''.b
+        @rbuf_offset = 0
+        @rbuf_empty = true
+      else
+        s = @rbuf.byteslice(@rbuf_offset, len)
+        @rbuf_offset += len
+        @rbuf_empty = @rbuf_offset == @rbuf.bytesize
+        rbuf_flush
+      end
+
+      @debug_output << %Q[-> #{s.dump}\n] if @debug_output
+      s
+    end
+
+    #
+    # Write
+    #
+
+    public
+
+    def write(*strs)
+      writing {
+        write0(*strs)
+      }
+    end
+
+    alias << write
+
+    def writeline(str)
+      writing {
+        write0 str + "\r\n"
+      }
+    end
+
+    private
+
+    def writing
+      @written_bytes = 0
+      @debug_output << '<- ' if @debug_output
+      yield
+      @debug_output << "\n" if @debug_output
+      bytes = @written_bytes
+      @written_bytes = nil
+      bytes
+    end
+
+    def write0(*strs)
+      @debug_output << strs.map(&:dump).join if @debug_output
+      orig_written_bytes = @written_bytes
+      strs.each_with_index do |str, i|
+        need_retry = true
+        case len = @io.write_nonblock(str, exception: false)
+        when Integer
+          @written_bytes += len
+          len -= str.bytesize
+          if len == 0
+            if strs.size == i+1
+              return @written_bytes - orig_written_bytes
+            else
+              need_retry = false
+              # next string
+            end
+          elsif len < 0
+            str = str.byteslice(len, -len)
+          else # len > 0
+            need_retry = false
+            # next string
+          end
+          # continue looping
+        when :wait_writable
+          (io = @io.to_io).wait_writable(@write_timeout) or raise Net::WriteTimeout.new(io)
+          # continue looping
+        end while need_retry
+      end
+    end
+
+    #
+    # Logging
+    #
+
+    private
+
+    def LOG_off
+      @save_debug_out = @debug_output
+      @debug_output = nil
+    end
+
+    def LOG_on
+      @debug_output = @save_debug_out
+    end
+
+    def LOG(msg)
+      return unless @debug_output
+      @debug_output << msg + "\n"
+    end
+  end
+
+
+  class InternetMessageIO < BufferedIO   #:nodoc: internal use only
+    def initialize(*, **)
+      super
+      @wbuf = nil
+    end
+
+    #
+    # Read
+    #
+
+    def each_message_chunk
+      LOG 'reading message...'
+      LOG_off()
+      read_bytes = 0
+      while (line = readuntil("\r\n")) != ".\r\n"
+        read_bytes += line.size
+        yield line.delete_prefix('.')
+      end
+      LOG_on()
+      LOG "read message (#{read_bytes} bytes)"
+    end
+
+    # *library private* (cannot handle 'break')
+    def each_list_item
+      while (str = readuntil("\r\n")) != ".\r\n"
+        yield str.chop
+      end
+    end
+
+    def write_message_0(src)
+      prev = @written_bytes
+      each_crlf_line(src) do |line|
+        write0 dot_stuff(line)
+      end
+      @written_bytes - prev
+    end
+
+    #
+    # Write
+    #
+
+    def write_message(src)
+      LOG "writing message from #{src.class}"
+      LOG_off()
+      len = writing {
+        using_each_crlf_line {
+          write_message_0 src
+        }
+      }
+      LOG_on()
+      LOG "wrote #{len} bytes"
+      len
+    end
+
+    def write_message_by_block(&block)
+      LOG 'writing message from block'
+      LOG_off()
+      len = writing {
+        using_each_crlf_line {
+          begin
+            block.call(WriteAdapter.new(self.method(:write_message_0)))
+          rescue LocalJumpError
+            # allow `break' from writer block
+          end
+        }
+      }
+      LOG_on()
+      LOG "wrote #{len} bytes"
+      len
+    end
+
+    private
+
+    def dot_stuff(s)
+      s.sub(/\A\./, '..')
+    end
+
+    def using_each_crlf_line
+      @wbuf = ''.b
+      yield
+      if not @wbuf.empty?   # unterminated last line
+        write0 dot_stuff(@wbuf.chomp) + "\r\n"
+      elsif @written_bytes == 0   # empty src
+        write0 "\r\n"
+      end
+      write0 ".\r\n"
+      @wbuf = nil
+    end
+
+    def each_crlf_line(src)
+      buffer_filling(@wbuf, src) do
+        while line = @wbuf.slice!(/\A[^\r\n]*(?:\n|\r(?:\n|(?!\z)))/)
+          yield line.chomp("\n") + "\r\n"
+        end
+      end
+    end
+
+    def buffer_filling(buf, src)
+      case src
+      when String    # for speeding up.
+        0.step(src.size - 1, 1024) do |i|
+          buf << src[i, 1024]
+          yield
+        end
+      when File    # for speeding up.
+        while s = src.read(1024)
+          buf << s
+          yield
+        end
+      else    # generic reader
+        src.each do |str|
+          buf << str
+          yield if buf.size > 1024
+        end
+        yield unless buf.empty?
+      end
+    end
+  end
+
+
+  #
+  # The writer adapter class
+  #
+  class WriteAdapter
+    def initialize(writer)
+      @writer = writer
+    end
+
+    def inspect
+      "#<#{self.class} writer=#{@writer.inspect}>"
+    end
+
+    def write(str)
+      @writer.call(str)
+    end
+
+    alias print write
+
+    def <<(str)
+      write str
+      self
+    end
+
+    def puts(str = '')
+      write str.chomp("\n") + "\n"
+    end
+
+    def printf(*args)
+      write sprintf(*args)
+    end
+  end
+
+
+  class ReadAdapter   #:nodoc: internal use only
+    def initialize(block)
+      @block = block
+    end
+
+    def inspect
+      "#<#{self.class}>"
+    end
+
+    def <<(str)
+      call_block(str, &@block) if @block
+    end
+
+    private
+
+    # This method is needed because @block must be called by yield,
+    # not Proc#call.  You can see difference when using `break' in
+    # the block.
+    def call_block(str)
+      yield str
+    end
+  end
+
+
+  module NetPrivate   #:nodoc: obsolete
+    Socket = ::Net::InternetMessageIO
+  end
+
+end   # module Net

--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -215,7 +215,7 @@ module Net # :nodoc:
 
     def rbuf_fill
       tmp = @rbuf_empty ? @rbuf : nil
-      case rv = @io.read_nonblock(BUFSIZE, tmp, exception: false)
+      case rv = @io.read(BUFSIZE, tmp)
       when String
         @rbuf_empty = false
         if rv.equal?(tmp)
@@ -313,7 +313,7 @@ module Net # :nodoc:
       orig_written_bytes = @written_bytes
       strs.each_with_index do |str, i|
         need_retry = true
-        case len = @io.write_nonblock(str, exception: false)
+        case len = @io.write(str)
         when Integer
           @written_bytes += len
           len -= str.bytesize

--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -21,7 +21,7 @@
 
 require 'socket'
 require 'timeout'
-require 'io/wait'
+# require 'io/wait'
 
 module Net # :nodoc:
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -564,8 +564,16 @@ Value OpenSSL_SSL_SSLSocket_connect(Env *env, Value self, Args args, Block *) {
     }
     if (!SSL_set_fd(ssl, fd))
         OpenSSL_SSL_raise_error(env, "SSL_set_fd");
-    if (SSL_connect(ssl) <= 0)
+    if (SSL_connect(ssl) <= 0) {
+        unsigned long err = ERR_peek_last_error();
+        const char *err_msg = ERR_reason_error_string(err);
+        const char *verify_msg = X509_verify_cert_error_string(SSL_get_verify_result(ssl));
+        if (err_msg)
+            fprintf(stderr, "err_msg = %s\n", err_msg);
+        if (verify_msg)
+            fprintf(stderr, "verify_msg = %s\n", verify_msg);
         OpenSSL_SSL_raise_error(env, "SSL_connect");
+    }
     return self;
 }
 

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -335,6 +335,7 @@ module OpenSSL
 
     class SSLSocket
       attr_reader :context, :hostname, :io
+      attr_accessor :sync_close # Dummy method
 
       __bind_method__ :initialize, :OpenSSL_SSL_SSLSocket_initialize
       __bind_method__ :close, :OpenSSL_SSL_SSLSocket_close
@@ -342,6 +343,14 @@ module OpenSSL
       __bind_method__ :hostname=, :OpenSSL_SSL_SSLSocket_set_hostname
       __bind_method__ :read, :OpenSSL_SSL_SSLSocket_read
       __bind_method__ :write, :OpenSSL_SSL_SSLSocket_write
+
+      def connect_nonblock(exception: false) = connect # Dummy method
+      def post_connection_check(address) = nil # Dummy method
+      def ssl_version = :TLS1_3 # Dummy method
+      def cipher = [:NONE] # Dummy method
+
+      # Methods forwarded to IO
+      def closed? = @io.closed?
     end
   end
 

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+#
+# Resolv is a thread-aware DNS resolver library written in Ruby.  Resolv can
+# handle multiple DNS requests concurrently without blocking the entire Ruby
+# interpreter.
+#
+# See also resolv-replace.rb to replace the libc resolver with Resolv.
+#
+# Resolv can look up various DNS resources using the DNS module directly.
+#
+# Examples:
+#
+#   p Resolv.getaddress "www.ruby-lang.org"
+#   p Resolv.getname "210.251.121.214"
+#
+#   Resolv::DNS.open do |dns|
+#     ress = dns.getresources "www.ruby-lang.org", Resolv::DNS::Resource::IN::A
+#     p ress.map(&:address)
+#     ress = dns.getresources "ruby-lang.org", Resolv::DNS::Resource::IN::MX
+#     p ress.map { |r| [r.exchange.to_s, r.preference] }
+#   end
+#
+#
+# == Bugs
+#
+# * NIS is not supported.
+# * /etc/nsswitch.conf is not supported.
+
+class Resolv
+
+  VERSION = "0.3.0"
+
+  ##
+  # A Resolv::DNS IPv4 address.
+
+  class IPv4
+
+    ##
+    # Regular expression IPv4 addresses must match.
+
+    Regex256 = /0
+               |1(?:[0-9][0-9]?)?
+               |2(?:[0-4][0-9]?|5[0-5]?|[6-9])?
+               |[3-9][0-9]?/x
+    Regex = /\A(#{Regex256})\.(#{Regex256})\.(#{Regex256})\.(#{Regex256})\z/
+
+    def self.create(arg)
+      case arg
+      when IPv4
+        return arg
+      when Regex
+        if (0..255) === (a = $1.to_i) &&
+           (0..255) === (b = $2.to_i) &&
+           (0..255) === (c = $3.to_i) &&
+           (0..255) === (d = $4.to_i)
+          return self.new([a, b, c, d].pack("CCCC"))
+        else
+          raise ArgumentError.new("IPv4 address with invalid value: " + arg)
+        end
+      else
+        raise ArgumentError.new("cannot interpret as IPv4 address: #{arg.inspect}")
+      end
+    end
+
+    def initialize(address) # :nodoc:
+      unless address.kind_of?(String)
+        raise ArgumentError, 'IPv4 address must be a string'
+      end
+      unless address.length == 4
+        raise ArgumentError, "IPv4 address expects 4 bytes but #{address.length} bytes"
+      end
+      @address = address
+    end
+
+    ##
+    # A String representation of this IPv4 address.
+
+    ##
+    # The raw IPv4 address as a String.
+
+    attr_reader :address
+
+    def to_s # :nodoc:
+      return sprintf("%d.%d.%d.%d", *@address.unpack("CCCC"))
+    end
+
+    def inspect # :nodoc:
+      return "#<#{self.class} #{self}>"
+    end
+
+    ##
+    # Turns this IPv4 address into a Resolv::DNS::Name.
+
+    def to_name
+      return DNS::Name.create(
+        '%d.%d.%d.%d.in-addr.arpa.' % @address.unpack('CCCC').reverse)
+    end
+
+    def ==(other) # :nodoc:
+      return @address == other.address
+    end
+
+    def eql?(other) # :nodoc:
+      return self == other
+    end
+
+    def hash # :nodoc:
+      return @address.hash
+    end
+  end
+
+  ##
+  # A Resolv::DNS IPv6 address.
+
+  class IPv6
+
+    ##
+    # IPv6 address format a:b:c:d:e:f:g:h
+    Regex_8Hex = /\A
+      (?:[0-9A-Fa-f]{1,4}:){7}
+         [0-9A-Fa-f]{1,4}
+      \z/x
+
+    ##
+    # Compressed IPv6 address format a::b
+
+    Regex_CompressedHex = /\A
+      ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?) ::
+      ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
+      \z/x
+
+    ##
+    # IPv4 mapped IPv6 address format a:b:c:d:e:f:w.x.y.z
+
+    Regex_6Hex4Dec = /\A
+      ((?:[0-9A-Fa-f]{1,4}:){6,6})
+      (\d+)\.(\d+)\.(\d+)\.(\d+)
+      \z/x
+
+    ##
+    # Compressed IPv4 mapped IPv6 address format a::b:w.x.y.z
+
+    Regex_CompressedHex4Dec = /\A
+      ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?) ::
+      ((?:[0-9A-Fa-f]{1,4}:)*)
+      (\d+)\.(\d+)\.(\d+)\.(\d+)
+      \z/x
+
+    ##
+    # IPv6 link local address format fe80:b:c:d:e:f:g:h%em1
+    Regex_8HexLinkLocal = /\A
+      [Ff][Ee]80
+      (?::[0-9A-Fa-f]{1,4}){7}
+      %[-0-9A-Za-z._~]+
+      \z/x
+
+    ##
+    # Compressed IPv6 link local address format fe80::b%em1
+
+    Regex_CompressedHexLinkLocal = /\A
+      [Ff][Ee]80:
+      (?:
+        ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?) ::
+        ((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
+        |
+        :((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
+      )?
+      :[0-9A-Fa-f]{1,4}%[-0-9A-Za-z._~]+
+      \z/x
+
+    ##
+    # A composite IPv6 address Regexp.
+
+    Regex = /
+      (?:#{Regex_8Hex}) |
+      (?:#{Regex_CompressedHex}) |
+      (?:#{Regex_6Hex4Dec}) |
+      (?:#{Regex_CompressedHex4Dec}) |
+      (?:#{Regex_8HexLinkLocal}) |
+      (?:#{Regex_CompressedHexLinkLocal})
+      /x
+
+    ##
+    # Creates a new IPv6 address from +arg+ which may be:
+    #
+    # IPv6:: returns +arg+.
+    # String:: +arg+ must match one of the IPv6::Regex* constants
+
+    def self.create(arg)
+      case arg
+      when IPv6
+        return arg
+      when String
+        address = ''.b
+        if Regex_8Hex =~ arg
+          arg.scan(/[0-9A-Fa-f]+/) {|hex| address << [hex.hex].pack('n')}
+        elsif Regex_CompressedHex =~ arg
+          prefix = $1
+          suffix = $2
+          a1 = ''.b
+          a2 = ''.b
+          prefix.scan(/[0-9A-Fa-f]+/) {|hex| a1 << [hex.hex].pack('n')}
+          suffix.scan(/[0-9A-Fa-f]+/) {|hex| a2 << [hex.hex].pack('n')}
+          omitlen = 16 - a1.length - a2.length
+          address << a1 << "\0" * omitlen << a2
+        elsif Regex_6Hex4Dec =~ arg
+          prefix, a, b, c, d = $1, $2.to_i, $3.to_i, $4.to_i, $5.to_i
+          if (0..255) === a && (0..255) === b && (0..255) === c && (0..255) === d
+            prefix.scan(/[0-9A-Fa-f]+/) {|hex| address << [hex.hex].pack('n')}
+            address << [a, b, c, d].pack('CCCC')
+          else
+            raise ArgumentError.new("not numeric IPv6 address: " + arg)
+          end
+        elsif Regex_CompressedHex4Dec =~ arg
+          prefix, suffix, a, b, c, d = $1, $2, $3.to_i, $4.to_i, $5.to_i, $6.to_i
+          if (0..255) === a && (0..255) === b && (0..255) === c && (0..255) === d
+            a1 = ''.b
+            a2 = ''.b
+            prefix.scan(/[0-9A-Fa-f]+/) {|hex| a1 << [hex.hex].pack('n')}
+            suffix.scan(/[0-9A-Fa-f]+/) {|hex| a2 << [hex.hex].pack('n')}
+            omitlen = 12 - a1.length - a2.length
+            address << a1 << "\0" * omitlen << a2 << [a, b, c, d].pack('CCCC')
+          else
+            raise ArgumentError.new("not numeric IPv6 address: " + arg)
+          end
+        else
+          raise ArgumentError.new("not numeric IPv6 address: " + arg)
+        end
+        return IPv6.new(address)
+      else
+        raise ArgumentError.new("cannot interpret as IPv6 address: #{arg.inspect}")
+      end
+    end
+
+    def initialize(address) # :nodoc:
+      unless address.kind_of?(String) && address.length == 16
+        raise ArgumentError.new('IPv6 address must be 16 bytes')
+      end
+      @address = address
+    end
+
+    ##
+    # The raw IPv6 address as a String.
+
+    attr_reader :address
+
+    def to_s # :nodoc:
+      sprintf("%x:%x:%x:%x:%x:%x:%x:%x", *@address.unpack("nnnnnnnn")).sub(/(^|:)0(:0)+(:|$)/, '::')
+    end
+
+    def inspect # :nodoc:
+      return "#<#{self.class} #{self}>"
+    end
+
+    ##
+    # Turns this IPv6 address into a Resolv::DNS::Name.
+    #--
+    # ip6.arpa should be searched too. [RFC3152]
+
+    def to_name
+      return DNS::Name.new(
+        @address.unpack("H32")[0].split(//).reverse + ['ip6', 'arpa'])
+    end
+
+    def ==(other) # :nodoc:
+      return @address == other.address
+    end
+
+    def eql?(other) # :nodoc:
+      return self == other
+    end
+
+    def hash # :nodoc:
+      return @address.hash
+    end
+  end
+end

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# Timeout long-running blocks
+#
+# == Synopsis
+#
+#   require 'timeout'
+#   status = Timeout::timeout(5) {
+#     # Something that should be interrupted if it takes more than 5 seconds...
+#   }
+#
+# == Description
+#
+# Timeout provides a way to auto-terminate a potentially long-running
+# operation if it hasn't finished in a fixed amount of time.
+#
+# Previous versions didn't use a module for namespacing, however
+# #timeout is provided for backwards compatibility.  You
+# should prefer Timeout.timeout instead.
+#
+# == Copyright
+#
+# Copyright:: (C) 2000  Network Applied Communication Laboratory, Inc.
+# Copyright:: (C) 2000  Information-technology Promotion Agency, Japan
+
+module Timeout
+  # The version
+  VERSION = "0.4.1"
+
+  # Internal error raised to when a timeout is triggered.
+  class ExitException < Exception
+    def exception(*) # :nodoc:
+      self
+    end
+  end
+
+  # Raised by Timeout.timeout when the block times out.
+  class Error < RuntimeError
+    def self.handle_timeout(message) # :nodoc:
+      exc = ExitException.new(message)
+
+      begin
+        yield exc
+      rescue ExitException => e
+        raise new(message) if exc.equal?(e)
+        raise
+      end
+    end
+  end
+
+  def timeout(sec, klass = nil, message = nil, &block)
+    # NATFIXME: For now just run the block without a timeout
+    yield(sec)
+  end
+  module_function :timeout
+end

--- a/net.rb
+++ b/net.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'net/http'
+
+puts Net::HTTP.get(URI('http://natalie-lang.org/'))
+puts Net::HTTP.get(URI('https://natalie-lang.org/specs'))

--- a/net.rb
+++ b/net.rb
@@ -23,6 +23,14 @@ TCPSocket.open('natalie-lang.org', 443) do |sock|
   puts ssl_sock.read
 end
 
+# net/http with debugging
+http = Net::HTTP.new('natalie-lang.org', 443)
+http.set_debug_output($stderr)
+http.use_ssl = true
+http.start do |h|
+  puts h.request_get(URI('https://natalie-lang.org/specs')).body
+end
+
 # Examples with net/http
 puts Net::HTTP.get(URI('http://natalie-lang.org/'))
 puts Net::HTTP.get(URI('https://natalie-lang.org/specs'))

--- a/net.rb
+++ b/net.rb
@@ -1,7 +1,28 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'socket'
 require 'net/http'
+require 'openssl'
 
+# Examples without net/http
+TCPSocket.open('natalie-lang.org', 80) do |sock|
+  sock.write("GET / HTTP/1.1\nHost: natalie-lang.org\nConnection: close\n\n")
+  puts sock.read
+end
+
+# NATFIXME: Update this example with the changes made to support net/http
+TCPSocket.open('natalie-lang.org', 443) do |sock|
+  ssl_context = OpenSSL::SSL::SSLContext.new
+  ssl_context.set_params
+  ssl_context.session_cache_mode = OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT | OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
+  ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
+  ssl_sock.hostname = 'natalie-lang.org'
+  ssl_sock.connect
+  ssl_sock.write("GET / HTTP/1.1\nHost: natalie-lang.org\nConnection: close\n\n")
+  puts ssl_sock.read
+end
+
+# Examples with net/http
 puts Net::HTTP.get(URI('http://natalie-lang.org/'))
 puts Net::HTTP.get(URI('https://natalie-lang.org/specs'))

--- a/spec/library/net-http/HTTPBadResponse_spec.rb
+++ b/spec/library/net-http/HTTPBadResponse_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPBadResponse" do
+  it "is a subclass of StandardError" do
+    Net::HTTPBadResponse.should < StandardError
+  end
+end

--- a/spec/library/net-http/HTTPClientExcepton_spec.rb
+++ b/spec/library/net-http/HTTPClientExcepton_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPClientException" do
+  it "is a subclass of Net::ProtoServerError" do
+    Net::HTTPClientException.should < Net::ProtoServerError
+  end
+
+  it "includes the Net::HTTPExceptions module" do
+    Net::HTTPClientException.should < Net::HTTPExceptions
+  end
+end

--- a/spec/library/net-http/HTTPError_spec.rb
+++ b/spec/library/net-http/HTTPError_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPError" do
+  it "is a subclass of Net::ProtocolError" do
+    Net::HTTPError.should < Net::ProtocolError
+  end
+
+  it "includes the Net::HTTPExceptions module" do
+    Net::HTTPError.should < Net::HTTPExceptions
+  end
+end

--- a/spec/library/net-http/HTTPFatalError_spec.rb
+++ b/spec/library/net-http/HTTPFatalError_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPFatalError" do
+  it "is a subclass of Net::ProtoFatalError" do
+    Net::HTTPFatalError.should < Net::ProtoFatalError
+  end
+
+  it "includes the Net::HTTPExceptions module" do
+    Net::HTTPFatalError.should < Net::HTTPExceptions
+  end
+end

--- a/spec/library/net-http/HTTPHeaderSyntaxError_spec.rb
+++ b/spec/library/net-http/HTTPHeaderSyntaxError_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPHeaderSyntaxError" do
+  it "is a subclass of StandardError" do
+    Net::HTTPHeaderSyntaxError.should < StandardError
+  end
+end

--- a/spec/library/net-http/HTTPRetriableError_spec.rb
+++ b/spec/library/net-http/HTTPRetriableError_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPRetriableError" do
+  it "is a subclass of Net::ProtoRetriableError" do
+    Net::HTTPRetriableError.should < Net::ProtoRetriableError
+  end
+
+  it "includes the Net::HTTPExceptions module" do
+    Net::HTTPRetriableError.should < Net::HTTPExceptions
+  end
+end

--- a/spec/library/net-http/HTTPServerException_spec.rb
+++ b/spec/library/net-http/HTTPServerException_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPServerException" do
+  it "is a subclass of Net::ProtoServerError and is warned as deprecated" do
+    -> { Net::HTTPServerException.should < Net::ProtoServerError }.should complain(/warning: constant Net::HTTPServerException is deprecated/)
+  end
+
+  it "includes the Net::HTTPExceptions module and is warned as deprecated" do
+    -> { Net::HTTPServerException.should < Net::HTTPExceptions }.should complain(/warning: constant Net::HTTPServerException is deprecated/)
+  end
+end

--- a/spec/library/net-http/http/Proxy_spec.rb
+++ b/spec/library/net-http/http/Proxy_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.Proxy" do
+  it "returns a new subclass of Net::HTTP" do
+    Net::HTTP.Proxy("localhost").should < Net::HTTP
+  end
+
+  it "returns Net::HTTP when the passed address is nil" do
+    Net::HTTP.Proxy(nil).should == Net::HTTP
+  end
+
+  it "sets the returned subclasses' proxy options based on the passed arguments" do
+    http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+    http_with_proxy.proxy_address.should == "localhost"
+    http_with_proxy.proxy_port.should eql(1234)
+    http_with_proxy.proxy_user.should == "rspec"
+    http_with_proxy.proxy_pass.should == "rocks"
+  end
+end
+
+describe "Net::HTTP#proxy?" do
+  describe "when self is no proxy class instance" do
+    it "returns false" do
+      Net::HTTP.new("localhost", 3333).proxy?.should be_false
+    end
+  end
+
+  describe "when self is a proxy class instance" do
+    it "returns false" do
+      http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+      http_with_proxy.new("localhost", 3333).proxy?.should be_true
+    end
+  end
+end

--- a/spec/library/net-http/http/active_spec.rb
+++ b/spec/library/net-http/http/active_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/started'
+
+describe "Net::HTTP#active?" do
+  it_behaves_like :net_http_started_p, :active?
+end

--- a/spec/library/net-http/http/address_spec.rb
+++ b/spec/library/net-http/http/address_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#address" do
+  it "returns the current host name" do
+    net = Net::HTTP.new("localhost")
+    net.address.should == "localhost"
+  end
+end

--- a/spec/library/net-http/http/close_on_empty_response_spec.rb
+++ b/spec/library/net-http/http/close_on_empty_response_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#close_on_empty_response" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "Net::HTTP#close_on_empty_response=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/spec/library/net-http/http/copy_spec.rb
+++ b/spec/library/net-http/http/copy_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#copy" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a COPY request to the passed path and returns the response" do
+    response = @http.copy("/request")
+    response.should be_kind_of(Net::HTTPResponse)
+    response.body.should == "Request type: COPY"
+  end
+end

--- a/spec/library/net-http/http/default_port_spec.rb
+++ b/spec/library/net-http/http/default_port_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.default_port" do
+  it "returns 80" do
+    Net::HTTP.http_default_port.should eql(80)
+  end
+end

--- a/spec/library/net-http/http/delete_spec.rb
+++ b/spec/library/net-http/http/delete_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#delete" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a DELETE request to the passed path and returns the response" do
+    response = @http.delete("/request")
+    response.should be_kind_of(Net::HTTPResponse)
+    response.body.should == "Request type: DELETE"
+  end
+end

--- a/spec/library/net-http/http/finish_spec.rb
+++ b/spec/library/net-http/http/finish_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#finish" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.new("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when self has been started" do
+    it "closes the tcp connection" do
+      @http.start
+      @http.finish
+      @http.started?.should be_false
+    end
+  end
+
+  describe "when self has not been started yet" do
+    it "raises an IOError" do
+      -> { @http.finish }.should raise_error(IOError)
+    end
+  end
+end

--- a/spec/library/net-http/http/fixtures/http_server.rb
+++ b/spec/library/net-http/http/fixtures/http_server.rb
@@ -1,0 +1,123 @@
+require 'socket'
+
+module NetHTTPSpecs
+  class NullWriter
+    def <<(s) end
+    def puts(*args) end
+    def print(*args) end
+    def printf(*args) end
+  end
+
+  class SmallHTTPServer
+    def initialize(bind_address)
+      @server = TCPServer.new(bind_address, 0)
+      @thread = Thread.new {
+        Thread.current.abort_on_exception = true
+        listen
+      }
+    end
+
+    def ip
+      @server.addr[3]
+    end
+
+    def port
+      @server.addr[1]
+    end
+
+    def listen
+      until @server.closed?
+        client = @server.accept
+        handle_client(client)
+      end
+    end
+
+    def handle_client(client)
+      begin
+        until client.closed?
+          request = client.gets("\r\n\r\n")
+          break unless request
+          if request == "CLOSE"
+            @server.close
+            break
+          end
+          handle_request(client, request)
+        end
+      ensure
+        client.close
+      end
+    end
+
+    def parse_request(request)
+      request, *headers = request.chomp.lines.map { |line| line.chomp }
+      request_method, request_uri, _http_version = request.split
+      headers = headers.map { |line| line.split(': ', 2) }.to_h
+      [request_method, request_uri, headers]
+    end
+
+    def handle_request(client, request)
+      request_method, request_uri, headers = parse_request(request)
+
+      if headers.include? 'Content-Length'
+        request_body_size = Integer(headers['Content-Length'])
+        request_body = client.read(request_body_size)
+      end
+
+      case request_uri
+      when '/'
+        raise request_method unless request_method == 'GET'
+        reply(client, "This is the index page.", request_method)
+      when '/request'
+        reply(client, "Request type: #{request_method}", request_method)
+      when '/request/body'
+        reply(client, request_body, request_method)
+      when '/request/header'
+        reply(client, headers.inspect, request_method)
+      when '/request/basic_auth'
+        reply(client, "username: \npassword: ", request_method)
+      else
+        raise request_uri
+      end
+    end
+
+    def reply(client, body, request_method)
+      client.print "HTTP/1.1 200 OK\r\n"
+      if request_method == 'HEAD'
+        client.close
+      else
+        client.print "Content-Type: text/plain\r\n"
+        client.print "Content-Length: #{body.bytesize}\r\n"
+        client.print "\r\n"
+        client.print body
+      end
+    end
+
+    def close
+      TCPSocket.open(ip, port) do |socket|
+        socket.write "CLOSE"
+      end
+      @thread.join
+    end
+  end
+
+  @server = nil
+
+  class << self
+    def port
+      raise "server not started" unless @server
+      @server.port
+    end
+
+    def start_server
+      bind_address = platform_is(:windows) ? "localhost" : "127.0.0.1"
+      @server = SmallHTTPServer.new(bind_address)
+    end
+
+    def stop_server
+      if @server
+        @server.close
+        @server = nil
+      end
+    end
+  end
+end

--- a/spec/library/net-http/http/get2_spec.rb
+++ b/spec/library/net-http/http/get2_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_get'
+
+describe "Net::HTTP#get2" do
+  it_behaves_like :net_http_request_get, :get2
+end

--- a/spec/library/net-http/http/get_print_spec.rb
+++ b/spec/library/net-http/http/get_print_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.get_print" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed URI" do
+    it "it prints the body of the specified uri to $stdout" do
+      -> do
+        Net::HTTP.get_print URI.parse("http://localhost:#{@port}/")
+      end.should output(/This is the index page\./)
+    end
+  end
+
+  describe "when passed host, path, port" do
+    it "it prints the body of the specified uri to $stdout" do
+      -> do
+        Net::HTTP.get_print 'localhost', "/", @port
+      end.should output(/This is the index page\./)
+    end
+  end
+end

--- a/spec/library/net-http/http/get_response_spec.rb
+++ b/spec/library/net-http/http/get_response_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.get_response" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed URI" do
+    it "returns the response for the specified uri" do
+      res = Net::HTTP.get_response(URI.parse("http://localhost:#{@port}/"))
+      res.content_type.should == "text/plain"
+      res.body.should == "This is the index page."
+    end
+  end
+
+  describe "when passed host, path, port" do
+    it "returns the response for the specified host-path-combination" do
+      res = Net::HTTP.get_response('localhost', "/", @port)
+      res.content_type.should == "text/plain"
+      res.body.should == "This is the index page."
+    end
+  end
+end

--- a/spec/library/net-http/http/get_spec.rb
+++ b/spec/library/net-http/http/get_spec.rb
@@ -1,0 +1,94 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.get" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed URI" do
+    it "returns the body of the specified uri" do
+      Net::HTTP.get(URI.parse("http://localhost:#{@port}/")).should == "This is the index page."
+    end
+  end
+
+  describe "when passed host, path, port" do
+    it "returns the body of the specified host-path-combination" do
+      Net::HTTP.get('localhost', "/", @port).should == "This is the index page."
+    end
+  end
+end
+
+quarantine! do # These specs fail frequently with CHECK_LEAKS=true
+describe "Net::HTTP.get" do
+  describe "when reading gzipped contents" do
+    def start_threads
+      require 'zlib'
+      require 'stringio'
+
+      server = nil
+      server_thread = Thread.new do
+        server = TCPServer.new("127.0.0.1", 0)
+        begin
+          c = server.accept
+        ensure
+          server.close
+        end
+        c.print "HTTP/1.1 200\r\n"
+        c.print "Content-Type: text/plain\r\n"
+        c.print "Content-Encoding: gzip\r\n"
+        s = StringIO.new
+        z = Zlib::GzipWriter.new(s)
+        begin
+          z.write 'Hello World!'
+        ensure
+          z.close
+        end
+        c.print "Content-Length: #{s.length}\r\n\r\n"
+        # Write partial gzip content
+        c.write s.string.byteslice(0..-2)
+        c.flush
+        c
+      end
+      Thread.pass until server && server_thread.stop?
+
+      client_thread = Thread.new do
+        Thread.current.report_on_exception = false
+        Net::HTTP.get("127.0.0.1", '/', server.connect_address.ip_port)
+      end
+
+      socket = server_thread.value
+      Thread.pass until client_thread.stop?
+
+      [socket, client_thread]
+    end
+
+    it "propagates exceptions interrupting the thread and does not replace it with Zlib::BufError" do
+      my_exception = Class.new(RuntimeError)
+      socket, client_thread = start_threads
+      begin
+        client_thread.raise my_exception, "my exception"
+        -> { client_thread.value }.should raise_error(my_exception)
+      ensure
+        socket.close
+      end
+    end
+
+    it "lets the kill Thread exception goes through and does not replace it with Zlib::BufError" do
+      socket, client_thread = start_threads
+      begin
+        client_thread.kill
+        client_thread.value.should == nil
+      ensure
+        socket.close
+      end
+    end
+  end
+end
+end

--- a/spec/library/net-http/http/head2_spec.rb
+++ b/spec/library/net-http/http/head2_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_head'
+
+describe "Net::HTTP#head2" do
+  it_behaves_like :net_http_request_head, :head2
+end

--- a/spec/library/net-http/http/head_spec.rb
+++ b/spec/library/net-http/http/head_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#head" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a HEAD request to the passed path and returns the response" do
+    response = @http.head("/request")
+    # HEAD requests have no responses
+    response.body.should be_nil
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.head("/request").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/http_default_port_spec.rb
+++ b/spec/library/net-http/http/http_default_port_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.http_default_port" do
+  it "returns 80" do
+    Net::HTTP.http_default_port.should eql(80)
+  end
+end

--- a/spec/library/net-http/http/https_default_port_spec.rb
+++ b/spec/library/net-http/http/https_default_port_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.https_default_port" do
+  it "returns 443" do
+    Net::HTTP.https_default_port.should eql(443)
+  end
+end

--- a/spec/library/net-http/http/initialize_spec.rb
+++ b/spec/library/net-http/http/initialize_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#initialize" do
+  it "is private" do
+    Net::HTTP.should have_private_instance_method(:initialize)
+  end
+
+  describe "when passed address" do
+    before :each do
+      @net = Net::HTTP.allocate
+      @net.send(:initialize, "localhost")
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @net.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the default HTTP port" do
+      @net.port.should eql(Net::HTTP.default_port)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @net.started?.should be_false
+    end
+  end
+
+  describe "when passed address, port" do
+    before :each do
+      @net = Net::HTTP.allocate
+      @net.send(:initialize, "localhost", 3333)
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @net.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the passed port" do
+      @net.port.should eql(3333)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @net.started?.should be_false
+    end
+  end
+end

--- a/spec/library/net-http/http/inspect_spec.rb
+++ b/spec/library/net-http/http/inspect_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#inspect" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+    @http = Net::HTTP.new("localhost", @port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "returns a String representation of self" do
+    @http.inspect.should be_kind_of(String)
+    @http.inspect.should == "#<Net::HTTP localhost:#{@port} open=false>"
+
+    @http.start
+    @http.inspect.should == "#<Net::HTTP localhost:#{@port} open=true>"
+  end
+end

--- a/spec/library/net-http/http/is_version_1_1_spec.rb
+++ b/spec/library/net-http/http/is_version_1_1_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/version_1_1'
+
+describe "Net::HTTP.is_version_1_1?" do
+  it_behaves_like :net_http_version_1_1_p, :is_version_1_1?
+end

--- a/spec/library/net-http/http/is_version_1_2_spec.rb
+++ b/spec/library/net-http/http/is_version_1_2_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/version_1_2'
+
+describe "Net::HTTP.is_version_1_2?" do
+  it_behaves_like :net_http_version_1_2_p, :is_version_1_2?
+end

--- a/spec/library/net-http/http/lock_spec.rb
+++ b/spec/library/net-http/http/lock_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#lock" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a LOCK request to the passed path and returns the response" do
+    response = @http.lock("/request", "test=test")
+    response.should be_kind_of(Net::HTTPResponse)
+    response.body.should == "Request type: LOCK"
+  end
+end

--- a/spec/library/net-http/http/mkcol_spec.rb
+++ b/spec/library/net-http/http/mkcol_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#mkcol" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a MKCOL request to the passed path and returns the response" do
+    response = @http.mkcol("/request")
+    response.should be_kind_of(Net::HTTPResponse)
+    response.body.should == "Request type: MKCOL"
+  end
+end

--- a/spec/library/net-http/http/move_spec.rb
+++ b/spec/library/net-http/http/move_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#head" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a MOVE request to the passed path and returns the response" do
+    response = @http.move("/request")
+    # HEAD requests have no responses
+    response.body.should == "Request type: MOVE"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.move("/request").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/new_spec.rb
+++ b/spec/library/net-http/http/new_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.new" do
+  describe "when passed address" do
+    before :each do
+      @http = Net::HTTP.new("localhost")
+    end
+
+    it "returns a Net::HTTP instance" do
+      @http.proxy?.should be_false
+      @http.instance_of?(Net::HTTP).should be_true
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @http.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the default HTTP port" do
+      @http.port.should eql(Net::HTTP.default_port)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @http.started?.should be_false
+    end
+  end
+
+  describe "when passed address, port" do
+    before :each do
+      @http = Net::HTTP.new("localhost", 3333)
+    end
+
+    it "returns a Net::HTTP instance" do
+      @http.proxy?.should be_false
+      @http.instance_of?(Net::HTTP).should be_true
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @http.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the passed port" do
+      @http.port.should eql(3333)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @http.started?.should be_false
+    end
+  end
+
+  describe "when passed address, port, *proxy_options" do
+    it "returns a Net::HTTP instance" do
+      http = Net::HTTP.new("localhost", 3333, "localhost")
+      http.proxy?.should be_true
+      http.instance_of?(Net::HTTP).should be_true
+      http.should be_kind_of(Net::HTTP)
+    end
+
+    it "correctly sets the passed Proxy options" do
+      http = Net::HTTP.new("localhost", 3333, "localhost")
+      http.proxy_address.should == "localhost"
+      http.proxy_port.should eql(80)
+      http.proxy_user.should be_nil
+      http.proxy_pass.should be_nil
+
+      http = Net::HTTP.new("localhost", 3333, "localhost", 1234)
+      http.proxy_address.should == "localhost"
+      http.proxy_port.should eql(1234)
+      http.proxy_user.should be_nil
+      http.proxy_pass.should be_nil
+
+      http = Net::HTTP.new("localhost", 3333, "localhost", 1234, "rubyspec")
+      http.proxy_address.should == "localhost"
+      http.proxy_port.should eql(1234)
+      http.proxy_user.should == "rubyspec"
+      http.proxy_pass.should be_nil
+
+      http = Net::HTTP.new("localhost", 3333, "localhost", 1234, "rubyspec", "rocks")
+      http.proxy_address.should == "localhost"
+      http.proxy_port.should eql(1234)
+      http.proxy_user.should == "rubyspec"
+      http.proxy_pass.should == "rocks"
+    end
+  end
+
+end

--- a/spec/library/net-http/http/newobj_spec.rb
+++ b/spec/library/net-http/http/newobj_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.newobj" do
+  before :each do
+    @net = Net::HTTP.newobj("localhost")
+  end
+
+  describe "when passed address" do
+    it "returns a new Net::HTTP instance" do
+      @net.should be_kind_of(Net::HTTP)
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @net.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the default HTTP port" do
+      @net.port.should eql(Net::HTTP.default_port)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @net.started?.should be_false
+    end
+  end
+
+  describe "when passed address, port" do
+    before :each do
+      @net = Net::HTTP.newobj("localhost", 3333)
+    end
+
+    it "returns a new Net::HTTP instance" do
+      @net.should be_kind_of(Net::HTTP)
+    end
+
+    it "sets the new Net::HTTP instance's address to the passed address" do
+      @net.address.should == "localhost"
+    end
+
+    it "sets the new Net::HTTP instance's port to the passed port" do
+      @net.port.should eql(3333)
+    end
+
+    it "does not start the new Net::HTTP instance" do
+      @net.started?.should be_false
+    end
+  end
+end

--- a/spec/library/net-http/http/open_timeout_spec.rb
+++ b/spec/library/net-http/http/open_timeout_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#open_timeout" do
+  it "returns the seconds to wait till the connection is open" do
+    net = Net::HTTP.new("localhost")
+    net.open_timeout.should eql(60)
+    net.open_timeout = 10
+    net.open_timeout.should eql(10)
+  end
+end
+
+describe "Net::HTTP#open_timeout=" do
+  it "sets the seconds to wait till the connection is open" do
+    net = Net::HTTP.new("localhost")
+    net.open_timeout = 10
+    net.open_timeout.should eql(10)
+  end
+
+  it "returns the newly set value" do
+    net = Net::HTTP.new("localhost")
+    (net.open_timeout = 10).should eql(10)
+  end
+end

--- a/spec/library/net-http/http/options_spec.rb
+++ b/spec/library/net-http/http/options_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#options" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an options request to the passed path and returns the response" do
+    response = @http.options("/request")
+
+    response.body.should == "Request type: OPTIONS"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.options("/request").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/port_spec.rb
+++ b/spec/library/net-http/http/port_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#port" do
+  it "returns the current port number" do
+    net = Net::HTTP.new("localhost", 3333)
+    net.port.should eql(3333)
+  end
+end

--- a/spec/library/net-http/http/post2_spec.rb
+++ b/spec/library/net-http/http/post2_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_post'
+
+describe "Net::HTTP#post2" do
+  it_behaves_like :net_http_request_post, :post2
+end

--- a/spec/library/net-http/http/post_form_spec.rb
+++ b/spec/library/net-http/http/post_form_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.post_form when passed URI" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  it "POSTs the passed form data to the given uri" do
+    uri = URI.parse("http://localhost:#{@port}/request/body")
+    data = { test: :data }
+
+    res = Net::HTTP.post_form(uri, data)
+    res.body.should == "test=data"
+  end
+end

--- a/spec/library/net-http/http/post_spec.rb
+++ b/spec/library/net-http/http/post_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require 'uri'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.post" do
+  before :each do
+    NetHTTPSpecs.start_server
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends post request to the specified URI and returns response" do
+    response = Net::HTTP.post(
+      URI("http://localhost:#{NetHTTPSpecs.port}/request"),
+      '{ "q": "ruby", "max": "50" }',
+      "Content-Type" => "application/json")
+    response.body.should == "Request type: POST"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    response = Net::HTTP.post(URI("http://localhost:#{NetHTTPSpecs.port}/request"), "test=test")
+    response.should be_kind_of(Net::HTTPResponse)
+  end
+
+  it "sends Content-Type: application/x-www-form-urlencoded by default" do
+    response = Net::HTTP.post(URI("http://localhost:#{NetHTTPSpecs.port}/request/header"), "test=test")
+    response.body.should include('"Content-Type"=>"application/x-www-form-urlencoded"')
+  end
+
+  it "does not support HTTP Basic Auth" do
+    response = Net::HTTP.post(
+      URI("http://john:qwerty@localhost:#{NetHTTPSpecs.port}/request/basic_auth"),
+      "test=test")
+    response.body.should == "username: \npassword: "
+  end
+end
+
+describe "Net::HTTP#post" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an post request to the passed path and returns the response" do
+    response = @http.post("/request", "test=test")
+    response.body.should == "Request type: POST"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.post("/request", "test=test").should be_kind_of(Net::HTTPResponse)
+  end
+
+  describe "when passed a block" do
+    it "yields fragments of the response body to the passed block" do
+      str = +""
+      @http.post("/request", "test=test") do |res|
+        str << res
+      end
+      str.should == "Request type: POST"
+    end
+
+    it "returns a Net::HTTPResponse" do
+      @http.post("/request", "test=test") {}.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/library/net-http/http/propfind_spec.rb
+++ b/spec/library/net-http/http/propfind_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#propfind" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an propfind request to the passed path and returns the response" do
+    response = @http.propfind("/request", "test=test")
+    response.body.should == "Request type: PROPFIND"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.propfind("/request", "test=test").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/proppatch_spec.rb
+++ b/spec/library/net-http/http/proppatch_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#proppatch" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an proppatch request to the passed path and returns the response" do
+    response = @http.proppatch("/request", "test=test")
+    response.body.should == "Request type: PROPPATCH"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.proppatch("/request", "test=test").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/proxy_address_spec.rb
+++ b/spec/library/net-http/http/proxy_address_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.proxy_address" do
+  describe "when self is no proxy class" do
+    it "returns nil" do
+      Net::HTTP.proxy_address.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class" do
+    it "returns the address for self's proxy connection" do
+      Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks").proxy_address.should == "localhost"
+    end
+  end
+end
+
+describe "Net::HTTP#proxy_address" do
+  describe "when self is no proxy class instance" do
+    it "returns nil" do
+      Net::HTTP.new("localhost", 3333).proxy_address.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class instance" do
+    it "returns the password for self's proxy connection" do
+      http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+      http_with_proxy.new("localhost", 3333).proxy_address.should == "localhost"
+    end
+  end
+end

--- a/spec/library/net-http/http/proxy_class_spec.rb
+++ b/spec/library/net-http/http/proxy_class_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.proxy_class?" do
+  it "returns true if self is a class created with Net::HTTP.Proxy" do
+    Net::HTTP.proxy_class?.should be_false
+    Net::HTTP.Proxy("localhost").proxy_class?.should be_true
+  end
+end

--- a/spec/library/net-http/http/proxy_pass_spec.rb
+++ b/spec/library/net-http/http/proxy_pass_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.proxy_pass" do
+  describe "when self is no proxy class" do
+    it "returns nil" do
+      Net::HTTP.proxy_pass.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class" do
+    it "returns nil if no password was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").proxy_pass.should be_nil
+    end
+
+    it "returns the password for self's proxy connection" do
+      Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks").proxy_pass.should == "rocks"
+    end
+  end
+end
+
+describe "Net::HTTP#proxy_pass" do
+  describe "when self is no proxy class instance" do
+    it "returns nil" do
+      Net::HTTP.new("localhost", 3333).proxy_pass.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class instance" do
+    it "returns nil if no password was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").new("localhost", 3333).proxy_pass.should be_nil
+    end
+
+    it "returns the password for self's proxy connection" do
+      http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+      http_with_proxy.new("localhost", 3333).proxy_pass.should == "rocks"
+    end
+  end
+end

--- a/spec/library/net-http/http/proxy_port_spec.rb
+++ b/spec/library/net-http/http/proxy_port_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.proxy_port" do
+  describe "when self is no proxy class" do
+    it "returns nil" do
+      Net::HTTP.proxy_port.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class" do
+    it "returns 80 if no port was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").proxy_port.should eql(80)
+    end
+
+    it "returns the port for self's proxy connection" do
+      Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks").proxy_port.should eql(1234)
+    end
+  end
+end
+
+describe "Net::HTTP#proxy_port" do
+  describe "when self is no proxy class instance" do
+    it "returns nil" do
+      Net::HTTP.new("localhost", 3333).proxy_port.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class instance" do
+    it "returns 80 if no port was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").new("localhost", 3333).proxy_port.should eql(80)
+    end
+
+    it "returns the port for self's proxy connection" do
+      http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+      http_with_proxy.new("localhost", 3333).proxy_port.should eql(1234)
+    end
+  end
+end

--- a/spec/library/net-http/http/proxy_user_spec.rb
+++ b/spec/library/net-http/http/proxy_user_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.proxy_user" do
+  describe "when self is no proxy class" do
+    it "returns nil" do
+      Net::HTTP.proxy_user.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class" do
+    it "returns nil if no username was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").proxy_user.should be_nil
+    end
+
+    it "returns the username for self's proxy connection" do
+      Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks").proxy_user.should == "rspec"
+    end
+  end
+end
+
+describe "Net::HTTP#proxy_user" do
+  describe "when self is no proxy class instance" do
+    it "returns nil" do
+      Net::HTTP.new("localhost", 3333).proxy_user.should be_nil
+    end
+  end
+
+  describe "when self is a proxy class instance" do
+    it "returns nil if no username was set for self's proxy connection" do
+      Net::HTTP.Proxy("localhost").new("localhost", 3333).proxy_user.should be_nil
+    end
+
+    it "returns the username for self's proxy connection" do
+      http_with_proxy = Net::HTTP.Proxy("localhost", 1234, "rspec", "rocks")
+      http_with_proxy.new("localhost", 3333).proxy_user.should == "rspec"
+    end
+  end
+end

--- a/spec/library/net-http/http/put2_spec.rb
+++ b/spec/library/net-http/http/put2_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_put'
+
+describe "Net::HTTP#put2" do
+  it_behaves_like :net_http_request_put, :put2
+end

--- a/spec/library/net-http/http/put_spec.rb
+++ b/spec/library/net-http/http/put_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#put" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an put request to the passed path and returns the response" do
+    response = @http.put("/request", "test=test")
+    response.body.should == "Request type: PUT"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.put("/request", "test=test").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/read_timeout_spec.rb
+++ b/spec/library/net-http/http/read_timeout_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#read_timeout" do
+  it "returns the seconds to wait until reading one block" do
+    net = Net::HTTP.new("localhost")
+    net.read_timeout.should eql(60)
+    net.read_timeout = 10
+    net.read_timeout.should eql(10)
+  end
+end
+
+describe "Net::HTTP#read_timeout=" do
+  it "sets the seconds to wait till the connection is open" do
+    net = Net::HTTP.new("localhost")
+    net.read_timeout = 10
+    net.read_timeout.should eql(10)
+  end
+
+  it "returns the newly set value" do
+    net = Net::HTTP.new("localhost")
+    (net.read_timeout = 10).should eql(10)
+  end
+end

--- a/spec/library/net-http/http/request_get_spec.rb
+++ b/spec/library/net-http/http/request_get_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_get'
+
+describe "Net::HTTP#request_get" do
+  it_behaves_like :net_http_request_get, :get2
+end

--- a/spec/library/net-http/http/request_head_spec.rb
+++ b/spec/library/net-http/http/request_head_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_head'
+
+describe "Net::HTTP#request_head" do
+  it_behaves_like :net_http_request_head, :request_head
+end

--- a/spec/library/net-http/http/request_post_spec.rb
+++ b/spec/library/net-http/http/request_post_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_post'
+
+describe "Net::HTTP#request_post" do
+  it_behaves_like :net_http_request_post, :request_post
+end

--- a/spec/library/net-http/http/request_put_spec.rb
+++ b/spec/library/net-http/http/request_put_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/request_put'
+
+describe "Net::HTTP#request_put" do
+  it_behaves_like :net_http_request_put, :request_put
+end

--- a/spec/library/net-http/http/request_spec.rb
+++ b/spec/library/net-http/http/request_spec.rb
@@ -1,0 +1,109 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#request" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed request_object" do
+    it "makes a HTTP Request based on the passed request_object" do
+      response = @http.request(Net::HTTP::Get.new("/request"), "test=test")
+      response.body.should == "Request type: GET"
+
+      response = @http.request(Net::HTTP::Head.new("/request"), "test=test")
+      response.body.should be_nil
+
+      response = @http.request(Net::HTTP::Post.new("/request"), "test=test")
+      response.body.should == "Request type: POST"
+
+      response = @http.request(Net::HTTP::Put.new("/request"), "test=test")
+      response.body.should == "Request type: PUT"
+
+      response = @http.request(Net::HTTP::Proppatch.new("/request"), "test=test")
+      response.body.should == "Request type: PROPPATCH"
+
+      response = @http.request(Net::HTTP::Lock.new("/request"), "test=test")
+      response.body.should == "Request type: LOCK"
+
+      response = @http.request(Net::HTTP::Unlock.new("/request"), "test=test")
+      response.body.should == "Request type: UNLOCK"
+
+      # TODO: Does not work?
+      #response = @http.request(Net::HTTP::Options.new("/request"), "test=test")
+      #response.body.should be_nil
+
+      response = @http.request(Net::HTTP::Propfind.new("/request"), "test=test")
+      response.body.should == "Request type: PROPFIND"
+
+      response = @http.request(Net::HTTP::Delete.new("/request"), "test=test")
+      response.body.should == "Request type: DELETE"
+
+      response = @http.request(Net::HTTP::Move.new("/request"), "test=test")
+      response.body.should == "Request type: MOVE"
+
+      response = @http.request(Net::HTTP::Copy.new("/request"), "test=test")
+      response.body.should == "Request type: COPY"
+
+      response = @http.request(Net::HTTP::Mkcol.new("/request"), "test=test")
+      response.body.should == "Request type: MKCOL"
+
+      response = @http.request(Net::HTTP::Trace.new("/request"), "test=test")
+      response.body.should == "Request type: TRACE"
+    end
+  end
+
+  describe "when passed request_object and request_body" do
+    it "sends the passed request_body when making the HTTP Request" do
+      response = @http.request(Net::HTTP::Get.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Head.new("/request/body"), "test=test")
+      response.body.should be_nil
+
+      response = @http.request(Net::HTTP::Post.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Put.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Proppatch.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Lock.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Unlock.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      # TODO: Does not work?
+      #response = @http.request(Net::HTTP::Options.new("/request/body"), "test=test")
+      #response.body.should be_nil
+
+      response = @http.request(Net::HTTP::Propfind.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Delete.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Move.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Copy.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Mkcol.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+
+      response = @http.request(Net::HTTP::Trace.new("/request/body"), "test=test")
+      response.body.should == "test=test"
+    end
+  end
+end

--- a/spec/library/net-http/http/request_types_spec.rb
+++ b/spec/library/net-http/http/request_types_spec.rb
@@ -1,0 +1,254 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP::Get" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Get.should < Net::HTTPRequest
+  end
+
+  it "represents the 'GET'-Request-Method" do
+    Net::HTTP::Get::METHOD.should == "GET"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Get::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Get::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Head" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Head.should < Net::HTTPRequest
+  end
+
+  it "represents the 'HEAD'-Request-Method" do
+    Net::HTTP::Head::METHOD.should == "HEAD"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Head::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has no Response Body" do
+    Net::HTTP::Head::RESPONSE_HAS_BODY.should be_false
+  end
+end
+
+describe "Net::HTTP::Post" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Post.should < Net::HTTPRequest
+  end
+
+  it "represents the 'POST'-Request-Method" do
+    Net::HTTP::Post::METHOD.should == "POST"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Post::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Post::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Put" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Put.should < Net::HTTPRequest
+  end
+
+  it "represents the 'PUT'-Request-Method" do
+    Net::HTTP::Put::METHOD.should == "PUT"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Put::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Put::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Delete" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Delete.should < Net::HTTPRequest
+  end
+
+  it "represents the 'DELETE'-Request-Method" do
+    Net::HTTP::Delete::METHOD.should == "DELETE"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Delete::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Delete::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Options" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Options.should < Net::HTTPRequest
+  end
+
+  it "represents the 'OPTIONS'-Request-Method" do
+    Net::HTTP::Options::METHOD.should == "OPTIONS"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Options::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has no Response Body" do
+    Net::HTTP::Options::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Trace" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Trace.should < Net::HTTPRequest
+  end
+
+  it "represents the 'TRACE'-Request-Method" do
+    Net::HTTP::Trace::METHOD.should == "TRACE"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Trace::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Trace::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Propfind" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Propfind.should < Net::HTTPRequest
+  end
+
+  it "represents the 'PROPFIND'-Request-Method" do
+    Net::HTTP::Propfind::METHOD.should == "PROPFIND"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Propfind::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Propfind::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Proppatch" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Proppatch.should < Net::HTTPRequest
+  end
+
+  it "represents the 'PROPPATCH'-Request-Method" do
+    Net::HTTP::Proppatch::METHOD.should == "PROPPATCH"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Proppatch::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Proppatch::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Mkcol" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Mkcol.should < Net::HTTPRequest
+  end
+
+  it "represents the 'MKCOL'-Request-Method" do
+    Net::HTTP::Mkcol::METHOD.should == "MKCOL"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Mkcol::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Mkcol::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Copy" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Copy.should < Net::HTTPRequest
+  end
+
+  it "represents the 'COPY'-Request-Method" do
+    Net::HTTP::Copy::METHOD.should == "COPY"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Copy::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Copy::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Move" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Move.should < Net::HTTPRequest
+  end
+
+  it "represents the 'MOVE'-Request-Method" do
+    Net::HTTP::Move::METHOD.should == "MOVE"
+  end
+
+  it "has no Request Body" do
+    Net::HTTP::Move::REQUEST_HAS_BODY.should be_false
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Move::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Lock" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Lock.should < Net::HTTPRequest
+  end
+
+  it "represents the 'LOCK'-Request-Method" do
+    Net::HTTP::Lock::METHOD.should == "LOCK"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Lock::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Lock::RESPONSE_HAS_BODY.should be_true
+  end
+end
+
+describe "Net::HTTP::Unlock" do
+  it "is a subclass of Net::HTTPRequest" do
+    Net::HTTP::Unlock.should < Net::HTTPRequest
+  end
+
+  it "represents the 'UNLOCK'-Request-Method" do
+    Net::HTTP::Unlock::METHOD.should == "UNLOCK"
+  end
+
+  it "has a Request Body" do
+    Net::HTTP::Unlock::REQUEST_HAS_BODY.should be_true
+  end
+
+  it "has a Response Body" do
+    Net::HTTP::Unlock::RESPONSE_HAS_BODY.should be_true
+  end
+end

--- a/spec/library/net-http/http/send_request_spec.rb
+++ b/spec/library/net-http/http/send_request_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#send_request" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+
+    # HEAD is special so handled separately
+    @methods = %w[
+      GET POST PUT DELETE
+      OPTIONS
+      PROPFIND PROPPATCH LOCK UNLOCK
+    ]
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  # TODO: Does only work with GET and POST requests
+  describe "when passed type, path" do
+    it "sends a HTTP Request of the passed type to the passed path" do
+      response = @http.send_request("HEAD", "/request")
+      response.body.should be_nil
+
+      (@methods - %w[POST PUT]).each do |method|
+        response = @http.send_request(method, "/request")
+        response.body.should == "Request type: #{method}"
+      end
+    end
+  end
+
+  describe "when passed type, path, body" do
+    it "sends a HTTP Request with the passed body" do
+      response = @http.send_request("HEAD", "/request/body", "test=test")
+      response.body.should be_nil
+
+      @methods.each do |method|
+        response = @http.send_request(method, "/request/body", "test=test")
+        response.body.should == "test=test"
+      end
+    end
+  end
+
+  describe "when passed type, path, body, headers" do
+    it "sends a HTTP Request with the passed headers" do
+      referer = 'https://www.ruby-lang.org/'.freeze
+
+      response = @http.send_request("HEAD", "/request/header", "test=test", "referer" => referer)
+      response.body.should be_nil
+
+      @methods.each do |method|
+        response = @http.send_request(method, "/request/header", "test=test", "referer" => referer)
+        response.body.should include('"Referer"=>"' + referer + '"')
+      end
+    end
+  end
+end

--- a/spec/library/net-http/http/set_debug_output_spec.rb
+++ b/spec/library/net-http/http/set_debug_output_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#set_debug_output when passed io" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.new("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sets the passed io as output stream for debugging" do
+    io = StringIO.new
+
+    @http.set_debug_output(io)
+    @http.start
+    io.string.should_not be_empty
+    size = io.string.size
+
+    @http.get("/")
+    io.string.size.should > size
+  end
+
+  it "outputs a warning when the connection has already been started" do
+    @http.start
+    -> { @http.set_debug_output(StringIO.new) }.should complain(/Net::HTTP#set_debug_output called after HTTP started/)
+  end
+end

--- a/spec/library/net-http/http/shared/request_get.rb
+++ b/spec/library/net-http/http/shared/request_get.rb
@@ -1,0 +1,41 @@
+describe :net_http_request_get, shared: true do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed no block" do
+    it "sends a GET request to the passed path and returns the response" do
+      response = @http.send(@method, "/request")
+      response.body.should == "Request type: GET"
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request")
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+
+  describe "when passed a block" do
+    it "sends a GET request to the passed path and returns the response" do
+      response = @http.send(@method, "/request") {}
+      response.body.should == "Request type: GET"
+    end
+
+    it "yields the response to the passed block" do
+      @http.send(@method, "/request") do |response|
+        response.body.should == "Request type: GET"
+      end
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request") {}
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/library/net-http/http/shared/request_head.rb
+++ b/spec/library/net-http/http/shared/request_head.rb
@@ -1,0 +1,41 @@
+describe :net_http_request_head, shared: true do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed no block" do
+    it "sends a head request to the passed path and returns the response" do
+      response = @http.send(@method, "/request")
+      response.body.should be_nil
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request")
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+
+  describe "when passed a block" do
+    it "sends a head request to the passed path and returns the response" do
+      response = @http.send(@method, "/request") {}
+      response.body.should be_nil
+    end
+
+    it "yields the response to the passed block" do
+      @http.send(@method, "/request") do |response|
+        response.body.should be_nil
+      end
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request") {}
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/library/net-http/http/shared/request_post.rb
+++ b/spec/library/net-http/http/shared/request_post.rb
@@ -1,0 +1,41 @@
+describe :net_http_request_post, shared: true do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed no block" do
+    it "sends a post request to the passed path and returns the response" do
+      response = @http.send(@method, "/request", "test=test")
+      response.body.should == "Request type: POST"
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request", "test=test")
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+
+  describe "when passed a block" do
+    it "sends a post request to the passed path and returns the response" do
+      response = @http.send(@method, "/request", "test=test") {}
+      response.body.should == "Request type: POST"
+    end
+
+    it "yields the response to the passed block" do
+      @http.send(@method, "/request", "test=test") do |response|
+        response.body.should == "Request type: POST"
+      end
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request", "test=test") {}
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/library/net-http/http/shared/request_put.rb
+++ b/spec/library/net-http/http/shared/request_put.rb
@@ -1,0 +1,41 @@
+describe :net_http_request_put, shared: true do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when passed no block" do
+    it "sends a put request to the passed path and returns the response" do
+      response = @http.send(@method, "/request", "test=test")
+      response.body.should == "Request type: PUT"
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request", "test=test")
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+
+  describe "when passed a block" do
+    it "sends a put request to the passed path and returns the response" do
+      response = @http.send(@method, "/request", "test=test") {}
+      response.body.should == "Request type: PUT"
+    end
+
+    it "yields the response to the passed block" do
+      @http.send(@method, "/request", "test=test") do |response|
+        response.body.should == "Request type: PUT"
+      end
+    end
+
+    it "returns a Net::HTTPResponse object" do
+      response = @http.send(@method, "/request", "test=test") {}
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/library/net-http/http/shared/started.rb
+++ b/spec/library/net-http/http/shared/started.rb
@@ -1,0 +1,26 @@
+describe :net_http_started_p, shared: true do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.new("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "returns true when self has been started" do
+    @http.start
+    @http.send(@method).should be_true
+  end
+
+  it "returns false when self has not been started yet" do
+    @http.send(@method).should be_false
+  end
+
+  it "returns false when self has been stopped again" do
+    @http.start
+    @http.finish
+    @http.send(@method).should be_false
+  end
+end

--- a/spec/library/net-http/http/shared/version_1_1.rb
+++ b/spec/library/net-http/http/shared/version_1_1.rb
@@ -1,0 +1,6 @@
+describe :net_http_version_1_1_p, shared: true do
+  it "returns the state of net/http 1.1 features" do
+    Net::HTTP.version_1_2
+    Net::HTTP.send(@method).should be_false
+  end
+end

--- a/spec/library/net-http/http/shared/version_1_2.rb
+++ b/spec/library/net-http/http/shared/version_1_2.rb
@@ -1,0 +1,6 @@
+describe :net_http_version_1_2_p, shared: true do
+  it "returns the state of net/http 1.2 features" do
+    Net::HTTP.version_1_2
+    Net::HTTP.send(@method).should be_true
+  end
+end

--- a/spec/library/net-http/http/socket_type_spec.rb
+++ b/spec/library/net-http/http/socket_type_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP.socket_type" do
+  it "returns BufferedIO" do
+    Net::HTTP.socket_type.should == Net::BufferedIO
+  end
+end

--- a/spec/library/net-http/http/start_spec.rb
+++ b/spec/library/net-http/http/start_spec.rb
@@ -1,0 +1,111 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP.start" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @port = NetHTTPSpecs.port
+  end
+
+  after :each do
+    NetHTTPSpecs.stop_server
+  end
+
+  describe "when not passed a block" do
+    before :each do
+      @http = Net::HTTP.start("localhost", @port)
+    end
+
+    after :each do
+      @http.finish if @http.started?
+    end
+
+    it "returns a new Net::HTTP object for the passed address and port" do
+      @http.should be_kind_of(Net::HTTP)
+      @http.address.should == "localhost"
+      @http.port.should == @port
+    end
+
+    it "opens the tcp connection" do
+      @http.started?.should be_true
+    end
+  end
+
+  describe "when passed a block" do
+    it "returns the blocks return value" do
+      Net::HTTP.start("localhost", @port) { :test }.should == :test
+    end
+
+    it "yields the new Net::HTTP object to the block" do
+      yielded = false
+      Net::HTTP.start("localhost", @port) do |net|
+        yielded = true
+        net.should be_kind_of(Net::HTTP)
+      end
+      yielded.should be_true
+    end
+
+    it "opens the tcp connection before yielding" do
+      Net::HTTP.start("localhost", @port) { |http| http.started?.should be_true }
+    end
+
+    it "closes the tcp connection after yielding" do
+      net = nil
+      Net::HTTP.start("localhost", @port) { |x| net = x }
+      net.started?.should be_false
+    end
+  end
+end
+
+describe "Net::HTTP#start" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.new("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "returns self" do
+    @http.start.should equal(@http)
+  end
+
+  it "opens the tcp connection" do
+    @http.start
+    @http.started?.should be_true
+  end
+
+  describe "when self has already been started" do
+    it "raises an IOError" do
+      @http.start
+      -> { @http.start }.should raise_error(IOError)
+    end
+  end
+
+  describe "when passed a block" do
+    it "returns the blocks return value" do
+      @http.start { :test }.should == :test
+    end
+
+    it "yields the new Net::HTTP object to the block" do
+      yielded = false
+      @http.start do |http|
+        yielded = true
+        http.should equal(@http)
+      end
+      yielded.should be_true
+    end
+
+    it "opens the tcp connection before yielding" do
+      @http.start { |http| http.started?.should be_true }
+    end
+
+    it "closes the tcp connection after yielding" do
+      @http.start { }
+      @http.started?.should be_false
+    end
+  end
+end

--- a/spec/library/net-http/http/started_spec.rb
+++ b/spec/library/net-http/http/started_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+require_relative 'shared/started'
+
+describe "Net::HTTP#started?" do
+  it_behaves_like :net_http_started_p, :started?
+end

--- a/spec/library/net-http/http/trace_spec.rb
+++ b/spec/library/net-http/http/trace_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#trace" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends a TRACE request to the passed path and returns the response" do
+    response = @http.trace("/request")
+    response.body.should == "Request type: TRACE"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.trace("/request").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/unlock_spec.rb
+++ b/spec/library/net-http/http/unlock_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/http_server'
+
+describe "Net::HTTP#unlock" do
+  before :each do
+    NetHTTPSpecs.start_server
+    @http = Net::HTTP.start("localhost", NetHTTPSpecs.port)
+  end
+
+  after :each do
+    @http.finish if @http.started?
+    NetHTTPSpecs.stop_server
+  end
+
+  it "sends an UNLOCK request to the passed path and returns the response" do
+    response = @http.unlock("/request", "test=test")
+    response.body.should == "Request type: UNLOCK"
+  end
+
+  it "returns a Net::HTTPResponse" do
+    @http.unlock("/request", "test=test").should be_kind_of(Net::HTTPResponse)
+  end
+end

--- a/spec/library/net-http/http/use_ssl_spec.rb
+++ b/spec/library/net-http/http/use_ssl_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTP#use_ssl?" do
+  it "returns false" do
+    http = Net::HTTP.new("localhost")
+    http.use_ssl?.should be_false
+  end
+end

--- a/spec/library/net-http/http/version_1_1_spec.rb
+++ b/spec/library/net-http/http/version_1_1_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/version_1_1'
+
+describe "Net::HTTP.version_1_1?" do
+  it_behaves_like :net_http_version_1_1_p, :version_1_1?
+end

--- a/spec/library/net-http/http/version_1_2_spec.rb
+++ b/spec/library/net-http/http/version_1_2_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/version_1_2'
+
+describe "Net::HTTP.version_1_2" do
+  it "turns on net/http 1.2 features" do
+    Net::HTTP.version_1_2
+
+    Net::HTTP.version_1_2?.should be_true
+    Net::HTTP.version_1_1?.should be_false
+  end
+
+  it "returns true" do
+    Net::HTTP.version_1_2.should be_true
+  end
+end
+
+describe "Net::HTTP.version_1_2?" do
+  it_behaves_like :net_http_version_1_2_p, :version_1_2?
+end

--- a/spec/library/net-http/httpexceptions/fixtures/classes.rb
+++ b/spec/library/net-http/httpexceptions/fixtures/classes.rb
@@ -1,0 +1,5 @@
+module NetHTTPExceptionsSpecs
+  class Simple < StandardError
+    include Net::HTTPExceptions
+  end
+end

--- a/spec/library/net-http/httpexceptions/initialize_spec.rb
+++ b/spec/library/net-http/httpexceptions/initialize_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPExceptions#initialize when passed message, response" do
+  before :each do
+    @exception = NetHTTPExceptionsSpecs::Simple.new("error message", "a http response")
+  end
+
+  it "calls super with the passed message" do
+    @exception.message.should == "error message"
+  end
+
+  it "sets self's response to the passed response" do
+    @exception.response.should == "a http response"
+  end
+end

--- a/spec/library/net-http/httpexceptions/response_spec.rb
+++ b/spec/library/net-http/httpexceptions/response_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPExceptions#response" do
+  it "returns self's response" do
+    exception = NetHTTPExceptionsSpecs::Simple.new("error message", "a http response")
+    exception.response.should == "a http response"
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/body_exist_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/body_exist_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#body_exist?" do
+  it "returns true when the response is expected to have a body" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.body_exist?.should be_true
+
+    request = Net::HTTPGenericRequest.new("POST", true, false, "/some/path")
+    request.body_exist?.should be_false
+  end
+
+  describe "when $VERBOSE is true" do
+    it "emits a warning" do
+      request = Net::HTTPGenericRequest.new("POST", true, false, "/some/path")
+      -> {
+        request.body_exist?
+      }.should complain(/body_exist\? is obsolete/, verbose: true)
+    end
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/body_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/body_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+
+describe "Net::HTTPGenericRequest#body" do
+  it "returns self's request body" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.body.should be_nil
+
+    request.body = "Some Content"
+    request.body.should == "Some Content"
+  end
+end
+
+describe "Net::HTTPGenericRequest#body=" do
+  before :each do
+    @request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+  end
+
+  it "sets self's body content to the passed String" do
+    @request.body = "Some Content"
+    @request.body.should == "Some Content"
+  end
+
+  it "sets self's body stream to nil" do
+    @request.body_stream = StringIO.new("")
+    @request.body = "Some Content"
+    @request.body_stream.should be_nil
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/body_stream_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/body_stream_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+
+describe "Net::HTTPGenericRequest#body_stream" do
+  it "returns self's body stream Object" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.body_stream.should be_nil
+
+    stream = StringIO.new("test")
+    request.body_stream = stream
+    request.body_stream.should equal(stream)
+  end
+end
+
+describe "Net::HTTPGenericRequest#body_stream=" do
+  before :each do
+    @request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    @stream = StringIO.new("test")
+  end
+
+  it "sets self's body stream to the passed Object" do
+    @request.body_stream = @stream
+    @request.body_stream.should equal(@stream)
+  end
+
+  it "sets self's body to nil" do
+    @request.body = "Some Content"
+    @request.body_stream = @stream
+    @request.body.should be_nil
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/exec_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/exec_spec.rb
@@ -1,0 +1,131 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+
+describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
+  before :each do
+    @socket = StringIO.new(+"")
+    @buffered_socket = Net::BufferedIO.new(@socket)
+  end
+
+  it "executes the request over the socket to the path using the HTTP version" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+
+    request.exec(@buffered_socket, "1.1", "/some/path")
+    str = @socket.string
+
+    str.should =~ %r[POST /some/path HTTP/1.1\r\n]
+    str.should =~ %r[Accept: \*/\*\r\n]
+    str[-4..-1].should == "\r\n\r\n"
+
+    request = Net::HTTPGenericRequest.new("GET", true, true, "/some/path",
+                                          "Content-Type" => "text/html")
+
+    request.exec(@buffered_socket, "1.0", "/some/other/path")
+    str = @socket.string
+
+    str.should =~ %r[GET /some/other/path HTTP/1.0\r\n]
+    str.should =~ %r[Accept: \*/\*\r\n]
+    str.should =~ %r[Content-Type: text/html\r\n]
+    str[-4..-1].should == "\r\n\r\n"
+  end
+
+  describe "when a request body is set" do
+    it "sets the 'Content-Type' header to 'application/x-www-form-urlencoded' unless the 'Content-Type' header is supplied" do
+      request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+      request.body = "Some Content"
+
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
+      str = @socket.string
+
+      str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
+      str.should =~ %r[Accept: \*/\*\r\n]
+      str.should =~ %r[Content-Type: application/x-www-form-urlencoded\r\n]
+      str.should =~ %r[Content-Length: 12\r\n]
+      str[-16..-1].should == "\r\n\r\nSome Content"
+    end
+
+    it "correctly sets the 'Content-Length' header and includes the body" do
+      request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path",
+                                            "Content-Type" => "text/html")
+      request.body = "Some Content"
+
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
+      str = @socket.string
+
+      str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
+      str.should =~ %r[Accept: \*/\*\r\n]
+      str.should =~ %r[Content-Type: text/html\r\n]
+      str.should =~ %r[Content-Length: 12\r\n]
+      str[-16..-1].should == "\r\n\r\nSome Content"
+    end
+  end
+
+  describe "when a body stream is set" do
+    it "sets the 'Content-Type' header to 'application/x-www-form-urlencoded' unless the 'Content-Type' header is supplied" do
+      request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path",
+                                            "Content-Length" => "10")
+      request.body_stream = StringIO.new("a" * 20)
+
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
+      str = @socket.string
+
+      str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
+      str.should =~ %r[Accept: \*/\*\r\n]
+      str.should =~ %r[Content-Type: application/x-www-form-urlencoded\r\n]
+      str.should =~ %r[Content-Length: 10\r\n]
+      str[-24..-1].should == "\r\n\r\naaaaaaaaaaaaaaaaaaaa"
+    end
+
+    it "sends the whole stream, regardless of the 'Content-Length' header" do
+      request = Net::HTTPGenericRequest.new("POST", true, true,"/some/path",
+                                            "Content-Type" => "text/html",
+                                            "Content-Length" => "10")
+      request.body_stream = StringIO.new("a" * 20)
+
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
+      str = @socket.string
+
+      str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
+      str.should =~ %r[Accept: \*/\*\r\n]
+      str.should =~ %r[Content-Type: text/html\r\n]
+      str.should =~ %r[Content-Length: 10\r\n]
+      str[-24..-1].should == "\r\n\r\naaaaaaaaaaaaaaaaaaaa"
+    end
+
+    it "sends the request in chunks when 'Transfer-Encoding' is set to 'chunked'" do
+      request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path",
+                                            "Content-Type" => "text/html",
+                                            "Transfer-Encoding" => "chunked")
+      datasize = 1024 * 10
+      request.body_stream = StringIO.new("a" * datasize)
+
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
+      str = @socket.string
+
+      str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
+      str.should =~ %r[Accept: \*/\*\r\n]
+      str.should =~ %r[Content-Type: text/html\r\n]
+      str.should =~ %r[Transfer-Encoding: chunked\r\n]
+      str =~ %r[\r\n\r\n]
+      str = $'
+      while datasize > 0
+        chunk_size_line, str = str.split(/\r\n/, 2)
+        chunk_size = chunk_size_line[/\A[0-9A-Fa-f]+/].to_i(16)
+        str.slice!(0, chunk_size).should == 'a' * chunk_size
+        datasize -= chunk_size
+        str.slice!(0, 2).should == "\r\n"
+      end
+      datasize.should == 0
+      str.should == %"0\r\n\r\n"
+    end
+
+    it "raises an ArgumentError when the 'Content-Length' is not set or 'Transfer-Encoding' is not set to 'chunked'" do
+      request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path",
+                                            "Content-Type" => "text/html")
+      request.body_stream = StringIO.new("Some Content")
+
+      -> { request.exec(@buffered_socket, "1.1", "/some/other/path") }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/inspect_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/inspect_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#inspect" do
+  it "returns a String representation of self" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.inspect.should == "#<Net::HTTPGenericRequest POST>"
+
+    request = Net::HTTPGenericRequest.new("GET", false, true, "/some/path")
+    request.inspect.should == "#<Net::HTTPGenericRequest GET>"
+
+    request = Net::HTTPGenericRequest.new("BLA", true, true, "/some/path")
+    request.inspect.should == "#<Net::HTTPGenericRequest BLA>"
+
+    # Subclasses
+    request = Net::HTTP::Get.new("/some/path")
+    request.inspect.should == "#<Net::HTTP::Get GET>"
+
+    request = Net::HTTP::Post.new("/some/path")
+    request.inspect.should == "#<Net::HTTP::Post POST>"
+
+    request = Net::HTTP::Trace.new("/some/path")
+    request.inspect.should == "#<Net::HTTP::Trace TRACE>"
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/method_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/method_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#method" do
+  it "returns self's request method" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.method.should == "POST"
+
+    request = Net::HTTPGenericRequest.new("GET", false, true, "/some/path")
+    request.method.should == "GET"
+
+    request = Net::HTTPGenericRequest.new("BLA", true, true, "/some/path")
+    request.method.should == "BLA"
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/path_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/path_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#path" do
+  it "returns self's request path" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.path.should == "/some/path"
+
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/other/path")
+    request.path.should == "/some/other/path"
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/request_body_permitted_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/request_body_permitted_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#request_body_permitted?" do
+  it "returns true when the request is expected to have a body" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.request_body_permitted?.should be_true
+
+    request = Net::HTTPGenericRequest.new("POST", false, true, "/some/path")
+    request.request_body_permitted?.should be_false
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/response_body_permitted_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/response_body_permitted_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#response_body_permitted?" do
+  it "returns true when the response is expected to have a body" do
+    request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+    request.response_body_permitted?.should be_true
+
+    request = Net::HTTPGenericRequest.new("POST", true, false, "/some/path")
+    request.response_body_permitted?.should be_false
+  end
+end

--- a/spec/library/net-http/httpgenericrequest/set_body_internal_spec.rb
+++ b/spec/library/net-http/httpgenericrequest/set_body_internal_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPGenericRequest#set_body_internal when passed string" do
+  before :each do
+    @request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
+  end
+
+  it "sets self's body to the passed string" do
+    @request.set_body_internal("Some Content")
+    @request.body.should == "Some Content"
+  end
+
+  it "raises an ArgumentError when the body or body_stream of self have already been set" do
+    @request.body = "Some Content"
+    -> { @request.set_body_internal("Some other Content") }.should raise_error(ArgumentError)
+
+    @request.body_stream = "Some Content"
+    -> { @request.set_body_internal("Some other Content") }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/library/net-http/httpheader/add_field_spec.rb
+++ b/spec/library/net-http/httpheader/add_field_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#add_field when passed key, value" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "adds the passed value to the header entry with the passed key" do
+    @headers.add_field("My-Header", "a")
+    @headers.get_fields("My-Header").should == ["a"]
+
+    @headers.add_field("My-Header", "b")
+    @headers.get_fields("My-Header").should == ["a", "b"]
+
+    @headers.add_field("My-Header", "c")
+    @headers.get_fields("My-Header").should == ["a", "b", "c"]
+  end
+
+  it "is case-insensitive" do
+    @headers.add_field("My-Header", "a")
+    @headers.get_fields("My-Header").should == ["a"]
+
+    @headers.add_field("my-header", "b")
+    @headers.get_fields("My-Header").should == ["a", "b"]
+
+    @headers.add_field("MY-HEADER", "c")
+    @headers.get_fields("My-Header").should == ["a", "b", "c"]
+  end
+end

--- a/spec/library/net-http/httpheader/basic_auth_spec.rb
+++ b/spec/library/net-http/httpheader/basic_auth_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#basic_auth when passed account, password" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "sets the 'Authorization' Header entry for basic authorization" do
+    @headers.basic_auth("rubyspec", "rocks")
+    @headers["Authorization"].should == "Basic cnVieXNwZWM6cm9ja3M="
+  end
+end

--- a/spec/library/net-http/httpheader/canonical_each_spec.rb
+++ b/spec/library/net-http/httpheader/canonical_each_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_capitalized'
+
+describe "Net::HTTPHeader#canonical_each" do
+  it_behaves_like :net_httpheader_each_capitalized, :canonical_each
+end

--- a/spec/library/net-http/httpheader/chunked_spec.rb
+++ b/spec/library/net-http/httpheader/chunked_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#chunked?" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns true if the 'Transfer-Encoding' header entry is set to chunked" do
+    @headers.chunked?.should be_false
+
+    @headers["Transfer-Encoding"] = "bla"
+    @headers.chunked?.should be_false
+
+    @headers["Transfer-Encoding"] = "blachunkedbla"
+    @headers.chunked?.should be_false
+
+    @headers["Transfer-Encoding"] = "chunked"
+    @headers.chunked?.should be_true
+  end
+end

--- a/spec/library/net-http/httpheader/content_length_spec.rb
+++ b/spec/library/net-http/httpheader/content_length_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#content_length" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns nil if no 'Content-Length' header entry is set" do
+    @headers.content_length.should be_nil
+  end
+
+  it "raises a Net::HTTPHeaderSyntaxError when the 'Content-Length' header entry has an invalid format" do
+    @headers["Content-Length"] = "invalid"
+    -> { @headers.content_length }.should raise_error(Net::HTTPHeaderSyntaxError)
+  end
+
+  it "returns the value of the 'Content-Length' header entry as an Integer" do
+    @headers["Content-Length"] = "123"
+    @headers.content_length.should eql(123)
+
+    @headers["Content-Length"] = "123valid"
+    @headers.content_length.should eql(123)
+
+    @headers["Content-Length"] = "valid123"
+    @headers.content_length.should eql(123)
+  end
+end
+
+describe "Net::HTTPHeader#content_length=" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "removes the 'Content-Length' entry if passed false or nil" do
+    @headers["Content-Length"] = "123"
+    @headers.content_length = nil
+    @headers["Content-Length"].should be_nil
+  end
+
+  it "sets the 'Content-Length' entry to the passed value" do
+    @headers.content_length = "123"
+    @headers["Content-Length"].should == "123"
+
+    @headers.content_length = "123valid"
+    @headers["Content-Length"].should == "123"
+  end
+
+  it "sets the 'Content-Length' entry to 0 if the passed value is not valid" do
+    @headers.content_length = "invalid123"
+    @headers["Content-Length"].should == "0"
+  end
+end

--- a/spec/library/net-http/httpheader/content_range_spec.rb
+++ b/spec/library/net-http/httpheader/content_range_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#content_range" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns a Range object that represents the 'Content-Range' header entry" do
+    @headers["Content-Range"] = "bytes 0-499/1234"
+    @headers.content_range.should == (0..499)
+
+    @headers["Content-Range"] = "bytes 500-1233/1234"
+    @headers.content_range.should == (500..1233)
+  end
+
+  it "returns nil when there is no 'Content-Range' header entry" do
+    @headers.content_range.should be_nil
+  end
+
+  it "raises a Net::HTTPHeaderSyntaxError when the 'Content-Range' has an invalid format" do
+    @headers["Content-Range"] = "invalid"
+    -> { @headers.content_range }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Content-Range"] = "bytes 123-abc"
+    -> { @headers.content_range }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Content-Range"] = "bytes abc-123"
+    -> { @headers.content_range }.should raise_error(Net::HTTPHeaderSyntaxError)
+  end
+end

--- a/spec/library/net-http/httpheader/content_type_spec.rb
+++ b/spec/library/net-http/httpheader/content_type_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_content_type'
+
+describe "Net::HTTPHeader#content_type" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the content type string, as per 'Content-Type' header entry" do
+    @headers["Content-Type"] = "text/html"
+    @headers.content_type.should == "text/html"
+
+    @headers["Content-Type"] = "text/html;charset=utf-8"
+    @headers.content_type.should == "text/html"
+  end
+
+  it "returns nil if the 'Content-Type' header entry does not exist" do
+    @headers.content_type.should be_nil
+  end
+end
+
+describe "Net::HTTPHeader#content_type=" do
+  it_behaves_like :net_httpheader_set_content_type, :content_type=
+end

--- a/spec/library/net-http/httpheader/delete_spec.rb
+++ b/spec/library/net-http/httpheader/delete_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#delete when passed key" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "removes the header entry with the passed key" do
+    @headers["My-Header"] = "test"
+    @headers.delete("My-Header")
+
+    @headers["My-Header"].should be_nil
+    @headers.size.should eql(0)
+  end
+
+  it "returns the removed values" do
+    @headers["My-Header"] = "test"
+    @headers.delete("My-Header").should == ["test"]
+  end
+
+  it "is case-insensitive" do
+    @headers["My-Header"] = "test"
+    @headers.delete("my-header")
+
+    @headers["My-Header"].should be_nil
+    @headers.size.should eql(0)
+  end
+end

--- a/spec/library/net-http/httpheader/each_capitalized_name_spec.rb
+++ b/spec/library/net-http/httpheader/each_capitalized_name_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#each_capitalized_name" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+    @headers["My-Header"] = "test"
+    @headers.add_field("My-Other-Header", "a")
+    @headers.add_field("My-Other-Header", "b")
+  end
+
+  describe "when passed a block" do
+    it "yields each header key to the passed block (keys capitalized)" do
+      res = []
+      @headers.each_capitalized_name do |key|
+        res << key
+      end
+      res.sort.should == ["My-Header", "My-Other-Header"]
+    end
+  end
+
+  describe "when passed no block" do
+    it "returns an Enumerator" do
+      enumerator = @headers.each_capitalized_name
+      enumerator.should be_an_instance_of(Enumerator)
+
+      res = []
+      enumerator.each do |key|
+        res << key
+      end
+      res.sort.should == ["My-Header", "My-Other-Header"]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/each_capitalized_spec.rb
+++ b/spec/library/net-http/httpheader/each_capitalized_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_capitalized'
+
+describe "Net::HTTPHeader#each_capitalized" do
+  it_behaves_like :net_httpheader_each_capitalized, :each_capitalized
+end

--- a/spec/library/net-http/httpheader/each_header_spec.rb
+++ b/spec/library/net-http/httpheader/each_header_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_header'
+
+describe "Net::HTTPHeader#each_header" do
+  it_behaves_like :net_httpheader_each_header, :each_header
+end

--- a/spec/library/net-http/httpheader/each_key_spec.rb
+++ b/spec/library/net-http/httpheader/each_key_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_name'
+
+describe "Net::HTTPHeader#each_key" do
+  it_behaves_like :net_httpheader_each_name, :each_key
+end

--- a/spec/library/net-http/httpheader/each_name_spec.rb
+++ b/spec/library/net-http/httpheader/each_name_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_name'
+
+describe "Net::HTTPHeader#each_name" do
+  it_behaves_like :net_httpheader_each_name, :each_name
+end

--- a/spec/library/net-http/httpheader/each_spec.rb
+++ b/spec/library/net-http/httpheader/each_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/each_header'
+
+describe "Net::HTTPHeader#each" do
+  it_behaves_like :net_httpheader_each_header, :each
+end

--- a/spec/library/net-http/httpheader/each_value_spec.rb
+++ b/spec/library/net-http/httpheader/each_value_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#each_value" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+    @headers["My-Header"] = "test"
+    @headers.add_field("My-Other-Header", "a")
+    @headers.add_field("My-Other-Header", "b")
+  end
+
+  describe "when passed a block" do
+    it "yields each header entry's joined values" do
+      res = []
+      @headers.each_value do |value|
+        res << value
+      end
+      res.sort.should == ["a, b", "test"]
+    end
+  end
+
+  describe "when passed no block" do
+    it "returns an Enumerator" do
+      enumerator = @headers.each_value
+      enumerator.should be_an_instance_of(Enumerator)
+
+      res = []
+      enumerator.each do |key|
+        res << key
+      end
+      res.sort.should == ["a, b", "test"]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/element_reference_spec.rb
+++ b/spec/library/net-http/httpheader/element_reference_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#[] when passed key" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the value of the header entry with the passed key" do
+    @headers["My-Header"] = "test"
+    @headers["My-Header"].should == "test"
+    @headers["My-Other-Header"] = "another test"
+    @headers["My-Other-Header"].should == "another test"
+  end
+
+  it "is case-insensitive" do
+    @headers["My-Header"] = "test"
+
+    @headers['My-Header'].should == "test"
+    @headers['my-Header'].should == "test"
+    @headers['My-header'].should == "test"
+    @headers['my-header'].should == "test"
+    @headers['MY-HEADER'].should == "test"
+  end
+
+  it "returns multi-element values joined together" do
+    @headers["My-Header"] = "test"
+    @headers.add_field("My-Header", "another test")
+    @headers.add_field("My-Header", "and one more")
+
+    @headers["My-Header"].should == "test, another test, and one more"
+  end
+
+  it "returns nil for non-existing entries" do
+    @headers["My-Header"].should be_nil
+    @headers["My-Other-Header"].should be_nil
+  end
+end

--- a/spec/library/net-http/httpheader/element_set_spec.rb
+++ b/spec/library/net-http/httpheader/element_set_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#[]= when passed key, value" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "sets the header entry with the passed key to the passed value" do
+    @headers["My-Header"] = "test"
+    @headers["My-Header"].should == "test"
+
+    @headers["My-Header"] = "overwritten"
+    @headers["My-Header"].should == "overwritten"
+
+    @headers["My-Other-Header"] = "another test"
+    @headers["My-Other-Header"].should == "another test"
+  end
+
+  it "is case-insensitive" do
+    @headers['My-Header'] = "test"
+    @headers['my-Header'] = "another test"
+    @headers['My-header'] = "and one more test"
+    @headers['my-header'] = "and another one"
+    @headers['MY-HEADER'] = "last one"
+
+    @headers["My-Header"].should == "last one"
+    @headers.size.should eql(1)
+  end
+
+  it "removes the header entry with the passed key when the value is false or nil" do
+    @headers['My-Header'] = "test"
+    @headers['My-Header'] = nil
+    @headers['My-Header'].should be_nil
+
+    @headers['My-Header'] = "test"
+    @headers['My-Header'] = false
+    @headers['My-Header'].should be_nil
+  end
+end

--- a/spec/library/net-http/httpheader/fetch_spec.rb
+++ b/spec/library/net-http/httpheader/fetch_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#fetch" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  describe "when passed key" do
+    it "returns the header entry for the passed key" do
+      @headers["My-Header"] = "test"
+      @headers.fetch("My-Header").should == "test"
+
+      @headers.add_field("My-Other-Header", "a")
+      @headers.add_field("My-Other-Header", "b")
+      @headers.add_field("My-Other-Header", "c")
+      @headers.fetch("My-Other-Header").should == "a, b, c"
+    end
+
+    it "is case-insensitive" do
+      @headers["My-Header"] = "test"
+      @headers.fetch("my-header").should == "test"
+      @headers.fetch("MY-HEADER").should == "test"
+    end
+
+    it "returns nil when there is no entry for the passed key" do
+      -> { @headers.fetch("my-header") }.should raise_error(IndexError)
+    end
+  end
+
+  describe "when passed key, default" do
+    it "returns the header entry for the passed key" do
+      @headers["My-Header"] = "test"
+      @headers.fetch("My-Header", "bla").should == "test"
+
+      @headers.add_field("My-Other-Header", "a")
+      @headers.add_field("My-Other-Header", "b")
+      @headers.add_field("My-Other-Header", "c")
+      @headers.fetch("My-Other-Header", "bla").should == "a, b, c"
+    end
+
+    # TODO: This raises a NoMethodError: undefined method `join' for "bla":String
+    it "returns the default value when there is no entry for the passed key" do
+      @headers.fetch("My-Header", "bla").should == "bla"
+    end
+  end
+
+  describe "when passed key and block" do
+    it "returns the header entry for the passed key" do
+      @headers["My-Header"] = "test"
+      @headers.fetch("My-Header") {}.should == "test"
+
+      @headers.add_field("My-Other-Header", "a")
+      @headers.add_field("My-Other-Header", "b")
+      @headers.add_field("My-Other-Header", "c")
+      -> {
+        @result = @headers.fetch("My-Other-Header", "bla") {}
+      }.should complain(/block supersedes default value argument/)
+      @result.should == "a, b, c"
+    end
+
+    # TODO: This raises a NoMethodError: undefined method `join' for "redaeh-ym":String
+    it "yieldsand returns the block's return value when there is no entry for the passed key" do
+      @headers.fetch("My-Header") { |key| key.reverse }.should == "redaeh-ym"
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/fixtures/classes.rb
+++ b/spec/library/net-http/httpheader/fixtures/classes.rb
@@ -1,0 +1,11 @@
+module NetHTTPHeaderSpecs
+  class Example
+    include Net::HTTPHeader
+
+    attr_accessor :body
+
+    def initialize
+      initialize_http_header({})
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/form_data_spec.rb
+++ b/spec/library/net-http/httpheader/form_data_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_form_data'
+
+describe "Net::HTTPHeader#form_data=" do
+  it_behaves_like :net_httpheader_set_form_data, :form_data=
+end

--- a/spec/library/net-http/httpheader/get_fields_spec.rb
+++ b/spec/library/net-http/httpheader/get_fields_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#get_fields when passed key" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns an Array containing the values of the header entry with the passed key" do
+    @headers["My-Header"] = "a"
+    @headers.get_fields("My-Header").should == ["a"]
+
+    @headers.add_field("My-Header", "b")
+    @headers.get_fields("My-Header").should == ["a", "b"]
+  end
+
+  it "returns a copy of the header entry values" do
+    @headers["My-Header"] = "a"
+
+    @headers.get_fields("My-Header").clear
+    @headers.get_fields("My-Header").should == ["a"]
+
+    @headers.get_fields("My-Header") << "b"
+    @headers.get_fields("My-Header").should == ["a"]
+  end
+
+  it "returns nil for non-existing header entries" do
+    @headers.get_fields("My-Header").should be_nil
+    @headers.get_fields("My-Other-header").should be_nil
+  end
+
+  it "is case-insensitive" do
+    @headers["My-Header"] = "test"
+    @headers.get_fields("My-Header").should == ["test"]
+    @headers.get_fields("my-header").should == ["test"]
+    @headers.get_fields("MY-HEADER").should == ["test"]
+  end
+end

--- a/spec/library/net-http/httpheader/initialize_http_header_spec.rb
+++ b/spec/library/net-http/httpheader/initialize_http_header_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#initialize_http_header when passed Hash" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.allocate
+  end
+
+  it "initializes the HTTP Header using the passed Hash" do
+    @headers.initialize_http_header("My-Header" => "test", "My-Other-Header" => "another test")
+    @headers["My-Header"].should == "test"
+    @headers["My-Other-Header"].should == "another test"
+  end
+
+  it "complains about duplicate keys when in verbose mode" do
+    -> do
+      @headers.initialize_http_header("My-Header" => "test", "my-header" => "another test")
+    end.should complain(/duplicated HTTP header/, verbose: true)
+  end
+end

--- a/spec/library/net-http/httpheader/key_spec.rb
+++ b/spec/library/net-http/httpheader/key_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#key? when passed key" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns true if the header entry with the passed key exists" do
+    @headers.key?("My-Header").should be_false
+    @headers["My-Header"] = "test"
+    @headers.key?("My-Header").should be_true
+  end
+
+  it "is case-insensitive" do
+    @headers["My-Header"] = "test"
+    @headers.key?("my-header").should be_true
+    @headers.key?("MY-HEADER").should be_true
+  end
+end

--- a/spec/library/net-http/httpheader/length_spec.rb
+++ b/spec/library/net-http/httpheader/length_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/size'
+
+describe "Net::HTTPHeader#length" do
+  it_behaves_like :net_httpheader_size, :length
+end

--- a/spec/library/net-http/httpheader/main_type_spec.rb
+++ b/spec/library/net-http/httpheader/main_type_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#main_type" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the 'main-content-type', as per 'Content-Type' header entry" do
+    @headers["Content-Type"] = "text/html"
+    @headers.main_type.should == "text"
+
+    @headers["Content-Type"] = "application/pdf"
+    @headers.main_type.should == "application"
+
+    @headers["Content-Type"] = "text/html;charset=utf-8"
+    @headers.main_type.should == "text"
+  end
+
+  it "returns nil if the 'Content-Type' header entry does not exist" do
+    @headers.main_type.should be_nil
+  end
+end

--- a/spec/library/net-http/httpheader/proxy_basic_auth_spec.rb
+++ b/spec/library/net-http/httpheader/proxy_basic_auth_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#proxy_basic_auth when passed account, password" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "sets the 'Proxy-Authorization' Header entry for basic authorization" do
+    @headers.proxy_basic_auth("rubyspec", "rocks")
+    @headers["Proxy-Authorization"].should == "Basic cnVieXNwZWM6cm9ja3M="
+  end
+end

--- a/spec/library/net-http/httpheader/range_length_spec.rb
+++ b/spec/library/net-http/httpheader/range_length_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#range_length" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the length of the Range represented by the 'Content-Range' header entry" do
+    @headers["Content-Range"] = "bytes 0-499/1234"
+    @headers.range_length.should eql(500)
+
+    @headers["Content-Range"] = "bytes 500-1233/1234"
+    @headers.range_length.should eql(734)
+  end
+
+  it "returns nil when there is no 'Content-Range' header entry" do
+    @headers.range_length.should be_nil
+  end
+
+  it "raises a Net::HTTPHeaderSyntaxError when the 'Content-Range' has an invalid format" do
+    @headers["Content-Range"] = "invalid"
+    -> { @headers.range_length }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Content-Range"] = "bytes 123-abc"
+    -> { @headers.range_length }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Content-Range"] = "bytes abc-123"
+    -> { @headers.range_length }.should raise_error(Net::HTTPHeaderSyntaxError)
+  end
+end

--- a/spec/library/net-http/httpheader/range_spec.rb
+++ b/spec/library/net-http/httpheader/range_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_range'
+
+describe "Net::HTTPHeader#range" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns a Range object that represents the 'Range' header entry" do
+    @headers["Range"] = "bytes=0-499"
+    @headers.range.should == [0..499]
+
+    @headers["Range"] = "bytes=500-1233"
+    @headers.range.should == [500..1233]
+
+    @headers["Range"] = "bytes=10-"
+    @headers.range.should == [10..-1]
+
+    @headers["Range"] = "bytes=-10"
+    @headers.range.should == [-10..-1]
+  end
+
+  it "returns nil when there is no 'Range' header entry" do
+    @headers.range.should be_nil
+  end
+
+  it "raises a Net::HTTPHeaderSyntaxError when the 'Range' has an invalid format" do
+    @headers["Range"] = "invalid"
+    -> { @headers.range }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Range"] = "bytes 123-abc"
+    -> { @headers.range }.should raise_error(Net::HTTPHeaderSyntaxError)
+
+    @headers["Range"] = "bytes abc-123"
+    -> { @headers.range }.should raise_error(Net::HTTPHeaderSyntaxError)
+  end
+
+  it "raises a Net::HTTPHeaderSyntaxError when the 'Range' was not specified" do
+    @headers["Range"] = "bytes=-"
+    -> { @headers.range }.should raise_error(Net::HTTPHeaderSyntaxError)
+  end
+end
+
+describe "Net::HTTPHeader#range=" do
+  it_behaves_like :net_httpheader_set_range, :range=
+end

--- a/spec/library/net-http/httpheader/set_content_type_spec.rb
+++ b/spec/library/net-http/httpheader/set_content_type_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_content_type'
+
+describe "Net::HTTPHeader#set_content_type" do
+  it_behaves_like :net_httpheader_set_content_type, :set_content_type
+end

--- a/spec/library/net-http/httpheader/set_form_data_spec.rb
+++ b/spec/library/net-http/httpheader/set_form_data_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_form_data'
+
+describe "Net::HTTPHeader#set_form_data" do
+  it_behaves_like :net_httpheader_set_form_data, :set_form_data
+end

--- a/spec/library/net-http/httpheader/set_range_spec.rb
+++ b/spec/library/net-http/httpheader/set_range_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/set_range'
+
+describe "Net::HTTPHeader#set_range" do
+  it_behaves_like :net_httpheader_set_range, :set_range
+end

--- a/spec/library/net-http/httpheader/shared/each_capitalized.rb
+++ b/spec/library/net-http/httpheader/shared/each_capitalized.rb
@@ -1,0 +1,31 @@
+describe :net_httpheader_each_capitalized, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+    @headers["my-header"] = "test"
+    @headers.add_field("my-Other-Header", "a")
+    @headers.add_field("My-Other-header", "b")
+  end
+
+  describe "when passed a block" do
+    it "yields each header entry to the passed block (capitalized keys, values joined)" do
+      res = []
+      @headers.send(@method) do |key, value|
+        res << [key, value]
+      end
+      res.sort.should == [["My-Header", "test"], ["My-Other-Header", "a, b"]]
+    end
+  end
+
+  describe "when passed no block" do
+    it "returns an Enumerator" do
+      enumerator = @headers.send(@method)
+      enumerator.should be_an_instance_of(Enumerator)
+
+      res = []
+      enumerator.each do |*key|
+        res << key
+      end
+      res.sort.should == [["My-Header", "test"], ["My-Other-Header", "a, b"]]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/each_header.rb
+++ b/spec/library/net-http/httpheader/shared/each_header.rb
@@ -1,0 +1,31 @@
+describe :net_httpheader_each_header, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+    @headers["My-Header"] = "test"
+    @headers.add_field("My-Other-Header", "a")
+    @headers.add_field("My-Other-Header", "b")
+  end
+
+  describe "when passed a block" do
+    it "yields each header entry to the passed block (keys in lower case, values joined)" do
+      res = []
+      @headers.send(@method) do |key, value|
+        res << [key, value]
+      end
+      res.sort.should == [["my-header", "test"], ["my-other-header", "a, b"]]
+    end
+  end
+
+  describe "when passed no block" do
+    it "returns an Enumerator" do
+      enumerator = @headers.send(@method)
+      enumerator.should be_an_instance_of(Enumerator)
+
+      res = []
+      enumerator.each do |*key|
+        res << key
+      end
+      res.sort.should == [["my-header", "test"], ["my-other-header", "a, b"]]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/each_name.rb
+++ b/spec/library/net-http/httpheader/shared/each_name.rb
@@ -1,0 +1,31 @@
+describe :net_httpheader_each_name, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+    @headers["My-Header"] = "test"
+    @headers.add_field("My-Other-Header", "a")
+    @headers.add_field("My-Other-Header", "b")
+  end
+
+  describe "when passed a block" do
+    it "yields each header key to the passed block (keys in lower case)" do
+      res = []
+      @headers.send(@method) do |key|
+        res << key
+      end
+      res.sort.should == ["my-header", "my-other-header"]
+    end
+  end
+
+  describe "when passed no block" do
+    it "returns an Enumerator" do
+      enumerator = @headers.send(@method)
+      enumerator.should be_an_instance_of(Enumerator)
+
+      res = []
+      enumerator.each do |key|
+        res << key
+      end
+      res.sort.should == ["my-header", "my-other-header"]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/set_content_type.rb
+++ b/spec/library/net-http/httpheader/shared/set_content_type.rb
@@ -1,0 +1,18 @@
+describe :net_httpheader_set_content_type, shared: true do
+  describe "when passed type, params" do
+    before :each do
+      @headers = NetHTTPHeaderSpecs::Example.new
+    end
+
+    it "sets the 'Content-Type' header entry based on the passed type and params" do
+      @headers.send(@method, "text/html")
+      @headers["Content-Type"].should == "text/html"
+
+      @headers.send(@method, "text/html", "charset" => "utf-8")
+      @headers["Content-Type"].should == "text/html; charset=utf-8"
+
+      @headers.send(@method, "text/html", "charset" => "utf-8", "rubyspec" => "rocks")
+      @headers["Content-Type"].split(/; /).sort.should == %w[charset=utf-8 rubyspec=rocks text/html]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/set_form_data.rb
+++ b/spec/library/net-http/httpheader/shared/set_form_data.rb
@@ -1,0 +1,27 @@
+describe :net_httpheader_set_form_data, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  describe "when passed params" do
+    it "automatically set the 'Content-Type' to 'application/x-www-form-urlencoded'" do
+      @headers.send(@method, "cmd" => "search", "q" => "ruby", "max" => "50")
+      @headers["Content-Type"].should == "application/x-www-form-urlencoded"
+    end
+
+    it "sets self's body based on the passed form parameters" do
+      @headers.send(@method, "cmd" => "search", "q" => "ruby", "max" => "50")
+      @headers.body.split("&").sort.should == ["cmd=search", "max=50", "q=ruby"]
+    end
+  end
+
+  describe "when passed params, separator" do
+    it "sets self's body based on the passed form parameters and the passed separator" do
+      @headers.send(@method, {"cmd" => "search", "q" => "ruby", "max" => "50"}, "&")
+      @headers.body.split("&").sort.should == ["cmd=search", "max=50", "q=ruby"]
+
+      @headers.send(@method, {"cmd" => "search", "q" => "ruby", "max" => "50"}, ";")
+      @headers.body.split(";").sort.should == ["cmd=search", "max=50", "q=ruby"]
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/set_range.rb
+++ b/spec/library/net-http/httpheader/shared/set_range.rb
@@ -1,0 +1,89 @@
+describe :net_httpheader_set_range, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  describe "when passed nil" do
+    it "returns nil" do
+      @headers.send(@method, nil).should be_nil
+    end
+
+    it "deletes the 'Range' header entry" do
+      @headers["Range"] = "bytes 0-499/1234"
+      @headers.send(@method, nil)
+      @headers["Range"].should be_nil
+    end
+  end
+
+  describe "when passed Numeric" do
+    it "sets the 'Range' header entry based on the passed Numeric" do
+      @headers.send(@method, 10)
+      @headers["Range"].should == "bytes=0-9"
+
+      @headers.send(@method, -10)
+      @headers["Range"].should == "bytes=-10"
+
+      @headers.send(@method, 10.9)
+      @headers["Range"].should == "bytes=0-9"
+    end
+  end
+
+  describe "when passed Range" do
+    it "sets the 'Range' header entry based on the passed Range" do
+      @headers.send(@method, 10..200)
+      @headers["Range"].should == "bytes=10-200"
+
+      @headers.send(@method, 1..5)
+      @headers["Range"].should == "bytes=1-5"
+
+      @headers.send(@method, 1...5)
+      @headers["Range"].should == "bytes=1-4"
+
+      @headers.send(@method, 234..567)
+      @headers["Range"].should == "bytes=234-567"
+
+      @headers.send(@method, -5..-1)
+      @headers["Range"].should == "bytes=-5"
+
+      @headers.send(@method, 1..-1)
+      @headers["Range"].should == "bytes=1-"
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when the first Range element is negative" do
+      -> { @headers.send(@method, -10..5) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when the last Range element is negative" do
+      -> { @headers.send(@method, 10..-5) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when the last Range element is smaller than the first" do
+      -> { @headers.send(@method, 10..5) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+  end
+
+  describe "when passed start, end" do
+    it "sets the 'Range' header entry based on the passed start and length values" do
+      @headers.send(@method, 10, 200)
+      @headers["Range"].should == "bytes=10-209"
+
+      @headers.send(@method, 1, 5)
+      @headers["Range"].should == "bytes=1-5"
+
+      @headers.send(@method, 234, 567)
+      @headers["Range"].should == "bytes=234-800"
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when start is negative" do
+      -> { @headers.send(@method, -10, 5) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when start + length is negative" do
+      -> { @headers.send(@method, 10, -15) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+
+    it "raises a Net::HTTPHeaderSyntaxError when length is negative" do
+      -> { @headers.send(@method, 10, -4) }.should raise_error(Net::HTTPHeaderSyntaxError)
+    end
+  end
+end

--- a/spec/library/net-http/httpheader/shared/size.rb
+++ b/spec/library/net-http/httpheader/shared/size.rb
@@ -1,0 +1,18 @@
+describe :net_httpheader_size, shared: true do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the number of header entries in self" do
+    @headers.send(@method).should eql(0)
+
+    @headers["a"] = "b"
+    @headers.send(@method).should eql(1)
+
+    @headers["b"] = "b"
+    @headers.send(@method).should eql(2)
+
+    @headers["c"] = "c"
+    @headers.send(@method).should eql(3)
+  end
+end

--- a/spec/library/net-http/httpheader/size_spec.rb
+++ b/spec/library/net-http/httpheader/size_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+require_relative 'shared/size'
+
+describe "Net::HTTPHeader#size" do
+  it_behaves_like :net_httpheader_size, :size
+end

--- a/spec/library/net-http/httpheader/sub_type_spec.rb
+++ b/spec/library/net-http/httpheader/sub_type_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#sub_type" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns the 'sub-content-type', as per 'Content-Type' header entry" do
+    @headers["Content-Type"] = "text/html"
+    @headers.sub_type.should == "html"
+
+    @headers["Content-Type"] = "application/pdf"
+    @headers.sub_type.should == "pdf"
+
+    @headers["Content-Type"] = "text/html;charset=utf-8"
+    @headers.sub_type.should == "html"
+  end
+
+  it "returns nil if no 'sub-content-type' is set" do
+    @headers["Content-Type"] = "text"
+    @headers.sub_type.should be_nil
+
+    @headers["Content-Type"] = "text;charset=utf-8"
+    @headers.sub_type.should be_nil
+  end
+
+  it "returns nil if the 'Content-Type' header entry does not exist" do
+    @headers.sub_type.should be_nil
+  end
+end

--- a/spec/library/net-http/httpheader/to_hash_spec.rb
+++ b/spec/library/net-http/httpheader/to_hash_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#to_hash" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns a Hash representing all Header entries (keys in lower case, values as arrays)" do
+    @headers.to_hash.should == {}
+
+    @headers["My-Header"] = "test"
+    @headers.to_hash.should == { "my-header" => ["test"] }
+
+    @headers.add_field("My-Header", "another test")
+    @headers.to_hash.should == { "my-header" => ["test", "another test"] }
+  end
+
+  it "does not allow modifying the headers from the returned hash" do
+    @headers.to_hash["my-header"] = ["test"]
+    @headers.to_hash.should == {}
+    @headers.key?("my-header").should be_false
+  end
+end

--- a/spec/library/net-http/httpheader/type_params_spec.rb
+++ b/spec/library/net-http/httpheader/type_params_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'fixtures/classes'
+
+describe "Net::HTTPHeader#type_params" do
+  before :each do
+    @headers = NetHTTPHeaderSpecs::Example.new
+  end
+
+  it "returns additional 'Content-Type' information as a Hash" do
+    @headers["Content-Type"] = "text/html;charset=utf-8"
+    @headers.type_params.should == {"charset" => "utf-8"}
+
+    @headers["Content-Type"] = "text/html; charset=utf-8; rubyspec=rocks"
+    @headers.type_params.should == {"charset" => "utf-8", "rubyspec" => "rocks"}
+  end
+
+  it "returns an empty Hash when no additional 'Content-Type' information is set" do
+    @headers.type_params.should == {}
+
+    @headers["Content-Type"] = "text/html"
+    @headers.type_params.should == {}
+  end
+end

--- a/spec/library/net-http/httprequest/initialize_spec.rb
+++ b/spec/library/net-http/httprequest/initialize_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+module NetHTTPRequestSpecs
+  class TestRequest < Net::HTTPRequest
+    METHOD = "TEST"
+    REQUEST_HAS_BODY  = false
+    RESPONSE_HAS_BODY = true
+  end
+end
+
+describe "Net::HTTPRequest#initialize" do
+  before :each do
+    @req = NetHTTPRequestSpecs::TestRequest.allocate
+  end
+
+  it "uses the METHOD constants to set the request method" do
+    @req.send(:initialize, "/some/path")
+    @req.method.should == "TEST"
+  end
+
+  it "uses the REQUEST_HAS_BODY to set whether the Request has a body or not" do
+    @req.send(:initialize, "/some/path")
+    @req.request_body_permitted?.should be_false
+  end
+
+  it "uses the RESPONSE_HAS_BODY to set whether the Response can have a body or not" do
+    @req.send(:initialize, "/some/path")
+    @req.response_body_permitted?.should be_true
+  end
+
+  describe "when passed path" do
+    it "sets self's path to the passed path" do
+      @req.send(:initialize, "/some/path")
+      @req.path.should == "/some/path"
+    end
+  end
+
+  describe "when passed path, headers" do
+    it "uses the passed headers Hash to initialize self's header entries" do
+      @req.send(:initialize, "/some/path", "Content-Type" => "text/html")
+      @req["Content-Type"].should == "text/html"
+    end
+  end
+end

--- a/spec/library/net-http/httpresponse/body_permitted_spec.rb
+++ b/spec/library/net-http/httpresponse/body_permitted_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse.body_permitted?" do
+  it "returns true if this response type can have a response body" do
+    Net::HTTPUnknownResponse.should.body_permitted?
+    Net::HTTPInformation.should_not.body_permitted?
+    Net::HTTPSuccess.should.body_permitted?
+    Net::HTTPRedirection.should.body_permitted?
+    Net::HTTPClientError.should.body_permitted?
+    Net::HTTPServerError.should.body_permitted?
+  end
+end

--- a/spec/library/net-http/httpresponse/body_spec.rb
+++ b/spec/library/net-http/httpresponse/body_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/body'
+
+describe "Net::HTTPResponse#body" do
+  it_behaves_like :net_httpresponse_body, :body
+end

--- a/spec/library/net-http/httpresponse/code_spec.rb
+++ b/spec/library/net-http/httpresponse/code_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#code" do
+  it "returns the result code string" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.code.should == "???"
+
+    res = Net::HTTPInformation.new("1.0", "1xx", "test response")
+    res.code.should == "1xx"
+
+    res = Net::HTTPSuccess.new("1.0", "2xx", "test response")
+    res.code.should == "2xx"
+
+    res = Net::HTTPRedirection.new("1.0", "3xx", "test response")
+    res.code.should == "3xx"
+
+    res = Net::HTTPClientError.new("1.0", "4xx", "test response")
+    res.code.should == "4xx"
+
+    res = Net::HTTPServerError.new("1.0", "5xx", "test response")
+    res.code.should == "5xx"
+  end
+end

--- a/spec/library/net-http/httpresponse/code_type_spec.rb
+++ b/spec/library/net-http/httpresponse/code_type_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#code_type" do
+  it "returns self's class" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.code_type.should == Net::HTTPUnknownResponse
+
+    res = Net::HTTPInformation.new("1.0", "1xx", "test response")
+    res.code_type.should == Net::HTTPInformation
+
+    res = Net::HTTPSuccess.new("1.0", "2xx", "test response")
+    res.code_type.should == Net::HTTPSuccess
+
+    res = Net::HTTPRedirection.new("1.0", "3xx", "test response")
+    res.code_type.should == Net::HTTPRedirection
+
+    res = Net::HTTPClientError.new("1.0", "4xx", "test response")
+    res.code_type.should == Net::HTTPClientError
+
+    res = Net::HTTPServerError.new("1.0", "5xx", "test response")
+    res.code_type.should == Net::HTTPServerError
+  end
+end

--- a/spec/library/net-http/httpresponse/entity_spec.rb
+++ b/spec/library/net-http/httpresponse/entity_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require_relative 'shared/body'
+
+describe "Net::HTTPResponse#entity" do
+  it_behaves_like :net_httpresponse_body, :entity
+end

--- a/spec/library/net-http/httpresponse/error_spec.rb
+++ b/spec/library/net-http/httpresponse/error_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#error!" do
+  it "raises self's class 'EXCEPTION_TYPE' Exception" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPError)
+
+    res = Net::HTTPInformation.new("1.0", "1xx", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPError)
+
+    res = Net::HTTPSuccess.new("1.0", "2xx", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPError)
+
+    res = Net::HTTPRedirection.new("1.0", "3xx", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPRetriableError)
+
+    res = Net::HTTPClientError.new("1.0", "4xx", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPClientException)
+
+    res = Net::HTTPServerError.new("1.0", "5xx", "test response")
+    -> { res.error! }.should raise_error(Net::HTTPFatalError)
+  end
+end

--- a/spec/library/net-http/httpresponse/error_type_spec.rb
+++ b/spec/library/net-http/httpresponse/error_type_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#error_type" do
+  it "returns self's class 'EXCEPTION_TYPE' constant" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.error_type.should == Net::HTTPError
+
+    res = Net::HTTPInformation.new("1.0", "1xx", "test response")
+    res.error_type.should == Net::HTTPError
+
+    res = Net::HTTPSuccess.new("1.0", "2xx", "test response")
+    res.error_type.should == Net::HTTPError
+
+    res = Net::HTTPRedirection.new("1.0", "3xx", "test response")
+    res.error_type.should == Net::HTTPRetriableError
+
+    res = Net::HTTPClientError.new("1.0", "4xx", "test response")
+    res.error_type.should == Net::HTTPClientException
+
+    res = Net::HTTPServerError.new("1.0", "5xx", "test response")
+    res.error_type.should == Net::HTTPFatalError
+  end
+end

--- a/spec/library/net-http/httpresponse/exception_type_spec.rb
+++ b/spec/library/net-http/httpresponse/exception_type_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse.exception_type" do
+  it "returns self's 'EXCEPTION_TYPE' constant" do
+    Net::HTTPUnknownResponse.exception_type.should == Net::HTTPError
+    Net::HTTPInformation.exception_type.should == Net::HTTPError
+    Net::HTTPSuccess.exception_type.should == Net::HTTPError
+    Net::HTTPRedirection.exception_type.should == Net::HTTPRetriableError
+    Net::HTTPClientError.exception_type.should == Net::HTTPClientException
+    Net::HTTPServerError.exception_type.should == Net::HTTPFatalError
+  end
+end

--- a/spec/library/net-http/httpresponse/header_spec.rb
+++ b/spec/library/net-http/httpresponse/header_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#header" do
+  it "returns self" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.response.should equal(res)
+  end
+end

--- a/spec/library/net-http/httpresponse/http_version_spec.rb
+++ b/spec/library/net-http/httpresponse/http_version_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#http_version" do
+  it "returns self's http version" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.http_version.should == "1.0"
+
+    res = Net::HTTPUnknownResponse.new("1.1", "???", "test response")
+    res.http_version.should == "1.1"
+  end
+end

--- a/spec/library/net-http/httpresponse/initialize_spec.rb
+++ b/spec/library/net-http/httpresponse/initialize_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#initialize when passed http_version, response_code, response_message" do
+  it "sets self http_version, response_code and response_message to the passed values" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.http_version.should == "1.0"
+    res.code.should == "???"
+    res.message.should == "test response"
+  end
+end

--- a/spec/library/net-http/httpresponse/inspect_spec.rb
+++ b/spec/library/net-http/httpresponse/inspect_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+
+describe "Net::HTTPResponse#inspect" do
+  it "returns a String representation of self" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=false>"
+
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    socket = Net::BufferedIO.new(StringIO.new("test body"))
+    res.reading_body(socket, true) {}
+    res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=true>"
+  end
+end

--- a/spec/library/net-http/httpresponse/message_spec.rb
+++ b/spec/library/net-http/httpresponse/message_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#message" do
+  it "returns self's response message" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.message.should == "test response"
+  end
+end

--- a/spec/library/net-http/httpresponse/msg_spec.rb
+++ b/spec/library/net-http/httpresponse/msg_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#msg" do
+  it "returns self's response message" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.message.should == "test response"
+  end
+end

--- a/spec/library/net-http/httpresponse/read_body_spec.rb
+++ b/spec/library/net-http/httpresponse/read_body_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require 'stringio'
+
+describe "Net::HTTPResponse#read_body" do
+  before :each do
+    @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+  end
+
+  describe "when passed no arguments" do
+    it "returns the read body" do
+      @res.reading_body(@socket, true) do
+        @res.read_body.should == "test body"
+      end
+    end
+
+    it "returns the previously read body if called a second time" do
+      @res.reading_body(@socket, true) do
+        @res.read_body.should equal(@res.read_body)
+      end
+    end
+  end
+
+  describe "when passed a buffer" do
+    it "reads the body to the passed buffer" do
+      @res.reading_body(@socket, true) do
+        buffer = +""
+        @res.read_body(buffer)
+        buffer.should == "test body"
+      end
+    end
+
+    it "returns the passed buffer" do
+      @res.reading_body(@socket, true) do
+        buffer = +""
+        @res.read_body(buffer).should equal(buffer)
+      end
+    end
+
+    it "raises an IOError if called a second time" do
+      @res.reading_body(@socket, true) do
+        @res.read_body(+"")
+        -> { @res.read_body(+"") }.should raise_error(IOError)
+      end
+    end
+  end
+
+  describe "when passed a block" do
+    it "reads the body and yields it to the passed block (in chunks)" do
+      @res.reading_body(@socket, true) do
+        yielded = false
+
+        buffer = +""
+        @res.read_body do |body|
+          yielded = true
+          buffer << body
+        end
+
+        yielded.should be_true
+        buffer.should == "test body"
+      end
+    end
+
+    it "returns the ReadAdapter" do
+      @res.reading_body(@socket, true) do
+        @res.read_body { nil }.should be_kind_of(Net::ReadAdapter)
+      end
+    end
+
+    it "raises an IOError if called a second time" do
+      @res.reading_body(@socket, true) do
+        @res.read_body {}
+        -> { @res.read_body {} }.should raise_error(IOError)
+      end
+    end
+  end
+
+  describe "when passed buffer and block" do
+    it "raises an ArgumentError" do
+      @res.reading_body(@socket, true) do
+        -> { @res.read_body(+"") {} }.should raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/library/net-http/httpresponse/read_header_spec.rb
+++ b/spec/library/net-http/httpresponse/read_header_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#read_header" do
+  it "returns self" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.response.should equal(res)
+  end
+end

--- a/spec/library/net-http/httpresponse/read_new_spec.rb
+++ b/spec/library/net-http/httpresponse/read_new_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require 'stringio'
+
+describe "Net::HTTPResponse.read_new" do
+  it "creates a HTTPResponse object based on the response read from the passed socket" do
+    socket = Net::BufferedIO.new(StringIO.new(<<EOS))
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+
+test-body
+EOS
+    response = Net::HTTPResponse.read_new(socket)
+
+    response.should be_kind_of(Net::HTTPOK)
+    response.code.should == "200"
+    response["Content-Type"].should == "text/html; charset=utf-8"
+
+    response.reading_body(socket, true) do
+      response.body.should == "test-body\n"
+    end
+  end
+end

--- a/spec/library/net-http/httpresponse/reading_body_spec.rb
+++ b/spec/library/net-http/httpresponse/reading_body_spec.rb
@@ -1,0 +1,58 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+require "stringio"
+
+describe "Net::HTTPResponse#reading_body" do
+  before :each do
+    @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+  end
+
+  describe "when body_allowed is true" do
+    it "reads and returns the response body for self from the passed socket" do
+      @res.reading_body(@socket, true) {}.should == "test body"
+      @res.body.should == "test body"
+    end
+
+    it "yields the passed block before reading the body" do
+      yielded = false
+
+      @res.reading_body(@socket, true) do
+        @res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=false>"
+        yielded = true
+      end
+
+      yielded.should be_true
+    end
+
+    describe "but the response type is not allowed to have a body" do
+      before :each do
+        @res = Net::HTTPInformation.new("1.0", "???", "test response")
+      end
+
+      it "returns nil" do
+        @res.reading_body(@socket, false) {}.should be_nil
+        @res.body.should be_nil
+      end
+
+      it "yields the passed block" do
+        yielded = false
+        @res.reading_body(@socket, true) { yielded = true }
+        yielded.should be_true
+      end
+    end
+  end
+
+  describe "when body_allowed is false" do
+    it "returns nil" do
+      @res.reading_body(@socket, false) {}.should be_nil
+      @res.body.should be_nil
+    end
+
+    it "yields the passed block" do
+      yielded = false
+      @res.reading_body(@socket, true) { yielded = true }
+      yielded.should be_true
+    end
+  end
+end

--- a/spec/library/net-http/httpresponse/response_spec.rb
+++ b/spec/library/net-http/httpresponse/response_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#response" do
+  it "returns self" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    res.response.should equal(res)
+  end
+end

--- a/spec/library/net-http/httpresponse/shared/body.rb
+++ b/spec/library/net-http/httpresponse/shared/body.rb
@@ -1,0 +1,20 @@
+require 'stringio'
+
+describe :net_httpresponse_body, shared: true do
+  before :each do
+    @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+  end
+
+  it "returns the read body" do
+    @res.reading_body(@socket, true) do
+      @res.send(@method).should == "test body"
+    end
+  end
+
+  it "returns the previously read body if called a second time" do
+    @res.reading_body(@socket, true) do
+      @res.send(@method).should equal(@res.send(@method))
+    end
+  end
+end

--- a/spec/library/net-http/httpresponse/value_spec.rb
+++ b/spec/library/net-http/httpresponse/value_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require 'net/http'
+
+describe "Net::HTTPResponse#value" do
+  it "raises an HTTP error for non 2xx HTTP Responses" do
+    res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
+    -> { res.value }.should raise_error(Net::HTTPError)
+
+    res = Net::HTTPInformation.new("1.0", "1xx", "test response")
+    -> { res.value }.should raise_error(Net::HTTPError)
+
+    res = Net::HTTPSuccess.new("1.0", "2xx", "test response")
+    -> { res.value }.should_not raise_error(Net::HTTPError)
+
+    res = Net::HTTPRedirection.new("1.0", "3xx", "test response")
+    -> { res.value }.should raise_error(Net::HTTPRetriableError)
+
+    res = Net::HTTPClientError.new("1.0", "4xx", "test response")
+    -> { res.value }.should raise_error(Net::HTTPClientException)
+
+    res = Net::HTTPServerError.new("1.0", "5xx", "test response")
+    -> { res.value }.should raise_error(Net::HTTPFatalError)
+  end
+end


### PR DESCRIPTION
This is going to be a long project to get some HTTP connectivity working, mostly to add the essential functionality to OpenSSL. I've added a simple script that I want to get working:
```ruby
require 'net/http'

puts Net::HTTP.get(URI('http://natalie-lang.org/'))
puts Net::HTTP.get(URI('https://natalie-lang.org/specs'))
```

I've taken some shortcuts with some required modules. It tried to import the Timeout gem, but this far it only used the exceptions from this code, so I've just limited this file to the exceptions and removed all the other dependencies in timeout.