### PR TITLE
Add encoding awareness to String#inspect

### DIFF
--- a/spec/core/string/inspect_spec.rb
+++ b/spec/core/string/inspect_spec.rb
@@ -20,20 +20,18 @@ describe "String#inspect" do
   end
 
   it "returns a string with special characters replaced with \\<char> notation for UTF-16" do
-    NATFIXME 'returns a string with special characters replaced with \\<char> notation for UTF-16', exception: SpecFailedException do
-      pairs = [
-        ["\a", '"\\a"'],
-        ["\b", '"\\b"'],
-        ["\t", '"\\t"'],
-        ["\n", '"\\n"'],
-        ["\v", '"\\v"'],
-        ["\f", '"\\f"'],
-        ["\r", '"\\r"'],
-        ["\e", '"\\e"']
-      ].map { |str, result| [str.encode('UTF-16LE'), result] }
+    pairs = [
+      ["\a", '"\\a"'],
+      ["\b", '"\\b"'],
+      ["\t", '"\\t"'],
+      ["\n", '"\\n"'],
+      ["\v", '"\\v"'],
+      ["\f", '"\\f"'],
+      ["\r", '"\\r"'],
+      ["\e", '"\\e"']
+    ].map { |str, result| [str.encode('UTF-16LE'), result] }
 
-      pairs.should be_computed_by(:inspect)
-    end
+    pairs.should be_computed_by(:inspect)
   end
 
   it "returns a string with \" and \\ escaped with a backslash" do
@@ -327,16 +325,12 @@ describe "String#inspect" do
   end
 
   it "uses \\x notation for broken UTF-8 sequences" do
-    NATFIXME 'uses \\x notation for broken UTF-8 sequences', exception: SpecFailedException do
-      "\xF0\x9F".inspect.should == '"\\xF0\\x9F"'
-    end
+    "\xF0\x9F".inspect.should == '"\\xF0\\x9F"'
   end
 
   it "works for broken US-ASCII strings" do
     s = "©".force_encoding("US-ASCII")
-    NATFIXME 'works for broken US-ASCII strings', exception: SpecFailedException do
-      s.inspect.should == '"\xC2\xA9"'
-    end
+    s.inspect.should == '"\xC2\xA9"'
   end
 
   describe "when default external is UTF-8" do
@@ -414,105 +408,103 @@ describe "String#inspect" do
     end
 
     it "returns a string with extended characters for Unicode strings" do
-      NATFIXME 'returns a string with extended characters for Unicode strings', exception: SpecFailedException do
-        [ [0240.chr('utf-8'), '" "'],
-          [0241.chr('utf-8'), '"¡"'],
-          [0242.chr('utf-8'), '"¢"'],
-          [0243.chr('utf-8'), '"£"'],
-          [0244.chr('utf-8'), '"¤"'],
-          [0245.chr('utf-8'), '"¥"'],
-          [0246.chr('utf-8'), '"¦"'],
-          [0247.chr('utf-8'), '"§"'],
-          [0250.chr('utf-8'), '"¨"'],
-          [0251.chr('utf-8'), '"©"'],
-          [0252.chr('utf-8'), '"ª"'],
-          [0253.chr('utf-8'), '"«"'],
-          [0254.chr('utf-8'), '"¬"'],
-          [0255.chr('utf-8'), '"­"'],
-          [0256.chr('utf-8'), '"®"'],
-          [0257.chr('utf-8'), '"¯"'],
-          [0260.chr('utf-8'), '"°"'],
-          [0261.chr('utf-8'), '"±"'],
-          [0262.chr('utf-8'), '"²"'],
-          [0263.chr('utf-8'), '"³"'],
-          [0264.chr('utf-8'), '"´"'],
-          [0265.chr('utf-8'), '"µ"'],
-          [0266.chr('utf-8'), '"¶"'],
-          [0267.chr('utf-8'), '"·"'],
-          [0270.chr('utf-8'), '"¸"'],
-          [0271.chr('utf-8'), '"¹"'],
-          [0272.chr('utf-8'), '"º"'],
-          [0273.chr('utf-8'), '"»"'],
-          [0274.chr('utf-8'), '"¼"'],
-          [0275.chr('utf-8'), '"½"'],
-          [0276.chr('utf-8'), '"¾"'],
-          [0277.chr('utf-8'), '"¿"'],
-          [0300.chr('utf-8'), '"À"'],
-          [0301.chr('utf-8'), '"Á"'],
-          [0302.chr('utf-8'), '"Â"'],
-          [0303.chr('utf-8'), '"Ã"'],
-          [0304.chr('utf-8'), '"Ä"'],
-          [0305.chr('utf-8'), '"Å"'],
-          [0306.chr('utf-8'), '"Æ"'],
-          [0307.chr('utf-8'), '"Ç"'],
-          [0310.chr('utf-8'), '"È"'],
-          [0311.chr('utf-8'), '"É"'],
-          [0312.chr('utf-8'), '"Ê"'],
-          [0313.chr('utf-8'), '"Ë"'],
-          [0314.chr('utf-8'), '"Ì"'],
-          [0315.chr('utf-8'), '"Í"'],
-          [0316.chr('utf-8'), '"Î"'],
-          [0317.chr('utf-8'), '"Ï"'],
-          [0320.chr('utf-8'), '"Ð"'],
-          [0321.chr('utf-8'), '"Ñ"'],
-          [0322.chr('utf-8'), '"Ò"'],
-          [0323.chr('utf-8'), '"Ó"'],
-          [0324.chr('utf-8'), '"Ô"'],
-          [0325.chr('utf-8'), '"Õ"'],
-          [0326.chr('utf-8'), '"Ö"'],
-          [0327.chr('utf-8'), '"×"'],
-          [0330.chr('utf-8'), '"Ø"'],
-          [0331.chr('utf-8'), '"Ù"'],
-          [0332.chr('utf-8'), '"Ú"'],
-          [0333.chr('utf-8'), '"Û"'],
-          [0334.chr('utf-8'), '"Ü"'],
-          [0335.chr('utf-8'), '"Ý"'],
-          [0336.chr('utf-8'), '"Þ"'],
-          [0337.chr('utf-8'), '"ß"'],
-          [0340.chr('utf-8'), '"à"'],
-          [0341.chr('utf-8'), '"á"'],
-          [0342.chr('utf-8'), '"â"'],
-          [0343.chr('utf-8'), '"ã"'],
-          [0344.chr('utf-8'), '"ä"'],
-          [0345.chr('utf-8'), '"å"'],
-          [0346.chr('utf-8'), '"æ"'],
-          [0347.chr('utf-8'), '"ç"'],
-          [0350.chr('utf-8'), '"è"'],
-          [0351.chr('utf-8'), '"é"'],
-          [0352.chr('utf-8'), '"ê"'],
-          [0353.chr('utf-8'), '"ë"'],
-          [0354.chr('utf-8'), '"ì"'],
-          [0355.chr('utf-8'), '"í"'],
-          [0356.chr('utf-8'), '"î"'],
-          [0357.chr('utf-8'), '"ï"'],
-          [0360.chr('utf-8'), '"ð"'],
-          [0361.chr('utf-8'), '"ñ"'],
-          [0362.chr('utf-8'), '"ò"'],
-          [0363.chr('utf-8'), '"ó"'],
-          [0364.chr('utf-8'), '"ô"'],
-          [0365.chr('utf-8'), '"õ"'],
-          [0366.chr('utf-8'), '"ö"'],
-          [0367.chr('utf-8'), '"÷"'],
-          [0370.chr('utf-8'), '"ø"'],
-          [0371.chr('utf-8'), '"ù"'],
-          [0372.chr('utf-8'), '"ú"'],
-          [0373.chr('utf-8'), '"û"'],
-          [0374.chr('utf-8'), '"ü"'],
-          [0375.chr('utf-8'), '"ý"'],
-          [0376.chr('utf-8'), '"þ"'],
-          [0377.chr('utf-8'), '"ÿ"']
-        ].should be_computed_by(:inspect)
-      end
+      [ [0240.chr('utf-8'), '" "'],
+        [0241.chr('utf-8'), '"¡"'],
+        [0242.chr('utf-8'), '"¢"'],
+        [0243.chr('utf-8'), '"£"'],
+        [0244.chr('utf-8'), '"¤"'],
+        [0245.chr('utf-8'), '"¥"'],
+        [0246.chr('utf-8'), '"¦"'],
+        [0247.chr('utf-8'), '"§"'],
+        [0250.chr('utf-8'), '"¨"'],
+        [0251.chr('utf-8'), '"©"'],
+        [0252.chr('utf-8'), '"ª"'],
+        [0253.chr('utf-8'), '"«"'],
+        [0254.chr('utf-8'), '"¬"'],
+        [0255.chr('utf-8'), '"­"'],
+        [0256.chr('utf-8'), '"®"'],
+        [0257.chr('utf-8'), '"¯"'],
+        [0260.chr('utf-8'), '"°"'],
+        [0261.chr('utf-8'), '"±"'],
+        [0262.chr('utf-8'), '"²"'],
+        [0263.chr('utf-8'), '"³"'],
+        [0264.chr('utf-8'), '"´"'],
+        [0265.chr('utf-8'), '"µ"'],
+        [0266.chr('utf-8'), '"¶"'],
+        [0267.chr('utf-8'), '"·"'],
+        [0270.chr('utf-8'), '"¸"'],
+        [0271.chr('utf-8'), '"¹"'],
+        [0272.chr('utf-8'), '"º"'],
+        [0273.chr('utf-8'), '"»"'],
+        [0274.chr('utf-8'), '"¼"'],
+        [0275.chr('utf-8'), '"½"'],
+        [0276.chr('utf-8'), '"¾"'],
+        [0277.chr('utf-8'), '"¿"'],
+        [0300.chr('utf-8'), '"À"'],
+        [0301.chr('utf-8'), '"Á"'],
+        [0302.chr('utf-8'), '"Â"'],
+        [0303.chr('utf-8'), '"Ã"'],
+        [0304.chr('utf-8'), '"Ä"'],
+        [0305.chr('utf-8'), '"Å"'],
+        [0306.chr('utf-8'), '"Æ"'],
+        [0307.chr('utf-8'), '"Ç"'],
+        [0310.chr('utf-8'), '"È"'],
+        [0311.chr('utf-8'), '"É"'],
+        [0312.chr('utf-8'), '"Ê"'],
+        [0313.chr('utf-8'), '"Ë"'],
+        [0314.chr('utf-8'), '"Ì"'],
+        [0315.chr('utf-8'), '"Í"'],
+        [0316.chr('utf-8'), '"Î"'],
+        [0317.chr('utf-8'), '"Ï"'],
+        [0320.chr('utf-8'), '"Ð"'],
+        [0321.chr('utf-8'), '"Ñ"'],
+        [0322.chr('utf-8'), '"Ò"'],
+        [0323.chr('utf-8'), '"Ó"'],
+        [0324.chr('utf-8'), '"Ô"'],
+        [0325.chr('utf-8'), '"Õ"'],
+        [0326.chr('utf-8'), '"Ö"'],
+        [0327.chr('utf-8'), '"×"'],
+        [0330.chr('utf-8'), '"Ø"'],
+        [0331.chr('utf-8'), '"Ù"'],
+        [0332.chr('utf-8'), '"Ú"'],
+        [0333.chr('utf-8'), '"Û"'],
+        [0334.chr('utf-8'), '"Ü"'],
+        [0335.chr('utf-8'), '"Ý"'],
+        [0336.chr('utf-8'), '"Þ"'],
+        [0337.chr('utf-8'), '"ß"'],
+        [0340.chr('utf-8'), '"à"'],
+        [0341.chr('utf-8'), '"á"'],
+        [0342.chr('utf-8'), '"â"'],
+        [0343.chr('utf-8'), '"ã"'],
+        [0344.chr('utf-8'), '"ä"'],
+        [0345.chr('utf-8'), '"å"'],
+        [0346.chr('utf-8'), '"æ"'],
+        [0347.chr('utf-8'), '"ç"'],
+        [0350.chr('utf-8'), '"è"'],
+        [0351.chr('utf-8'), '"é"'],
+        [0352.chr('utf-8'), '"ê"'],
+        [0353.chr('utf-8'), '"ë"'],
+        [0354.chr('utf-8'), '"ì"'],
+        [0355.chr('utf-8'), '"í"'],
+        [0356.chr('utf-8'), '"î"'],
+        [0357.chr('utf-8'), '"ï"'],
+        [0360.chr('utf-8'), '"ð"'],
+        [0361.chr('utf-8'), '"ñ"'],
+        [0362.chr('utf-8'), '"ò"'],
+        [0363.chr('utf-8'), '"ó"'],
+        [0364.chr('utf-8'), '"ô"'],
+        [0365.chr('utf-8'), '"õ"'],
+        [0366.chr('utf-8'), '"ö"'],
+        [0367.chr('utf-8'), '"÷"'],
+        [0370.chr('utf-8'), '"ø"'],
+        [0371.chr('utf-8'), '"ù"'],
+        [0372.chr('utf-8'), '"ú"'],
+        [0373.chr('utf-8'), '"û"'],
+        [0374.chr('utf-8'), '"ü"'],
+        [0375.chr('utf-8'), '"ý"'],
+        [0376.chr('utf-8'), '"þ"'],
+        [0377.chr('utf-8'), '"ÿ"']
+      ].should be_computed_by(:inspect)
     end
   end
 

--- a/src/encoding/us_ascii_encoding_object.cpp
+++ b/src/encoding/us_ascii_encoding_object.cpp
@@ -16,10 +16,10 @@ std::pair<bool, StringView> UsAsciiEncodingObject::next_char(const String &strin
     if (*index >= string.size())
         return { true, StringView() };
     size_t i = *index;
+    (*index)++;
     unsigned char c = string[i];
     if ((int)c > 127)
         return { false, StringView(&string, i, 1) };
-    (*index)++;
     return { true, StringView(&string, i, 1) };
 }
 


### PR DESCRIPTION
A second attempt at the original change of  #1825. This also fixes a bug in the US-ASCII encoding object, where looping through the chars of a string with high ascii values would result in an infinite loop.