### PR TITLE
Implement StringIO#closed?

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -37,6 +37,10 @@ class StringIO
     nil
   end
 
+  def closed?
+    closed_read? && closed_write?
+  end
+
   def close_read
     @read_closed = true
     nil

--- a/spec/library/stringio/closed_spec.rb
+++ b/spec/library/stringio/closed_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "StringIO#closed?" do
+  it "returns true if self is completely closed" do
+    io = StringIO.new("example", "r+")
+    io.close_read
+    io.closed?.should be_false
+    io.close_write
+    io.closed?.should be_true
+
+    io = StringIO.new("example", "r+")
+    io.close
+    io.closed?.should be_true
+  end
+end


### PR DESCRIPTION
This should fix the crash in the specs of `StringIO#readpartial`