### PR TITLE
Fix return value of StringIO#set_encoding

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -242,7 +242,7 @@ class StringIO
     unless @string.frozen?
       @string.force_encoding(@external_encoding)
     end
-    @external_encoding
+    self
   end
 
   def size

--- a/spec/library/stringio/set_encoding_spec.rb
+++ b/spec/library/stringio/set_encoding_spec.rb
@@ -3,8 +3,7 @@ require_relative '../../spec_helper'
 
 describe "StringIO#set_encoding" do
   it "sets the encoding of the underlying String if the String is not frozen" do
-    # str = "".encode(Encoding::US_ASCII)
-    str = "".encode(Encoding::BINARY)
+    str = "".encode(Encoding::US_ASCII)
 
     io = StringIO.new(str)
     io.set_encoding Encoding::UTF_8
@@ -12,12 +11,10 @@ describe "StringIO#set_encoding" do
   end
 
   it "does not set the encoding of the underlying String if the String is frozen" do
-    # str = "".encode(Encoding::US_ASCII).freeze
-    str = "".encode(Encoding::BINARY).freeze
+    str = "".encode(Encoding::US_ASCII).freeze
 
     io = StringIO.new(str)
     io.set_encoding Encoding::UTF_8
-    # io.string.encoding.should == Encoding::US_ASCII
-    io.string.encoding.should == Encoding::BINARY
+    io.string.encoding.should == Encoding::US_ASCII
   end
 end

--- a/spec/library/stringio/shared/write.rb
+++ b/spec/library/stringio/shared/write.rb
@@ -86,12 +86,12 @@ describe :stringio_write_string, shared: true do
   it "transcodes the given string when the external encoding is set and neither is BINARY" do
     utf8_str = "hello"
     io = StringIO.new.set_encoding(Encoding::UTF_16BE)
-    NATFIXME 'Fix return value of StringIO#set_encoding', exception: NoMethodError, message: "undefined method `external_encoding' for an instance of Encoding" do
-      io.external_encoding.should == Encoding::UTF_16BE
+    io.external_encoding.should == Encoding::UTF_16BE
 
-      io.send(@method, utf8_str)
+    io.send(@method, utf8_str)
 
-      expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+    expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+    NATFIXME 'transcodes the given string when the external encoding is set and neither is BINARY', exception: SpecFailedException do
       io.string.bytes.should == expected
     end
   end
@@ -99,13 +99,11 @@ describe :stringio_write_string, shared: true do
   it "does not transcode the given string when the external encoding is set and the string encoding is BINARY" do
     str = "été".b
     io = StringIO.new.set_encoding(Encoding::UTF_16BE)
-    NATFIXME 'Fix return value of StringIO#set_encoding', exception: NoMethodError, message: "undefined method `external_encoding' for an instance of Encoding" do
-      io.external_encoding.should == Encoding::UTF_16BE
+    io.external_encoding.should == Encoding::UTF_16BE
 
-      io.send(@method, str)
+    io.send(@method, str)
 
-      io.string.bytes.should == str.bytes
-    end
+    io.string.bytes.should == str.bytes
   end
 end
 

--- a/spec/library/stringio/shared/write.rb
+++ b/spec/library/stringio/shared/write.rb
@@ -44,6 +44,69 @@ describe :stringio_write_string, shared: true do
     @io.send(@method, 'test')
     @io.pos.should eql(4)
   end
+
+  # NATFIXME: Concurrency, we probably need a mutex
+  xit "handles concurrent writes correctly" do
+    @io = StringIO.new
+    n = 8
+    go = false
+    threads = n.times.map { |i|
+      Thread.new {
+        Thread.pass until go
+        @io.write i.to_s
+      }
+    }
+    go = true
+    threads.each(&:join)
+    @io.string.size.should == n.times.map(&:to_s).join.size
+  end
+
+  it "handles writing non-ASCII UTF-8 after seek" do
+    @io.binmode
+    @io << "\x80"
+    @io.pos = 0
+    @io << "\x81"
+    @io.string.should == "\x812345".b
+  end
+
+  it "handles writing with position < buffer size" do
+    @io.pos = 2
+    @io.write "abc"
+    @io.string.should == "12abc"
+
+    @io.pos = 2
+    @io.write "de"
+    @io.string.should == "12dec"
+
+    @io.pos = 2
+    @io.write "fghi"
+    @io.string.should == "12fghi"
+  end
+
+  it "transcodes the given string when the external encoding is set and neither is BINARY" do
+    utf8_str = "hello"
+    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
+    NATFIXME 'Fix return value of StringIO#set_encoding', exception: NoMethodError, message: "undefined method `external_encoding' for an instance of Encoding" do
+      io.external_encoding.should == Encoding::UTF_16BE
+
+      io.send(@method, utf8_str)
+
+      expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+      io.string.bytes.should == expected
+    end
+  end
+
+  it "does not transcode the given string when the external encoding is set and the string encoding is BINARY" do
+    str = "été".b
+    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
+    NATFIXME 'Fix return value of StringIO#set_encoding', exception: NoMethodError, message: "undefined method `external_encoding' for an instance of Encoding" do
+      io.external_encoding.should == Encoding::UTF_16BE
+
+      io.send(@method, str)
+
+      io.string.bytes.should == str.bytes
+    end
+  end
 end
 
 describe :stringio_write_not_writable, shared: true do


### PR DESCRIPTION
Which is not tested in its own specs, but the specs of `StringIO#write` depend on its behaviour.