### PR TITLE
Add PlatformGuard.implementation?

### DIFF
--- a/test/support/platform_guard.rb
+++ b/test/support/platform_guard.rb
@@ -1,6 +1,11 @@
 class PlatformGuard
   POINTER_SIZE = 0.size * 8
 
+  # We'll add a real implementation the moment rubyspecs gets Natalie-specific specs
+  def self.implementation?(*)
+    false
+  end
+
   def self.windows?
     false
   end


### PR DESCRIPTION
This guards checks for specific Ruby implementations, we probably shouldn't try to be compatible with these corner cases.

Currently, it's only used for specific load paths in MRI.