### PR TITLE
Do not print diffs in specs run in CI

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -464,6 +464,8 @@ class Matcher
   end
 
   def diff(actual, expected)
+    return if ENV['CI']
+
     actual_file = Tempfile.create('actual')
     actual_file.write(actual)
     actual_file.close


### PR DESCRIPTION
This should resolve an issue with invalid YAML for a lot of specs (I've used `command_line/backtrace_limit_spec.rb` as an example).