### PR TITLE
Implement Module#ruby2_keywords

### DIFF
--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -89,6 +89,9 @@ public:
     static size_t hash(Key *&);
     static bool compare(Key *&, Key *&, void *);
 
+    static bool is_ruby2_keywords_hash(Env *, Value);
+    static Value ruby2_keywords_hash(Env *, Value);
+
     size_t size() const { return m_hashmap.size(); }
     Value size(Env *) const;
 
@@ -228,6 +231,7 @@ private:
     TM::Hashmap<Key *, Value> m_hashmap { hash, compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
     bool m_is_comparing_by_identity { false };
+    bool m_is_ruby2_keywords_hash { false };
     Value m_default_value { nullptr };
     ProcObject *m_default_proc { nullptr };
 };

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -157,6 +157,7 @@ public:
     Value alias_method(Env *, Value, Value);
     Value remove_method(Env *, Args);
     Value undef_method(Env *, Args);
+    Value ruby2_keywords(Env *, Value);
 
     bool eqeqeq(Env *env, Value other) {
         return other->is_a(env, this);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -763,6 +763,8 @@ gen.static_binding('GC', 'print_stats', 'GCModule', 'print_stats', argc: 0, pass
 gen.static_binding('GC', 'start', 'GCModule', 'start', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding('Hash', '[]', 'HashObject', 'square_new', argc: :any, pass_env: true, pass_block: false, pass_klass: true, return_type: :Object)
+gen.static_binding('Hash', 'ruby2_keywords_hash?', 'HashObject', 'is_ruby2_keywords_hash', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.static_binding('Hash', 'ruby2_keywords_hash', 'HashObject', 'ruby2_keywords_hash', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Hash', '==', 'HashObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Hash', '>=', 'HashObject', 'gte', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Hash', '>', 'HashObject', 'gt', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1067,6 +1067,7 @@ gen.binding('Module', 'public_instance_method', 'ModuleObject', 'public_instance
 gen.binding('Module', 'remove_class_variable', 'ModuleObject', 'remove_class_variable', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'remove_const', 'ModuleObject', 'remove_const', argc: 1, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)
 gen.binding('Module', 'remove_method', 'ModuleObject', 'remove_method', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Module', 'ruby2_keywords', 'ModuleObject', 'ruby2_keywords', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'to_s', 'ModuleObject', 'inspect', argc: 0, pass_env: true, pass_block: false, aliases: ['inspect'], return_type: :Object)
 gen.binding('Module', 'undef_method', 'ModuleObject', 'undef_method', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 

--- a/spec/core/hash/ruby2_keywords_hash_spec.rb
+++ b/spec/core/hash/ruby2_keywords_hash_spec.rb
@@ -1,0 +1,83 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Hash.ruby2_keywords_hash?" do
+  it "returns false if the Hash is not a keywords Hash" do
+    Hash.ruby2_keywords_hash?({}).should == false
+  end
+
+  it "returns true if the Hash is a keywords Hash marked by Module#ruby2_keywords" do
+    obj = Class.new {
+      ruby2_keywords def m(*args)
+        args.last
+      end
+    }.new
+    Hash.ruby2_keywords_hash?(obj.m(a: 1)).should == true
+  end
+
+  it "raises TypeError for non-Hash" do
+    -> { Hash.ruby2_keywords_hash?(nil) }.should raise_error(TypeError)
+  end
+end
+
+describe "Hash.ruby2_keywords_hash" do
+  it "returns a copy of a Hash and marks the copy as a keywords Hash" do
+    h = {a: 1}.freeze
+    kw = Hash.ruby2_keywords_hash(h)
+    Hash.ruby2_keywords_hash?(h).should == false
+    Hash.ruby2_keywords_hash?(kw).should == true
+    kw.should == h
+  end
+
+  it "returns an instance of the subclass if called on an instance of a subclass of Hash" do
+    h = HashSpecs::MyHash.new
+    h[:a] = 1
+    kw = Hash.ruby2_keywords_hash(h)
+    kw.class.should == HashSpecs::MyHash
+    Hash.ruby2_keywords_hash?(h).should == false
+    Hash.ruby2_keywords_hash?(kw).should == true
+    kw.should == h
+  end
+
+  it "copies instance variables" do
+    h = {a: 1}
+    h.instance_variable_set(:@foo, 42)
+    kw = Hash.ruby2_keywords_hash(h)
+    kw.instance_variable_get(:@foo).should == 42
+  end
+
+  it "copies the hash internals" do
+    h = {a: 1}
+    kw = Hash.ruby2_keywords_hash(h)
+    h[:a] = 2
+    kw[:a].should == 1
+  end
+
+  it "raises TypeError for non-Hash" do
+    -> { Hash.ruby2_keywords_hash(nil) }.should raise_error(TypeError)
+  end
+
+  it "retains the default value" do
+    hash = Hash.new(1)
+    Hash.ruby2_keywords_hash(hash).default.should == 1
+    hash[:a] = 1
+    Hash.ruby2_keywords_hash(hash).default.should == 1
+  end
+
+  it "retains the default_proc" do
+    pr = proc { |h, k| h[k] = [] }
+    hash = Hash.new(&pr)
+    Hash.ruby2_keywords_hash(hash).default_proc.should == pr
+    hash[:a] = 1
+    Hash.ruby2_keywords_hash(hash).default_proc.should == pr
+  end
+
+  ruby_version_is '3.3' do
+    it "retains compare_by_identity_flag" do
+      hash = {}.compare_by_identity
+      Hash.ruby2_keywords_hash(hash).compare_by_identity?.should == true
+      hash[:a] = 1
+      Hash.ruby2_keywords_hash(hash).compare_by_identity?.should == true
+    end
+  end
+end

--- a/spec/core/hash/ruby2_keywords_hash_spec.rb
+++ b/spec/core/hash/ruby2_keywords_hash_spec.rb
@@ -7,12 +7,14 @@ describe "Hash.ruby2_keywords_hash?" do
   end
 
   it "returns true if the Hash is a keywords Hash marked by Module#ruby2_keywords" do
-    obj = Class.new {
-      ruby2_keywords def m(*args)
-        args.last
-      end
-    }.new
-    Hash.ruby2_keywords_hash?(obj.m(a: 1)).should == true
+    NATFIXME 'Implement Module.ruby2_keywords' do
+      obj = Class.new {
+        ruby2_keywords def m(*args)
+          args.last
+        end
+      }.new
+      Hash.ruby2_keywords_hash?(obj.m(a: 1)).should == true
+    end
   end
 
   it "raises TypeError for non-Hash" do
@@ -58,18 +60,22 @@ describe "Hash.ruby2_keywords_hash" do
   end
 
   it "retains the default value" do
-    hash = Hash.new(1)
-    Hash.ruby2_keywords_hash(hash).default.should == 1
-    hash[:a] = 1
-    Hash.ruby2_keywords_hash(hash).default.should == 1
+    NATFIXME 'Issue with Hash#dup', exception: SpecFailedException do
+      hash = Hash.new(1)
+      Hash.ruby2_keywords_hash(hash).default.should == 1
+      hash[:a] = 1
+      Hash.ruby2_keywords_hash(hash).default.should == 1
+    end
   end
 
   it "retains the default_proc" do
-    pr = proc { |h, k| h[k] = [] }
-    hash = Hash.new(&pr)
-    Hash.ruby2_keywords_hash(hash).default_proc.should == pr
-    hash[:a] = 1
-    Hash.ruby2_keywords_hash(hash).default_proc.should == pr
+    NATFIXME 'Issue with Hash#dup', exception: SpecFailedException do
+      pr = proc { |h, k| h[k] = [] }
+      hash = Hash.new(&pr)
+      Hash.ruby2_keywords_hash(hash).default_proc.should == pr
+      hash[:a] = 1
+      Hash.ruby2_keywords_hash(hash).default_proc.should == pr
+    end
   end
 
   ruby_version_is '3.3' do

--- a/spec/core/hash/ruby2_keywords_hash_spec.rb
+++ b/spec/core/hash/ruby2_keywords_hash_spec.rb
@@ -7,14 +7,12 @@ describe "Hash.ruby2_keywords_hash?" do
   end
 
   it "returns true if the Hash is a keywords Hash marked by Module#ruby2_keywords" do
-    NATFIXME 'Implement Module.ruby2_keywords' do
-      obj = Class.new {
-        ruby2_keywords def m(*args)
-          args.last
-        end
-      }.new
-      Hash.ruby2_keywords_hash?(obj.m(a: 1)).should == true
-    end
+    obj = Class.new {
+      ruby2_keywords def m(*args)
+        args.last
+      end
+    }.new
+    Hash.ruby2_keywords_hash?(obj.m(a: 1)).should == true
   end
 
   it "raises TypeError for non-Hash" do

--- a/spec/core/module/ruby2_keywords_spec.rb
+++ b/spec/core/module/ruby2_keywords_spec.rb
@@ -1,0 +1,297 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Module#ruby2_keywords" do
+  class << self
+    ruby2_keywords def mark(*args)
+      args
+    end
+  end
+
+  it "marks the final hash argument as keyword hash" do
+    last = mark(1, 2, a: "a").last
+    Hash.ruby2_keywords_hash?(last).should == true
+  end
+
+  it "makes a copy of the hash and only marks the copy as keyword hash" do
+    obj = Object.new
+    obj.singleton_class.class_exec do
+      def regular(*args)
+        args.last
+      end
+    end
+
+    h = {a: 1}
+
+    last = mark(**h).last
+    Hash.ruby2_keywords_hash?(last).should == true
+    Hash.ruby2_keywords_hash?(h).should == false
+
+    last2 = mark(**last).last # last is already marked
+    Hash.ruby2_keywords_hash?(last2).should == true
+    Hash.ruby2_keywords_hash?(last).should == true
+    last2.should_not.equal?(last)
+    Hash.ruby2_keywords_hash?(h).should == false
+  end
+
+  it "makes a copy and unmark the Hash when calling a method taking (arg)" do
+    obj = Object.new
+    obj.singleton_class.class_exec do
+      def single(arg)
+        arg
+      end
+    end
+
+    h = { a: 1 }
+    args = mark(**h)
+    marked = args.last
+    Hash.ruby2_keywords_hash?(marked).should == true
+
+    after_usage = obj.single(*args)
+    after_usage.should == h
+    after_usage.should_not.equal?(h)
+    after_usage.should_not.equal?(marked)
+    Hash.ruby2_keywords_hash?(after_usage).should == false
+    Hash.ruby2_keywords_hash?(marked).should == true
+  end
+
+  it "makes a copy and unmark the Hash when calling a method taking (**kw)" do
+    obj = Object.new
+    obj.singleton_class.class_exec do
+      def kwargs(**kw)
+        kw
+      end
+    end
+
+    h = { a: 1 }
+    args = mark(**h)
+    marked = args.last
+    Hash.ruby2_keywords_hash?(marked).should == true
+
+    after_usage = obj.kwargs(*args)
+    after_usage.should == h
+    after_usage.should_not.equal?(h)
+    after_usage.should_not.equal?(marked)
+    Hash.ruby2_keywords_hash?(after_usage).should == false
+    Hash.ruby2_keywords_hash?(marked).should == true
+  end
+
+  ruby_version_is "3.2" do
+    it "makes a copy and unmark the Hash when calling a method taking (*args)" do
+      obj = Object.new
+      obj.singleton_class.class_exec do
+        def splat(*args)
+          args.last
+        end
+
+        def splat1(arg, *args)
+          args.last
+        end
+
+        def proc_call(*args)
+          -> *a { a.last }.call(*args)
+        end
+      end
+
+      h = { a: 1 }
+      args = mark(**h)
+      marked = args.last
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      after_usage = obj.splat(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(1, **h)
+      marked = args.last
+      after_usage = obj.splat1(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(**h)
+      marked = args.last
+      after_usage = obj.proc_call(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(**h)
+      marked = args.last
+      after_usage = obj.send(:splat, *args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+      Hash.ruby2_keywords_hash?(marked).should == true
+    end
+  end
+
+  ruby_version_is ""..."3.2" do
+    # https://bugs.ruby-lang.org/issues/18625
+    it "does NOT copy the Hash when calling a method taking (*args)" do
+      obj = Object.new
+      obj.singleton_class.class_exec do
+        def splat(*args)
+          args.last
+        end
+
+        def splat1(arg, *args)
+          args.last
+        end
+
+        def proc_call(*args)
+          -> *a { a.last }.call(*args)
+        end
+      end
+
+      h = { a: 1 }
+      args = mark(**h)
+      marked = args.last
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      after_usage = obj.splat(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should.equal?(marked) # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(after_usage).should == true # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(1, **h)
+      marked = args.last
+      after_usage = obj.splat1(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should.equal?(marked) # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(after_usage).should == true # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(**h)
+      marked = args.last
+      after_usage = obj.proc_call(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should.equal?(marked) # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(after_usage).should == true # https://bugs.ruby-lang.org/issues/18625
+      Hash.ruby2_keywords_hash?(marked).should == true
+
+      args = mark(**h)
+      marked = args.last
+      after_usage = obj.send(:splat, *args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      send_copies = RUBY_ENGINE == "ruby" # inconsistent with Proc#call above for CRuby
+      after_usage.equal?(marked).should == !send_copies
+      Hash.ruby2_keywords_hash?(after_usage).should == !send_copies
+      Hash.ruby2_keywords_hash?(marked).should == true
+    end
+  end
+
+  it "applies to the underlying method and applies across aliasing" do
+    obj = Object.new
+
+    obj.singleton_class.class_exec do
+      def foo(*a) a.last end
+      alias_method :bar, :foo
+      ruby2_keywords :foo
+
+      def baz(*a) a.last end
+      ruby2_keywords :baz
+      alias_method :bob, :baz
+    end
+
+    last = obj.foo(1, 2, a: "a")
+    Hash.ruby2_keywords_hash?(last).should == true
+
+    last = obj.bar(1, 2, a: "a")
+    Hash.ruby2_keywords_hash?(last).should == true
+
+    last = obj.baz(1, 2, a: "a")
+    Hash.ruby2_keywords_hash?(last).should == true
+
+    last = obj.bob(1, 2, a: "a")
+    Hash.ruby2_keywords_hash?(last).should == true
+  end
+
+  it "returns nil" do
+    obj = Object.new
+
+    obj.singleton_class.class_exec do
+      def foo(*a) end
+
+      ruby2_keywords(:foo).should == nil
+    end
+  end
+
+  it "raises NameError when passed not existing method name" do
+    obj = Object.new
+
+    -> {
+      obj.singleton_class.class_exec do
+        ruby2_keywords :not_existing
+      end
+    }.should raise_error(NameError, /undefined method [`']not_existing'/)
+  end
+
+  it "accepts String as well" do
+    obj = Object.new
+
+    obj.singleton_class.class_exec do
+      def foo(*a) a.last end
+      ruby2_keywords "foo"
+    end
+
+    last = obj.foo(1, 2, a: "a")
+    Hash.ruby2_keywords_hash?(last).should == true
+  end
+
+  it "raises TypeError when passed not Symbol or String" do
+    obj = Object.new
+
+    -> {
+      obj.singleton_class.class_exec do
+        ruby2_keywords Object.new
+      end
+    }.should raise_error(TypeError, /is not a symbol nor a string/)
+  end
+
+  it "prints warning when a method does not accept argument splat" do
+    obj = Object.new
+    def obj.foo(a, b, c) end
+
+    -> {
+      obj.singleton_class.class_exec do
+        ruby2_keywords :foo
+      end
+    }.should complain(/Skipping set of ruby2_keywords flag for/)
+  end
+
+  it "prints warning when a method accepts keywords" do
+    obj = Object.new
+    def obj.foo(a:, b:) end
+
+    -> {
+      obj.singleton_class.class_exec do
+        ruby2_keywords :foo
+      end
+    }.should complain(/Skipping set of ruby2_keywords flag for/)
+  end
+
+  it "prints warning when a method accepts keyword splat" do
+    obj = Object.new
+    def obj.foo(**a) end
+
+    -> {
+      obj.singleton_class.class_exec do
+        ruby2_keywords :foo
+      end
+    }.should complain(/Skipping set of ruby2_keywords flag for/)
+  end
+end

--- a/spec/core/module/ruby2_keywords_spec.rb
+++ b/spec/core/module/ruby2_keywords_spec.rb
@@ -50,8 +50,10 @@ describe "Module#ruby2_keywords" do
     after_usage = obj.single(*args)
     after_usage.should == h
     after_usage.should_not.equal?(h)
-    after_usage.should_not.equal?(marked)
-    Hash.ruby2_keywords_hash?(after_usage).should == false
+    NATFIXME 'makes a copy and unmark the Hash when calling a method taking (arg)', exception: SpecFailedException do
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+    end
     Hash.ruby2_keywords_hash?(marked).should == true
   end
 
@@ -68,12 +70,14 @@ describe "Module#ruby2_keywords" do
     marked = args.last
     Hash.ruby2_keywords_hash?(marked).should == true
 
-    after_usage = obj.kwargs(*args)
-    after_usage.should == h
-    after_usage.should_not.equal?(h)
-    after_usage.should_not.equal?(marked)
-    Hash.ruby2_keywords_hash?(after_usage).should == false
-    Hash.ruby2_keywords_hash?(marked).should == true
+    NATFIXME 'makes a copy and unmark the Hash when calling a method taking (**kw)', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      after_usage = obj.kwargs(*args)
+      after_usage.should == h
+      after_usage.should_not.equal?(h)
+      after_usage.should_not.equal?(marked)
+      Hash.ruby2_keywords_hash?(after_usage).should == false
+      Hash.ruby2_keywords_hash?(marked).should == true
+    end
   end
 
   ruby_version_is "3.2" do
@@ -101,8 +105,10 @@ describe "Module#ruby2_keywords" do
       after_usage = obj.splat(*args)
       after_usage.should == h
       after_usage.should_not.equal?(h)
-      after_usage.should_not.equal?(marked)
-      Hash.ruby2_keywords_hash?(after_usage).should == false
+      NATFIXME 'makes a copy and unmark the Hash when calling a method taking (*args)', exception: SpecFailedException do
+        after_usage.should_not.equal?(marked)
+        Hash.ruby2_keywords_hash?(after_usage).should == false
+      end
       Hash.ruby2_keywords_hash?(marked).should == true
 
       args = mark(1, **h)
@@ -110,8 +116,10 @@ describe "Module#ruby2_keywords" do
       after_usage = obj.splat1(*args)
       after_usage.should == h
       after_usage.should_not.equal?(h)
-      after_usage.should_not.equal?(marked)
-      Hash.ruby2_keywords_hash?(after_usage).should == false
+      NATFIXME 'makes a copy and unmark the Hash when calling a method taking (*args)', exception: SpecFailedException do
+        after_usage.should_not.equal?(marked)
+        Hash.ruby2_keywords_hash?(after_usage).should == false
+      end
       Hash.ruby2_keywords_hash?(marked).should == true
 
       args = mark(**h)
@@ -119,8 +127,10 @@ describe "Module#ruby2_keywords" do
       after_usage = obj.proc_call(*args)
       after_usage.should == h
       after_usage.should_not.equal?(h)
-      after_usage.should_not.equal?(marked)
-      Hash.ruby2_keywords_hash?(after_usage).should == false
+      NATFIXME 'makes a copy and unmark the Hash when calling a method taking (*args)', exception: SpecFailedException do
+        after_usage.should_not.equal?(marked)
+        Hash.ruby2_keywords_hash?(after_usage).should == false
+      end
       Hash.ruby2_keywords_hash?(marked).should == true
 
       args = mark(**h)
@@ -128,8 +138,10 @@ describe "Module#ruby2_keywords" do
       after_usage = obj.send(:splat, *args)
       after_usage.should == h
       after_usage.should_not.equal?(h)
-      after_usage.should_not.equal?(marked)
-      Hash.ruby2_keywords_hash?(after_usage).should == false
+      NATFIXME 'makes a copy and unmark the Hash when calling a method taking (*args)', exception: SpecFailedException do
+        after_usage.should_not.equal?(marked)
+        Hash.ruby2_keywords_hash?(after_usage).should == false
+      end
       Hash.ruby2_keywords_hash?(marked).should == true
     end
   end
@@ -211,7 +223,9 @@ describe "Module#ruby2_keywords" do
     Hash.ruby2_keywords_hash?(last).should == true
 
     last = obj.bar(1, 2, a: "a")
-    Hash.ruby2_keywords_hash?(last).should == true
+    NATFIXME 'applies to the underlying method and applies across aliasing', exception: SpecFailedException do
+      Hash.ruby2_keywords_hash?(last).should == true
+    end
 
     last = obj.baz(1, 2, a: "a")
     Hash.ruby2_keywords_hash?(last).should == true
@@ -266,32 +280,38 @@ describe "Module#ruby2_keywords" do
     obj = Object.new
     def obj.foo(a, b, c) end
 
-    -> {
-      obj.singleton_class.class_exec do
-        ruby2_keywords :foo
-      end
-    }.should complain(/Skipping set of ruby2_keywords flag for/)
+    NATFIXME 'prints warning when a method does not accept argument splat', exception: SpecFailedException do
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
   end
 
   it "prints warning when a method accepts keywords" do
     obj = Object.new
     def obj.foo(a:, b:) end
 
-    -> {
-      obj.singleton_class.class_exec do
-        ruby2_keywords :foo
-      end
-    }.should complain(/Skipping set of ruby2_keywords flag for/)
+    NATFIXME 'prints warning when a method accepts keywords', exception: SpecFailedException do
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
   end
 
   it "prints warning when a method accepts keyword splat" do
     obj = Object.new
     def obj.foo(**a) end
 
-    -> {
-      obj.singleton_class.class_exec do
-        ruby2_keywords :foo
-      end
-    }.should complain(/Skipping set of ruby2_keywords flag for/)
+    NATFIXME 'prints warning when a method accepts keyword splat', exception: SpecFailedException do
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
   end
 end

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -19,6 +19,16 @@ bool HashObject::compare(Key *&a, Key *&b, void *env) {
     return a->key.send((Env *)env, "eql?"_s, { b->key })->is_truthy();
 }
 
+bool HashObject::is_ruby2_keywords_hash(Env *env, Value hash) {
+    return hash->as_hash_or_raise(env)->m_is_ruby2_keywords_hash;
+}
+
+Value HashObject::ruby2_keywords_hash(Env *env, Value hash) {
+    auto result = hash->as_hash_or_raise(env)->dup(env)->as_hash();
+    result->m_is_ruby2_keywords_hash = true;
+    return result;
+}
+
 Value HashObject::compare_by_identity(Env *env) {
     assert_not_frozen(env);
     this->m_is_comparing_by_identity = true;


### PR DESCRIPTION
It's one of those things that I would rather not have, but a surprising number of gems depend on it (I tried to import `delegate` and this was the first error).

On the positive side: it showed two issues with `Hash#dup` that have yakshaved.