### PR TITLE
Implement throw and catch

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -86,6 +86,10 @@ public:
         raise(class_name, message);
     }
 
+    void set_catch(Value value) { m_catch = value; }
+    bool has_catch() const;
+    bool has_catch(Value value) const;
+
     void warn(String);
 
     template <typename... Args>
@@ -180,5 +184,6 @@ private:
     const ModuleObject *m_module { nullptr };
     Value m_match { nullptr };
     ExceptionObject *m_exception { nullptr };
+    Value m_catch { nullptr };
 };
 }

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -87,7 +87,6 @@ public:
     }
 
     void set_catch(Value value) { m_catch = value; }
-    bool has_catch() const;
     bool has_catch(Value value) const;
 
     void warn(String);

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -40,6 +40,7 @@ public:
     static Value binding(Env *env);
     static Value caller(Env *env, Value start = nullptr, Value length = nullptr);
     static Value caller_locations(Env *env, Value start = nullptr, Value length = nullptr);
+    static Value catch_method(Env *, Value = nullptr, Block * = nullptr);
     static Value Complex(Env *env, Value real, Value imaginary, Value exception);
     static Value Complex(Env *env, Value real, Value imaginary, bool exception = true);
     static Value cur_dir(Env *env);

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -69,6 +69,7 @@ public:
     static Value String(Env *env, Value value);
     static Value test(Env *, Value, Value);
     static Value this_method(Env *env);
+    static Value throw_method(Env *, Value, Value = nullptr);
     static bool block_given(Env *env, Block *block) { return !!block; }
 
     Value define_singleton_method(Env *env, Value name, Block *block);

--- a/include/natalie/throw_catch_exception.hpp
+++ b/include/natalie/throw_catch_exception.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "natalie/forward.hpp"
+#include "natalie/value.hpp"
+
+namespace Natalie {
+
+class ThrowCatchException : public Cell {
+public:
+    ThrowCatchException(Value name, Value value = nullptr)
+        : m_name { name }
+        , m_value { value } { }
+
+    Value get_name() const { return m_name; }
+    Value get_value() const { return m_value; }
+
+    void visit_children(Visitor &visitor);
+
+private:
+    Value m_name { nullptr };
+    Value m_value { nullptr };
+};
+
+}

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -924,6 +924,7 @@ gen.module_function_binding('Kernel', 'binding', 'KernelModule', 'binding', argc
 gen.module_function_binding('Kernel', 'block_given?', 'KernelModule', 'block_given', argc: 0, pass_env: true, pass_block: true, return_type: :bool)
 gen.module_function_binding('Kernel', 'caller', 'KernelModule', 'caller', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'caller_locations', 'KernelModule', 'caller_locations', argc: 0..2, pass_env: true, pass_block: false, return_type: :Object)
+gen.module_function_binding('Kernel', 'catch', 'KernelModule', 'catch_method', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
 gen.module_function_binding('Kernel', 'Complex', 'KernelModule', 'Complex', argc: 1..2, kwargs: [:exception], pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', '__dir__', 'KernelModule', 'cur_dir', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'exit', 'KernelModule', 'exit', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -948,6 +948,7 @@ gen.module_function_binding('Kernel', 'spawn', 'KernelModule', 'spawn', argc: 1.
 gen.module_function_binding('Kernel', 'srand', 'RandomObject', 'srand', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'String', 'KernelModule', 'String', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'test', 'KernelModule', 'test', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
+gen.module_function_binding('Kernel', 'throw', 'KernelModule', 'throw_method', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'class', 'KernelModule', 'klass_obj', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'clone', 'KernelModule', 'clone', argc: 0, kwargs: [:freeze], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'define_singleton_method', 'KernelModule', 'define_singleton_method', argc: 1, pass_env: true, pass_block: true, return_type: :Object)

--- a/spec/core/exception/uncaught_throw_error_spec.rb
+++ b/spec/core/exception/uncaught_throw_error_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../spec_helper'
+
+describe "UncaughtThrowError#tag" do
+  it "returns the object thrown" do
+    begin
+      throw :abc
+
+    rescue UncaughtThrowError => e
+      e.tag.should == :abc
+    end
+  end
+end

--- a/spec/core/kernel/catch_spec.rb
+++ b/spec/core/kernel/catch_spec.rb
@@ -1,0 +1,127 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Kernel.catch" do
+  before :each do
+    ScratchPad.clear
+  end
+
+  it "executes its block and catches a thrown value matching its argument" do
+    catch :thrown_key do
+      ScratchPad.record :catch_block
+      throw :thrown_key
+      ScratchPad.record :throw_failed
+    end
+    ScratchPad.recorded.should == :catch_block
+  end
+
+  it "returns the second value passed to throw" do
+    catch(:thrown_key) { throw :thrown_key, :catch_value }.should == :catch_value
+  end
+
+  it "returns the last expression evaluated if throw was not called" do
+    catch(:thrown_key) { 1; :catch_block }.should == :catch_block
+  end
+
+  it "passes the given symbol to its block" do
+    catch :thrown_key do |tag|
+      ScratchPad.record tag
+    end
+    ScratchPad.recorded.should == :thrown_key
+  end
+
+  it "raises an ArgumentError if a Symbol is thrown for a String catch value" do
+    -> { catch("exit") { throw :exit } }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if a String with different identity is thrown" do
+    -> { catch("exit") { throw "exit" } }.should raise_error(ArgumentError)
+  end
+
+  it "catches a Symbol when thrown a matching Symbol" do
+    catch :thrown_key do
+      ScratchPad.record :catch_block
+      throw :thrown_key
+    end
+    ScratchPad.recorded.should == :catch_block
+  end
+
+  it "catches a String when thrown a String with the same identity" do
+    key = "thrown_key"
+    catch key do
+      ScratchPad.record :catch_block
+      throw key
+    end
+    ScratchPad.recorded.should == :catch_block
+  end
+
+  it "accepts an object as an argument" do
+    catch(Object.new) { :catch_block }.should == :catch_block
+  end
+
+  it "yields an object when called without arguments" do
+    catch { |tag| tag }.should be_an_instance_of(Object)
+  end
+
+  it "can be used even in a method different from where throw is called" do
+    class CatchSpecs
+      def self.throwing_method
+        throw :blah, :thrown_value
+      end
+      def self.catching_method
+        catch :blah do
+          throwing_method
+        end
+      end
+    end
+    CatchSpecs.catching_method.should == :thrown_value
+  end
+
+  describe "when nested" do
+    before :each do
+      ScratchPad.record []
+    end
+
+    it "catches across invocation boundaries" do
+      catch :one do
+        ScratchPad << 1
+        catch :two do
+          ScratchPad << 2
+          catch :three do
+            ScratchPad << 3
+            throw :one
+            ScratchPad << 4
+          end
+          ScratchPad << 5
+        end
+        ScratchPad << 6
+      end
+
+      ScratchPad.recorded.should == [1, 2, 3]
+    end
+
+    it "catches in the nested invocation with the same key object" do
+      catch :thrown_key do
+        ScratchPad << 1
+        catch :thrown_key do
+          ScratchPad << 2
+          throw :thrown_key
+          ScratchPad << 3
+        end
+        ScratchPad << 4
+      end
+
+      ScratchPad.recorded.should == [1, 2, 4]
+    end
+  end
+
+  it "raises LocalJumpError if no block is given" do
+    -> { catch :blah }.should raise_error(LocalJumpError)
+  end
+end
+
+describe "Kernel#catch" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:catch)
+  end
+end

--- a/spec/core/kernel/catch_spec.rb
+++ b/spec/core/kernel/catch_spec.rb
@@ -122,6 +122,8 @@ end
 
 describe "Kernel#catch" do
   it "is a private method" do
-    Kernel.should have_private_instance_method(:catch)
+    NATFIXME 'is a private method', exception: SpecFailedException do
+      Kernel.should have_private_instance_method(:catch)
+    end
   end
 end

--- a/spec/core/kernel/catch_spec.rb
+++ b/spec/core/kernel/catch_spec.rb
@@ -122,8 +122,6 @@ end
 
 describe "Kernel#catch" do
   it "is a private method" do
-    NATFIXME 'is a private method', exception: SpecFailedException do
-      Kernel.should have_private_instance_method(:catch)
-    end
+    Kernel.should have_private_instance_method(:catch)
   end
 end

--- a/spec/core/kernel/throw_spec.rb
+++ b/spec/core/kernel/throw_spec.rb
@@ -1,0 +1,80 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Kernel.throw" do
+  it "transfers control to the end of the active catch block waiting for symbol" do
+    catch(:blah) do
+      :value
+      throw :blah
+      fail("throw didn't transfer the control")
+    end.should be_nil
+  end
+
+  it "transfers control to the innermost catch block waiting for the same symbol" do
+    one = two = three = 0
+    catch :duplicate do
+      catch :duplicate do
+        catch :duplicate do
+          one = 1
+          throw :duplicate
+        end
+        two = 2
+        throw :duplicate
+      end
+      three = 3
+      throw :duplicate
+    end
+    [one, two, three].should == [1, 2, 3]
+  end
+
+  it "sets the return value of the catch block to nil by default" do
+    res = catch :blah do
+      throw :blah
+    end
+    res.should == nil
+  end
+
+  it "sets the return value of the catch block to a value specified as second parameter" do
+    res = catch :blah do
+      throw :blah, :return_value
+    end
+    res.should == :return_value
+  end
+
+  it "raises an ArgumentError if there is no catch block for the symbol" do
+    -> { throw :blah }.should raise_error(ArgumentError)
+  end
+
+  it "raises an UncaughtThrowError if there is no catch block for the symbol" do
+    -> { throw :blah }.should raise_error(UncaughtThrowError)
+  end
+
+  it "raises ArgumentError if 3 or more arguments provided" do
+    -> {
+      catch :blah do
+        throw :blah, :return_value, 2
+      end
+    }.should raise_error(ArgumentError)
+
+    -> {
+      catch :blah do
+        throw :blah, :return_value, 2, 3, 4, 5
+      end
+    }.should raise_error(ArgumentError)
+  end
+
+  it "can throw an object" do
+    -> {
+      obj = Object.new
+      catch obj do
+        throw obj
+      end
+    }.should_not raise_error(NameError)
+  end
+end
+
+describe "Kernel#throw" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:throw)
+  end
+end

--- a/spec/core/kernel/throw_spec.rb
+++ b/spec/core/kernel/throw_spec.rb
@@ -75,6 +75,8 @@ end
 
 describe "Kernel#throw" do
   it "is a private method" do
-    Kernel.should have_private_instance_method(:throw)
+    NATFIXME 'is a private method', exception: SpecFailedException do
+      Kernel.should have_private_instance_method(:throw)
+    end
   end
 end

--- a/spec/core/kernel/throw_spec.rb
+++ b/spec/core/kernel/throw_spec.rb
@@ -75,8 +75,6 @@ end
 
 describe "Kernel#throw" do
   it "is a private method" do
-    NATFIXME 'is a private method', exception: SpecFailedException do
-      Kernel.should have_private_instance_method(:throw)
-    end
+    Kernel.should have_private_instance_method(:throw)
   end
 end

--- a/spec/language/throw_spec.rb
+++ b/spec/language/throw_spec.rb
@@ -1,0 +1,81 @@
+require_relative '../spec_helper'
+
+describe "The throw keyword" do
+  it "abandons processing" do
+    i = 0
+    catch(:done) do
+      loop do
+        i += 1
+        throw :done if i > 4
+      end
+      i += 1
+    end
+    i.should == 5
+  end
+
+  it "supports a second parameter" do
+    msg = catch(:exit) do
+      throw :exit,:msg
+    end
+    msg.should == :msg
+  end
+
+  it "uses nil as a default second parameter" do
+    msg = catch(:exit) do
+      throw :exit
+    end
+    msg.should == nil
+  end
+
+  it "clears the current exception" do
+    catch :exit do
+      begin
+        raise "exception"
+      rescue
+        throw :exit
+      end
+    end
+    $!.should be_nil
+  end
+
+  it "allows any object as its argument" do
+    catch(1) { throw 1, 2 }.should == 2
+    o = Object.new
+    catch(o) { throw o, o }.should == o
+  end
+
+  it "does not convert strings to a symbol" do
+    -> { catch(:exit) { throw "exit" } }.should raise_error(ArgumentError)
+  end
+
+  it "unwinds stack from within a method" do
+    def throw_method(handler, val)
+      throw handler, val
+    end
+
+    catch(:exit) do
+      throw_method(:exit, 5)
+    end.should == 5
+  end
+
+  it "unwinds stack from within a lambda" do
+    c = -> { throw :foo, :msg }
+    catch(:foo) { c.call }.should == :msg
+  end
+
+  it "raises an ArgumentError if outside of scope of a matching catch" do
+    -> { throw :test, 5 }.should raise_error(ArgumentError)
+    -> { catch(:different) { throw :test, 5 } }.should raise_error(ArgumentError)
+  end
+
+  it "raises an UncaughtThrowError if used to exit a thread" do
+    catch(:what) do
+      t = Thread.new {
+        -> {
+          throw :what
+        }.should raise_error(UncaughtThrowError)
+      }
+      t.join
+    end
+  end
+end

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -210,10 +210,6 @@ void Env::raise_not_comparable_error(Value lhs, Value rhs) {
     raise("ArgumentError", std::move(message));
 }
 
-bool Env::has_catch() const {
-    return m_catch || (m_caller && m_caller->has_catch());
-}
-
 bool Env::has_catch(Value value) const {
     return (m_catch && value->equal(m_catch)) || (m_caller && m_caller->has_catch(value)) || (m_outer && m_outer->has_catch(value));
 }
@@ -379,5 +375,6 @@ void Env::visit_children(Visitor &visitor) {
     visitor.visit(m_module);
     visitor.visit(m_match);
     visitor.visit(m_exception);
+    visitor.visit(m_catch);
 }
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -210,6 +210,14 @@ void Env::raise_not_comparable_error(Value lhs, Value rhs) {
     raise("ArgumentError", std::move(message));
 }
 
+bool Env::has_catch() const {
+    return m_catch || (m_caller && m_caller->has_catch());
+}
+
+bool Env::has_catch(Value value) const {
+    return (m_catch && value->equal(m_catch)) || (m_caller && m_caller->has_catch(value)) || (m_outer && m_outer->has_catch(value));
+}
+
 void Env::warn(String message) {
     Value _stderr = global_get("$stderr"_s);
     message = String::format("warning: {}", message);

--- a/src/exception.rb
+++ b/src/exception.rb
@@ -35,7 +35,14 @@ end
 
 class StandardError < Exception; end
   class ArgumentError < StandardError; end
-    class UncaughtThrowError < ArgumentError; end
+    class UncaughtThrowError < ArgumentError
+      attr_reader :tag, :value
+      def initialize(tag, value, message = nil)
+        super(message)
+        @tag = tag
+        @value = value
+      end
+    end
   # end ArgumentError subclasses
   class EncodingError < StandardError; end
   class FiberError < StandardError; end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -884,12 +884,5 @@ module Kernel
   ensure
     Thread.current.thread_variable_get(:__catch_stack).pop
   end
-
-  def throw(name, value = nil)
-    if !Thread.current.thread_variable?(:__catch_stack) || Thread.current.thread_variable_get(:__catch_stack).empty?
-      raise UncaughtThrowError.new(name, value)
-    end
-    raise ThrowCatchException.new(name, value)
-  end
   # NATFIXME: End PoC for Throw/Catch
 end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -856,15 +856,4 @@ module Kernel
   rescue
     nil
   end
-
-  # NATFIXME: PoC for Throw/Catch, should be implemented in C++ and not use Exception base class
-  class ThrowCatchException < Exception
-    attr_reader :name, :value
-
-    def initialize(name, value = nil)
-      @name = name
-      @value = value
-    end
-  end
-  # NATFIXME: End PoC for Throw/Catch
 end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -886,6 +886,9 @@ module Kernel
   end
 
   def throw(name, value = nil)
+    if !Thread.current.thread_variable?(:__catch_stack) || Thread.current.thread_variable_get(:__catch_stack).empty?
+      raise UncaughtThrowError.new(name, value)
+    end
     raise ThrowCatchException.new(name, value)
   end
   # NATFIXME: End PoC for Throw/Catch

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -866,23 +866,5 @@ module Kernel
       @value = value
     end
   end
-
-  def catch(name = Object.new)
-    unless Thread.current.thread_variable?(:__catch_stack)
-      Thread.current.thread_variable_set(:__catch_stack, [])
-    end
-    Thread.current.thread_variable_get(:__catch_stack) << name
-    yield(name)
-  rescue ThrowCatchException => e
-    if e.name.equal?(name)
-      e.value
-    elsif Thread.current.thread_variable_get(:__catch_stack).any? { |v| v.equal?(e.name) }
-      raise
-    else
-      raise ArgumentError, "uncaught throw #{e.name.inspect}"
-    end
-  ensure
-    Thread.current.thread_variable_get(:__catch_stack).pop
-  end
   # NATFIXME: End PoC for Throw/Catch
 end

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -729,4 +729,18 @@ Value KernelModule::this_method(Env *env) {
     return SymbolObject::intern(method->name());
 }
 
+Value KernelModule::throw_method(Env *env, Value name, Value value) {
+    auto thread = ThreadObject::current();
+    if (!thread->has_thread_variable(env, "__catch_stack"_s) || thread->thread_variable_get(env, "__catch_stack"_s)->as_array()->is_empty()) {
+        auto klass = GlobalEnv::the()->Object()->const_fetch("UncaughtThrowError"_s)->as_class();
+        auto exception = _new(env, klass, { name, value }, nullptr)->as_exception();
+        env->raise_exception(exception);
+    }
+
+    auto klass = fetch_nested_const({ "Kernel"_s, "ThrowCatchException"_s })->as_class();
+    auto exception = _new(env, klass, { name, value }, nullptr)->as_exception();
+    env->raise_exception(exception);
+    NAT_UNREACHABLE();
+}
+
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -99,10 +99,8 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
     } catch (ThrowCatchException *e) {
         if (e->get_name()->equal(name)) {
             return e->get_value();
-        } else if (env->has_catch(e->get_name())) {
-            throw e;
         } else {
-            env->raise("ArgumentError", "uncaught throw {}", e->get_name()->inspect_str(env));
+            throw e;
         }
     }
 }
@@ -751,9 +749,10 @@ Value KernelModule::this_method(Env *env) {
 }
 
 Value KernelModule::throw_method(Env *env, Value name, Value value) {
-    if (!env->has_catch()) {
+    if (!env->has_catch(name)) {
         auto klass = GlobalEnv::the()->Object()->const_fetch("UncaughtThrowError"_s)->as_class();
-        auto exception = _new(env, klass, { name, value }, nullptr)->as_exception();
+        auto message = StringObject::format("uncaught throw {}", name->inspect_str(env));
+        auto exception = _new(env, klass, { name, value, message }, nullptr)->as_exception();
         env->raise_exception(exception);
     }
 

--- a/src/throw_catch_exception.cpp
+++ b/src/throw_catch_exception.cpp
@@ -1,0 +1,11 @@
+#include "natalie/throw_catch_exception.hpp"
+#include "natalie.hpp"
+
+namespace Natalie {
+
+void ThrowCatchException::visit_children(Visitor &visitor) {
+    visitor.visit(m_name);
+    visitor.visit(m_value);
+}
+
+}


### PR DESCRIPTION
For now this is a PoC in Ruby: it does pass the tests, but we probably shouldn't use an Exception object in the throw operations. I had to play around with it a bit at first, since I didn't really know how they were supposed to work.

I've seen this in use in many of the stdgems, so implementing this would simplify the process of importing those from MRI.