### PR TITLE
Add batcat as an alternative to bat

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -328,6 +328,8 @@ class Runner
   def print_cpp_source(path)
     if system('which bat 2>&1 >/dev/null')
       system('bat', path, '-lcpp')
+    elsif system('which batcat 2>&1 >/dev/null')
+      system('batcat', path, '-lcpp')
     else
       puts File.read(path)
       puts '-' * 80


### PR DESCRIPTION
From the package info of bat on Debian Sid:

 In this package the executable and its manpage have been renamed from ‘bat’ to
 ‘batcat’ because of a file name clash with another Debian package.