### PR TITLE
Add OpenSSL::X509::Certificate

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -37,6 +37,11 @@ static void OpenSSL_SSL_cleanup(VoidPObject *self) {
     SSL_free(ssl);
 }
 
+static void OpenSSL_X509_cleanup(VoidPObject *self) {
+    auto x509 = static_cast<X509 *>(self->void_ptr());
+    X509_free(x509);
+}
+
 static void OpenSSL_X509_NAME_cleanup(VoidPObject *self) {
     auto name = static_cast<X509_NAME *>(self->void_ptr());
     X509_NAME_free(name);
@@ -398,6 +403,18 @@ Value OpenSSL_PKey_RSA_export(Env *env, Value self, Args args, Block *) {
     if (size <= 0)
         OpenSSL_raise_error(env, "BIO_get_mem_data");
     return new StringObject { data, static_cast<size_t>(size) };
+}
+
+Value OpenSSL_X509_Certificate_initialize(Env *env, Value self, Args args, Block *) {
+    // NATFIXME: Support arguments
+    args.ensure_argc_is(env, 0);
+
+    X509 *x509 = X509_new();
+    if (!x509)
+        OpenSSL_raise_error(env, "X509_new");
+    self->ivar_set(env, "@x509"_s, new VoidPObject { x509, OpenSSL_X509_cleanup });
+
+    return self;
 }
 
 Value OpenSSL_KDF_pbkdf2_hmac(Env *env, Value self, Args args, Block *) {

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -417,6 +417,30 @@ Value OpenSSL_X509_Certificate_initialize(Env *env, Value self, Args args, Block
     return self;
 }
 
+Value OpenSSL_X509_Certificate_version(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    const auto version = X509_get_version(x509);
+    return Value::integer(version);
+}
+
+Value OpenSSL_X509_Certificate_set_version(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+
+    const auto version = args[0]->to_int(env)->to_nat_int_t();
+    if (version < 0) {
+        auto CertificateError = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "CertificateError"_s })->as_class();
+        env->raise(CertificateError, "version must be >= 0!");
+    }
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    if (!X509_set_version(x509, version))
+        OpenSSL_raise_error(env, "X509_set_version");
+
+    return args[0];
+}
+
 Value OpenSSL_KDF_pbkdf2_hmac(Env *env, Value self, Args args, Block *) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_is(env, 1);

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -179,6 +179,10 @@ module OpenSSL
   module X509
     class NameError < OpenSSLError; end
 
+    class Certificate
+      __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
+    end
+
     class Name
       OBJECT_TYPE_TEMPLATE = {
         'C'               => ASN1::PRINTABLESTRING,

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -177,10 +177,13 @@ module OpenSSL
   end
 
   module X509
+    class CertificateError < OpenSSLError; end
     class NameError < OpenSSLError; end
 
     class Certificate
       __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
+      __bind_method__ :version, :OpenSSL_X509_Certificate_version
+      __bind_method__ :version=, :OpenSSL_X509_Certificate_set_version
     end
 
     class Name

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -1,0 +1,78 @@
+require_relative '../../../../spec_helper'
+require 'openssl'
+
+describe "OpenSSL::X509::Store#verify" do
+  it "returns true for valid certificate" do
+    key = OpenSSL::PKey::RSA.new 2048
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 10
+    cert.not_after = cert.not_before + 365 * 24 * 60 * 60
+    cert.sign key, OpenSSL::Digest.new('SHA256')
+    store = OpenSSL::X509::Store.new
+    store.add_cert(cert)
+    [store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
+  end
+
+  it "returns false for an expired certificate" do
+    key = OpenSSL::PKey::RSA.new 2048
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 10
+    cert.not_after = Time.now - 5
+    cert.sign key, OpenSSL::Digest.new('SHA256')
+    store = OpenSSL::X509::Store.new
+    store.add_cert(cert)
+    store.verify(cert).should == false
+  end
+
+  it "returns false for an expired root certificate" do
+    root_key = OpenSSL::PKey::RSA.new 2048
+    root_cert = OpenSSL::X509::Certificate.new
+    root_cert.version = 2
+    root_cert.serial = 1
+    root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+    root_cert.issuer = root_cert.subject
+    root_cert.public_key = root_key.public_key
+    root_cert.not_before = Time.now - 10
+    root_cert.not_after = Time.now - 5
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ef.subject_certificate = root_cert
+    ef.issuer_certificate = root_cert
+    root_cert.add_extension(ef.create_extension("basicConstraints","CA:TRUE",true))
+    root_cert.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
+    root_cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
+    root_cert.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
+    root_cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+
+
+    key = OpenSSL::PKey::RSA.new 2048
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 2
+    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby certificate"
+    cert.issuer = root_cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ef.subject_certificate = cert
+    ef.issuer_certificate = root_cert
+    cert.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
+    cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
+    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+
+    store = OpenSSL::X509::Store.new
+    store.add_cert(root_cert)
+    store.add_cert(cert)
+    store.verify(cert).should == false
+  end
+end

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -4,8 +4,8 @@ require 'openssl'
 describe "OpenSSL::X509::Store#verify" do
   it "returns true for valid certificate" do
     key = OpenSSL::PKey::RSA.new 2048
-    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
-      cert = OpenSSL::X509::Certificate.new
+    cert = OpenSSL::X509::Certificate.new
+    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
       cert.version = 2
       cert.serial = 1
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
@@ -22,8 +22,8 @@ describe "OpenSSL::X509::Store#verify" do
 
   it "returns false for an expired certificate" do
     key = OpenSSL::PKey::RSA.new 2048
-    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
-      cert = OpenSSL::X509::Certificate.new
+    cert = OpenSSL::X509::Certificate.new
+    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
       cert.version = 2
       cert.serial = 1
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
@@ -40,8 +40,8 @@ describe "OpenSSL::X509::Store#verify" do
 
   it "returns false for an expired root certificate" do
     root_key = OpenSSL::PKey::RSA.new 2048
-    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
-      root_cert = OpenSSL::X509::Certificate.new
+    root_cert = OpenSSL::X509::Certificate.new
+    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
       root_cert.version = 2
       root_cert.serial = 1
       root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -4,75 +4,81 @@ require 'openssl'
 describe "OpenSSL::X509::Store#verify" do
   it "returns true for valid certificate" do
     key = OpenSSL::PKey::RSA.new 2048
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 1
-    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
-    cert.issuer = cert.subject
-    cert.public_key = key.public_key
-    cert.not_before = Time.now - 10
-    cert.not_after = cert.not_before + 365 * 24 * 60 * 60
-    cert.sign key, OpenSSL::Digest.new('SHA256')
-    store = OpenSSL::X509::Store.new
-    store.add_cert(cert)
-    [store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
+    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = 2
+      cert.serial = 1
+      cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+      cert.issuer = cert.subject
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 10
+      cert.not_after = cert.not_before + 365 * 24 * 60 * 60
+      cert.sign key, OpenSSL::Digest.new('SHA256')
+      store = OpenSSL::X509::Store.new
+      store.add_cert(cert)
+      [store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
+    end
   end
 
   it "returns false for an expired certificate" do
     key = OpenSSL::PKey::RSA.new 2048
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 1
-    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
-    cert.issuer = cert.subject
-    cert.public_key = key.public_key
-    cert.not_before = Time.now - 10
-    cert.not_after = Time.now - 5
-    cert.sign key, OpenSSL::Digest.new('SHA256')
-    store = OpenSSL::X509::Store.new
-    store.add_cert(cert)
-    store.verify(cert).should == false
+    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = 2
+      cert.serial = 1
+      cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+      cert.issuer = cert.subject
+      cert.public_key = key.public_key
+      cert.not_before = Time.now - 10
+      cert.not_after = Time.now - 5
+      cert.sign key, OpenSSL::Digest.new('SHA256')
+      store = OpenSSL::X509::Store.new
+      store.add_cert(cert)
+      store.verify(cert).should == false
+    end
   end
 
   it "returns false for an expired root certificate" do
     root_key = OpenSSL::PKey::RSA.new 2048
-    root_cert = OpenSSL::X509::Certificate.new
-    root_cert.version = 2
-    root_cert.serial = 1
-    root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
-    root_cert.issuer = root_cert.subject
-    root_cert.public_key = root_key.public_key
-    root_cert.not_before = Time.now - 10
-    root_cert.not_after = Time.now - 5
-    ef = OpenSSL::X509::ExtensionFactory.new
-    ef.subject_certificate = root_cert
-    ef.issuer_certificate = root_cert
-    root_cert.add_extension(ef.create_extension("basicConstraints","CA:TRUE",true))
-    root_cert.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
-    root_cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
-    root_cert.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
-    root_cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+    NATFIXME 'Implement OpenSSL::X509::Certificate', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Certificate' do
+      root_cert = OpenSSL::X509::Certificate.new
+      root_cert.version = 2
+      root_cert.serial = 1
+      root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
+      root_cert.issuer = root_cert.subject
+      root_cert.public_key = root_key.public_key
+      root_cert.not_before = Time.now - 10
+      root_cert.not_after = Time.now - 5
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = root_cert
+      ef.issuer_certificate = root_cert
+      root_cert.add_extension(ef.create_extension("basicConstraints","CA:TRUE",true))
+      root_cert.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
+      root_cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
+      root_cert.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
+      root_cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
 
 
-    key = OpenSSL::PKey::RSA.new 2048
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 2
-    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby certificate"
-    cert.issuer = root_cert.subject
-    cert.public_key = key.public_key
-    cert.not_before = Time.now
-    cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60
-    ef = OpenSSL::X509::ExtensionFactory.new
-    ef.subject_certificate = cert
-    ef.issuer_certificate = root_cert
-    cert.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
-    cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
-    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+      key = OpenSSL::PKey::RSA.new 2048
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = 2
+      cert.serial = 2
+      cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby certificate"
+      cert.issuer = root_cert.subject
+      cert.public_key = key.public_key
+      cert.not_before = Time.now
+      cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate = root_cert
+      cert.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
+      cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
+      cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
 
-    store = OpenSSL::X509::Store.new
-    store.add_cert(root_cert)
-    store.add_cert(cert)
-    store.verify(cert).should == false
+      store = OpenSSL::X509::Store.new
+      store.add_cert(root_cert)
+      store.add_cert(cert)
+      store.verify(cert).should == false
+    end
   end
 end

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -5,8 +5,8 @@ describe "OpenSSL::X509::Store#verify" do
   it "returns true for valid certificate" do
     key = OpenSSL::PKey::RSA.new 2048
     cert = OpenSSL::X509::Certificate.new
-    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
-      cert.version = 2
+    cert.version = 2
+    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
       cert.serial = 1
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       cert.issuer = cert.subject
@@ -23,8 +23,8 @@ describe "OpenSSL::X509::Store#verify" do
   it "returns false for an expired certificate" do
     key = OpenSSL::PKey::RSA.new 2048
     cert = OpenSSL::X509::Certificate.new
-    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
-      cert.version = 2
+    cert.version = 2
+    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
       cert.serial = 1
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       cert.issuer = cert.subject
@@ -41,8 +41,8 @@ describe "OpenSSL::X509::Store#verify" do
   it "returns false for an expired root certificate" do
     root_key = OpenSSL::PKey::RSA.new 2048
     root_cert = OpenSSL::X509::Certificate.new
-    NATFIXME 'Implement OpenSSL::X509::Certificate#version=', exception: NoMethodError, message: "undefined method `version=' for an instance of OpenSSL::X509::Certificate" do
-      root_cert.version = 2
+    root_cert.version = 2
+    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
       root_cert.serial = 1
       root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       root_cert.issuer = root_cert.subject

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -13,6 +13,38 @@ describe "OpenSSL::OPENSSL_VERSION" do
   end
 end
 
+describe "OpenSSL::X509::Certificate#version" do
+  it "can be set and queried" do
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.version.should == 2
+  end
+
+  it "has a default version" do
+    cert = OpenSSL::X509::Certificate.new
+    # Default version might depend on OpenSSL settings/version, so just check the type
+    cert.version.should be_kind_of(Integer)
+  end
+
+  it "coerces the input with #to_int" do
+    version = mock("version")
+    version.should_receive(:to_int).and_return(1)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = version
+    cert.version.should == 1
+  end
+
+  it "raises a TypeError on invalid input type" do
+    cert = OpenSSL::X509::Certificate.new
+    -> { cert.version = Object.new }.should raise_error(TypeError, "no implicit conversion of Object into Integer")
+  end
+
+  it "requires the version to be positive" do
+    cert = OpenSSL::X509::Certificate.new
+    -> { cert.version = -1 }.should raise_error(OpenSSL::X509::CertificateError, "version must be >= 0!")
+  end
+end
+
 describe "OpenSSL::X509::Name#initialize" do
   it "can handle input with types" do
     input = [


### PR DESCRIPTION
And implement the `version` accessors.

At first glance it looked very easy to add the next step (accessors for `serial`) as well, but that one has a very hairy yak called `OpenSSL::BN` in its path.