### PR TITLE
Write hooks for global variables

### DIFF
--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -84,6 +84,7 @@ public:
     Value global_alias(Env *, SymbolObject *, SymbolObject *);
     ArrayObject *global_list(Env *);
     void global_set_read_hook(Env *, SymbolObject *, bool, GlobalVariableInfo::read_hook_t read_hook);
+    void global_set_write_hook(Env *, SymbolObject *, GlobalVariableInfo::write_hook_t);
 
     void set_main_env(Env *main_env) { m_main_env = main_env; }
     Env *main_env() { return m_main_env; }

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -9,16 +9,18 @@ namespace Natalie {
 class GlobalVariableInfo : public Cell {
 public:
     using read_hook_t = std::function<Value(Env *, GlobalVariableInfo &)>;
+    using write_hook_t = std::function<Object *(Env *, Value, GlobalVariableInfo &)>;
 
     GlobalVariableInfo(Object *object, bool readonly)
         : m_object { object }
         , m_readonly { readonly } { }
 
-    void set_object(Object *object) { m_object = object; }
+    void set_object(Env *, Object *);
     Value object(Env *);
     bool is_readonly() const { return m_readonly; }
 
     void set_read_hook(read_hook_t read_hook) { m_read_hook = read_hook; }
+    void set_write_hook(write_hook_t write_hook) { m_write_hook = write_hook; }
 
     virtual void visit_children(Visitor &visitor) override final;
 
@@ -26,6 +28,7 @@ private:
     class Object *m_object { nullptr };
     bool m_readonly;
     read_hook_t m_read_hook { nullptr };
+    write_hook_t m_write_hook { nullptr };
 };
 
 }

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -9,7 +9,7 @@ namespace Natalie {
 class GlobalVariableInfo : public Cell {
 public:
     using read_hook_t = std::function<Value(Env *, GlobalVariableInfo &)>;
-    using write_hook_t = std::function<Object *(Env *, Value, GlobalVariableInfo &)>;
+    using write_hook_t = Object *(*)(Env *, Value, GlobalVariableInfo &);
 
     GlobalVariableInfo(Object *object, bool readonly)
         : m_object { object }

--- a/include/natalie/global_variable_info/access_hooks.hpp
+++ b/include/natalie/global_variable_info/access_hooks.hpp
@@ -8,4 +8,8 @@ namespace GlobalVariableAccessHooks::ReadHooks {
     Value getpid(Env *, GlobalVariableInfo &);
 }
 
+namespace GlobalVariableAccessHooks::WriteHooks {
+    Object *to_int(Env *, Value, GlobalVariableInfo &);
+}
+
 }

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -744,29 +744,23 @@ describe "Predefined global $." do
   end
 
   it "can be assigned a Float" do
-    NATFIXME 'can be assigned a Float', exception: SpecFailedException do
-      $. = 123.5
-      $..should == 123
-    end
+    $. = 123.5
+    $..should == 123
   end
 
   it "should call #to_int to convert the object to an Integer" do
-    NATFIXME 'should call #to_int to convert the object to an Integer', exception: SpecFailedException do
-      obj = mock("good-value")
-      obj.should_receive(:to_int).and_return(321)
+    obj = mock("good-value")
+    obj.should_receive(:to_int).and_return(321)
 
-      $. = obj
-      $..should == 321
-    end
+    $. = obj
+    $..should == 321
   end
 
   it "raises TypeError if object can't be converted to an Integer" do
-    NATFIXME "raises TypeError if object can't be converted to an Integer", exception: SpecFailedException do
-      obj = mock("bad-value")
-      obj.should_receive(:to_int).and_return('abc')
+    obj = mock("bad-value")
+    obj.should_receive(:to_int).and_return('abc')
 
-      -> { $. = obj }.should raise_error(TypeError)
-    end
+    -> { $. = obj }.should raise_error(TypeError)
   end
 end
 

--- a/spec/library/English/English_spec.rb
+++ b/spec/library/English/English_spec.rb
@@ -86,11 +86,6 @@ describe "English" do
   end
 
   it "aliases $INPUT_LINE_NUMBER to $." do
-    NATFIXME '$. is initialized with 0 in MRI, but is nil in Natalie, work around this limitation by reading a line', exception: SpecFailedException do
-      $..should_not be_nil
-    end
-    File.open(__FILE__) { |f| f.readline }
-    # NATFIXME: Remove the read above once this issue is fixed
     $INPUT_LINE_NUMBER.should_not be_nil
     $INPUT_LINE_NUMBER.should == $.
   end

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -2,6 +2,14 @@
 
 namespace Natalie {
 
+void GlobalVariableInfo::set_object(Env *env, Object *object) {
+    if (m_write_hook) {
+        m_object = m_write_hook(env, object, *this);
+    } else {
+        m_object = object;
+    }
+}
+
 Value GlobalVariableInfo::object(Env *env) {
     if (m_read_hook)
         return m_read_hook(env, *this);

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -5,13 +5,20 @@ namespace Natalie {
 
 namespace GlobalVariableAccessHooks::ReadHooks {
 
-    Value getpid(Env *, GlobalVariableInfo &info) {
+    Value getpid(Env *env, GlobalVariableInfo &info) {
         Object *pid = new IntegerObject { ::getpid() };
-        info.set_object(pid);
+        info.set_object(env, pid);
         info.set_read_hook(nullptr);
         return pid;
     }
 
+}
+
+namespace GlobalVariableAccessHooks::WriteHooks {
+
+    Object *to_int(Env *env, Value v, GlobalVariableInfo &) {
+        return v->to_int(env);
+    }
 }
 
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -414,6 +414,7 @@ Env *build_top_env() {
     env->global_set("$?"_s, NilObject::the(), true);
 
     env->global_set("$."_s, Value::integer(0));
+    GlobalEnv::the()->global_set_write_hook(env, "$."_s, GlobalVariableAccessHooks::WriteHooks::to_int);
 
     Value ENV = new Natalie::Object {};
     Object->const_set("ENV"_s, ENV);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -413,6 +413,8 @@ Env *build_top_env() {
 
     env->global_set("$?"_s, NilObject::the(), true);
 
+    env->global_set("$."_s, Value::integer(0));
+
     Value ENV = new Natalie::Object {};
     Object->const_set("ENV"_s, ENV);
     ENV->extend_once(env, Enumerable);


### PR DESCRIPTION
Once again, just a framework and an implementation for a single global variable.

With these two options combined, we can do some cool stuff like storing `$~` (the last regexp match) thread-local, and set read hooks for related variables like `$'` so they get updated automatically.