### PR TITLE
Improvements to OpenSSL::BN

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -930,6 +930,16 @@ Value OpenSSL_BN_cmp(Env *env, Value self, Args args, Block *) {
     return Value::integer(BN_cmp(bn, other_bn));
 }
 
+Value OpenSSL_BN_to_i(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+    auto bn = static_cast<BIGNUM *>(self->ivar_get(env, "@bn"_s)->as_void_p()->void_ptr());
+    auto str = BN_bn2dec(bn);
+    if (!str)
+        OpenSSL_raise_error(env, "BN_bn2dec");
+    Defer str_free { [str] { OPENSSL_free(str); } };
+    return IntegerObject::create(str);
+}
+
 Value OpenSSL_Random_random_bytes(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
     Value length = args[0]->to_int(env);

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -86,6 +86,9 @@ module OpenSSL
 
     __bind_method__ :initialize, :OpenSSL_BN_initialize
     __bind_method__ :<=>, :OpenSSL_BN_cmp
+    __bind_method__ :to_i, :OpenSSL_BN_to_i
+
+    alias to_int to_i
   end
 
   module Random

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -19,6 +19,11 @@ describe "OpenSSL::BN" do
       bn = OpenSSL::BN.new(1234)
       bn.should be_kind_of(OpenSSL::BN)
     end
+
+    it "can be constructor with a different BN object" do
+      bn = OpenSSL::BN.new(1234)
+      bn.should == OpenSSL::BN.new(bn)
+    end
   end
 
   describe "OpenSSL::BN#<=>" do

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -15,14 +15,29 @@ end
 
 describe "OpenSSL::BN" do
   describe "OpenSSL::BN.new" do
-    it "can be constructed with an integer in the int64 range" do
+    it "can be constructed with an Integer" do
       bn = OpenSSL::BN.new(1234)
+      bn.should be_kind_of(OpenSSL::BN)
+
+      bn = OpenSSL::BN.new(1 << 30) # Natalie Bignum type
       bn.should be_kind_of(OpenSSL::BN)
     end
 
     it "can be constructor with a different BN object" do
       bn = OpenSSL::BN.new(1234)
       bn.should == OpenSSL::BN.new(bn)
+    end
+
+    it "can be constructed with a String" do
+      bn = OpenSSL::BN.new("1234")
+      bn.should be_kind_of(OpenSSL::BN)
+      bn.to_i.should == 1234
+    end
+
+    it "can be constructed with a String with a base" do
+      bn = OpenSSL::BN.new("1234", 16)
+      bn.should be_kind_of(OpenSSL::BN)
+      bn.to_i.should == 0x1234
     end
   end
 
@@ -36,12 +51,21 @@ describe "OpenSSL::BN" do
       OpenSSL::BN.new(1234).should == 1234
       OpenSSL::BN.new(1234).should != 4321
     end
+
+    it "can compare a OpenSSL::BN instance to a Natalie Bignum type" do
+      OpenSSL::BN.new(1 << 30).should == 1 << 30
+    end
   end
 
   describe "OpenSSL::BN#to_i" do
     it "returns the value as an Integer" do
       bn = OpenSSL::BN.new(1234)
       bn.to_i.should == 1234
+    end
+
+    it "supports the Natalie Bignum type" do
+      bn = OpenSSL::BN.new(1 << 30)
+      bn.to_i.should == 1 << 30
     end
   end
 end

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -37,6 +37,13 @@ describe "OpenSSL::BN" do
       OpenSSL::BN.new(1234).should != 4321
     end
   end
+
+  describe "OpenSSL::BN#to_i" do
+    it "returns the value as an Integer" do
+      bn = OpenSSL::BN.new(1234)
+      bn.to_i.should == 1234
+    end
+  end
 end
 
 describe "OpenSSL::X509::Certificate" do


### PR DESCRIPTION
* Add a `#to_i` method to improve the interoperability with Ruby's native numeric format (and we needed that in some tests as well)
* Support String and Bigint type in constructor (which resulted in less code)