### PR TITLE
Small cleanups in StringIO

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -1,4 +1,6 @@
 class StringIO
+  VERSION = '3.1.0'.freeze
+
   attr_reader :string, :lineno
 
   private def initialize(string = '', mode = nil)

--- a/spec/library/stringio/inspect_spec.rb
+++ b/spec/library/stringio/inspect_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require "stringio"
+
+describe "StringIO#inspect" do
+  it "returns the same as #to_s" do
+    io = StringIO.new("example")
+    io.inspect.should == io.to_s
+  end
+
+  it "does not include the contents" do
+    io = StringIO.new("contents")
+    io.inspect.should_not include("contents")
+  end
+
+  it "uses the regular Object#inspect without any instance variable" do
+    io = StringIO.new("example")
+    io.inspect.should =~ /\A#<StringIO:0x\h+>\z/
+  end
+end

--- a/spec/library/stringio/path_spec.rb
+++ b/spec/library/stringio/path_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "StringIO#path" do
+  it "is not defined" do
+    -> { StringIO.new("path").path }.should raise_error(NoMethodError)
+  end
+end


### PR DESCRIPTION
* Define a `VERSION`, this is required for the specs of `each` and `each_line`
* Import passing specs.