### PR TITLE
Raise an error when calling initialize on an initialized class

### DIFF
--- a/spec/core/class/initialize_spec.rb
+++ b/spec/core/class/initialize_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../spec_helper'
+
+describe "Class#initialize" do
+  it "is private" do
+    Class.should have_private_method(:initialize)
+  end
+
+  it "raises a TypeError when called on already initialized classes" do
+    ->{
+      Integer.send :initialize
+    }.should raise_error(TypeError)
+
+    ->{
+      Object.send :initialize
+    }.should raise_error(TypeError)
+  end
+
+  # See [redmine:2601]
+  it "raises a TypeError when called on BasicObject" do
+    ->{
+      BasicObject.send :initialize
+    }.should raise_error(TypeError)
+  end
+
+  describe "when given the Class" do
+    before :each do
+      @uninitialized = Class.allocate
+    end
+
+    it "raises a TypeError" do
+      ->{@uninitialized.send(:initialize, Class)}.should raise_error(TypeError)
+    end
+  end
+end

--- a/spec/core/class/initialize_spec.rb
+++ b/spec/core/class/initialize_spec.rb
@@ -2,7 +2,9 @@ require_relative '../../spec_helper'
 
 describe "Class#initialize" do
   it "is private" do
-    Class.should have_private_method(:initialize)
+    NATFIXME 'Implement have_private_method and Kernel#private_methods', exception: NoMethodError, message: "undefined method `have_private_method' for main" do
+      Class.should have_private_method(:initialize)
+    end
   end
 
   it "raises a TypeError when called on already initialized classes" do

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -3,6 +3,8 @@
 namespace Natalie {
 
 Value ClassObject::initialize(Env *env, Value superclass, Block *block) {
+    if (m_is_initialized)
+        env->raise("TypeError", "already initialized class");
     if (!superclass)
         superclass = GlobalEnv::the()->Object();
     if (!superclass->is_class())


### PR DESCRIPTION
This resolves the infinite loops seen in `spec/core/class/initialize_spec.rb`