### PR TITLE
Add some additional read/write methods to StringIO

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -209,6 +209,14 @@ class StringIO
     end
   end
 
+  def read_nonblock(length = nil, buffer = nil, exception: true)
+    result = read(length, buffer)
+    if length&.to_int&.positive? && (result.nil? || result.empty?)
+      raise EOFError, 'end of file reached'
+    end
+    result
+  end
+
   def set_encoding(external_encoding, _ = nil, **_options)
     @external_encoding = external_encoding || Encoding.default_external
     unless @string.frozen?

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -216,6 +216,7 @@ class StringIO
     end
     result
   end
+  alias sysread read_nonblock
 
   def set_encoding(external_encoding, _ = nil, **_options)
     @external_encoding = external_encoding || Encoding.default_external

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -305,6 +305,7 @@ class StringIO
   end
 
   alias << write
+  alias syswrite write
 
   def write_nonblock(argument, exception: true)
     write(argument)

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -306,6 +306,10 @@ class StringIO
 
   alias << write
 
+  def write_nonblock(argument, exception: true)
+    write(argument)
+  end
+
   private def __assert_not_read_closed
     raise IOError, 'not opened for reading' if closed_read?
   end

--- a/spec/library/stringio/read_nonblock_spec.rb
+++ b/spec/library/stringio/read_nonblock_spec.rb
@@ -1,0 +1,55 @@
+require_relative '../../spec_helper'
+require "stringio"
+require_relative 'shared/read'
+require_relative 'shared/sysread'
+
+describe "StringIO#read_nonblock when passed length, buffer" do
+  it_behaves_like :stringio_read, :read_nonblock
+
+  it "accepts :exception option" do
+    io = StringIO.new("example")
+    io.read_nonblock(3, buffer = "", exception: true)
+    buffer.should == "exa"
+  end
+end
+
+describe "StringIO#read_nonblock when passed length" do
+  it_behaves_like :stringio_read_length, :read_nonblock
+
+  it "accepts :exception option" do
+    io = StringIO.new("example")
+    io.read_nonblock(3, exception: true).should == "exa"
+  end
+end
+
+describe "StringIO#read_nonblock when passed nil" do
+  it_behaves_like :stringio_read_nil, :read_nonblock
+end
+
+describe "StringIO#read_nonblock when passed length" do
+  it_behaves_like :stringio_sysread_length, :read_nonblock
+end
+
+describe "StringIO#read_nonblock" do
+
+  it "accepts an exception option" do
+    stringio = StringIO.new('foo')
+    stringio.read_nonblock(3, exception: false).should == 'foo'
+  end
+
+  context "when exception option is set to false" do
+    context "when the end is reached" do
+      it "returns nil" do
+        stringio = StringIO.new('')
+        stringio << "hello"
+        NATFIXME 'Implement StringIO#rewind', exception: NoMethodError, message: "undefined method `rewind' for an instance of StringIO" do
+          stringio.rewind
+
+          stringio.read_nonblock(5).should == "hello"
+          stringio.read_nonblock(5, exception: false).should be_nil
+        end
+      end
+    end
+  end
+
+end

--- a/spec/library/stringio/shared/sysread.rb
+++ b/spec/library/stringio/shared/sysread.rb
@@ -1,0 +1,15 @@
+describe :stringio_sysread_length, shared: true do
+  before :each do
+    @io = StringIO.new("example")
+  end
+
+  it "returns an empty String when passed 0 and no data remains" do
+    @io.send(@method, 8).should == "example"
+    @io.send(@method, 0).should == ""
+  end
+
+  it "raises an EOFError when passed length > 0 and no data remains" do
+    @io.read.should == "example"
+    -> { @io.send(@method, 1) }.should raise_error(EOFError)
+  end
+end

--- a/spec/library/stringio/sysread_spec.rb
+++ b/spec/library/stringio/sysread_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../spec_helper'
+require "stringio"
+require_relative 'shared/read'
+
+describe "StringIO#sysread when passed length, buffer" do
+  it_behaves_like :stringio_read, :sysread
+end
+
+describe "StringIO#sysread when passed [length]" do
+  it_behaves_like :stringio_read_length, :sysread
+end
+
+describe "StringIO#sysread when passed no arguments" do
+  it_behaves_like :stringio_read_no_arguments, :sysread
+
+  it "returns an empty String if at EOF" do
+    @io.sysread.should == "example"
+    @io.sysread.should == ""
+  end
+end
+
+describe "StringIO#sysread when self is not readable" do
+  it_behaves_like :stringio_read_not_readable, :sysread
+end
+
+describe "StringIO#sysread when passed nil" do
+  it_behaves_like :stringio_read_nil, :sysread
+
+  it "returns an empty String if at EOF" do
+    @io.sysread(nil).should == "example"
+    @io.sysread(nil).should == ""
+  end
+end
+
+describe "StringIO#sysread when passed [length]" do
+  before :each do
+    @io = StringIO.new("example")
+  end
+
+  it "raises an EOFError when self's position is at the end" do
+    @io.pos = 7
+    -> { @io.sysread(10) }.should raise_error(EOFError)
+  end
+
+  it "returns an empty String when length is 0" do
+    @io.sysread(0).should == ""
+  end
+end

--- a/spec/library/stringio/syswrite_spec.rb
+++ b/spec/library/stringio/syswrite_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/write'
+
+describe "StringIO#syswrite when passed [Object]" do
+  it_behaves_like :stringio_write, :syswrite
+end
+
+describe "StringIO#syswrite when passed [String]" do
+  it_behaves_like :stringio_write_string, :syswrite
+end
+
+describe "StringIO#syswrite when self is not writable" do
+  it_behaves_like :stringio_write_not_writable, :syswrite
+end
+
+describe "StringIO#syswrite when in append mode" do
+  it_behaves_like :stringio_write_append, :syswrite
+end

--- a/spec/library/stringio/write_nonblock_spec.rb
+++ b/spec/library/stringio/write_nonblock_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/write'
+
+describe "StringIO#write_nonblock when passed [Object]" do
+  it_behaves_like :stringio_write, :write_nonblock
+end
+
+describe "StringIO#write_nonblock when passed [String]" do
+  it_behaves_like :stringio_write_string, :write_nonblock
+
+  it "accepts :exception option" do
+    io = StringIO.new("12345", "a")
+    io.write_nonblock("67890", exception: true)
+    io.string.should == "1234567890"
+  end
+end
+
+describe "StringIO#write_nonblock when self is not writable" do
+  it_behaves_like :stringio_write_not_writable, :write_nonblock
+end
+
+describe "StringIO#write_nonblock when in append mode" do
+  it_behaves_like :stringio_write_append, :write_nonblock
+end


### PR DESCRIPTION
Specifically the `sys` and `_nonblock` versions, which are simply the same as the regular read and write when working with an internal string buffer. 