### PR TITLE
Implement Digest#to_s

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -40,7 +40,13 @@ module Digest
     end
 
     def inspect
+      return super if method(:update).owner == ::Digest::Instance
       "#<#{self.class}: #{hexdigest}>"
+    end
+
+    def to_s
+      return super if method(:update).owner == ::Digest::Instance
+      hexdigest
     end
 
     def self.included(klass)

--- a/spec/library/digest/md5/to_s_spec.rb
+++ b/spec/library/digest/md5/to_s_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+
+require 'digest/md5'
+
+require_relative 'shared/constants'
+
+describe "Digest::MD5#to_s" do
+
+  it "returns a hexdigest" do
+    cur_digest = Digest::MD5.new
+    cur_digest.to_s.should == MD5Constants::BlankHexdigest
+  end
+
+  it "does not change the internal state" do
+    cur_digest = Digest::MD5.new
+    cur_digest.to_s.should == MD5Constants::BlankHexdigest
+    cur_digest.to_s.should == MD5Constants::BlankHexdigest
+
+    cur_digest << MD5Constants::Contents
+    cur_digest.to_s.should == MD5Constants::Hexdigest
+    cur_digest.to_s.should == MD5Constants::Hexdigest
+  end
+
+end

--- a/spec/library/digest/sha256/to_s_spec.rb
+++ b/spec/library/digest/sha256/to_s_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/constants'
+
+describe "Digest::SHA256#to_s" do
+
+  it "returns a hexdigest" do
+    cur_digest = Digest::SHA256.new
+    cur_digest.to_s.should == SHA256Constants::BlankHexdigest
+  end
+
+  it "does not change the internal state" do
+    cur_digest = Digest::SHA256.new
+    cur_digest.to_s.should == SHA256Constants::BlankHexdigest
+    cur_digest.to_s.should == SHA256Constants::BlankHexdigest
+
+    cur_digest << SHA256Constants::Contents
+    cur_digest.to_s.should == SHA256Constants::Hexdigest
+    cur_digest.to_s.should == SHA256Constants::Hexdigest
+  end
+
+end

--- a/spec/library/digest/sha384/to_s_spec.rb
+++ b/spec/library/digest/sha384/to_s_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/constants'
+
+describe "Digest::SHA384#to_s" do
+
+  it "returns a hexdigest" do
+    cur_digest = Digest::SHA384.new
+    cur_digest.to_s.should == SHA384Constants::BlankHexdigest
+  end
+
+  it "does not change the internal state" do
+    cur_digest = Digest::SHA384.new
+    cur_digest.to_s.should == SHA384Constants::BlankHexdigest
+    cur_digest.to_s.should == SHA384Constants::BlankHexdigest
+
+    cur_digest << SHA384Constants::Contents
+    cur_digest.to_s.should == SHA384Constants::Hexdigest
+    cur_digest.to_s.should == SHA384Constants::Hexdigest
+  end
+
+end

--- a/spec/library/digest/sha512/to_s_spec.rb
+++ b/spec/library/digest/sha512/to_s_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../spec_helper'
+require_relative 'shared/constants'
+
+describe "Digest::SHA512#to_s" do
+
+  it "returns a hexdigest" do
+    cur_digest = Digest::SHA512.new
+    cur_digest.to_s.should == SHA512Constants::BlankHexdigest
+  end
+
+  it "does not change the internal state" do
+    cur_digest = Digest::SHA512.new
+    cur_digest.to_s.should == SHA512Constants::BlankHexdigest
+    cur_digest.to_s.should == SHA512Constants::BlankHexdigest
+
+    cur_digest << SHA512Constants::Contents
+    cur_digest.to_s.should == SHA512Constants::Hexdigest
+    cur_digest.to_s.should == SHA512Constants::Hexdigest
+  end
+
+end


### PR DESCRIPTION
And fix the unlikely scenarion where Digest::Instance#inspect was called on an object that was not an actual digest object.