### PR TITLE
Make StringObject::inspect as const

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -229,7 +229,7 @@ public:
 
     StringObject *to_str() { return this; }
 
-    StringObject *inspect(Env *);
+    StringObject *inspect(Env *) const;
 
     StringObject &operator=(StringObject other) {
         this->m_string = other.m_string;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -496,7 +496,7 @@ Value StringObject::tr_in_place(Env *env, Value from_value, Value to_value) {
     return this;
 }
 
-StringObject *StringObject::inspect(Env *env) {
+StringObject *StringObject::inspect(Env *env) const {
     StringObject *out = new StringObject { "\"" };
 
     size_t index = 0;


### PR DESCRIPTION
A tiny yak I bumped into when I was trying to fix something else.