### PR TITLE
Add accessors for not_after/not_before to OpenSSL::X509::Certificate

### DIFF
--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -621,6 +621,44 @@ Value OpenSSL_X509_Certificate_set_issuer(Env *env, Value self, Args args, Block
     return args[0];
 }
 
+Value OpenSSL_X509_Certificate_not_after(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    auto time = X509_get0_notAfter(x509);
+    if (!time)
+        OpenSSL_raise_error(env, "X509_get0_notAfter");
+    tm tm;
+    if (!ASN1_TIME_to_tm(time, &tm))
+        return NilObject::the();
+
+    auto Time = find_top_level_const(env, "Time"_s)->as_class();
+    time_t time_since_epoch = mktime(&tm);
+    auto kwargs = new HashObject { env, { "in"_s, Value::integer(0) } };
+    return Time->send(env, "at"_s, Args { { Value::integer(time_since_epoch), kwargs }, true });
+}
+
+Value OpenSSL_X509_Certificate_set_not_after(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    auto time = args[0];
+
+    auto Time = find_top_level_const(env, "Time"_s)->as_class();
+    if (!time->is_a(env, Time)) {
+        time = KernelModule::Integer(env, time, 0, true);
+        time = Time->send(env, "at"_s, { time });
+    }
+    ASN1_TIME *asn1 = ASN1_UTCTIME_set(nullptr, time->as_time()->to_i(env)->as_integer()->to_nat_int_t());
+    if (!asn1)
+        OpenSSL_raise_error(env, "ASN1_TIME_set");
+    Defer asn1_time_free { [asn1]() { ASN1_TIME_free(asn1); } };
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    if (!X509_set1_notAfter(x509, asn1))
+        OpenSSL_raise_error(env, "X509_set1_notAfter");
+
+    return args[0];
+}
+
 Value OpenSSL_X509_Certificate_not_before(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -621,6 +621,44 @@ Value OpenSSL_X509_Certificate_set_issuer(Env *env, Value self, Args args, Block
     return args[0];
 }
 
+Value OpenSSL_X509_Certificate_not_before(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    auto time = X509_get0_notBefore(x509);
+    if (!time)
+        OpenSSL_raise_error(env, "X509_get0_notBefore");
+    tm tm;
+    if (!ASN1_TIME_to_tm(time, &tm))
+        return NilObject::the();
+
+    auto Time = find_top_level_const(env, "Time"_s)->as_class();
+    time_t time_since_epoch = mktime(&tm);
+    auto kwargs = new HashObject { env, { "in"_s, Value::integer(0) } };
+    return Time->send(env, "at"_s, Args { { Value::integer(time_since_epoch), kwargs }, true });
+}
+
+Value OpenSSL_X509_Certificate_set_not_before(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    auto time = args[0];
+
+    auto Time = find_top_level_const(env, "Time"_s)->as_class();
+    if (!time->is_a(env, Time)) {
+        time = KernelModule::Integer(env, time, 0, true);
+        time = Time->send(env, "at"_s, { time });
+    }
+    ASN1_TIME *asn1 = ASN1_UTCTIME_set(nullptr, time->as_time()->to_i(env)->as_integer()->to_nat_int_t());
+    if (!asn1)
+        OpenSSL_raise_error(env, "ASN1_TIME_set");
+    Defer asn1_time_free { [asn1]() { ASN1_TIME_free(asn1); } };
+
+    auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s)->as_void_p()->void_ptr());
+    if (!X509_set1_notBefore(x509, asn1))
+        OpenSSL_raise_error(env, "X509_set1_notBefore");
+
+    return args[0];
+}
+
 Value OpenSSL_X509_Certificate_public_key(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
 

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -212,6 +212,8 @@ module OpenSSL
       __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
       __bind_method__ :issuer, :OpenSSL_X509_Certificate_issuer
       __bind_method__ :issuer=, :OpenSSL_X509_Certificate_set_issuer
+      __bind_method__ :not_before, :OpenSSL_X509_Certificate_not_before
+      __bind_method__ :not_before=, :OpenSSL_X509_Certificate_set_not_before
       __bind_method__ :public_key, :OpenSSL_X509_Certificate_public_key
       __bind_method__ :public_key=, :OpenSSL_X509_Certificate_set_public_key
       __bind_method__ :serial, :OpenSSL_X509_Certificate_serial

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -212,6 +212,8 @@ module OpenSSL
       __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
       __bind_method__ :issuer, :OpenSSL_X509_Certificate_issuer
       __bind_method__ :issuer=, :OpenSSL_X509_Certificate_set_issuer
+      __bind_method__ :not_after, :OpenSSL_X509_Certificate_not_after
+      __bind_method__ :not_after=, :OpenSSL_X509_Certificate_set_not_after
       __bind_method__ :not_before, :OpenSSL_X509_Certificate_not_before
       __bind_method__ :not_before=, :OpenSSL_X509_Certificate_set_not_before
       __bind_method__ :public_key, :OpenSSL_X509_Certificate_public_key

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -10,8 +10,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
     cert.issuer = cert.subject
     cert.public_key = key.public_key
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_before=', exception: NoMethodError, message: "undefined method `not_before=' for an instance of OpenSSL::X509::Certificate" do
-      cert.not_before = Time.now - 10
+    cert.not_before = Time.now - 10
+    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
       cert.not_after = cert.not_before + 365 * 24 * 60 * 60
       cert.sign key, OpenSSL::Digest.new('SHA256')
       store = OpenSSL::X509::Store.new
@@ -28,8 +28,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
     cert.issuer = cert.subject
     cert.public_key = key.public_key
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_before=', exception: NoMethodError, message: "undefined method `not_before=' for an instance of OpenSSL::X509::Certificate" do
-      cert.not_before = Time.now - 10
+    cert.not_before = Time.now - 10
+    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
       cert.not_after = Time.now - 5
       cert.sign key, OpenSSL::Digest.new('SHA256')
       store = OpenSSL::X509::Store.new
@@ -46,8 +46,8 @@ describe "OpenSSL::X509::Store#verify" do
     root_cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=truffleruby/CN=TruffleRuby CA"
     root_cert.issuer = root_cert.subject
     root_cert.public_key = root_key.public_key
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_before=', exception: NoMethodError, message: "undefined method `not_before=' for an instance of OpenSSL::X509::Certificate" do
-      root_cert.not_before = Time.now - 10
+    root_cert.not_before = Time.now - 10
+    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
       root_cert.not_after = Time.now - 5
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = root_cert

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -11,8 +11,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.issuer = cert.subject
     cert.public_key = key.public_key
     cert.not_before = Time.now - 10
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
-      cert.not_after = cert.not_before + 365 * 24 * 60 * 60
+    cert.not_after = cert.not_before + 365 * 24 * 60 * 60
+    NATFIXME 'Implement OpenSSL::X509::Certificate#sign', exception: NoMethodError, message: "undefined method `sign' for an instance of OpenSSL::X509::Certificate" do
       cert.sign key, OpenSSL::Digest.new('SHA256')
       store = OpenSSL::X509::Store.new
       store.add_cert(cert)
@@ -29,8 +29,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.issuer = cert.subject
     cert.public_key = key.public_key
     cert.not_before = Time.now - 10
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
-      cert.not_after = Time.now - 5
+    cert.not_after = Time.now - 5
+    NATFIXME 'Implement OpenSSL::X509::Certificate#sign', exception: NoMethodError, message: "undefined method `sign' for an instance of OpenSSL::X509::Certificate" do
       cert.sign key, OpenSSL::Digest.new('SHA256')
       store = OpenSSL::X509::Store.new
       store.add_cert(cert)
@@ -47,8 +47,8 @@ describe "OpenSSL::X509::Store#verify" do
     root_cert.issuer = root_cert.subject
     root_cert.public_key = root_key.public_key
     root_cert.not_before = Time.now - 10
-    NATFIXME 'Implement OpenSSL::X509::Certificate#not_after=', exception: NoMethodError, message: "undefined method `not_after=' for an instance of OpenSSL::X509::Certificate" do
-      root_cert.not_after = Time.now - 5
+    root_cert.not_after = Time.now - 5
+    NATFIXME 'Implement OpenSSL::X509::ExtensionFactory', exception: NameError, message: 'uninitialized constant OpenSSL::X509::ExtensionFactory' do
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = root_cert
       ef.issuer_certificate = root_cert

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -57,6 +57,56 @@ describe "OpenSSL::X509::Certificate" do
     end
   end
 
+  describe "OpenSSL::X509::Certificate#not_before" do
+    before :each do
+      # Time compare with different timezones is broken in Natalie, so run this in UTC.
+      # The following code yields `true` in MRI, but `false` in Natalie:
+      #
+      #     Time.new(2024, 1, 1, 0, 0, 0, 3600) == Time.new(2023, 12, 31, 23, 0, 0, 0)
+      @tz, ENV["TZ"] = ENV["TZ"], "UTC"
+    end
+
+    after :each do
+      ENV["TZ"] = @tz
+    end
+
+    it "can be set and queried with Time" do
+      time = Time.now - 10
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = time
+      cert.not_before.should > time - 1
+      cert.not_before.should < time + 1
+    end
+
+    it "can be set with Integer" do
+      time = Time.now - 10
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = time.to_i
+      cert.not_before.should > time - 1
+      cert.not_before.should < time + 1
+    end
+
+    it "returns time in UTC" do
+      ENV["TZ"] = "CET"
+      time = Time.new(2024, 1, 1, 0, 0, 0, 3600)
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before = time
+      cert.not_before.should == Time.new(2023, 12, 31, 23, 0, 0, 0)
+    end
+
+    it "has no default value" do
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_before.should be_nil
+    end
+
+    it "cannot be set with String" do
+      cert = OpenSSL::X509::Certificate.new
+      -> {
+        cert.not_before = "2999-01-01 00:00:00"
+      }.should raise_error(ArgumentError, /invalid value for Integer\(\):/)
+    end
+  end
+
   describe "OpenSSL::X509::Certificate#public_key" do
     it "can be set and queried with OpenSSL::PKey::RSA" do
       key = OpenSSL::PKey::RSA.new(2048)

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -57,6 +57,56 @@ describe "OpenSSL::X509::Certificate" do
     end
   end
 
+  describe "OpenSSL::X509::Certificate#not_after" do
+    before :each do
+      # Time compare with different timezones is broken in Natalie, so run this in UTC.
+      # The following code yields `true` in MRI, but `false` in Natalie:
+      #
+      #     Time.new(2024, 1, 1, 0, 0, 0, 3600) == Time.new(2023, 12, 31, 23, 0, 0, 0)
+      @tz, ENV["TZ"] = ENV["TZ"], "UTC"
+    end
+
+    after :each do
+      ENV["TZ"] = @tz
+    end
+
+    it "can be set and queried with Time" do
+      time = Time.now + 10
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_after = time
+      cert.not_after.should > time - 1
+      cert.not_after.should < time + 1
+    end
+
+    it "can be set with Integer" do
+      time = Time.now + 10
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_after = time.to_i
+      cert.not_after.should > time - 1
+      cert.not_after.should < time + 1
+    end
+
+    it "returns time in UTC" do
+      ENV["TZ"] = "CET"
+      time = Time.new(2024, 1, 1, 0, 0, 0, 3600)
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_after = time
+      cert.not_after.should == Time.new(2023, 12, 31, 23, 0, 0, 0)
+    end
+
+    it "has no default value" do
+      cert = OpenSSL::X509::Certificate.new
+      cert.not_after.should be_nil
+    end
+
+    it "cannot be set with String" do
+      cert = OpenSSL::X509::Certificate.new
+      -> {
+        cert.not_after = "2999-01-01 00:00:00"
+      }.should raise_error(ArgumentError, /invalid value for Integer\(\):/)
+    end
+  end
+
   describe "OpenSSL::X509::Certificate#not_before" do
     before :each do
       # Time compare with different timezones is broken in Natalie, so run this in UTC.


### PR DESCRIPTION
The tests include some workaround to force it to run in the UTC timezone, otherwise we're running into issues with our Time class.