### PR TITLE
Implement first version Zlib::Deflate#deflate

### DIFF
--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -99,7 +99,6 @@ void Zlib_do_deflate(Env *env, Value self, const String &string, int flush) {
             int have = ZLIB_BUF_SIZE - strm->avail_out;
             result->append((char *)out, have);
         } while (strm->avail_out == 0);
-        assert(strm->avail_in == 0);
     } while (index < string.length());
 }
 

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -112,6 +112,18 @@ Value Zlib_deflate_append(Env *env, Value self, Args args, Block *) {
     return self;
 }
 
+Value Zlib_deflate_deflate(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_between(env, 1, 2);
+    auto string = args[0]->as_string_or_raise(env);
+    auto flush = Z_NO_FLUSH;
+    if (auto flush_obj = args.at(1, nullptr); flush_obj)
+        flush = flush_obj->as_integer_or_raise(env)->to_nat_int_t();
+
+    Zlib_do_deflate(env, self, string->string(), flush);
+
+    return string;
+}
+
 Value Zlib_deflate_set_dictionary(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
     auto dictionary = args.at(0)->to_str(env);

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -55,7 +55,7 @@ Value Zlib_deflate_initialize(Env *env, Value self, Args args, Block *) {
 
     auto stream = new z_stream {};
     self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_stream_cleanup));
-    self->ivar_set(env, "@result"_s, new StringObject);
+    self->ivar_set(env, "@result"_s, new StringObject("", Encoding::ASCII_8BIT));
     auto in = new unsigned char[ZLIB_BUF_SIZE];
     self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
@@ -120,7 +120,7 @@ Value Zlib_deflate_deflate(Env *env, Value self, Args args, Block *) {
 
     Zlib_do_deflate(env, self, string->string(), flush);
 
-    return string;
+    return self->ivar_get(env, "@result"_s);
 }
 
 Value Zlib_deflate_set_dictionary(Env *env, Value self, Args args, Block *) {

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -78,6 +78,7 @@ module Zlib
   class Deflate < ZStream
     __bind_method__ :initialize, :Zlib_deflate_initialize
     __bind_method__ :<<, :Zlib_deflate_append
+    __bind_method__ :deflate, :Zlib_deflate_deflate
     __bind_method__ :set_dictionary, :Zlib_deflate_set_dictionary
     __bind_method__ :finish, :Zlib_deflate_finish
     __bind_method__ :close, :Zlib_deflate_close

--- a/spec/library/zlib/deflate/deflate_spec.rb
+++ b/spec/library/zlib/deflate/deflate_spec.rb
@@ -43,10 +43,10 @@ describe "Zlib::Deflate#deflate" do
   it "deflates some data" do
     data = "\000" * 10
 
-    NATFIXME 'Implement Zlib::Deflate#deflate', exception: NoMethodError, message: "undefined method `deflate' for an instance of Zlib::Deflate" do
-      zipped = @deflator.deflate data, Zlib::FINISH
-      @deflator.finish
+    zipped = @deflator.deflate data, Zlib::FINISH
+    @deflator.finish
 
+    NATFIXME 'Mark as binary and set size', exception: SpecFailedException do
       zipped.should == [120, 156, 99, 96, 128, 1, 0, 0, 10, 0, 1].pack('C*')
     end
   end
@@ -54,10 +54,10 @@ describe "Zlib::Deflate#deflate" do
   it "deflates lots of data" do
     data = "\000" * 32 * 1024
 
-    NATFIXME 'Implement Zlib::Deflate#deflate', exception: NoMethodError, message: "undefined method `deflate' for an instance of Zlib::Deflate" do
-      zipped = @deflator.deflate data, Zlib::FINISH
-      @deflator.finish
+    zipped = @deflator.deflate data, Zlib::FINISH
+    @deflator.finish
 
+    NATFIXME 'Mark as binary and set size', exception: SpecFailedException do
       zipped.should == ([120, 156, 237, 193, 1, 1, 0, 0] +
                         [0, 128, 144, 254, 175, 238, 8, 10] +
                         Array.new(31, 0) +
@@ -66,7 +66,7 @@ describe "Zlib::Deflate#deflate" do
   end
 
   it "has a binary encoding" do
-    NATFIXME 'Implement Zlib::Deflate#deflate', exception: NoMethodError, message: "undefined method `deflate'" do
+    NATFIXME 'Fix binary encoding', exception: SpecFailedException do
       @deflator.deflate("").encoding.should == Encoding::BINARY
       @deflator.finish.encoding.should == Encoding::BINARY
     end
@@ -88,10 +88,8 @@ describe "Zlib::Deflate#deflate" do
       2.times do
         @input = @random_generator.bytes(20000)
         @original << @input
-        NATFIXME 'Implement Zlib::Deflate#deflate', exception: NoMethodError, message: "undefined method `deflate'" do
-          @deflator.deflate(@input) do |chunk|
-            @chunks << chunk
-          end
+        @deflator.deflate(@input) do |chunk|
+          @chunks << chunk
         end
       end
     end
@@ -113,9 +111,7 @@ describe "Zlib::Deflate#deflate" do
     it "deflates chunked data without errors" do
       final = @deflator.finish
       @chunks << final
-      NATFIXME 'deflates chunked data', exception: SpecFailedException do
-        @original.should == Zlib.inflate(@chunks.join)
-      end
+      @original.should == Zlib.inflate(@chunks.join)
     end
 
   end
@@ -123,11 +119,9 @@ describe "Zlib::Deflate#deflate" do
   describe "with break" do
     before :each do
       @input = @random_generator.bytes(20000)
-      NATFIXME 'Implement Zlib::Deflate#deflate', exception: NoMethodError, message: "undefined method `deflate'" do
-        @deflator.deflate(@input) do |chunk|
-          @chunks << chunk
-          break
-        end
+      @deflator.deflate(@input) do |chunk|
+        @chunks << chunk
+        break
       end
     end
 
@@ -148,9 +142,7 @@ describe "Zlib::Deflate#deflate" do
     it "deflates chunked data without errors" do
       final = @deflator.finish
       @chunks << final
-      NATFIXME 'deflates chunked data', exception: SpecFailedException do
-        @input.should == Zlib.inflate(@chunks.join)
-      end
+      @input.should == Zlib.inflate(@chunks.join)
     end
 
   end

--- a/spec/library/zlib/deflate/deflate_spec.rb
+++ b/spec/library/zlib/deflate/deflate_spec.rb
@@ -46,9 +46,7 @@ describe "Zlib::Deflate#deflate" do
     zipped = @deflator.deflate data, Zlib::FINISH
     @deflator.finish
 
-    NATFIXME 'Mark as binary and set size', exception: SpecFailedException do
-      zipped.should == [120, 156, 99, 96, 128, 1, 0, 0, 10, 0, 1].pack('C*')
-    end
+    zipped.should == [120, 156, 99, 96, 128, 1, 0, 0, 10, 0, 1].pack('C*')
   end
 
   it "deflates lots of data" do
@@ -57,7 +55,7 @@ describe "Zlib::Deflate#deflate" do
     zipped = @deflator.deflate data, Zlib::FINISH
     @deflator.finish
 
-    NATFIXME 'Mark as binary and set size', exception: SpecFailedException do
+    NATFIXME 'Large data still breaks', exception: SpecFailedException do
       zipped.should == ([120, 156, 237, 193, 1, 1, 0, 0] +
                         [0, 128, 144, 254, 175, 238, 8, 10] +
                         Array.new(31, 0) +
@@ -66,10 +64,8 @@ describe "Zlib::Deflate#deflate" do
   end
 
   it "has a binary encoding" do
-    NATFIXME 'Fix binary encoding', exception: SpecFailedException do
-      @deflator.deflate("").encoding.should == Encoding::BINARY
-      @deflator.finish.encoding.should == Encoding::BINARY
-    end
+    @deflator.deflate("").encoding.should == Encoding::BINARY
+    @deflator.finish.encoding.should == Encoding::BINARY
   end
 end
 


### PR DESCRIPTION
It still breaks when given huge input (the same issue is probably present in `Zlib::Deflate#<<`, but not tested in the specs), and does not support blocks.