### PR TITLE
Add accessors for serial to OpenSSL::X509::Certificate

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -74,6 +74,18 @@ static void OpenSSL_X509_Name_raise_error(Env *env, const char *func) {
     OpenSSL_raise_error(env, func, NameError->as_class());
 }
 
+static Value OpenSSL_BN_new(Env *env, const ASN1_INTEGER *asn1) {
+    auto value = BN_secure_new();
+    if (!value)
+        OpenSSL_raise_error(env, "BN_secure_new");
+    if (!ASN1_INTEGER_to_BN(asn1, value))
+        OpenSSL_raise_error(env, "ASN1_INTEGER_to_BN");
+    auto BN = fetch_nested_const({ "OpenSSL"_s, "BN"_s })->as_class();
+    auto bn = Object::allocate(env, BN, {}, nullptr);
+    bn->ivar_set(env, "@bn"_s, new VoidPObject { value, OpenSSL_BN_cleanup });
+    return bn;
+}
+
 Value OpenSSL_fixed_length_secure_compare(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 2);
     auto a = args[0]->to_str(env);
@@ -430,25 +442,24 @@ Value OpenSSL_X509_Certificate_serial(Env *env, Value self, Args args, Block *) 
     args.ensure_argc_is(env, 0);
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
-    const auto asn1_serial = X509_get0_serialNumber(x509);
-    uint64_t serial;
-    if (!ASN1_INTEGER_get_uint64(&serial, asn1_serial))
-        OpenSSL_raise_error(env, "ASN1_INTEGER_get_uint64");
-
-    return Value::integer(serial);
+    const auto serial = X509_get0_serialNumber(x509);
+    return OpenSSL_BN_new(env, serial);
 }
 
 Value OpenSSL_X509_Certificate_set_serial(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
+    auto serial = args[0];
 
-    const auto serial = static_cast<uint64_t>(args[0]->to_int(env)->to_nat_int_t());
+    auto BN = fetch_nested_const({ "OpenSSL"_s, "BN"_s })->as_class();
+    if (!serial->is_a(env, BN))
+        serial = Object::_new(env, BN, { serial }, nullptr);
     auto asn1_serial = ASN1_INTEGER_new();
     if (!asn1_serial)
         OpenSSL_raise_error(env, "ASN1_INTEGER_new");
     Defer asn1_serial_free { [&asn1_serial]() { ASN1_INTEGER_free(asn1_serial); } };
-    if (!ASN1_INTEGER_set_uint64(asn1_serial, serial))
-        OpenSSL_raise_error(env, "ASN1_INTEGER_set_uint64");
-
+    auto bn = static_cast<BIGNUM *>(serial->ivar_get(env, "@bn"_s)->as_void_p()->void_ptr());
+    if (!BN_to_ASN1_INTEGER(bn, asn1_serial))
+        OpenSSL_raise_error(env, "BN_to_ASN1_INTEGER");
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
     if (!X509_set_serialNumber(x509, asn1_serial))
         OpenSSL_raise_error(env, "X509_set_serialNumber");

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -684,6 +684,16 @@ Value OpenSSL_BN_initialize(Env *env, Value self, Args args, Block *) {
     return self;
 }
 
+Value OpenSSL_BN_cmp(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    auto other = args[0];
+    if (!other->is_a(env, self->klass()))
+        other = Object::_new(env, self->klass(), args, nullptr);
+    auto bn = static_cast<BIGNUM *>(self->ivar_get(env, "@bn"_s)->as_void_p()->void_ptr());
+    auto other_bn = static_cast<BIGNUM *>(other->ivar_get(env, "@bn"_s)->as_void_p()->void_ptr());
+    return Value::integer(BN_cmp(bn, other_bn));
+}
+
 Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
     Value length = args[0]->to_int(env);

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -182,6 +182,8 @@ module OpenSSL
 
     class Certificate
       __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
+      __bind_method__ :serial, :OpenSSL_X509_Certificate_serial
+      __bind_method__ :serial=, :OpenSSL_X509_Certificate_set_serial
       __bind_method__ :version, :OpenSSL_X509_Certificate_version
       __bind_method__ :version=, :OpenSSL_X509_Certificate_set_version
     end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -82,7 +82,10 @@ module OpenSSL
   end
 
   class BN
+    include Comparable
+
     __bind_method__ :initialize, :OpenSSL_BN_initialize
+    __bind_method__ :<=>, :OpenSSL_BN_cmp
   end
 
   module Random

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -81,6 +81,10 @@ module OpenSSL
     __constant__('BMPSTRING', 'int', 'V_ASN1_BMPSTRING')
   end
 
+  class BN
+    __bind_method__ :initialize, :OpenSSL_BN_initialize
+  end
+
   module Random
     __bind_static_method__ :random_bytes, :OpenSSL_Random_random_bytes
   end

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -6,8 +6,8 @@ describe "OpenSSL::X509::Store#verify" do
     key = OpenSSL::PKey::RSA.new 2048
     cert = OpenSSL::X509::Certificate.new
     cert.version = 2
-    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
-      cert.serial = 1
+    cert.serial = 1
+    NATFIXME 'Implement OpenSSL::X509::Certificate#subject=', exception: NoMethodError, message: "undefined method `subject=' for an instance of OpenSSL::X509::Certificate" do
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       cert.issuer = cert.subject
       cert.public_key = key.public_key
@@ -24,8 +24,8 @@ describe "OpenSSL::X509::Store#verify" do
     key = OpenSSL::PKey::RSA.new 2048
     cert = OpenSSL::X509::Certificate.new
     cert.version = 2
-    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
-      cert.serial = 1
+    cert.serial = 1
+    NATFIXME 'Implement OpenSSL::X509::Certificate#subject=', exception: NoMethodError, message: "undefined method `subject=' for an instance of OpenSSL::X509::Certificate" do
       cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       cert.issuer = cert.subject
       cert.public_key = key.public_key
@@ -42,8 +42,8 @@ describe "OpenSSL::X509::Store#verify" do
     root_key = OpenSSL::PKey::RSA.new 2048
     root_cert = OpenSSL::X509::Certificate.new
     root_cert.version = 2
-    NATFIXME 'Implement OpenSSL::X509::Certificate#serial=', exception: NoMethodError, message: "undefined method `serial=' for an instance of OpenSSL::X509::Certificate" do
-      root_cert.serial = 1
+    root_cert.serial = 1
+    NATFIXME 'Implement OpenSSL::X509::Certificate#subject=', exception: NoMethodError, message: "undefined method `subject=' for an instance of OpenSSL::X509::Certificate" do
       root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
       root_cert.issuer = root_cert.subject
       root_cert.public_key = root_key.public_key

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -13,177 +13,183 @@ describe "OpenSSL::OPENSSL_VERSION" do
   end
 end
 
-describe "OpenSSL::BN.new" do
-  it "can be constructed with an integer in the int64 range" do
-    bn = OpenSSL::BN.new(1234)
-    bn.should be_kind_of(OpenSSL::BN)
+describe "OpenSSL::BN" do
+  describe "OpenSSL::BN.new" do
+    it "can be constructed with an integer in the int64 range" do
+      bn = OpenSSL::BN.new(1234)
+      bn.should be_kind_of(OpenSSL::BN)
+    end
+  end
+
+  describe "OpenSSL::BN#<=>" do
+    it "can compare two OpenSSL::BN instances" do
+      OpenSSL::BN.new(1234).should == OpenSSL::BN.new(1234)
+      OpenSSL::BN.new(1234).should != OpenSSL::BN.new(4321)
+    end
+
+    it "can compare a OpenSSL::BN instance to an Integer" do
+      OpenSSL::BN.new(1234).should == 1234
+      OpenSSL::BN.new(1234).should != 4321
+    end
   end
 end
 
-describe "OpenSSL::BN#<=>" do
-  it "can compare two OpenSSL::BN instances" do
-    OpenSSL::BN.new(1234).should == OpenSSL::BN.new(1234)
-    OpenSSL::BN.new(1234).should != OpenSSL::BN.new(4321)
+describe "OpenSSL::X509::Certificate" do
+  describe "OpenSSL::X509::Certificate#serial" do
+    it "can be set and queried with integer" do
+      cert = OpenSSL::X509::Certificate.new
+      cert.serial = 2
+      cert.serial.should == 2
+    end
+
+    it "can be set and queried with OpenSSL::BN" do
+      cert = OpenSSL::X509::Certificate.new
+      cert.serial = OpenSSL::BN.new(2)
+      cert.serial.should == OpenSSL::BN.new(2)
+    end
+
+    it "has a default serial" do
+      cert = OpenSSL::X509::Certificate.new
+      # Default serial might depend on OpenSSL settings/version, so just check the type
+      cert.serial.should be_kind_of(OpenSSL::BN)
+    end
+
+    it "does not require the serial to be positive" do
+      cert = OpenSSL::X509::Certificate.new
+      -> { cert.serial = -1 }.should_not raise_error
+    end
+
+    it "raises a TypeError on invalid input type" do
+      cert = OpenSSL::X509::Certificate.new
+      -> { cert.serial = Object.new }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
+    end
+
+    it "does not coerce the input with #to_int" do
+      serial = mock("version")
+      serial.should_not_receive(:to_int)
+      cert = OpenSSL::X509::Certificate.new
+      -> { cert.serial = serial }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
+    end
   end
 
-  it "can compare a OpenSSL::BN instance to an Integer" do
-    OpenSSL::BN.new(1234).should == 1234
-    OpenSSL::BN.new(1234).should != 4321
-  end
-end
+  describe "OpenSSL::X509::Certificate#version" do
+    it "can be set and queried" do
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = 2
+      cert.version.should == 2
+    end
 
-describe "OpenSSL::X509::Certificate#serial" do
-  it "can be set and queried with integer" do
-    cert = OpenSSL::X509::Certificate.new
-    cert.serial = 2
-    cert.serial.should == 2
-  end
+    it "has a default version" do
+      cert = OpenSSL::X509::Certificate.new
+      # Default version might depend on OpenSSL settings/version, so just check the type
+      cert.version.should be_kind_of(Integer)
+    end
 
-  it "can be set and queried with OpenSSL::BN" do
-    cert = OpenSSL::X509::Certificate.new
-    cert.serial = OpenSSL::BN.new(2)
-    cert.serial.should == OpenSSL::BN.new(2)
-  end
+    it "coerces the input with #to_int" do
+      version = mock("version")
+      version.should_receive(:to_int).and_return(1)
+      cert = OpenSSL::X509::Certificate.new
+      cert.version = version
+      cert.version.should == 1
+    end
 
-  it "has a default serial" do
-    cert = OpenSSL::X509::Certificate.new
-    # Default serial might depend on OpenSSL settings/version, so just check the type
-    cert.serial.should be_kind_of(OpenSSL::BN)
-  end
+    it "raises a TypeError on invalid input type" do
+      cert = OpenSSL::X509::Certificate.new
+      -> { cert.version = Object.new }.should raise_error(TypeError, "no implicit conversion of Object into Integer")
+    end
 
-  it "does not require the serial to be positive" do
-    cert = OpenSSL::X509::Certificate.new
-    -> { cert.serial = -1 }.should_not raise_error
-  end
-
-  it "raises a TypeError on invalid input type" do
-    cert = OpenSSL::X509::Certificate.new
-    -> { cert.serial = Object.new }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
-  end
-
-  it "does not coerce the input with #to_int" do
-    serial = mock("version")
-    serial.should_not_receive(:to_int)
-    cert = OpenSSL::X509::Certificate.new
-    -> { cert.serial = serial }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
-  end
-end
-
-describe "OpenSSL::X509::Certificate#version" do
-  it "can be set and queried" do
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.version.should == 2
-  end
-
-  it "has a default version" do
-    cert = OpenSSL::X509::Certificate.new
-    # Default version might depend on OpenSSL settings/version, so just check the type
-    cert.version.should be_kind_of(Integer)
-  end
-
-  it "coerces the input with #to_int" do
-    version = mock("version")
-    version.should_receive(:to_int).and_return(1)
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = version
-    cert.version.should == 1
-  end
-
-  it "raises a TypeError on invalid input type" do
-    cert = OpenSSL::X509::Certificate.new
-    -> { cert.version = Object.new }.should raise_error(TypeError, "no implicit conversion of Object into Integer")
-  end
-
-  it "requires the version to be positive" do
-    cert = OpenSSL::X509::Certificate.new
-    -> { cert.version = -1 }.should raise_error(OpenSSL::X509::CertificateError, "version must be >= 0!")
+    it "requires the version to be positive" do
+      cert = OpenSSL::X509::Certificate.new
+      -> { cert.version = -1 }.should raise_error(OpenSSL::X509::CertificateError, "version must be >= 0!")
+    end
   end
 end
 
-describe "OpenSSL::X509::Name#initialize" do
-  it "can handle input with types" do
-    input = [
-      ["DC", "org", OpenSSL::ASN1::IA5STRING],
-      ["DC", "ruby-lang", OpenSSL::ASN1::IA5STRING],
-      ["CN", "www.ruby-lang.org", OpenSSL::ASN1::UTF8STRING]
-    ]
-    name = OpenSSL::X509::Name.new(input)
+describe "OpenSSL::X509::Name" do
+  describe "OpenSSL::X509::Name#initialize" do
+    it "can handle input with types" do
+      input = [
+        ["DC", "org", OpenSSL::ASN1::IA5STRING],
+        ["DC", "ruby-lang", OpenSSL::ASN1::IA5STRING],
+        ["CN", "www.ruby-lang.org", OpenSSL::ASN1::UTF8STRING]
+      ]
+      name = OpenSSL::X509::Name.new(input)
 
-    ary = name.to_a
+      ary = name.to_a
 
-    ary[0][0].should == "DC"
-    ary[1][0].should == "DC"
-    ary[2][0].should == "CN"
-    ary[0][1].should == "org"
-    ary[1][1].should == "ruby-lang"
-    ary[2][1].should == "www.ruby-lang.org"
-    ary[0][2].should == OpenSSL::ASN1::IA5STRING
-    ary[1][2].should == OpenSSL::ASN1::IA5STRING
-    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+      ary[0][0].should == "DC"
+      ary[1][0].should == "DC"
+      ary[2][0].should == "CN"
+      ary[0][1].should == "org"
+      ary[1][1].should == "ruby-lang"
+      ary[2][1].should == "www.ruby-lang.org"
+      ary[0][2].should == OpenSSL::ASN1::IA5STRING
+      ary[1][2].should == OpenSSL::ASN1::IA5STRING
+      ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+    end
+
+    it "can handle input without types" do
+      input = [
+        ["DC", "org"],
+        ["DC", "ruby-lang"],
+        ["CN", "www.ruby-lang.org"]
+      ]
+      name = OpenSSL::X509::Name.new(input)
+
+      ary = name.to_a
+
+      ary[0][0].should == "DC"
+      ary[1][0].should == "DC"
+      ary[2][0].should == "CN"
+      ary[0][1].should == "org"
+      ary[1][1].should == "ruby-lang"
+      ary[2][1].should == "www.ruby-lang.org"
+      ary[0][2].should == OpenSSL::ASN1::IA5STRING
+      ary[1][2].should == OpenSSL::ASN1::IA5STRING
+      ary[2][2].should == OpenSSL::ASN1::UTF8STRING
+    end
+
+    it "can use a custom template" do
+      template = { "DC" => OpenSSL::ASN1::UTF8STRING}
+      template.default = OpenSSL::ASN1::IA5STRING
+      input = [
+        ["DC", "org"],
+        ["DC", "ruby-lang"],
+        ["CN", "www.ruby-lang.org"]
+      ]
+      name = OpenSSL::X509::Name.new(input, template)
+
+      ary = name.to_a
+
+      ary[0][0].should == "DC"
+      ary[1][0].should == "DC"
+      ary[2][0].should == "CN"
+      ary[0][1].should == "org"
+      ary[1][1].should == "ruby-lang"
+      ary[2][1].should == "www.ruby-lang.org"
+      ary[0][2].should == OpenSSL::ASN1::UTF8STRING
+      ary[1][2].should == OpenSSL::ASN1::UTF8STRING
+      ary[2][2].should == OpenSSL::ASN1::IA5STRING
+    end
   end
 
-  it "can handle input without types" do
-    input = [
-      ["DC", "org"],
-      ["DC", "ruby-lang"],
-      ["CN", "www.ruby-lang.org"]
-    ]
-    name = OpenSSL::X509::Name.new(input)
+  describe "OpenSSL::X509::Name#to_s" do
+    it "returns the correct string" do
+      name = OpenSSL::X509::Name.new
+      name.add_entry("DC", "org")
+      name.add_entry("DC", "ruby-lang")
+      name.add_entry("CN", "www.ruby-lang.org")
 
-    ary = name.to_a
-
-    ary[0][0].should == "DC"
-    ary[1][0].should == "DC"
-    ary[2][0].should == "CN"
-    ary[0][1].should == "org"
-    ary[1][1].should == "ruby-lang"
-    ary[2][1].should == "www.ruby-lang.org"
-    ary[0][2].should == OpenSSL::ASN1::IA5STRING
-    ary[1][2].should == OpenSSL::ASN1::IA5STRING
-    ary[2][2].should == OpenSSL::ASN1::UTF8STRING
-  end
-
-  it "can use a custom template" do
-    template = { "DC" => OpenSSL::ASN1::UTF8STRING}
-    template.default = OpenSSL::ASN1::IA5STRING
-    input = [
-      ["DC", "org"],
-      ["DC", "ruby-lang"],
-      ["CN", "www.ruby-lang.org"]
-    ]
-    name = OpenSSL::X509::Name.new(input, template)
-
-    ary = name.to_a
-
-    ary[0][0].should == "DC"
-    ary[1][0].should == "DC"
-    ary[2][0].should == "CN"
-    ary[0][1].should == "org"
-    ary[1][1].should == "ruby-lang"
-    ary[2][1].should == "www.ruby-lang.org"
-    ary[0][2].should == OpenSSL::ASN1::UTF8STRING
-    ary[1][2].should == OpenSSL::ASN1::UTF8STRING
-    ary[2][2].should == OpenSSL::ASN1::IA5STRING
-  end
-end
-
-describe "OpenSSL::X509::Name#to_s" do
-  it "returns the correct string" do
-    name = OpenSSL::X509::Name.new
-    name.add_entry("DC", "org")
-    name.add_entry("DC", "ruby-lang")
-    name.add_entry("CN", "www.ruby-lang.org")
-
-    name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
-    name.to_s(OpenSSL::X509::Name::COMPAT).should == "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
-    name.to_s(OpenSSL::X509::Name::RFC2253).should == "CN=www.ruby-lang.org,DC=ruby-lang,DC=org"
-    name.to_s(OpenSSL::X509::Name::ONELINE).should == "DC = org, DC = ruby-lang, CN = www.ruby-lang.org"
-    name.to_s(OpenSSL::X509::Name::MULTILINE).should == <<~NAME.chomp
-      domainComponent           = org
-      domainComponent           = ruby-lang
-      commonName                = www.ruby-lang.org
-    NAME
+      name.to_s.should == "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
+      name.to_s(OpenSSL::X509::Name::COMPAT).should == "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
+      name.to_s(OpenSSL::X509::Name::RFC2253).should == "CN=www.ruby-lang.org,DC=ruby-lang,DC=org"
+      name.to_s(OpenSSL::X509::Name::ONELINE).should == "DC = org, DC = ruby-lang, CN = www.ruby-lang.org"
+      name.to_s(OpenSSL::X509::Name::MULTILINE).should == <<~NAME.chomp
+        domainComponent           = org
+        domainComponent           = ruby-lang
+        commonName                = www.ruby-lang.org
+      NAME
+    end
   end
 end
 

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -20,6 +20,18 @@ describe "OpenSSL::BN.new" do
   end
 end
 
+describe "OpenSSL::BN#<=>" do
+  it "can compare two OpenSSL::BN instances" do
+    OpenSSL::BN.new(1234).should == OpenSSL::BN.new(1234)
+    OpenSSL::BN.new(1234).should != OpenSSL::BN.new(4321)
+  end
+
+  it "can compare a OpenSSL::BN instance to an Integer" do
+    OpenSSL::BN.new(1234).should == 1234
+    OpenSSL::BN.new(1234).should != 4321
+  end
+end
+
 describe "OpenSSL::X509::Certificate#serial" do
   it "can be set and queried with integer" do
     cert = OpenSSL::X509::Certificate.new

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -13,6 +13,13 @@ describe "OpenSSL::OPENSSL_VERSION" do
   end
 end
 
+describe "OpenSSL::BN.new" do
+  it "can be constructed with an integer in the int64 range" do
+    bn = OpenSSL::BN.new(1234)
+    bn.should be_kind_of(OpenSSL::BN)
+  end
+end
+
 describe "OpenSSL::X509::Certificate#serial" do
   it "can be set and queried with integer" do
     cert = OpenSSL::X509::Certificate.new

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -13,6 +13,43 @@ describe "OpenSSL::OPENSSL_VERSION" do
   end
 end
 
+describe "OpenSSL::X509::Certificate#serial" do
+  it "can be set and queried with integer" do
+    cert = OpenSSL::X509::Certificate.new
+    cert.serial = 2
+    cert.serial.should == 2
+  end
+
+  it "can be set and queried with OpenSSL::BN" do
+    cert = OpenSSL::X509::Certificate.new
+    cert.serial = OpenSSL::BN.new(2)
+    cert.serial.should == OpenSSL::BN.new(2)
+  end
+
+  it "has a default serial" do
+    cert = OpenSSL::X509::Certificate.new
+    # Default serial might depend on OpenSSL settings/version, so just check the type
+    cert.serial.should be_kind_of(OpenSSL::BN)
+  end
+
+  it "does not require the serial to be positive" do
+    cert = OpenSSL::X509::Certificate.new
+    -> { cert.serial = -1 }.should_not raise_error
+  end
+
+  it "raises a TypeError on invalid input type" do
+    cert = OpenSSL::X509::Certificate.new
+    -> { cert.serial = Object.new }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
+  end
+
+  it "does not coerce the input with #to_int" do
+    serial = mock("version")
+    serial.should_not_receive(:to_int)
+    cert = OpenSSL::X509::Certificate.new
+    -> { cert.serial = serial }.should raise_error(TypeError, 'Cannot convert into OpenSSL::BN')
+  end
+end
+
 describe "OpenSSL::X509::Certificate#version" do
   it "can be set and queried" do
     cert = OpenSSL::X509::Certificate.new


### PR DESCRIPTION
This includes a very crude version of `OpenSSL::BN`, which only supports `int64_t` sized input (BN is a shorthand for Bignum, so the current implementation is completely missing the point), but at least we can continue with the X509 part.