### PR TITLE
Implement IO#wait and IO#write_nonblock

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -113,6 +113,7 @@ public:
     static Value try_convert(Env *, Value);
     Value ungetbyte(Env *, Value);
     Value ungetc(Env *, Value);
+    Value wait(Env *, Args);
     Value wait_readable(Env *, Value = nullptr);
     Value wait_writable(Env *, Value = nullptr);
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -130,6 +130,10 @@ protected:
     int write(Env *, Value);
 
 private:
+    static const nat_int_t WAIT_READABLE = 1;
+    static const nat_int_t WAIT_PRIORITY = 2;
+    static const nat_int_t WAIT_WRITABLE = 4;
+
     ssize_t blocking_read(Env *env, void *buf, int count) const;
 
     EncodingObject *m_external_encoding { nullptr };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -77,6 +77,7 @@ public:
     bool is_closed() const { return m_closed; }
     bool is_close_on_exec(Env *) const;
     bool is_eof(Env *);
+    bool is_nonblock(Env *) const;
     bool isatty(Env *) const;
     int lineno(Env *) const;
     static Value pipe(Env *, Value, Value, Block *, ClassObject *);
@@ -95,6 +96,7 @@ public:
     void set_fileno(int fileno) { m_fileno = fileno; }
     Value set_lineno(Env *, Value);
     Value set_sync(Env *, Value);
+    void set_nonblock(Env *, bool) const;
     Value stat(Env *) const;
     static Value sysopen(Env *, Value, Value = nullptr, Value = nullptr);
     Value read(Env *, Value, Value);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -121,6 +121,7 @@ public:
 
     Value write(Env *, Args);
     static Value write_file(Env *, Args);
+    Value write_nonblock(Env *, Value, Value = nullptr);
 
     Value get_path() const;
     void set_path(StringObject *path) { m_path = path; }

--- a/lib/io/nonblock.cpp
+++ b/lib/io/nonblock.cpp
@@ -9,33 +9,13 @@ Value init_nonblock(Env *env, Value self) {
 
 Value IO_is_nonblock(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
-    const auto io = self->as_io()->fileno();
-    const auto flags = fcntl(io, F_GETFL);
-    if (flags < 0)
-        env->raise_errno();
-    if (flags & O_NONBLOCK)
+    if (self->as_io()->is_nonblock(env))
         return TrueObject::the();
     return FalseObject::the();
 }
 
 Value IO_set_nonblock(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
-    const auto io = self->as_io()->fileno();
-    auto flags = fcntl(io, F_GETFL);
-    if (flags < 0)
-        env->raise_errno();
-    if (args.at(0)->is_truthy()) {
-        if ((flags & O_NONBLOCK) != O_NONBLOCK) {
-            flags |= O_NONBLOCK;
-            if (fcntl(io, F_SETFL, flags) < 0)
-                env->raise_errno();
-        }
-    } else {
-        if (flags & O_NONBLOCK) {
-            flags &= ~O_NONBLOCK;
-            if (fcntl(io, F_SETFL, flags) < 0)
-                env->raise_errno();
-        }
-    }
+    self->as_io()->set_nonblock(env, args.at(0)->is_truthy());
     return args.at(0);
 }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -911,6 +911,7 @@ gen.binding('IO', 'tell', 'IoObject', 'pos', argc: 0, pass_env: true, pass_block
 gen.binding('IO', 'to_io', 'IoObject', 'to_io', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetbyte', 'IoObject', 'ungetbyte', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'ungetc', 'IoObject', 'ungetc', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'wait', 'IoObject', 'wait', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'wait_readable', 'IoObject', 'wait_readable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'wait_writable', 'IoObject', 'wait_writable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -915,6 +915,7 @@ gen.binding('IO', 'wait', 'IoObject', 'wait', argc: :any, pass_env: true, pass_b
 gen.binding('IO', 'wait_readable', 'IoObject', 'wait_readable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'wait_writable', 'IoObject', 'wait_writable', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('IO', 'write', 'IoObject', 'write', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('IO', 'write_nonblock', 'IoObject', 'write_nonblock', argc: 1, kwargs: [:exception], pass_env: true, pass_block: false, return_type: :Object)
 
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'abort', 'KernelModule', 'abort_method', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/io/write_nonblock_spec.rb
+++ b/spec/core/io/write_nonblock_spec.rb
@@ -1,0 +1,96 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/write'
+
+# See https://bugs.ruby-lang.org/issues/5954#note-5
+platform_is_not :windows do
+  describe "IO#write_nonblock on a file" do
+    before :each do
+      @filename = tmp("IO_syswrite_file") + $$.to_s
+      File.open(@filename, "w") do |file|
+        file.write_nonblock("012345678901234567890123456789")
+      end
+      @file = File.open(@filename, "r+")
+      @readonly_file = File.open(@filename)
+    end
+
+    after :each do
+      @file.close if @file
+      @readonly_file.close if @readonly_file
+      rm_r @filename
+    end
+
+    it "writes all of the string's bytes but does not buffer them" do
+      written = @file.write_nonblock("abcde")
+      written.should == 5
+      File.open(@filename) do |file|
+        file.sysread(10).should == "abcde56789"
+        file.seek(0)
+        @file.fsync
+        file.sysread(10).should == "abcde56789"
+      end
+    end
+
+    it "does not modify the passed argument" do
+      File.open(@filename, "w") do |f|
+        f.set_encoding(Encoding::IBM437)
+        # A character whose codepoint differs between UTF-8 and IBM437
+        f.write_nonblock("ƒ".freeze)
+      end
+
+      File.binread(@filename).bytes.should == [198, 146]
+    end
+
+    it "checks if the file is writable if writing zero bytes" do
+      -> {
+         @readonly_file.write_nonblock("")
+      }.should raise_error(IOError)
+    end
+  end
+
+  describe "IO#write_nonblock" do
+    it_behaves_like :io_write, :write_nonblock
+    it_behaves_like :io_write_no_transcode, :write_nonblock
+  end
+end
+
+describe 'IO#write_nonblock' do
+  before do
+    @read, @write = IO.pipe
+  end
+
+  after do
+    @read.close
+    @write.close
+  end
+
+  it "raises an exception extending IO::WaitWritable when the write would block" do
+    -> {
+      loop { @write.write_nonblock('a' * 10_000) }
+    }.should raise_error(IO::WaitWritable) { |e|
+      platform_is_not :windows do
+        e.should be_kind_of(Errno::EAGAIN)
+      end
+      platform_is :windows do
+        e.should be_kind_of(Errno::EWOULDBLOCK)
+      end
+    }
+  end
+
+  context "when exception option is set to false" do
+    it "returns :wait_writable when the operation would block" do
+      loop {
+        break if @write.write_nonblock("a" * 10_000, exception: false) == :wait_writable
+      }
+      @write.write_nonblock("a" * 10_000, exception: false).should == :wait_writable
+    end
+  end
+
+  platform_is_not :windows do
+    it 'sets the IO in nonblock mode' do
+      require 'io/nonblock'
+      @write.write_nonblock('a')
+      @write.should.nonblock?
+    end
+  end
+end

--- a/spec/library/io-wait/fixtures/classes.rb
+++ b/spec/library/io-wait/fixtures/classes.rb
@@ -1,0 +1,12 @@
+module IOWaitSpec
+  def self.exhaust_write_buffer(io)
+    written = 0
+    buf = " " * 4096
+
+    begin
+      written += io.write_nonblock(buf)
+    rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+      return written
+    end while true
+  end
+end

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -1,0 +1,144 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is ''...'3.2' do
+  require 'io/wait'
+end
+
+describe "IO#wait" do
+  before :each do
+    @io = File.new(__FILE__ )
+
+    if /mswin|mingw/ =~ RUBY_PLATFORM
+      require 'socket'
+      @r, @w = Socket.pair(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+    else
+      @r, @w = IO.pipe
+    end
+  end
+
+  after :each do
+    @io.close unless @io.closed?
+
+    @r.close unless @r.closed?
+    @w.close unless @w.closed?
+  end
+
+  context "[events, timeout] passed" do
+    ruby_version_is ""..."3.2" do
+      it "returns self when the READABLE event is ready during the timeout" do
+        @w.write('data to read')
+        @r.wait(IO::READABLE, 2).should.equal?(@r)
+      end
+
+      it "returns self when the WRITABLE event is ready during the timeout" do
+        @w.wait(IO::WRITABLE, 0).should.equal?(@w)
+      end
+    end
+
+    ruby_version_is "3.2" do
+      it "returns events mask when the READABLE event is ready during the timeout" do
+        @w.write('data to read')
+        @r.wait(IO::READABLE, 2).should == IO::READABLE
+      end
+
+      it "returns events mask when the WRITABLE event is ready during the timeout" do
+        @w.wait(IO::WRITABLE, 0).should == IO::WRITABLE
+      end
+    end
+
+    it "waits for the READABLE event to be ready" do
+      queue = Queue.new
+      thread = Thread.new { queue.pop; sleep 1; @w.write('data to read') };
+
+      queue.push('signal');
+      @r.wait(IO::READABLE, 2).should_not == nil
+
+      thread.join
+    end
+
+    it "waits for the WRITABLE event to be ready" do
+      written_bytes = IOWaitSpec.exhaust_write_buffer(@w)
+
+      queue = Queue.new
+      thread = Thread.new { queue.pop; sleep 1; @r.read(written_bytes) };
+
+      queue.push('signal');
+      @w.wait(IO::WRITABLE, 2).should_not == nil
+
+      thread.join
+    end
+
+    it "returns nil when the READABLE event is not ready during the timeout" do
+      @w.wait(IO::READABLE, 0).should == nil
+    end
+
+    it "returns nil when the WRITABLE event is not ready during the timeout" do
+      IOWaitSpec.exhaust_write_buffer(@w)
+      @w.wait(IO::WRITABLE, 0).should == nil
+    end
+
+    it "raises IOError when io is closed (closed stream (IOError))" do
+      @io.close
+      -> { @io.wait(IO::READABLE, 0) }.should raise_error(IOError, "closed stream")
+    end
+
+    ruby_version_is "3.2" do
+      it "raises ArgumentError when events is not positive" do
+        -> { @w.wait(0, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+        -> { @w.wait(-1, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+      end
+    end
+  end
+
+  context "[timeout, mode] passed" do
+    it "accepts :r, :read, :readable mode to check READABLE event" do
+      @io.wait(0, :r).should == @io
+      @io.wait(0, :read).should == @io
+      @io.wait(0, :readable).should == @io
+    end
+
+    it "accepts :w, :write, :writable mode to check WRITABLE event" do
+      @io.wait(0, :w).should == @io
+      @io.wait(0, :write).should == @io
+      @io.wait(0, :writable).should == @io
+    end
+
+    it "accepts :rw, :read_write, :readable_writable mode to check READABLE and WRITABLE events" do
+      @io.wait(0, :rw).should == @io
+      @io.wait(0, :read_write).should == @io
+      @io.wait(0, :readable_writable).should == @io
+    end
+
+    it "accepts a list of modes" do
+       @io.wait(0, :r, :w, :rw).should == @io
+    end
+
+    # It works at least since 2.7 but by some reason may fail on 3.1
+    ruby_version_is "3.2" do
+      it "accepts timeout and mode in any order" do
+        @io.wait(0, :r).should == @io
+        @io.wait(:r, 0).should == @io
+        @io.wait(:r, 0, :w).should == @io
+      end
+    end
+
+    it "raises ArgumentError when passed wrong Symbol value as mode argument" do
+      -> { @io.wait(0, :wrong) }.should raise_error(ArgumentError, "unsupported mode: wrong")
+    end
+
+    # It works since 3.0 but by some reason may fail on 3.1
+    ruby_version_is "3.2" do
+      it "raises ArgumentError when several Integer arguments passed" do
+        -> { @w.wait(0, 10, :r) }.should raise_error(ArgumentError, "timeout given more than once")
+      end
+    end
+
+    ruby_version_is "3.2" do
+      it "raises IOError when io is closed (closed stream (IOError))" do
+        @io.close
+        -> { @io.wait(0, :r) }.should raise_error(IOError, "closed stream")
+      end
+    end
+  end
+end

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -60,9 +60,9 @@ describe "IO#wait" do
     end
 
     it "waits for the WRITABLE event to be ready" do
-      NATFIXME 'Implement IO#write_nonblock', exception: NoMethodError, message: "undefined method `write_nonblock' for an instance of IO" do
-        written_bytes = IOWaitSpec.exhaust_write_buffer(@w)
+      written_bytes = IOWaitSpec.exhaust_write_buffer(@w)
 
+      NATFIXME 'Implement Queue', exception: NameError, message: 'uninitialized constant Queue' do
         queue = Queue.new
         thread = Thread.new { queue.pop; sleep 1; @r.read(written_bytes) };
 
@@ -78,10 +78,8 @@ describe "IO#wait" do
     end
 
     it "returns nil when the WRITABLE event is not ready during the timeout" do
-      NATFIXME 'Implement IO#write_nonblock', exception: NoMethodError, message: "undefined method `write_nonblock' for an instance of IO" do
-        IOWaitSpec.exhaust_write_buffer(@w)
-        @w.wait(IO::WRITABLE, 0).should == nil
-      end
+      IOWaitSpec.exhaust_write_buffer(@w)
+      @w.wait(IO::WRITABLE, 0).should == nil
     end
 
     it "raises IOError when io is closed (closed stream (IOError))" do

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -38,35 +38,43 @@ describe "IO#wait" do
 
     ruby_version_is "3.2" do
       it "returns events mask when the READABLE event is ready during the timeout" do
-        @w.write('data to read')
-        @r.wait(IO::READABLE, 2).should == IO::READABLE
+        NATFIXME 'returns events mask when the READABLE event is ready during the timeout', exception: SpecFailedException do
+          @w.write('data to read')
+          @r.wait(IO::READABLE, 2).should == IO::READABLE
+        end
       end
 
       it "returns events mask when the WRITABLE event is ready during the timeout" do
-        @w.wait(IO::WRITABLE, 0).should == IO::WRITABLE
+        NATFIXME 'returns events mask when the WRITABLE event is ready during the timeout', exception: SpecFailedException do
+          @w.wait(IO::WRITABLE, 0).should == IO::WRITABLE
+        end
       end
     end
 
     it "waits for the READABLE event to be ready" do
-      queue = Queue.new
-      thread = Thread.new { queue.pop; sleep 1; @w.write('data to read') };
+      NATFIXME 'Implement Queue', exception: NameError, message: 'uninitialized constant Queue' do
+        queue = Queue.new
+        thread = Thread.new { queue.pop; sleep 1; @w.write('data to read') };
 
-      queue.push('signal');
-      @r.wait(IO::READABLE, 2).should_not == nil
+        queue.push('signal');
+        @r.wait(IO::READABLE, 2).should_not == nil
 
-      thread.join
+        thread.join
+      end
     end
 
     it "waits for the WRITABLE event to be ready" do
-      written_bytes = IOWaitSpec.exhaust_write_buffer(@w)
+      NATFIXME 'Implement IO#write_nonblock', exception: NoMethodError, message: "undefined method `write_nonblock' for an instance of IO" do
+        written_bytes = IOWaitSpec.exhaust_write_buffer(@w)
 
-      queue = Queue.new
-      thread = Thread.new { queue.pop; sleep 1; @r.read(written_bytes) };
+        queue = Queue.new
+        thread = Thread.new { queue.pop; sleep 1; @r.read(written_bytes) };
 
-      queue.push('signal');
-      @w.wait(IO::WRITABLE, 2).should_not == nil
+        queue.push('signal');
+        @w.wait(IO::WRITABLE, 2).should_not == nil
 
-      thread.join
+        thread.join
+      end
     end
 
     it "returns nil when the READABLE event is not ready during the timeout" do
@@ -74,70 +82,92 @@ describe "IO#wait" do
     end
 
     it "returns nil when the WRITABLE event is not ready during the timeout" do
-      IOWaitSpec.exhaust_write_buffer(@w)
-      @w.wait(IO::WRITABLE, 0).should == nil
+      NATFIXME 'Implement IO#write_nonblock', exception: NoMethodError, message: "undefined method `write_nonblock' for an instance of IO" do
+        IOWaitSpec.exhaust_write_buffer(@w)
+        @w.wait(IO::WRITABLE, 0).should == nil
+      end
     end
 
     it "raises IOError when io is closed (closed stream (IOError))" do
       @io.close
-      -> { @io.wait(IO::READABLE, 0) }.should raise_error(IOError, "closed stream")
+      NATFIXME 'raises IOError when io is closed (closed stream (IOError))', exception: SpecFailedException do
+        -> { @io.wait(IO::READABLE, 0) }.should raise_error(IOError, "closed stream")
+      end
     end
 
     ruby_version_is "3.2" do
       it "raises ArgumentError when events is not positive" do
-        -> { @w.wait(0, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
-        -> { @w.wait(-1, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+        NATFIXME 'raises ArgumentError when events is not positive', exception: SpecFailedException do
+          -> { @w.wait(0, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+          -> { @w.wait(-1, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+        end
       end
     end
   end
 
   context "[timeout, mode] passed" do
     it "accepts :r, :read, :readable mode to check READABLE event" do
-      @io.wait(0, :r).should == @io
-      @io.wait(0, :read).should == @io
-      @io.wait(0, :readable).should == @io
+      NATFIXME 'accepts :r, :read, :readable mode to check READABLE event', exception: SpecFailedException do
+        @io.wait(0, :r).should == @io
+        @io.wait(0, :read).should == @io
+        @io.wait(0, :readable).should == @io
+      end
     end
 
     it "accepts :w, :write, :writable mode to check WRITABLE event" do
-      @io.wait(0, :w).should == @io
-      @io.wait(0, :write).should == @io
-      @io.wait(0, :writable).should == @io
+      NATFIXME 'accepts :w, :write, :writable mode to check WRITABLE event', exception: SpecFailedException do
+        @io.wait(0, :w).should == @io
+        @io.wait(0, :write).should == @io
+        @io.wait(0, :writable).should == @io
+      end
     end
 
     it "accepts :rw, :read_write, :readable_writable mode to check READABLE and WRITABLE events" do
-      @io.wait(0, :rw).should == @io
-      @io.wait(0, :read_write).should == @io
-      @io.wait(0, :readable_writable).should == @io
+      NATFIXME 'accepts :rw, :read_write, :readable_writable mode to check READABLE and WRITABLE events', exception: SpecFailedException do
+        @io.wait(0, :rw).should == @io
+        @io.wait(0, :read_write).should == @io
+        @io.wait(0, :readable_writable).should == @io
+      end
     end
 
     it "accepts a list of modes" do
-       @io.wait(0, :r, :w, :rw).should == @io
+      NATFIXME 'accepts a list of modes', exception: SpecFailedException do
+        @io.wait(0, :r, :w, :rw).should == @io
+      end
     end
 
     # It works at least since 2.7 but by some reason may fail on 3.1
     ruby_version_is "3.2" do
       it "accepts timeout and mode in any order" do
-        @io.wait(0, :r).should == @io
-        @io.wait(:r, 0).should == @io
-        @io.wait(:r, 0, :w).should == @io
+        NATFIXME 'accepts timeout and mode in any order', exception: SpecFailedException do
+          @io.wait(0, :r).should == @io
+          @io.wait(:r, 0).should == @io
+          @io.wait(:r, 0, :w).should == @io
+        end
       end
     end
 
     it "raises ArgumentError when passed wrong Symbol value as mode argument" do
-      -> { @io.wait(0, :wrong) }.should raise_error(ArgumentError, "unsupported mode: wrong")
+      NATFIXME 'raises ArgumentError when passed wrong Symbol value as mode argument', exception: SpecFailedException do
+        -> { @io.wait(0, :wrong) }.should raise_error(ArgumentError, "unsupported mode: wrong")
+      end
     end
 
     # It works since 3.0 but by some reason may fail on 3.1
     ruby_version_is "3.2" do
       it "raises ArgumentError when several Integer arguments passed" do
-        -> { @w.wait(0, 10, :r) }.should raise_error(ArgumentError, "timeout given more than once")
+        NATFIXME 'raises ArgumentError when several Integer arguments passed', exception: SpecFailedException do
+          -> { @w.wait(0, 10, :r) }.should raise_error(ArgumentError, "timeout given more than once")
+        end
       end
     end
 
     ruby_version_is "3.2" do
       it "raises IOError when io is closed (closed stream (IOError))" do
         @io.close
-        -> { @io.wait(0, :r) }.should raise_error(IOError, "closed stream")
+        NATFIXME 'raises IOError when io is closed (closed stream (IOError))', exception: SpecFailedException do
+          -> { @io.wait(0, :r) }.should raise_error(IOError, "closed stream")
+        end
       end
     end
   end

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -95,10 +95,8 @@ describe "IO#wait" do
 
     ruby_version_is "3.2" do
       it "raises ArgumentError when events is not positive" do
-        NATFIXME 'raises ArgumentError when events is not positive', exception: SpecFailedException do
-          -> { @w.wait(0, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
-          -> { @w.wait(-1, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
-        end
+        -> { @w.wait(0, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
+        -> { @w.wait(-1, 0) }.should raise_error(ArgumentError, "Events must be positive integer!")
       end
     end
   end

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -99,58 +99,44 @@ describe "IO#wait" do
 
   context "[timeout, mode] passed" do
     it "accepts :r, :read, :readable mode to check READABLE event" do
-      NATFIXME 'accepts :r, :read, :readable mode to check READABLE event', exception: SpecFailedException do
-        @io.wait(0, :r).should == @io
-        @io.wait(0, :read).should == @io
-        @io.wait(0, :readable).should == @io
-      end
+      @io.wait(0, :r).should == @io
+      @io.wait(0, :read).should == @io
+      @io.wait(0, :readable).should == @io
     end
 
     it "accepts :w, :write, :writable mode to check WRITABLE event" do
-      NATFIXME 'accepts :w, :write, :writable mode to check WRITABLE event', exception: SpecFailedException do
-        @io.wait(0, :w).should == @io
-        @io.wait(0, :write).should == @io
-        @io.wait(0, :writable).should == @io
-      end
+      @io.wait(0, :w).should == @io
+      @io.wait(0, :write).should == @io
+      @io.wait(0, :writable).should == @io
     end
 
     it "accepts :rw, :read_write, :readable_writable mode to check READABLE and WRITABLE events" do
-      NATFIXME 'accepts :rw, :read_write, :readable_writable mode to check READABLE and WRITABLE events', exception: SpecFailedException do
-        @io.wait(0, :rw).should == @io
-        @io.wait(0, :read_write).should == @io
-        @io.wait(0, :readable_writable).should == @io
-      end
+      @io.wait(0, :rw).should == @io
+      @io.wait(0, :read_write).should == @io
+      @io.wait(0, :readable_writable).should == @io
     end
 
     it "accepts a list of modes" do
-      NATFIXME 'accepts a list of modes', exception: SpecFailedException do
-        @io.wait(0, :r, :w, :rw).should == @io
-      end
+      @io.wait(0, :r, :w, :rw).should == @io
     end
 
     # It works at least since 2.7 but by some reason may fail on 3.1
     ruby_version_is "3.2" do
       it "accepts timeout and mode in any order" do
-        NATFIXME 'accepts timeout and mode in any order', exception: SpecFailedException do
-          @io.wait(0, :r).should == @io
-          @io.wait(:r, 0).should == @io
-          @io.wait(:r, 0, :w).should == @io
-        end
+        @io.wait(0, :r).should == @io
+        @io.wait(:r, 0).should == @io
+        @io.wait(:r, 0, :w).should == @io
       end
     end
 
     it "raises ArgumentError when passed wrong Symbol value as mode argument" do
-      NATFIXME 'raises ArgumentError when passed wrong Symbol value as mode argument', exception: SpecFailedException do
-        -> { @io.wait(0, :wrong) }.should raise_error(ArgumentError, "unsupported mode: wrong")
-      end
+      -> { @io.wait(0, :wrong) }.should raise_error(ArgumentError, "unsupported mode: wrong")
     end
 
     # It works since 3.0 but by some reason may fail on 3.1
     ruby_version_is "3.2" do
       it "raises ArgumentError when several Integer arguments passed" do
-        NATFIXME 'raises ArgumentError when several Integer arguments passed', exception: SpecFailedException do
-          -> { @w.wait(0, 10, :r) }.should raise_error(ArgumentError, "timeout given more than once")
-        end
+        -> { @w.wait(0, 10, :r) }.should raise_error(ArgumentError, "timeout given more than once")
       end
     end
 

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -38,16 +38,12 @@ describe "IO#wait" do
 
     ruby_version_is "3.2" do
       it "returns events mask when the READABLE event is ready during the timeout" do
-        NATFIXME 'returns events mask when the READABLE event is ready during the timeout', exception: SpecFailedException do
-          @w.write('data to read')
-          @r.wait(IO::READABLE, 2).should == IO::READABLE
-        end
+        @w.write('data to read')
+        @r.wait(IO::READABLE, 2).should == IO::READABLE
       end
 
       it "returns events mask when the WRITABLE event is ready during the timeout" do
-        NATFIXME 'returns events mask when the WRITABLE event is ready during the timeout', exception: SpecFailedException do
-          @w.wait(IO::WRITABLE, 0).should == IO::WRITABLE
-        end
+        @w.wait(IO::WRITABLE, 0).should == IO::WRITABLE
       end
     end
 

--- a/spec/library/io-wait/wait_spec.rb
+++ b/spec/library/io-wait/wait_spec.rb
@@ -90,9 +90,7 @@ describe "IO#wait" do
 
     it "raises IOError when io is closed (closed stream (IOError))" do
       @io.close
-      NATFIXME 'raises IOError when io is closed (closed stream (IOError))', exception: SpecFailedException do
-        -> { @io.wait(IO::READABLE, 0) }.should raise_error(IOError, "closed stream")
-      end
+      -> { @io.wait(IO::READABLE, 0) }.should raise_error(IOError, "closed stream")
     end
 
     ruby_version_is "3.2" do
@@ -165,9 +163,7 @@ describe "IO#wait" do
     ruby_version_is "3.2" do
       it "raises IOError when io is closed (closed stream (IOError))" do
         @io.close
-        NATFIXME 'raises IOError when io is closed (closed stream (IOError))', exception: SpecFailedException do
-          -> { @io.wait(0, :r) }.should raise_error(IOError, "closed stream")
-        end
+        -> { @io.wait(0, :r) }.should raise_error(IOError, "closed stream")
       end
     end
   end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -834,6 +834,10 @@ Value IoObject::ungetc(Env *env, Value c) {
     return ungetbyte(env, c->to_str(env));
 }
 
+Value IoObject::wait(Env *env, Args args) {
+    return NilObject::the();
+}
+
 Value IoObject::wait_readable(Env *env, Value timeout) {
     auto read_ios = new ArrayObject { this };
     auto select_result = IoObject::select(env, read_ios, nullptr, nullptr, timeout);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -835,6 +835,7 @@ Value IoObject::ungetc(Env *env, Value c) {
 }
 
 Value IoObject::wait(Env *env, Args args) {
+    raise_if_closed(env);
     return NilObject::the();
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -836,6 +836,13 @@ Value IoObject::ungetc(Env *env, Value c) {
 
 Value IoObject::wait(Env *env, Args args) {
     raise_if_closed(env);
+
+    if (args.size() == 2 && args[0]->is_integer() && args[1]->is_numeric()) {
+        const auto events = args[0]->to_int(env)->to_nat_int_t();
+        if (events <= 0)
+            env->raise("ArgumentError", "Events must be positive integer!");
+    }
+
     return NilObject::the();
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -1112,6 +1112,10 @@ void IoObject::build_constants(Env *, ClassObject *klass) {
     klass->const_set("SEEK_END"_s, Value::integer(SEEK_END));
     klass->const_set("SEEK_DATA"_s, Value::integer(SEEK_DATA));
     klass->const_set("SEEK_HOLE"_s, Value::integer(SEEK_HOLE));
+
+    klass->const_set("READABLE"_s, Value::integer(WAIT_READABLE));
+    klass->const_set("PRIORITY"_s, Value::integer(WAIT_PRIORITY));
+    klass->const_set("WRITABLE"_s, Value::integer(WAIT_WRITABLE));
 }
 
 }


### PR DESCRIPTION
And refactor `IO#wait_readable` and `IO#wait_writable` to use `IO#wait` to make the code more generic (which will become useful once we actually start working on the Fiber scheduler for IO). Include some minor refactors to reduce the code duplication when setting IO objects to nonblock.