### PR TITLE
Add IO#wait_readable and IO#wait_writable

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -113,6 +113,7 @@ public:
     static Value try_convert(Env *, Value);
     Value ungetbyte(Env *, Value);
     Value ungetc(Env *, Value);
+    Value wait_readable(Env *, Value = nullptr);
 
     Value write(Env *, Args);
     static Value write_file(Env *, Args);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -114,6 +114,7 @@ public:
     Value ungetbyte(Env *, Value);
     Value ungetc(Env *, Value);
     Value wait_readable(Env *, Value = nullptr);
+    Value wait_writable(Env *, Value = nullptr);
 
     Value write(Env *, Args);
     static Value write_file(Env *, Args);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -911,6 +911,7 @@ gen.binding('IO', 'tell', 'IoObject', 'pos', argc: 0, pass_env: true, pass_block
 gen.binding('IO', 'to_io', 'IoObject', 'to_io', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetbyte', 'IoObject', 'ungetbyte', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetc', 'IoObject', 'ungetc', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'wait_readable', 'IoObject', 'wait_readable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -912,6 +912,7 @@ gen.binding('IO', 'to_io', 'IoObject', 'to_io', argc: 0, pass_env: true, pass_bl
 gen.binding('IO', 'ungetbyte', 'IoObject', 'ungetbyte', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetc', 'IoObject', 'ungetc', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'wait_readable', 'IoObject', 'wait_readable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'wait_writable', 'IoObject', 'wait_writable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/library/io-wait/wait_readable_spec.rb
+++ b/spec/library/io-wait/wait_readable_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../spec_helper'
+
+ruby_version_is ''...'3.2' do
+  require 'io/wait'
+end
+
+describe "IO#wait_readable" do
+  before :each do
+    @io = File.new(__FILE__ )
+  end
+
+  after :each do
+    @io.close
+  end
+
+  it "waits for the IO to become readable with no timeout" do
+    @io.wait_readable.should == @io
+  end
+
+  it "waits for the IO to become readable with the given timeout" do
+    @io.wait_readable(1).should == @io
+  end
+
+  it "waits for the IO to become readable with the given large timeout" do
+    @io.wait_readable(365 * 24 * 60 * 60).should == @io
+  end
+end

--- a/spec/library/io-wait/wait_writable_spec.rb
+++ b/spec/library/io-wait/wait_writable_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+ruby_version_is ''...'3.2' do
+  require 'io/wait'
+end
+
+describe "IO#wait_writable" do
+  it "waits for the IO to become writable with no timeout" do
+    STDOUT.wait_writable.should == STDOUT
+  end
+
+  it "waits for the IO to become writable with the given timeout" do
+    STDOUT.wait_writable(1).should == STDOUT
+  end
+
+  it "waits for the IO to become writable with the given large timeout" do
+    # Represents one year and is larger than a 32-bit int
+    STDOUT.wait_writable(365 * 24 * 60 * 60).should == STDOUT
+  end
+end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -834,6 +834,14 @@ Value IoObject::ungetc(Env *env, Value c) {
     return ungetbyte(env, c->to_str(env));
 }
 
+Value IoObject::wait_readable(Env *env, Value timeout) {
+    auto read_ios = new ArrayObject { this };
+    auto select_result = IoObject::select(env, read_ios, nullptr, nullptr, timeout);
+    if (select_result->is_nil())
+        return NilObject::the();
+    return this;
+}
+
 int IoObject::rewind(Env *env) {
     raise_if_closed(env);
     errno = 0;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -842,6 +842,14 @@ Value IoObject::wait_readable(Env *env, Value timeout) {
     return this;
 }
 
+Value IoObject::wait_writable(Env *env, Value timeout) {
+    auto write_ios = new ArrayObject { this };
+    auto select_result = IoObject::select(env, nullptr, write_ios, nullptr, timeout);
+    if (select_result->is_nil())
+        return NilObject::the();
+    return this;
+}
+
 int IoObject::rewind(Env *env) {
     raise_if_closed(env);
     errno = 0;


### PR DESCRIPTION
For now they're pretty much similar to using `IO.select` with itself as the read or write ids.  The next step is to include the Fiber scheduler ( #1184)