### PR TITLE
Implement StringIO#each_codepoint

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -101,6 +101,12 @@ class StringIO
     self
   end
 
+  def each_codepoint
+    return enum_for(:each_codepoint) unless block_given?
+
+    each_char { |c| yield c.ord }
+  end
+
   def eof?
     @index >= @string.length
   end

--- a/spec/library/stringio/each_codepoint_spec.rb
+++ b/spec/library/stringio/each_codepoint_spec.rb
@@ -1,0 +1,9 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/codepoints'
+
+# See redmine #1667
+describe "StringIO#each_codepoint" do
+  it_behaves_like :stringio_codepoints, :each_codepoint
+end

--- a/spec/library/stringio/shared/codepoints.rb
+++ b/spec/library/stringio/shared/codepoints.rb
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+describe :stringio_codepoints, shared: true do
+  before :each do
+    @io = StringIO.new("∂φ/∂x = gaîté")
+    @enum = @io.send(@method)
+  end
+
+  it "returns an Enumerator" do
+    @enum.should be_an_instance_of(Enumerator)
+  end
+
+  it "yields each codepoint code in turn" do
+    @enum.to_a.should == [8706, 966, 47, 8706, 120, 32, 61, 32, 103, 97, 238, 116, 233]
+  end
+
+  it "yields each codepoint starting from the current position" do
+    @io.pos = 15
+    @enum.to_a.should == [238, 116, 233]
+  end
+
+  it "raises an error if reading invalid sequence" do
+    @io.pos = 1  # inside of a multibyte sequence
+    -> { @enum.first }.should raise_error(ArgumentError)
+  end
+
+  it "raises an IOError if not readable" do
+    @io.close_read
+    -> { @enum.to_a }.should raise_error(IOError)
+
+    io = StringIO.new("xyz", "w")
+    -> { io.send(@method).to_a }.should raise_error(IOError)
+  end
+
+
+  it "calls the given block" do
+    r  = []
+    @io.send(@method){|c| r << c }
+    r.should == [8706, 966, 47, 8706, 120, 32, 61, 32, 103, 97, 238, 116, 233]
+  end
+
+  it "returns self" do
+    @io.send(@method) {|l| l }.should equal(@io)
+  end
+
+end

--- a/spec/library/stringio/shared/codepoints.rb
+++ b/spec/library/stringio/shared/codepoints.rb
@@ -15,12 +15,16 @@ describe :stringio_codepoints, shared: true do
 
   it "yields each codepoint starting from the current position" do
     @io.pos = 15
-    @enum.to_a.should == [238, 116, 233]
+    NATFIXME 'Use index for byte count instead of character count', exception: SpecFailedException do
+      @enum.to_a.should == [238, 116, 233]
+    end
   end
 
   it "raises an error if reading invalid sequence" do
     @io.pos = 1  # inside of a multibyte sequence
-    -> { @enum.first }.should raise_error(ArgumentError)
+    NATFIXME 'Use index for byte count instead of character count', exception: SpecFailedException do
+      -> { @enum.first }.should raise_error(ArgumentError)
+    end
   end
 
   it "raises an IOError if not readable" do


### PR DESCRIPTION
By the looks of it, we have to treat the index value as a byte based instead of character based. This might affect some other methods as well, and the other specs don't do much with multibyte characters. Fixing these last two issues is going to be nasty.