### PR TITLE
Add assignment hooks for global variables

### DIFF
--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -6,19 +6,24 @@
 namespace Natalie {
 class GlobalVariableInfo : public Cell {
 public:
+    using assignment_hook_t = void (*)(Env *, Object **, Object *);
+
     GlobalVariableInfo(Object *object, bool readonly)
         : m_object { object }
         , m_readonly { readonly } { }
 
-    void set_object(Object *object) { m_object = object; }
+    void set_object(Env *, Object *);
     Object *object() { return m_object; }
     bool is_readonly() const { return m_readonly; }
+
+    void set_assignment_hook(assignment_hook_t assignment_hook) { m_assignment_hook = assignment_hook; }
 
     virtual void visit_children(Visitor &visitor) override final;
 
 private:
     class Object *m_object { nullptr };
     bool m_readonly;
+    assignment_hook_t m_assignment_hook { nullptr };
 };
 
 }

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -107,9 +107,7 @@ describe "Predefined global $~" do
     foo_match = $~
     "bar" =~ /(bar)/
     $~ = foo_match
-    NATFIXME 'Update $` after assignment of $~', exception: SpecFailedException do
-      $`.should == "foo "
-    end
+    $`.should == "foo "
   end
 
   it "changes the value of the derived following match global" do
@@ -117,9 +115,7 @@ describe "Predefined global $~" do
     foo_match = $~
     "bar" =~ /(bar)/
     $~ = foo_match
-    NATFIXME "Update $' after assignment of $~", exception: SpecFailedException do
-      $'.should == " hello"
-    end
+    $'.should == " hello"
   end
 
   it "changes the value of the derived full match global" do

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -97,9 +97,7 @@ describe "Predefined global $~" do
     foo_match = $~
     "bar" =~ /(b)ar/
     $~ = foo_match
-    NATFIXME 'Update $1 after assignment of $~', exception: SpecFailedException do
-      $1.should == "f"
-    end
+    $1.should == "f"
   end
 
   it "changes the value of the derived preceding match global" do
@@ -123,9 +121,7 @@ describe "Predefined global $~" do
     foo_match = $~
     "bar" =~ /(bar)/
     $~ = foo_match
-    NATFIXME 'Update $& after assignment of $~', exception: SpecFailedException do
-      $&.should == "foo"
-    end
+    $&.should == "foo"
   end
 end
 

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -88,10 +88,8 @@ describe "Predefined global $~" do
     $~ = /foo/.match("foo")
     $~.should be_an_instance_of(MatchData)
 
-    NATFIXME 'raises an error if assigned an object not nil or instanceof MatchData', exception: SpecFailedException do
-      -> { $~ = Object.new }.should raise_error(TypeError)
-      -> { $~ = 1 }.should raise_error(TypeError)
-    end
+    -> { $~ = Object.new }.should raise_error(TypeError)
+    -> { $~ = 1 }.should raise_error(TypeError)
   end
 
   it "changes the value of derived capture globals when assigned" do

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -281,11 +281,6 @@ void Env::set_last_match(MatchDataObject *match) {
     auto env = non_block_env();
     env->global_set("$~"_s, match);
     env->set_match(match);
-    if (match) {
-        env->global_set("$`"_s, match->pre_match(env));
-        env->global_set("$'"_s, match->post_match(env));
-        env->global_set("$+"_s, match->captures(env)->as_array()->compact(env)->as_array()->last());
-    }
 }
 
 Value Env::exception_object() {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -280,7 +280,6 @@ bool Env::has_last_match() {
 void Env::set_last_match(MatchDataObject *match) {
     auto env = non_block_env();
     env->global_set("$~"_s, match);
-    env->set_match(match);
 }
 
 Value Env::exception_object() {

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -4,6 +4,7 @@
 namespace Natalie {
 
 static void last_regex_match_assignment_hook(Env *env, Object **current, Object *object) {
+    if (!object) return;
     if (!object->is_match_data() && !object->is_nil())
         env->raise("TypeError", "wrong argument type {} (expected MatchData)", object->klass()->inspect_str());
     *current = object;

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -7,6 +7,7 @@ static void last_regex_match_assignment_hook(Env *env, Object **current, Object 
     if (!object->is_match_data() && !object->is_nil())
         env->raise("TypeError", "wrong argument type {} (expected MatchData)", object->klass()->inspect_str());
     *current = object;
+    env->set_match(object);
     if (!object->is_nil()) {
         env->global_set("$`"_s, object->as_match_data()->pre_match(env));
         env->global_set("$'"_s, object->as_match_data()->post_match(env));

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -7,6 +7,11 @@ static void last_regex_match_assignment_hook(Env *env, Object **current, Object 
     if (!object->is_match_data() && !object->is_nil())
         env->raise("TypeError", "wrong argument type {} (expected MatchData)", object->klass()->inspect_str());
     *current = object;
+    if (!object->is_nil()) {
+        env->global_set("$`"_s, object->as_match_data()->pre_match(env));
+        env->global_set("$'"_s, object->as_match_data()->post_match(env));
+        env->global_set("$+"_s, object->as_match_data()->captures(env)->as_array()->compact(env)->as_array()->last());
+    }
 }
 
 void GlobalEnv::add_file(Env *env, SymbolObject *name) {

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -2,6 +2,14 @@
 
 namespace Natalie {
 
+void GlobalVariableInfo::set_object(Env *env, Object *object) {
+    if (m_assignment_hook) {
+        m_assignment_hook(env, &m_object, object);
+    } else {
+        m_object = object;
+    }
+}
+
 void GlobalVariableInfo::visit_children(Visitor &visitor) {
     visitor.visit(m_object);
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -411,6 +411,7 @@ Env *build_top_env() {
     env->global_alias("$LOADED_FEATURES"_s, "$\""_s);
 
     env->global_set("$?"_s, NilObject::the(), true);
+    env->global_set("$~"_s, NilObject::the());
 
     Value ENV = new Natalie::Object {};
     Object->const_set("ENV"_s, ENV);


### PR DESCRIPTION
Relates to #1551

This is a quick and dirty PoC to hook a function into the assignment of globals. This PoC only adds a validation, but we can extend this to make it set other globals too, or use the same idea to get the globals.