### PR TITLE
Use __constant__ macro in zlib to define constants

### DIFF
--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -5,27 +5,6 @@
 using namespace Natalie;
 
 Value init_zlib(Env *env, Value self) {
-    auto Zlib = GlobalEnv::the()->Object()->const_get("Zlib"_s);
-    if (!Zlib) {
-        Zlib = new ModuleObject { "Zlib" };
-        GlobalEnv::the()->Object()->const_set("Zlib"_s, Zlib);
-    }
-    Zlib->const_set("ASCII"_s, Value::integer(Z_ASCII));
-    Zlib->const_set("BEST_COMPRESSION"_s, Value::integer(Z_BEST_COMPRESSION));
-    Zlib->const_set("BEST_SPEED"_s, Value::integer(Z_BEST_SPEED));
-    Zlib->const_set("BINARY"_s, Value::integer(Z_BINARY));
-    Zlib->const_set("DEFAULT_COMPRESSION"_s, Value::integer(Z_DEFAULT_COMPRESSION));
-    Zlib->const_set("DEFAULT_STRATEGY"_s, Value::integer(Z_DEFAULT_STRATEGY));
-    Zlib->const_set("DEF_MEM_LEVEL"_s, Value::integer(8)); // Not defined in the zlib source, value copied from MRI documentation
-    Zlib->const_set("FILTERED"_s, Value::integer(Z_FILTERED));
-    Zlib->const_set("FINISH"_s, Value::integer(Z_FINISH));
-    Zlib->const_set("FIXED"_s, Value::integer(Z_FIXED));
-    Zlib->const_set("HUFFMAN_ONLY"_s, Value::integer(Z_HUFFMAN_ONLY));
-    Zlib->const_set("MAX_MEM_LEVEL"_s, Value::integer(MAX_MEM_LEVEL));
-    Zlib->const_set("MAX_WBITS"_s, Value::integer(MAX_WBITS));
-    Zlib->const_set("NO_COMPRESSION"_s, Value::integer(Z_NO_COMPRESSION));
-    Zlib->const_set("RLE"_s, Value::integer(Z_RLE));
-    Zlib->const_set("UNKNOWN"_s, Value::integer(Z_UNKNOWN));
     return NilObject::the();
 }
 

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -4,6 +4,23 @@ require 'zlib.cpp'
 __ld_flags__ '-lz'
 
 module Zlib
+  __constant__ 'ASCII', 'int', 'Z_ASCII'
+  __constant__ 'BEST_COMPRESSION', 'int', 'Z_BEST_COMPRESSION'
+  __constant__ 'BEST_SPEED', 'int', 'Z_BEST_SPEED'
+  __constant__ 'BINARY', 'int', 'Z_BINARY'
+  __constant__ 'DEFAULT_COMPRESSION', 'int', 'Z_DEFAULT_COMPRESSION'
+  __constant__ 'DEFAULT_STRATEGY', 'int', 'Z_DEFAULT_STRATEGY'
+  DEF_MEM_LEVEL = 8 # Not defined in the zlib source, value copied from MRI documentation
+  __constant__ 'FILTERED', 'int', 'Z_FILTERED'
+  __constant__ 'FINISH', 'int', 'Z_FINISH'
+  __constant__ 'FIXED', 'int', 'Z_FIXED'
+  __constant__ 'HUFFMAN_ONLY', 'int', 'Z_HUFFMAN_ONLY'
+  __constant__ 'MAX_MEM_LEVEL', 'int', 'MAX_MEM_LEVEL'
+  __constant__ 'MAX_WBITS', 'int', 'MAX_WBITS'
+  __constant__ 'NO_COMPRESSION', 'int', 'Z_NO_COMPRESSION'
+  __constant__ 'RLE', 'int', 'Z_RLE'
+  __constant__ 'UNKNOWN', 'int', 'Z_UNKNOWN'
+
   class Error < StandardError; end
   class BufError < Error; end
   class DataError < Error; end


### PR DESCRIPTION
This results in code that is a bit easier to understand, less repetitive, and has some `#ifdef` checks for free.