### PR TITLE
Add RbConfig::CONFIG['LIBPATHENV']

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -261,7 +261,7 @@ class Runner
 
   def run_temp_and_wait(path)
     build_dir = File.expand_path('../build', __dir__)
-    var_name = RUBY_PLATFORM =~ /darwin/ ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH'
+    var_name = RbConfig::CONFIG['LIBPATHENV']
     env = { var_name => Natalie::Compiler::CppBackend::LIB_PATHS.join(':') }
     pid = spawn(env, path, *ARGV)
     Process.wait(pid)

--- a/src/rbconfig.rb
+++ b/src/rbconfig.rb
@@ -6,6 +6,7 @@ module RbConfig
     "EXEEXT" => (RUBY_PLATFORM =~ /msys/ ? '.exe' : ''),
     "DLEXT" => (RUBY_PLATFORM =~ /darwin/ ? 'bundle' : 'so'),
     "SOEXT" => (RUBY_PLATFORM =~ /darwin/ ? 'dylib' : 'so'),
+    "LIBPATHENV" => (RUBY_PLATFORM =~ /darwin/ ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH'),
     "host_cpu" => RUBY_PLATFORM.split('-')[0],
     "host_os" => RUBY_PLATFORM.split('-')[1],
     "AR" => "ar",


### PR DESCRIPTION
And use this value in the executable, instead of hardcoding the result values and using a platform check.