### PR TITLE
Remove inline directives from dir.rb

### DIFF
--- a/src/dir.rb
+++ b/src/dir.rb
@@ -1,10 +1,3 @@
-require 'natalie/inline'
-
-__inline__ '#include <dirent.h>'
-__inline__ '#include <sys/param.h>'
-__inline__ '#include <sys/types.h>'
-__inline__ '#include <unistd.h>'
-
 class Dir
   class << self
     def tmpdir


### PR DESCRIPTION
This file is pure Ruby, so it doesn't use them.