### PR TITLE
Updates to Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Prerequisites:
 - libtool
 - GNU make
 - gcc or clang
-- Ruby 3.0 or higher with dev headers
+- Ruby 3.1 or higher with dev headers
   - Using [rbenv](https://github.com/rbenv/rbenv) to install Ruby is preferred.
-  - Installing [rbenv-aliases](https://github.com/tpope/rbenv-aliases) along with rbenv helps with matching Ruby versions like `3.0` to the latest patch release.
+  - Installing [rbenv-aliases](https://github.com/tpope/rbenv-aliases) along with rbenv helps with matching Ruby versions like `3.1` to the latest patch release.
   - If not using rbenv or another version manager, you'll need the `ruby` and `ruby-dev` package from your system.
 - ccache (optional, but recommended)
 - compiledb (optional, but recommended)

--- a/Rakefile
+++ b/Rakefile
@@ -268,7 +268,7 @@ DOCKER_FLAGS = '-e DOCKER=true ' +
     ''
   end
 
-DEFAULT_HOST_RUBY_VERSION = 'ruby3.2'.freeze
+DEFAULT_HOST_RUBY_VERSION = 'ruby3.3'.freeze
 
 task :docker_build_gcc do
   sh "docker build -t natalie_gcc_#{ruby_version_string} " \


### PR DESCRIPTION
* README: We need at least Ruby 3.1 to support the default hash arguments.
* Rakefile: Make Ruby 3.3 the default.