### PR TITLE
Certificate validation in OpenSSL

### DIFF
--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -6,10 +6,13 @@ require 'openssl'
 
 # Warning: OpenSSL support is a work in progress and should not be used for anything other than testing.
 TCPSocket.open('natalie-lang.org', 443) do |sock|
+  cert_store = OpenSSL::X509::Store.new
+
   ssl_context = OpenSSL::SSL::SSLContext.new
   ssl_context.min_version = :TLS1_3
   ssl_context.max_version = :TLS1_3
   ssl_context.security_level = 3
+
   ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
   ssl_sock.connect
 

--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -12,7 +12,8 @@ TCPSocket.open('natalie-lang.org', 443) do |sock|
   ssl_context = OpenSSL::SSL::SSLContext.new
   ssl_context.min_version = :TLS1_3
   ssl_context.max_version = :TLS1_3
-  ssl_context.security_level = 3
+  ssl_context.security_level = 2
+  ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
   ssl_context.cert_store = cert_store
 
   ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)

--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -13,6 +13,7 @@ TCPSocket.open('natalie-lang.org', 443) do |sock|
   ssl_context.min_version = :TLS1_3
   ssl_context.max_version = :TLS1_3
   ssl_context.security_level = 3
+  ssl_context.cert_store = cert_store
 
   ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
   ssl_sock.connect

--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -7,6 +7,7 @@ require 'openssl'
 # Warning: OpenSSL support is a work in progress and should not be used for anything other than testing.
 TCPSocket.open('natalie-lang.org', 443) do |sock|
   cert_store = OpenSSL::X509::Store.new
+  cert_store.set_default_paths
 
   ssl_context = OpenSSL::SSL::SSLContext.new
   ssl_context.min_version = :TLS1_3

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -464,6 +464,7 @@ Value OpenSSL_SSL_SSLSocket_initialize(Env *env, Value self, Args args, Block *)
         if (!context->is_a(env, SSLContext->as_class()))
             env->raise("TypeError", "wrong argument type {} (expected OpenSSL/SSL/CTX)", context->klass()->inspect_str());
     }
+    context->send(env, "setup"_s);
     auto *ctx = static_cast<SSL_CTX *>(context->ivar_get(env, "@ctx"_s)->as_void_p()->void_ptr());
     SSL *ssl = SSL_new(ctx);
     if (!ssl)

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -431,6 +431,17 @@ Value OpenSSL_SSL_SSLContext_set_security_level(Env *env, Value self, Args args,
     return args[0];
 }
 
+Value OpenSSL_SSL_SSLContext_setup(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+
+    if (self->is_frozen())
+        return NilObject::the();
+
+    self->freeze();
+
+    return TrueObject::the();
+}
+
 Value OpenSSL_SSL_SSLSocket_initialize(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_between(env, 1, 2);
     auto io = args.at(0);

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -440,6 +440,23 @@ Value OpenSSL_SSL_SSLContext_set_security_level(Env *env, Value self, Args args,
     return args[0];
 }
 
+Value OpenSSL_SSL_SSLContext_verify_mode(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+    auto ctx = static_cast<SSL_CTX *>(self->ivar_get(env, "@ctx"_s)->as_void_p()->void_ptr());
+    auto verify_mode = SSL_CTX_get_verify_mode(ctx);
+    return Value::integer(verify_mode);
+}
+
+Value OpenSSL_SSL_SSLContext_set_verify_mode(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 1);
+    auto verify_mode = args[0]->to_int(env)->to_nat_int_t();
+
+    auto ctx = static_cast<SSL_CTX *>(self->ivar_get(env, "@ctx"_s)->as_void_p()->void_ptr());
+    SSL_CTX_set_verify(ctx, verify_mode, nullptr);
+
+    return args[0];
+}
+
 Value OpenSSL_SSL_SSLContext_setup(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -379,6 +379,9 @@ Value OpenSSL_SSL_SSLContext_set_max_version(Env *env, Value self, Args args, Bl
     args.ensure_argc_is(env, 1);
     auto version = args[0];
 
+    if (self->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", self->to_s(env)->string());
+
     if (version->is_string() || version->is_symbol()) {
         version = StringObject::format("{}_VERSION", version->to_s(env)->string());
         const auto SSL = fetch_nested_const({ "OpenSSL"_s, "SSL"_s })->as_module();
@@ -397,6 +400,9 @@ Value OpenSSL_SSL_SSLContext_set_max_version(Env *env, Value self, Args args, Bl
 Value OpenSSL_SSL_SSLContext_set_min_version(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
     auto version = args[0];
+
+    if (self->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", self->to_s(env)->string());
 
     if (version->is_string() || version->is_symbol()) {
         version = StringObject::format("{}_VERSION", version->to_s(env)->string());
@@ -424,6 +430,9 @@ Value OpenSSL_SSL_SSLContext_security_level(Env *env, Value self, Args args, Blo
 Value OpenSSL_SSL_SSLContext_set_security_level(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 1);
     auto security_level = args[0]->to_int(env)->to_nat_int_t();
+
+    if (self->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", self->to_s(env)->string());
 
     auto ctx = static_cast<SSL_CTX *>(self->ivar_get(env, "@ctx"_s)->as_void_p()->void_ptr());
     SSL_CTX_set_security_level(ctx, security_level);

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -448,6 +448,16 @@ Value OpenSSL_SSL_SSLContext_setup(Env *env, Value self, Args args, Block *) {
 
     self->freeze();
 
+    auto cert_store = self->ivar_get(env, "@cert_store"_s);
+    if (!cert_store->is_nil()) {
+        auto Store = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Store"_s })->as_class();
+        if (!cert_store->is_a(env, Store))
+            env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/STORE)", cert_store->klass()->inspect_str());
+        auto ctx = static_cast<SSL_CTX *>(self->ivar_get(env, "@ctx"_s)->as_void_p()->void_ptr());
+        auto store = static_cast<X509_STORE *>(cert_store->ivar_get(env, "@store"_s)->as_void_p()->void_ptr());
+        SSL_CTX_set1_cert_store(ctx, store);
+    }
+
     return TrueObject::the();
 }
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -1181,3 +1181,11 @@ Value OpenSSL_X509_Store_initialize(Env *env, Value self, Args args, Block *) {
     self->ivar_set(env, "@store"_s, new VoidPObject { store, OpenSSL_X509_STORE_cleanup });
     return self;
 }
+
+Value OpenSSL_X509_Store_set_default_paths(Env *env, Value self, Args args, Block *) {
+    args.ensure_argc_is(env, 0);
+    auto store = static_cast<X509_STORE *>(self->ivar_get(env, "@store"_s)->as_void_p()->void_ptr());
+    if (!X509_STORE_set_default_paths(store))
+        OpenSSL_X509_Store_raise_error(env, "X509_STORE_set_default_paths");
+    return NilObject::the();
+}

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -175,6 +175,9 @@ module OpenSSL
       __bind_method__ :min_version=, :OpenSSL_SSL_SSLContext_set_min_version
       __bind_method__ :security_level, :OpenSSL_SSL_SSLContext_security_level
       __bind_method__ :security_level=, :OpenSSL_SSL_SSLContext_set_security_level
+      __bind_method__ :setup, :OpenSSL_SSL_SSLContext_setup
+
+      alias freeze setup
     end
 
     class SSLSocket

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -216,6 +216,7 @@ module OpenSSL
   module X509
     class CertificateError < OpenSSLError; end
     class NameError < OpenSSLError; end
+    class StoreError < OpenSSLError; end
 
     class Certificate
       __bind_method__ :initialize, :OpenSSL_X509_Certificate_initialize
@@ -274,6 +275,10 @@ module OpenSSL
 
         alias parse parse_openssl
       end
+    end
+
+    class Store
+      __bind_method__ :initialize, :OpenSSL_X509_Store_initialize
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -167,6 +167,12 @@ module OpenSSL
     __constant__ 'TLS1_2_VERSION', 'int'
     __constant__ 'TLS1_3_VERSION', 'int'
 
+    __constant__ 'VERIFY_NONE', 'int', 'SSL_VERIFY_NONE'
+    __constant__ 'VERIFY_PEER', 'int', 'SSL_VERIFY_PEER'
+    __constant__ 'VERIFY_FAIL_IF_NO_PEER_CERT', 'int', 'SSL_VERIFY_FAIL_IF_NO_PEER_CERT'
+    __constant__ 'VERIFY_CLIENT_ONCE', 'int', 'SSL_VERIFY_CLIENT_ONCE'
+    __constant__ 'VERIFY_POST_HANDSHAKE', 'int', 'SSL_VERIFY_POST_HANDSHAKE'
+
     class SSLError < OpenSSLError; end
 
     class SSLContext
@@ -176,6 +182,8 @@ module OpenSSL
       __bind_method__ :security_level, :OpenSSL_SSL_SSLContext_security_level
       __bind_method__ :security_level=, :OpenSSL_SSL_SSLContext_set_security_level
       __bind_method__ :setup, :OpenSSL_SSL_SSLContext_setup
+      __bind_method__ :verify_mode, :OpenSSL_SSL_SSLContext_verify_mode
+      __bind_method__ :verify_mode=, :OpenSSL_SSL_SSLContext_set_verify_mode
 
       attr_accessor :cert_store
 

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -279,6 +279,7 @@ module OpenSSL
 
     class Store
       __bind_method__ :initialize, :OpenSSL_X509_Store_initialize
+      __bind_method__ :set_default_paths, :OpenSSL_X509_Store_set_default_paths
     end
   end
 end

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -177,6 +177,8 @@ module OpenSSL
       __bind_method__ :security_level=, :OpenSSL_SSL_SSLContext_set_security_level
       __bind_method__ :setup, :OpenSSL_SSL_SSLContext_setup
 
+      attr_accessor :cert_store
+
       alias freeze setup
     end
 

--- a/spec/library/openssl/x509/store/verify_spec.rb
+++ b/spec/library/openssl/x509/store/verify_spec.rb
@@ -13,8 +13,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.not_before = Time.now - 10
     cert.not_after = cert.not_before + 365 * 24 * 60 * 60
     cert.sign key, OpenSSL::Digest.new('SHA256')
-    NATFIXME 'Implement OpenSSL::X509::Store', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Store' do
-      store = OpenSSL::X509::Store.new
+    store = OpenSSL::X509::Store.new
+    NATFIXME 'Implement OpenSSL::X509::Store#add_cert', exception: NoMethodError, message: "undefined method `add_cert' for an instance of OpenSSL::X509::Store" do
       store.add_cert(cert)
       [store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
     end
@@ -31,8 +31,8 @@ describe "OpenSSL::X509::Store#verify" do
     cert.not_before = Time.now - 10
     cert.not_after = Time.now - 5
     cert.sign key, OpenSSL::Digest.new('SHA256')
-    NATFIXME 'Implement OpenSSL::X509::Store', exception: NameError, message: 'uninitialized constant OpenSSL::X509::Store' do
-      store = OpenSSL::X509::Store.new
+    store = OpenSSL::X509::Store.new
+    NATFIXME 'Implement OpenSSL::X509::Store#add_cert', exception: NoMethodError, message: "undefined method `add_cert' for an instance of OpenSSL::X509::Store" do
       store.add_cert(cert)
       store.verify(cert).should == false
     end

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -462,6 +462,15 @@ describe "OpenSSL::X509::Name" do
   end
 end
 
+describe "OpenSSL::X509::Store" do
+  describe ".new" do
+    it "can be constructed without arguments" do
+      store = OpenSSL::X509::Store.new
+      store.should be_kind_of(OpenSSL::X509::Store)
+    end
+  end
+end
+
 describe "OpenSSL::SSL::SSLContext" do
   describe ".new" do
     it "can be constructed without arguments" do

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -623,6 +623,12 @@ describe "OpenSSL::SSL::SSLSocket#initialize" do
     ssl_socket.context.should == context
   end
 
+  it "calls SSLContext#setup" do
+    context = OpenSSL::SSL::SSLContext.new
+    ssl_socket = OpenSSL::SSL::SSLSocket.new($stderr, context)
+    context.setup.should be_nil
+  end
+
   it "raises a TypeError if the first argument is not an IO object" do
     -> {
       OpenSSL::SSL::SSLSocket.new(42)

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -488,6 +488,37 @@ describe "OpenSSL::SSL::SSLContext" do
     # NATFIXME: It can be constructed with 1 argument too, but that is deprecated, do we want to reproduce that?
   end
 
+  describe "#cert_store" do
+    it "can be set using a Store" do
+      cert_store = OpenSSL::X509::Store.new
+      context = OpenSSL::SSL::SSLContext.new
+      context.cert_store = cert_store
+      context.cert_store.should be_kind_of(OpenSSL::X509::Store)
+    end
+
+    it "returns the same object" do
+      cert_store = OpenSSL::X509::Store.new
+      context = OpenSSL::SSL::SSLContext.new
+      context.cert_store = cert_store
+      context.cert_store.should equal(cert_store)
+    end
+
+    it "saves the Store as an instance variable" do
+      cert_store = OpenSSL::X509::Store.new
+      context = OpenSSL::SSL::SSLContext.new
+      context.instance_variables.should_not.include?(:@cert_store)
+      context.cert_store = cert_store
+      context.instance_variables.should.include?(:@cert_store)
+    end
+
+    it "can be set to any type (It raises an exception when calling setup)" do
+      cert_store = Object.new
+      context = OpenSSL::SSL::SSLContext.new
+      context.cert_store = cert_store
+      context.cert_store.should == cert_store
+    end
+  end
+
   describe "#max_version=" do
     it "can be set using a constant" do
       context = OpenSSL::SSL::SSLContext.new
@@ -603,6 +634,13 @@ describe "OpenSSL::SSL::SSLContext" do
       context = OpenSSL::SSL::SSLContext.new
       context.setup
       context.setup.should be_nil
+    end
+
+    it "validates the cert_store object" do
+      cert_store = Object.new
+      context = OpenSSL::SSL::SSLContext.new
+      context.cert_store = cert_store
+      -> { context.setup }.should raise_error(TypeError, "wrong argument type Object (expected OpenSSL/X509/STORE)")
     end
   end
 end

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -584,6 +584,27 @@ describe "OpenSSL::SSL::SSLContext" do
       context.security_level.should == -2
     end
   end
+
+  describe "#setup" do
+    it "freezes the context" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.should_not.frozen?
+
+      context.setup
+      context.should.frozen?
+    end
+
+    it "returns true the first time it is called" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.setup.should be_true
+    end
+
+    it "returns nil the next time it is called" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.setup
+      context.setup.should be_nil
+    end
+  end
 end
 
 describe "OpenSSL::SSL::SSLSocket#initialize" do

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -469,6 +469,13 @@ describe "OpenSSL::X509::Store" do
       store.should be_kind_of(OpenSSL::X509::Store)
     end
   end
+
+  describe "#set_default_paths" do
+    it "can be called" do
+      store = OpenSSL::X509::Store.new
+      store.set_default_paths.should be_nil
+    end
+  end
 end
 
 describe "OpenSSL::SSL::SSLContext" do


### PR DESCRIPTION
I never knew there were this many hoops to jump through before OpenSSL starts to check your certificates.

Certificate validation has been added to the example script. We should be ready now to start looking at  #1781 again.