### PR TITLE
Add read hook to global variables

### DIFF
--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -83,6 +83,7 @@ public:
     Value global_set(Env *, SymbolObject *, Value, bool = false);
     Value global_alias(Env *, SymbolObject *, SymbolObject *);
     ArrayObject *global_list(Env *);
+    void global_set_read_hook(Env *, SymbolObject *, bool, GlobalVariableInfo::read_hook_t read_hook);
 
     void set_main_env(Env *main_env) { m_main_env = main_env; }
     Env *main_env() { return m_main_env; }

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -1,24 +1,31 @@
 #pragma once
 
+#include <functional>
+
 #include "natalie/forward.hpp"
 #include "natalie/gc.hpp"
 
 namespace Natalie {
 class GlobalVariableInfo : public Cell {
 public:
+    using read_hook_t = std::function<Value(Env *, GlobalVariableInfo &)>;
+
     GlobalVariableInfo(Object *object, bool readonly)
         : m_object { object }
         , m_readonly { readonly } { }
 
     void set_object(Object *object) { m_object = object; }
-    Object *object() { return m_object; }
+    Value object(Env *);
     bool is_readonly() const { return m_readonly; }
+
+    void set_read_hook(read_hook_t read_hook) { m_read_hook = read_hook; }
 
     virtual void visit_children(Visitor &visitor) override final;
 
 private:
     class Object *m_object { nullptr };
     bool m_readonly;
+    read_hook_t m_read_hook { nullptr };
 };
 
 }

--- a/include/natalie/global_variable_info/access_hooks.hpp
+++ b/include/natalie/global_variable_info/access_hooks.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "natalie/global_variable_info.hpp"
+
+namespace Natalie {
+
+namespace GlobalVariableAccessHooks::ReadHooks {
+    Value getpid(Env *, GlobalVariableInfo &);
+}
+
+}

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -2,6 +2,12 @@
 
 namespace Natalie {
 
+Value GlobalVariableInfo::object(Env *env) {
+    if (m_read_hook)
+        return m_read_hook(env, *this);
+    return m_object;
+}
+
 void GlobalVariableInfo::visit_children(Visitor &visitor) {
     visitor.visit(m_object);
 }

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -1,0 +1,17 @@
+#include "natalie/global_variable_info/access_hooks.hpp"
+#include "natalie.hpp"
+
+namespace Natalie {
+
+namespace GlobalVariableAccessHooks::ReadHooks {
+
+    Value getpid(Env *, GlobalVariableInfo &info) {
+        Object *pid = new IntegerObject { ::getpid() };
+        info.set_object(pid);
+        info.set_read_hook(nullptr);
+        return pid;
+    }
+
+}
+
+}

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -1,5 +1,6 @@
 #include "natalie.hpp"
 #include "natalie/forward.hpp"
+#include "natalie/global_variable_info/access_hooks.hpp"
 #include "natalie/value.hpp"
 #include <ctype.h>
 #include <math.h>
@@ -405,7 +406,7 @@ Env *build_top_env() {
 
     env->global_set("$/"_s, new StringObject { "\n", 1 });
 
-    env->global_set("$$"_s, Value::integer(getpid()));
+    GlobalEnv::the()->global_set_read_hook(env, "$$"_s, true, GlobalVariableAccessHooks::ReadHooks::getpid);
 
     env->global_set("$\""_s, new ArrayObject {}, true);
     env->global_alias("$LOADED_FEATURES"_s, "$\""_s);


### PR DESCRIPTION
This implements the idea in  #1551 (or part of it, write variables are not yet implemented, and we still have to write it in C++ instead of Ruby as the tweet says).
For now, it is only implemented for `$$`, which adds the behaviour to cache the result. The following code:
```ruby
$stdout.syswrite("before first call")
$stdout.syswrite("#{$$}")
$stdout.syswrite("after first call, before second call")
$stdout.syswrite("#{$$}")
$stdout.syswrite("after second call")
```
Now results in an `strace` log like this for both MRI and Natalie:
```
write(1, "before first call", 17)       = 17
getpid()                                = 60093
write(1, "60093", 5)                    = 5
write(1, "after first call, before second "..., 36) = 36
write(1, "60093", 5)                    = 5
write(1, "after second call", 17)       = 17
```
There is no more need to fill this global at the start, instead we call `getpid` when needed, and save the result.