### PR TITLE
Add example scripts for OpenSSL sockets

### DIFF
--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'socket'
+require 'openssl'
+
+# Warning: OpenSSL support is a work in progress and should not be used for anything other than testing.
+TCPSocket.open('natalie-lang.org', 443) do |sock|
+  ssl_context = OpenSSL::SSL::SSLContext.new
+  ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
+  ssl_sock.connect
+
+  ssl_sock.write("GET / HTTP/1.1\r\nHost: natalie-lang.org\r\nConnection: close\r\n\r\n")
+  body = ssl_sock.read
+  puts body.sub(/\A.*?(<html)/m, '\\1')
+end

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -370,7 +370,14 @@ Value OpenSSL_SSL_SSLSocket_connect(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
     auto ssl = static_cast<SSL *>(self->ivar_get(env, "@ssl"_s)->as_void_p()->void_ptr());
     auto fd = self->ivar_get(env, "@io"_s)->as_io()->fileno();
-    const auto flags = fcntl(fd, F_GETFL);
+    auto flags = fcntl(fd, F_GETFL);
+    if (flags < 0)
+        env->raise_errno();
+    if (flags & O_NONBLOCK) {
+        flags &= ~O_NONBLOCK;
+        if (fcntl(fd, F_SETFL, flags) < 0)
+            env->raise_errno();
+    }
     if (!SSL_set_fd(ssl, fd))
         OpenSSL_raise_error(env, "SSL_set_fd");
     if (!SSL_connect(ssl))


### PR DESCRIPTION
This serves mostly as an easy way to test the sockets (related to  #1781, or extracted from that case). I don't want to turn this into a unit test, since it has dependencies on network and external servers. We can add that once we have SSL servers working.

The SSL sockets broke after the nonblock settings in Socket have been added, this change adds a reversal of that setting if the socket is being used in an SSL connection.