### PR TITLE
Add optional arity argument to bind_method and bind_static_method macros

### DIFF
--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -35,20 +35,20 @@ module Natalie
 
       private
 
-      def generate_bind_method(transform, ruby_name, cpp_name = ruby_name)
+      def generate_bind_method(transform, ruby_name, cpp_name = ruby_name, arity = -1)
         ruby_name = comptime_symbol(ruby_name)
         cpp_name = comptime_symbol(cpp_name)
-        arity = -1 # FIXME: not sure how to calculate this without more info
+        arity = arity.value unless arity.is_a?(Integer)
         transform.exec_and_push(
           :method,
           "self->define_method(env, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
         )
       end
 
-      def generate_bind_static_method(transform, ruby_name, cpp_name = ruby_name)
+      def generate_bind_static_method(transform, ruby_name, cpp_name = ruby_name, arity = -1)
         ruby_name = comptime_symbol(ruby_name)
         cpp_name = comptime_symbol(cpp_name)
-        arity = -1 # FIXME: not sure how to calculate this without more info
+        arity = arity.value unless arity.is_a?(Integer)
         transform.exec_and_push(
           :method,
           "self->klass()->define_method(env, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -56,8 +56,8 @@ module Zlib
   #class << self
   __bind_static_method__ :adler32, :Zlib_adler32
   __bind_static_method__ :crc32, :Zlib_crc32
-  __bind_static_method__ :crc_table, :Zlib_crc_table
-  __bind_static_method__ :zlib_version, :Zlib_zlib_version
+  __bind_static_method__ :crc_table, :Zlib_crc_table, 0
+  __bind_static_method__ :zlib_version, :Zlib_zlib_version, 0
   #end
 
   def self.deflate(...)
@@ -69,19 +69,19 @@ module Zlib
   end
 
   class ZStream
-    __bind_method__ :adler, :Zlib_ZStream_adler
-    __bind_method__ :avail_in, :Zlib_ZStream_avail_in
-    __bind_method__ :avail_out, :Zlib_ZStream_avail_out
-    __bind_method__ :data_type, :Zlib_ZStream_data_type
+    __bind_method__ :adler, :Zlib_ZStream_adler, 0
+    __bind_method__ :avail_in, :Zlib_ZStream_avail_in, 0
+    __bind_method__ :avail_out, :Zlib_ZStream_avail_out, 0
+    __bind_method__ :data_type, :Zlib_ZStream_data_type, 0
   end
   
   class Deflate < ZStream
     __bind_method__ :initialize, :Zlib_deflate_initialize
-    __bind_method__ :<<, :Zlib_deflate_append
+    __bind_method__ :<<, :Zlib_deflate_append, 1
     __bind_method__ :deflate, :Zlib_deflate_deflate
-    __bind_method__ :set_dictionary, :Zlib_deflate_set_dictionary
-    __bind_method__ :finish, :Zlib_deflate_finish
-    __bind_method__ :close, :Zlib_deflate_close
+    __bind_method__ :set_dictionary, :Zlib_deflate_set_dictionary, 1
+    __bind_method__ :finish, :Zlib_deflate_finish, 0
+    __bind_method__ :close, :Zlib_deflate_close, 0
 
     class << self
       def deflate(input, level = -1)
@@ -100,9 +100,9 @@ module Zlib
 
   class Inflate < ZStream
     __bind_method__ :initialize, :Zlib_inflate_initialize
-    __bind_method__ :<<, :Zlib_inflate_append
-    __bind_method__ :finish, :Zlib_inflate_finish
-    __bind_method__ :close, :Zlib_inflate_close
+    __bind_method__ :<<, :Zlib_inflate_append, 1
+    __bind_method__ :finish, :Zlib_inflate_finish, 0
+    __bind_method__ :close, :Zlib_inflate_close, 0
 
     class << self
       def inflate(input)


### PR DESCRIPTION
And use zlib as an example on how to use them.

Previously:
```
$ bin/natalie -rzlib -e 'p Zlib.method(:zlib_version).arity'
-1
```
With this change:
```
$ bin/natalie -rzlib -e 'p Zlib.method(:zlib_version).arity'
0
```