### PR TITLE
Convert inline CPP source to an include statement

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -21,6 +21,7 @@ public:
 
     Value initialize(Env *, Args, Block *);
 
+    static Value absolute_path(Env *env, Value path, Value dir = nullptr);
     static Value expand_path(Env *env, Value path, Value root);
     static void unlink(Env *env, Value path);
     static Value unlink(Env *env, Args args);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -560,6 +560,7 @@ gen.binding('Fiber', 'storage', 'FiberObject', 'storage', argc: 0, pass_env: tru
 gen.binding('Fiber', 'storage=', 'FiberObject', 'set_storage', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Fiber', 'to_s', 'FiberObject', 'inspect', argc: 0, pass_env: true, pass_block: false, aliases: ['inspect'], return_type: :Object)
 
+gen.static_binding('File', 'absolute_path', 'FileObject', 'absolute_path', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'absolute_path?', 'FileObject', 'is_absolute_path', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding('File', 'atime', 'FileObject', 'atime', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('File', 'blockdev?', 'FileObject', 'is_blockdev', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -261,16 +261,13 @@ module Natalie
           puts "Expected #{path} to contain function: `#{init_function}`"
           raise CompileError, "could not load #{name}"
         end
-        unless File.absolute_path?(path)
-          path = File.join(Dir.pwd, path)
-        end
         ::Prism::StatementsNode.new(
           [
             Prism.call_node(
               receiver: nil,
               name: :__internal_inline_code__,
               arguments: [
-                Prism.string_node(unescaped: "#include \"#{path}\"", location: location)
+                Prism.string_node(unescaped: "#include \"#{File.absolute_path(path)}\"", location: location)
               ],
               location: location
             ),

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -267,7 +267,7 @@ module Natalie
               receiver: nil,
               name: :__internal_inline_code__,
               arguments: [
-                Prism.string_node(unescaped: cpp_source, location: location)
+                Prism.string_node(unescaped: "#include \"#{path}\"", location: location)
               ],
               location: location
             ),

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -261,6 +261,9 @@ module Natalie
           puts "Expected #{path} to contain function: `#{init_function}`"
           raise CompileError, "could not load #{name}"
         end
+        unless File.absolute_path?(path)
+          path = File.join(Dir.pwd, path)
+        end
         ::Prism::StatementsNode.new(
           [
             Prism.call_node(

--- a/spec/core/file/absolute_path_spec.rb
+++ b/spec/core/file/absolute_path_spec.rb
@@ -57,52 +57,40 @@ describe "File.absolute_path" do
   end
 
   it "returns the argument if it's an absolute pathname" do
-    NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-      File.absolute_path(@abs).should == @abs
-    end
+    File.absolute_path(@abs).should == @abs
   end
 
   it "resolves paths relative to the current working directory" do
     path = File.dirname(@abs)
     Dir.chdir(path) do
-      NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-        File.absolute_path('hello.txt').should == File.join(Dir.pwd, 'hello.txt')
-      end
+      File.absolute_path('hello.txt').should == File.join(Dir.pwd, 'hello.txt')
     end
   end
 
   it "does not expand '~' to a home directory." do
-    NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-      File.absolute_path('~').should_not == File.expand_path('~')
-    end
+    File.absolute_path('~').should_not == File.expand_path('~')
   end
 
   platform_is_not :windows do
     it "does not expand '~' when given dir argument" do
-      NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-        File.absolute_path('~', '/').should == '/~'
-      end
+      File.absolute_path('~', '/').should == '/~'
     end
   end
 
   it "does not expand '~user' to a home directory." do
     path = File.dirname(@abs)
     Dir.chdir(path) do
-      NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-        File.absolute_path('~user').should == File.join(Dir.pwd, '~user')
-      end
+      File.absolute_path('~user').should == File.join(Dir.pwd, '~user')
     end
   end
 
   it "accepts a second argument of a directory from which to resolve the path" do
-    NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
+    NATFIXME 'accepts a second argument of a directory from which to resolve the path', exception: SpecFailedException do
       File.absolute_path(__FILE__, __dir__).should == @abs
     end
   end
 
   it "calls #to_path on its argument" do
-    NATFIXME 'Implement File.absolute_path', exception: NoMethodError, message: "undefined method `absolute_path' for class File" do
-      File.absolute_path(mock_to_path(@abs)).should == @abs
-    end
+    File.absolute_path(mock_to_path(@abs)).should == @abs
   end
 end

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -68,6 +68,20 @@ Value FileObject::initialize(Env *env, Args args, Block *block) {
     return this;
 }
 
+Value FileObject::absolute_path(Env *env, Value path, Value dir) {
+    path = ioutil::convert_using_to_path(env, path);
+    if (path->as_string()->start_with(env, { new StringObject { "/" } }))
+        return path;
+    if ((!dir || dir->is_nil()) && path->as_string()->eq(env, new StringObject { "~" }))
+        return path;
+
+    auto File = GlobalEnv::the()->Object()->const_get("File"_s);
+    assert(File);
+    if (!dir || dir->is_nil())
+        dir = DirObject::pwd(env);
+    return File->send(env, "join"_s, { dir, path });
+}
+
 Value FileObject::expand_path(Env *env, Value path, Value root) {
     path->assert_type(env, Object::Type::String, "String");
 


### PR DESCRIPTION
The preprocessor does not care about the file extension, and will happily include the C++ file. This preserves the file and line number of the original file, which makes debugging a lot easier.