### PR TITLE
Add mutex to StringIO

### DIFF
--- a/spec/library/stringio/putc_spec.rb
+++ b/spec/library/stringio/putc_spec.rb
@@ -43,15 +43,12 @@ describe "StringIO#putc when passed [String]" do
     threads = n.times.map { |i|
       Thread.new {
         Thread.pass until go
-        # NATFIXME: occasional "negative argument" in stringio.rb:289
-        #@io.putc i.to_s
+        @io.putc i.to_s
       }
     }
     go = true
     threads.each(&:join)
-    NATFIXME 'wrong number', exception: SpecFailedException do
-      @io.string.size.should == n
-    end
+    @io.string.size.should == n
   end
 end
 

--- a/spec/library/stringio/shared/write.rb
+++ b/spec/library/stringio/shared/write.rb
@@ -45,8 +45,7 @@ describe :stringio_write_string, shared: true do
     @io.pos.should eql(4)
   end
 
-  # NATFIXME: Concurrency, we probably need a mutex
-  xit "handles concurrent writes correctly" do
+  it "handles concurrent writes correctly" do
     @io = StringIO.new
     n = 8
     go = false


### PR DESCRIPTION
For now it only wraps the write operations, since those are the only one with concurrency specs. The read operations should probably use this same mutex as well.