### PR TITLE
Load Prism from build directory -- never Rubygems

### DIFF
--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -1,5 +1,5 @@
-$LOAD_PATH << File.expand_path('../../build/prism/lib', __dir__)
-$LOAD_PATH << File.expand_path('../../build/prism/ext', __dir__)
+$LOAD_PATH.unshift(File.expand_path('../../build/prism/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../build/prism/ext', __dir__))
 require 'prism'
 
 module Prism


### PR DESCRIPTION
Having the `prism` gem installed locally was causing issues for me.