### PR TITLE
Implement Zlib::GzipFile

### DIFF
--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -117,4 +117,36 @@ module Zlib
       end
     end
   end
+
+  class GzipFile
+    class Error < Zlib::Error; end
+
+    attr_writer :orig_name
+
+    def initialize(io)
+      @io = io
+      @closed = false
+    end
+
+    def close
+      @closed = true
+    end
+
+    def orig_name
+      raise GzipFile::Error, 'closed gzip stream' if @closed
+
+      @orig_name
+    end
+  end
+
+  class GzipWriter < GzipFile
+    class << self
+      def wrap(io)
+        gzip_writer = new(io)
+        yield(gzip_writer)
+      ensure
+        gzip_writer.close
+      end
+    end
+  end
 end

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -132,6 +132,10 @@ module Zlib
       @closed = true
     end
 
+    def closed?
+      @closed
+    end
+
     def comment
       raise GzipFile::Error, 'closed gzip stream' if @closed
 

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -121,7 +121,7 @@ module Zlib
   class GzipFile
     class Error < Zlib::Error; end
 
-    attr_writer :orig_name
+    attr_writer :comment, :orig_name
 
     def initialize(io)
       @io = io
@@ -130,6 +130,12 @@ module Zlib
 
     def close
       @closed = true
+    end
+
+    def comment
+      raise GzipFile::Error, 'closed gzip stream' if @closed
+
+      @comment
     end
 
     def orig_name

--- a/spec/library/zlib/gzipfile/close_spec.rb
+++ b/spec/library/zlib/gzipfile/close_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require 'stringio'
+require 'zlib'
+
+describe "Zlib::GzipFile#close" do
+  it "finishes the stream and closes the io" do
+    io = StringIO.new "".b
+    Zlib::GzipWriter.wrap io do |gzio|
+      gzio.close
+
+      gzio.should.closed?
+
+      -> { gzio.orig_name }.should \
+        raise_error(Zlib::GzipFile::Error, 'closed gzip stream')
+      -> { gzio.comment }.should \
+        raise_error(Zlib::GzipFile::Error, 'closed gzip stream')
+    end
+
+    io.string[10..-1].should == ([3] + Array.new(9,0)).pack('C*')
+  end
+end

--- a/spec/library/zlib/gzipfile/close_spec.rb
+++ b/spec/library/zlib/gzipfile/close_spec.rb
@@ -16,6 +16,8 @@ describe "Zlib::GzipFile#close" do
         raise_error(Zlib::GzipFile::Error, 'closed gzip stream')
     end
 
-    io.string[10..-1].should == ([3] + Array.new(9,0)).pack('C*')
+    NATFIXME 'Actually write the gzip file', exception: SpecFailedException do
+      io.string[10..-1].should == ([3] + Array.new(9,0)).pack('C*')
+    end
   end
 end

--- a/spec/library/zlib/gzipfile/closed_spec.rb
+++ b/spec/library/zlib/gzipfile/closed_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+require 'stringio'
+require 'zlib'
+
+describe "Zlib::GzipFile#closed?" do
+  it "returns the closed status" do
+    io = StringIO.new
+    Zlib::GzipWriter.wrap io do |gzio|
+      gzio.should_not.closed?
+
+      gzio.close
+
+      gzio.should.closed?
+    end
+  end
+end

--- a/spec/library/zlib/gzipfile/comment_spec.rb
+++ b/spec/library/zlib/gzipfile/comment_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'stringio'
+require 'zlib'
+
+describe "Zlib::GzipFile#comment" do
+  before :each do
+    @io = StringIO.new
+  end
+
+  it "returns the name" do
+    Zlib::GzipWriter.wrap @io do |gzio|
+      gzio.comment = 'name'
+
+      gzio.comment.should == 'name'
+    end
+  end
+
+  it "raises an error on a closed stream" do
+    Zlib::GzipWriter.wrap @io do |gzio|
+      gzio.close
+
+      -> { gzio.comment }.should \
+        raise_error(Zlib::GzipFile::Error, 'closed gzip stream')
+    end
+  end
+end

--- a/spec/library/zlib/gzipfile/orig_name_spec.rb
+++ b/spec/library/zlib/gzipfile/orig_name_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'stringio'
+require 'zlib'
+
+describe "Zlib::GzipFile#orig_name" do
+  before :each do
+    @io = StringIO.new
+  end
+
+  it "returns the name" do
+    Zlib::GzipWriter.wrap @io do |gzio|
+      gzio.orig_name = 'name'
+
+      gzio.orig_name.should == 'name'
+    end
+  end
+
+  it "raises an error on a closed stream" do
+    Zlib::GzipWriter.wrap @io do |gzio|
+      gzio.close
+
+      -> { gzio.orig_name }.should \
+        raise_error(Zlib::GzipFile::Error, 'closed gzip stream')
+    end
+  end
+end


### PR DESCRIPTION
This is a base class for `GzipReader` and `GzipWriter`, we need this as a framework to implement those.