### PR TITLE
Use upstream specs to check if Complex/Rational is frozen

### DIFF
--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -14,10 +14,8 @@ describe "Kernel.Complex()" do
 
   describe "when passed [Complex]" do
     it "returns the passed Complex number" do
-      NATFIXME 'when passed [Complex]', exception: SpecFailedException do
-        Complex(Complex(1, 2)).should == Complex(1, 2)
-        Complex(Complex(-3.4, bignum_value)).should == Complex(-3.4, bignum_value)
-      end
+      Complex(Complex(1, 2)).should == Complex(1, 2)
+      Complex(Complex(-3.4, bignum_value)).should == Complex(-3.4, bignum_value)
     end
   end
 

--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -1,0 +1,332 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/kernel/complex'
+require_relative 'fixtures/Complex'
+
+describe "Kernel.Complex()" do
+  describe "when passed [Complex, Complex]" do
+    it "returns a new Complex number based on the two given numbers" do
+      NATFIXME 'returns a new Complex number based on the two given numbers', exception: NoMethodError, message: "undefined method `negative?' for an instance of Complex" do
+        Complex(Complex(3, 4), Complex(5, 6)).should == Complex(3 - 6, 4 + 5)
+        Complex(Complex(1.5, 2), Complex(-5, 6.3)).should == Complex(1.5 - 6.3, 2 - 5)
+      end
+    end
+  end
+
+  describe "when passed [Complex]" do
+    it "returns the passed Complex number" do
+      NATFIXME 'when passed [Complex]', exception: SpecFailedException do
+        Complex(Complex(1, 2)).should == Complex(1, 2)
+        Complex(Complex(-3.4, bignum_value)).should == Complex(-3.4, bignum_value)
+      end
+    end
+  end
+
+  describe "when passed [Integer, Integer]" do
+    it "returns a new Complex number" do
+      Complex(1, 2).should be_an_instance_of(Complex)
+      Complex(1, 2).real.should == 1
+      Complex(1, 2).imag.should == 2
+
+      Complex(-3, -5).should be_an_instance_of(Complex)
+      Complex(-3, -5).real.should == -3
+      Complex(-3, -5).imag.should == -5
+
+      Complex(3.5, -4.5).should be_an_instance_of(Complex)
+      Complex(3.5, -4.5).real.should == 3.5
+      Complex(3.5, -4.5).imag.should == -4.5
+
+      Complex(bignum_value, 30).should be_an_instance_of(Complex)
+      Complex(bignum_value, 30).real.should == bignum_value
+      Complex(bignum_value, 30).imag.should == 30
+    end
+  end
+
+  describe "when passed [Integer/Float]" do
+    it "returns a new Complex number with 0 as the imaginary component" do
+      # Guard against the Mathn library
+      guard -> { !defined?(Math.rsqrt) } do
+        Complex(1).should be_an_instance_of(Complex)
+        Complex(1).imag.should == 0
+        Complex(1).real.should == 1
+
+        Complex(-3).should be_an_instance_of(Complex)
+        Complex(-3).imag.should == 0
+        Complex(-3).real.should == -3
+
+        Complex(-4.5).should be_an_instance_of(Complex)
+        Complex(-4.5).imag.should == 0
+        Complex(-4.5).real.should == -4.5
+
+        Complex(bignum_value).should be_an_instance_of(Complex)
+        Complex(bignum_value).imag.should == 0
+        Complex(bignum_value).real.should == bignum_value
+      end
+    end
+  end
+
+  describe "when passed [String]" do
+    it_behaves_like :kernel_complex, :Complex_method, KernelSpecs
+
+    context "invalid argument" do
+      it "raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding" do
+        NATFIXME 'raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding', exception: SpecFailedException do
+          -> {
+            Complex("79+4i".encode("UTF-16"))
+          }.should raise_error(Encoding::CompatibilityError, "ASCII incompatible encoding: UTF-16")
+        end
+      end
+
+      it "raises ArgumentError for unrecognised Strings" do
+        NATFIXME 'raises ArgumentError for unrecognised Strings', exception: SpecFailedException do
+          -> {
+            Complex("ruby")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "ruby"')
+        end
+      end
+
+      it "raises ArgumentError for trailing garbage" do
+        NATFIXME 'raises ArgumentError for trailing garbage', exception: SpecFailedException do
+          -> {
+            Complex("79+4iruby")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "79+4iruby"')
+        end
+      end
+
+      it "does not understand Float::INFINITY" do
+        NATFIXME 'does not understand Float::INFINITY', exception: SpecFailedException do
+          -> {
+            Complex("Infinity")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "Infinity"')
+
+          -> {
+            Complex("-Infinity")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "-Infinity"')
+        end
+      end
+
+      it "does not understand Float::NAN" do
+        NATFIXME 'does not understand Float::NAN', exception: SpecFailedException do
+          -> {
+            Complex("NaN")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "NaN"')
+        end
+      end
+
+      it "does not understand a sequence of _" do
+        NATFIXME 'does not understand a sequence of _', exception: SpecFailedException do
+          -> {
+            Complex("7__9+4__0i")
+          }.should raise_error(ArgumentError, 'invalid value for convert(): "7__9+4__0i"')
+        end
+      end
+
+      it "does not allow null-byte" do
+        NATFIXME 'does not allow null-byte', exception: SpecFailedException do
+          -> {
+            Complex("1-2i\0")
+          }.should raise_error(ArgumentError, "string contains null byte")
+        end
+      end
+    end
+
+    context "invalid argument and exception: false passed" do
+      it "raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding" do
+        NATFIXME 'raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding', exception: SpecFailedException do
+          -> {
+            Complex("79+4i".encode("UTF-16"), exception: false)
+          }.should raise_error(Encoding::CompatibilityError, "ASCII incompatible encoding: UTF-16")
+        end
+      end
+
+      it "returns nil for unrecognised Strings" do
+        NATFIXME 'returns nil for unrecognised Strings', exception: SpecFailedException do
+          Complex("ruby", exception: false).should == nil
+        end
+      end
+
+      it "returns nil when trailing garbage" do
+        NATFIXME 'returns nil when trailing garbage', exception: SpecFailedException do
+          Complex("79+4iruby", exception: false).should == nil
+        end
+      end
+
+      it "returns nil for Float::INFINITY" do
+        NATFIXME 'returns nil for Float::INFINITY', exception: SpecFailedException do
+          Complex("Infinity", exception: false).should == nil
+          Complex("-Infinity", exception: false).should == nil
+        end
+      end
+
+      it "returns nil for Float::NAN" do
+        NATFIXME 'returns nil for Float::NAN', exception: SpecFailedException do
+          Complex("NaN", exception: false).should == nil
+        end
+      end
+
+      it "returns nil when there is a sequence of _" do
+        NATFIXME 'returns nil when there is a sequence of _', exception: SpecFailedException do
+          Complex("7__9+4__0i", exception: false).should == nil
+        end
+      end
+
+      it "returns nil when String contains null-byte" do
+        NATFIXME 'returns nil when String contains null-byte', exception: SpecFailedException do
+          Complex("1-2i\0", exception: false).should == nil
+        end
+      end
+    end
+  end
+
+  describe "when passes [String, String]" do
+    it "needs to be reviewed for spec completeness"
+  end
+
+  describe "when passed an Object which responds to #to_c" do
+    it "returns the passed argument" do
+      obj = Object.new; def obj.to_c; 1i end
+      NATFIXME 'when passed an Object which responds to #to_c', exception: SpecFailedException do
+        Complex(obj).should == Complex(0, 1)
+      end
+    end
+  end
+
+  describe "when passed a Numeric which responds to #real? with false" do
+    it "returns the passed argument" do
+      n = mock_numeric("unreal")
+      NATFIXME 'when passed a Numeric which responds to #real? with false', exception: SpecFailedException do
+        n.should_receive(:real?).any_number_of_times.and_return(false)
+        Complex(n).should equal(n)
+      end
+    end
+  end
+
+  describe "when passed a Numeric which responds to #real? with true" do
+    it "returns a Complex with the passed argument as the real component and 0 as the imaginary component" do
+      n = mock_numeric("real")
+      n.should_receive(:real?).any_number_of_times.and_return(true)
+      result = Complex(n)
+      result.real.should equal(n)
+      result.imag.should equal(0)
+    end
+  end
+
+  describe "when passed Numerics n1 and n2 and at least one responds to #real? with false" do
+    [[false, false], [false, true], [true, false]].each do |r1, r2|
+      it "returns n1 + n2 * Complex(0, 1)" do
+        n1 = mock_numeric("n1")
+        n2 = mock_numeric("n2")
+        n3 = mock_numeric("n3")
+        n4 = mock_numeric("n4")
+        NATFIXME 'when passed Numerics n1 and n2 and at least one responds to #real? with false', exception: ArgumentError, message: 'comparison of MockNumeric with 0 failed' do
+          n1.should_receive(:real?).any_number_of_times.and_return(r1)
+          n2.should_receive(:real?).any_number_of_times.and_return(r2)
+          n2.should_receive(:*).with(Complex(0, 1)).and_return(n3)
+          n1.should_receive(:+).with(n3).and_return(n4)
+          Complex(n1, n2).should equal(n4)
+        end
+      end
+    end
+  end
+
+  describe "when passed two Numerics and both respond to #real? with true" do
+    it "returns a Complex with the passed arguments as real and imaginary components respectively" do
+      n1 = mock_numeric("n1")
+      n2 = mock_numeric("n2")
+      n1.should_receive(:real?).any_number_of_times.and_return(true)
+      n2.should_receive(:real?).any_number_of_times.and_return(true)
+      result = Complex(n1, n2)
+      result.real.should equal(n1)
+      result.imag.should equal(n2)
+    end
+  end
+
+  describe "when passed a single non-Numeric" do
+    it "coerces the passed argument using #to_c" do
+      n = mock("n")
+      c = Complex(0, 0)
+      NATFIXME 'when passed a single non-Numeric', exception: SpecFailedException do
+        n.should_receive(:to_c).and_return(c)
+        Complex(n).should equal(c)
+      end
+    end
+  end
+
+  describe "when passed a non-Numeric second argument" do
+    it "raises TypeError" do
+      NATFIXME 'when passed a non-Numeric second argument', exception: SpecFailedException do
+        -> { Complex(:sym, :sym) }.should raise_error(TypeError)
+        -> { Complex(0,    :sym) }.should raise_error(TypeError)
+      end
+    end
+  end
+
+  describe "when passed nil" do
+    it "raises TypeError" do
+      NATFIXME 'when passed nil', exception: SpecFailedException do
+        -> { Complex(nil) }.should raise_error(TypeError, "can't convert nil into Complex")
+        -> { Complex(0, nil) }.should raise_error(TypeError, "can't convert nil into Complex")
+        -> { Complex(nil, 0) }.should raise_error(TypeError, "can't convert nil into Complex")
+      end
+    end
+  end
+
+  describe "when passed exception: false" do
+    describe "and [Numeric]" do
+      it "returns a complex number" do
+        NATFIXME '[Numeric]', exception: SpecFailedException do
+          Complex("123", exception: false).should == Complex(123)
+        end
+      end
+    end
+
+    describe "and [non-Numeric]" do
+      it "swallows an error" do
+        NATFIXME '[non-Numeric]', exception: SpecFailedException do
+          Complex(:sym, exception: false).should == nil
+        end
+      end
+    end
+
+    describe "and [non-Numeric, Numeric] argument" do
+      it "throws a TypeError" do
+        NATFIXME '[non-Numeric, Numeric] argument', exception: SpecFailedException do
+          -> { Complex(:sym, 0, exception: false) }.should raise_error(TypeError, "not a real")
+        end
+      end
+    end
+
+    describe "and [anything, non-Numeric] argument" do
+      it "swallows an error" do
+        Complex("a",  :sym, exception: false).should == nil
+        NATFIXME '[anything, non-Numeric] argument', exception: NoMethodError, message: "undefined method `real' for nil" do
+          Complex(:sym, :sym, exception: false).should == nil
+          Complex(0,    :sym, exception: false).should == nil
+        end
+      end
+    end
+
+    describe "and non-numeric String arguments" do
+      it "swallows an error" do
+        Complex("a", "b", exception: false).should == nil
+        Complex("a", 0, exception: false).should == nil
+        NATFIXME 'non-numeric String arguments', exception: NoMethodError, message: "undefined method `real' for nil" do
+          Complex(0, "b", exception: false).should == nil
+        end
+      end
+    end
+
+    describe "and nil arguments" do
+      it "swallows an error" do
+        Complex(nil, exception: false).should == nil
+        NATFIXME 'nil arguments', exception: NoMethodError, message: "undefined method `real' for nil" do
+          Complex(0, nil, exception: false).should == nil
+          Complex(nil, 0, exception: false).should == nil
+        end
+      end
+    end
+  end
+
+  it "freezes its result" do
+    Complex(1).frozen?.should == true
+  end
+end

--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -271,9 +271,7 @@ describe "Kernel.Complex()" do
   describe "when passed exception: false" do
     describe "and [Numeric]" do
       it "returns a complex number" do
-        NATFIXME '[Numeric]', exception: SpecFailedException do
-          Complex("123", exception: false).should == Complex(123)
-        end
+        Complex("123", exception: false).should == Complex(123)
       end
     end
 

--- a/spec/core/kernel/fixtures/Complex.rb
+++ b/spec/core/kernel/fixtures/Complex.rb
@@ -1,0 +1,5 @@
+module KernelSpecs
+  def self.Complex_method(string)
+    Complex(string)
+  end
+end

--- a/spec/shared/kernel/complex.rb
+++ b/spec/shared/kernel/complex.rb
@@ -1,0 +1,193 @@
+# Specs shared by Kernel#Complex() and String#to_c()
+describe :kernel_complex, shared: true do
+
+  it "returns a Complex object" do
+    @object.send(@method, '9').should be_an_instance_of(Complex)
+  end
+
+  it "understands integers" do
+    NATFIXME 'understands integers', exception: SpecFailedException do
+      @object.send(@method, '20').should == Complex(20)
+    end
+  end
+
+  it "understands negative integers" do
+    NATFIXME 'understands negative integers', exception: SpecFailedException do
+      @object.send(@method, '-3').should == Complex(-3)
+    end
+  end
+
+  it "understands fractions (numerator/denominator) for the real part" do
+    NATFIXME 'understands fractions (numerator/denominator) for the real part', exception: SpecFailedException do
+      @object.send(@method, '2/3').should == Complex(Rational(2, 3))
+    end
+  end
+
+  it "understands fractions (numerator/denominator) for the imaginary part" do
+    NATFIXME 'understands fractions (numerator/denominator) for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '4+2/3i').should == Complex(4, Rational(2, 3))
+    end
+  end
+
+  it "understands negative fractions (-numerator/denominator) for the real part" do
+    NATFIXME 'understands negative fractions (-numerator/denominator) for the real part', exception: SpecFailedException do
+      @object.send(@method, '-2/3').should == Complex(Rational(-2, 3))
+    end
+  end
+
+  it "understands negative fractions (-numerator/denominator) for the imaginary part" do
+    NATFIXME 'understands negative fractions (-numerator/denominator) for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '7-2/3i').should == Complex(7, Rational(-2, 3))
+    end
+  end
+
+  it "understands floats (a.b) for the real part" do
+    NATFIXME 'understands floats (a.b) for the real part', exception: SpecFailedException do
+      @object.send(@method, '2.3').should == Complex(2.3)
+    end
+  end
+
+  it "understands floats (a.b) for the imaginary part" do
+    NATFIXME 'understands floats (a.b) for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '4+2.3i').should == Complex(4, 2.3)
+    end
+  end
+
+  it "understands negative floats (-a.b) for the real part" do
+    NATFIXME 'understands negative floats (-a.b) for the real part', exception: SpecFailedException do
+      @object.send(@method, '-2.33').should == Complex(-2.33)
+    end
+  end
+
+  it "understands negative floats (-a.b) for the imaginary part" do
+    NATFIXME 'understands negative floats (-a.b) for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '7-28.771i').should == Complex(7, -28.771)
+    end
+  end
+
+  it "understands an integer followed by 'i' to mean that integer is the imaginary part" do
+    NATFIXME "understands an integer followed by 'i' to mean that integer is the imaginary part", exception: SpecFailedException do
+      @object.send(@method, '35i').should == Complex(0,35)
+    end
+  end
+
+  it "understands a negative integer followed by 'i' to mean that negative integer is the imaginary part" do
+    NATFIXME "understands a negative integer followed by 'i' to mean that negative integer is the imaginary part", exception: SpecFailedException do
+      @object.send(@method, '-29i').should == Complex(0,-29)
+    end
+  end
+
+  it "understands an 'i' by itself as denoting a complex number with an imaginary part of 1" do
+    NATFIXME "understands an 'i' by itself as denoting a complex number with an imaginary part of 1", exception: SpecFailedException do
+      @object.send(@method, 'i').should == Complex(0,1)
+    end
+  end
+
+  it "understands a '-i' by itself as denoting a complex number with an imaginary part of -1" do
+    NATFIXME "understands a '-i' by itself as denoting a complex number with an imaginary part of -1", exception: SpecFailedException do
+      @object.send(@method, '-i').should == Complex(0,-1)
+    end
+  end
+
+  it "understands 'a+bi' to mean a complex number with 'a' as the real part, 'b' as the imaginary" do
+    NATFIXME "understands 'a+bi' to mean a complex number with 'a' as the real part, 'b' as the imaginary", exception: SpecFailedException do
+      @object.send(@method, '79+4i').should == Complex(79,4)
+    end
+  end
+
+  it "understands 'a-bi' to mean a complex number with 'a' as the real part, '-b' as the imaginary" do
+    NATFIXME "understands 'a-bi' to mean a complex number with 'a' as the real part, '-b' as the imaginary", exception: SpecFailedException do
+      @object.send(@method, '79-4i').should == Complex(79,-4)
+    end
+  end
+
+  it "understands 'a+i' to mean a complex number with 'a' as the real part, 1i as the imaginary" do
+    NATFIXME "understands 'a+i' to mean a complex number with 'a' as the real part, 1i as the imaginary", exception: SpecFailedException do
+      @object.send(@method, '79+i').should == Complex(79, 1)
+    end
+  end
+
+  it "understands 'a-i' to mean a complex number with 'a' as the real part, -1i as the imaginary" do
+    NATFIXME "understands 'a-i' to mean a complex number with 'a' as the real part, -1i as the imaginary", exception: SpecFailedException do
+      @object.send(@method, '79-i').should == Complex(79, -1)
+    end
+  end
+
+  it "understands i, I, j, and J imaginary units" do
+    NATFIXME 'understands i, I, j, and J imaginary units', exception: SpecFailedException do
+      @object.send(@method, '79+4i').should == Complex(79, 4)
+      @object.send(@method, '79+4I').should == Complex(79, 4)
+      @object.send(@method, '79+4j').should == Complex(79, 4)
+      @object.send(@method, '79+4J').should == Complex(79, 4)
+    end
+  end
+
+  it "understands scientific notation for the real part" do
+    NATFIXME 'understands scientific notation for the real part', exception: SpecFailedException do
+      @object.send(@method, '2e3+4i').should == Complex(2e3,4)
+    end
+  end
+
+  it "understands negative scientific notation for the real part" do
+    NATFIXME 'understands negative scientific notation for the real part', exception: SpecFailedException do
+      @object.send(@method, '-2e3+4i').should == Complex(-2e3,4)
+    end
+  end
+
+  it "understands scientific notation for the imaginary part" do
+    NATFIXME 'understands scientific notation for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '4+2e3i').should == Complex(4, 2e3)
+    end
+  end
+
+  it "understands negative scientific notation for the imaginary part" do
+    NATFIXME 'understands negative scientific notation for the imaginary part', exception: SpecFailedException do
+      @object.send(@method, '4-2e3i').should == Complex(4, -2e3)
+    end
+  end
+
+  it "understands scientific notation for the real and imaginary part in the same String" do
+    NATFIXME 'understands scientific notation for the real and imaginary part in the same String', exception: SpecFailedException do
+      @object.send(@method, '2e3+2e4i').should == Complex(2e3,2e4)
+    end
+  end
+
+  it "understands negative scientific notation for the real and imaginary part in the same String" do
+    NATFIXME 'understands negative scientific notation for the real and imaginary part in the same String', exception: SpecFailedException do
+      @object.send(@method, '-2e3-2e4i').should == Complex(-2e3,-2e4)
+    end
+  end
+
+  it "understands scientific notation with e and E" do
+    NATFIXME 'understands scientific notation with e and E', exception: SpecFailedException do
+      @object.send(@method, '2e3+2e4i').should == Complex(2e3, 2e4)
+      @object.send(@method, '2E3+2E4i').should == Complex(2e3, 2e4)
+    end
+  end
+
+  it "understands 'm@a' to mean a complex number in polar form with 'm' as the modulus, 'a' as the argument" do
+    NATFIXME "understands 'm@a' to mean a complex number in polar form with 'm' as the modulus, 'a' as the argument", exception: SpecFailedException do
+      @object.send(@method, '79@4').should == Complex.polar(79, 4)
+      @object.send(@method, '-79@4').should == Complex.polar(-79, 4)
+      @object.send(@method, '79@-4').should == Complex.polar(79, -4)
+    end
+  end
+
+  it "ignores leading whitespaces" do
+    NATFIXME 'ignores leading whitespaces', exception: SpecFailedException do
+      @object.send(@method, '  79+4i').should == Complex(79, 4)
+    end
+  end
+
+  it "ignores trailing whitespaces" do
+    NATFIXME 'ignores trailing whitespaces', exception: SpecFailedException do
+      @object.send(@method, '79+4i  ').should == Complex(79, 4)
+    end
+  end
+
+  it "understands _" do
+    NATFIXME 'understands _', exception: SpecFailedException do
+      @object.send(@method, '7_9+4_0i').should == Complex(79, 40)
+    end
+  end
+end

--- a/spec/shared/kernel/complex.rb
+++ b/spec/shared/kernel/complex.rb
@@ -6,15 +6,11 @@ describe :kernel_complex, shared: true do
   end
 
   it "understands integers" do
-    NATFIXME 'understands integers', exception: SpecFailedException do
-      @object.send(@method, '20').should == Complex(20)
-    end
+    @object.send(@method, '20').should == Complex(20)
   end
 
   it "understands negative integers" do
-    NATFIXME 'understands negative integers', exception: SpecFailedException do
-      @object.send(@method, '-3').should == Complex(-3)
-    end
+    @object.send(@method, '-3').should == Complex(-3)
   end
 
   it "understands fractions (numerator/denominator) for the real part" do

--- a/spec/shared/kernel/complex.rb
+++ b/spec/shared/kernel/complex.rb
@@ -38,9 +38,7 @@ describe :kernel_complex, shared: true do
   end
 
   it "understands floats (a.b) for the real part" do
-    NATFIXME 'understands floats (a.b) for the real part', exception: SpecFailedException do
-      @object.send(@method, '2.3').should == Complex(2.3)
-    end
+    @object.send(@method, '2.3').should == Complex(2.3)
   end
 
   it "understands floats (a.b) for the imaginary part" do
@@ -50,9 +48,7 @@ describe :kernel_complex, shared: true do
   end
 
   it "understands negative floats (-a.b) for the real part" do
-    NATFIXME 'understands negative floats (-a.b) for the real part', exception: SpecFailedException do
-      @object.send(@method, '-2.33').should == Complex(-2.33)
-    end
+    @object.send(@method, '-2.33').should == Complex(-2.33)
   end
 
   it "understands negative floats (-a.b) for the imaginary part" do

--- a/spec/shared/rational/Rational.rb
+++ b/spec/shared/rational/Rational.rb
@@ -145,4 +145,8 @@ describe :kernel_Rational, shared: true do
       end
     end
   end
+
+  it "freezes its result" do
+    Rational(1).frozen?.should == true
+  end
 end

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -110,6 +110,10 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value excepti
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
+    if (real->is_string()) {
+        if (auto real_int = Integer(env, real, 10, false); real_int && !real_int->is_nil())
+            real = real_int;
+    }
 
     if (real->is_complex() && imaginary == nullptr) {
         return real;

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -111,7 +111,9 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value excepti
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
 
-    if (imaginary == nullptr) {
+    if (real->is_complex() && imaginary == nullptr) {
+        return real;
+    } else if (imaginary == nullptr) {
         return new ComplexObject { real };
     } else if (real->is_string()) {
         // NATFIXME: Add support for strings too.

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -111,8 +111,11 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value excepti
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
     if (real->is_string()) {
-        if (auto real_int = Integer(env, real, 10, false); real_int && !real_int->is_nil())
+        if (auto real_int = Integer(env, real, 10, false); real_int && !real_int->is_nil()) {
             real = real_int;
+        } else if (auto real_float = Float(env, real, false); real_float && !real_float->is_nil()) {
+            real = real_float;
+        }
     }
 
     if (real->is_complex() && imaginary == nullptr) {

--- a/test/natalie/complex_test.rb
+++ b/test/natalie/complex_test.rb
@@ -25,10 +25,4 @@ describe 'complex' do
   it 'does not have have Comparable mixin more than once' do
     Complex.ancestors.count(Comparable).should == 1
   end
-
-  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1007 is merged
-  it 'is frozen' do
-    r = Complex(1)
-    r.frozen?.should == true
-  end
 end

--- a/test/natalie/rational_test.rb
+++ b/test/natalie/rational_test.rb
@@ -12,10 +12,4 @@ describe 'rational' do
     reduced.numerator.should == 10
     reduced.denominator.should == 3
   end
-
-  # NATFIXME: Remove this and sync upstream spec once https://github.com/ruby/spec/pull/1007 is merged
-  it 'is frozen' do
-    r = Rational(1)
-    r.frozen?.should == true
-  end
 end


### PR DESCRIPTION
Special shout out to the following spec:
```ruby
it "raises ArgumentError for trailing garbage" do
  -> {
    Complex("79+4iruby")
  }.should raise_error(ArgumentError, 'invalid value for convert(): "79+4iruby"')
end
```
So, according to the specs Ruby is garbage :thinking: 