### PR TITLE
Add OpenSSL::PKey::RSA

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -163,6 +163,19 @@ module OpenSSL
     class KDFError < OpenSSLError; end
   end
 
+  module PKey
+    class PKeyError < OpenSSLError; end
+    class RSAError < PKeyError; end
+
+    class RSA
+      __bind_method__ :initialize, :OpenSSL_PKey_RSA_initialize
+      __bind_method__ :export, :OpenSSL_PKey_RSA_export
+
+      alias to_pem export
+      alias to_s export
+    end
+  end
+
   module X509
     class NameError < OpenSSLError; end
 


### PR DESCRIPTION
For now this is limited to creating a key and exporting it to PEM.

This change is good enough to get https://github.com/ruby/spec/blob/master/library/openssl/x509/store/verify_spec.rb to pass one more line.