### PR TITLE
Move IO::SEEK_* constant definition to CPP file

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -123,6 +123,8 @@ public:
     void set_path(StringObject *path) { m_path = path; }
     void set_path(String path) { m_path = new StringObject { path }; }
 
+    static void build_constants(Env *env, ClassObject *klass);
+
 protected:
     void raise_if_closed(Env *) const;
     int write(Env *, Value);

--- a/src/io.rb
+++ b/src/io.rb
@@ -47,12 +47,6 @@ class IO
     end
   end
 
-  SEEK_SET = 0
-  SEEK_CUR = 1
-  SEEK_END = 2
-  SEEK_DATA = 3
-  SEEK_HOLE = 4
-
   def printf(format_string, *arguments)
     print(Kernel.sprintf(format_string, *arguments))
   end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -1106,4 +1106,12 @@ Value IoObject::readline(Env *env, Value sep, Value limit, Value chomp) {
     return result;
 }
 
+void IoObject::build_constants(Env *, ClassObject *klass) {
+    klass->const_set("SEEK_SET"_s, Value::integer(SEEK_SET));
+    klass->const_set("SEEK_CUR"_s, Value::integer(SEEK_CUR));
+    klass->const_set("SEEK_END"_s, Value::integer(SEEK_END));
+    klass->const_set("SEEK_DATA"_s, Value::integer(SEEK_DATA));
+    klass->const_set("SEEK_HOLE"_s, Value::integer(SEEK_HOLE));
+}
+
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -156,6 +156,7 @@ Env *build_top_env() {
     ClassObject *IO = Object->subclass(env, "IO", Object::Type::Io);
     Object->const_set("IO"_s, IO);
     IO->include_once(env, Enumerable);
+    IoObject::build_constants(env, IO);
 
     ClassObject *File = IO->subclass(env, "File");
     Object->const_set("File"_s, File);


### PR DESCRIPTION
This way we can use the constants of the libs to determine the value, instead of having to redefine them in a Ruby file