### PR TITLE
Add autoload for Set

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -390,13 +390,3 @@ class Set
   end
   alias >= superset?
 end
-
-module Enumerable
-  def to_set(&block)
-    if block
-      Set.new(map(&block))
-    else
-      Set.new(self)
-    end
-  end
-end

--- a/spec/core/enumerable/fixtures/classes.rb
+++ b/spec/core/enumerable/fixtures/classes.rb
@@ -342,4 +342,10 @@ module EnumerableSpecs
       @block.call(*args)
     end
   end
+
+  # Set is a core class since Ruby 3.2
+  ruby_version_is '3.2' do
+    class SetSubclass < Set
+    end
+  end
 end # EnumerableSpecs utility classes

--- a/spec/core/enumerable/to_set_spec.rb
+++ b/spec/core/enumerable/to_set_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "3.2" do
+  describe "Enumerable#to_set" do
+    it "returns a new Set created from self" do
+      [1, 2, 3].to_set.should == Set[1, 2, 3]
+      {a: 1, b: 2}.to_set.should == Set[[:b, 2], [:a, 1]]
+    end
+
+    it "passes down passed blocks" do
+      [1, 2, 3].to_set { |x| x * x }.should == Set[1, 4, 9]
+    end
+
+    it "instantiates an object of provided as the first argument set class" do
+      set = [1, 2, 3].to_set(EnumerableSpecs::SetSubclass)
+      set.should be_kind_of(EnumerableSpecs::SetSubclass)
+      set.to_a.sort.should == [1, 2, 3]
+    end
+
+    it "does not need explicit `require 'set'`" do
+      output = ruby_exe(<<~RUBY, options: '--disable-gems', args: '2>&1')
+        puts [1, 2, 3].to_set
+      RUBY
+
+      output.chomp.should == "#<Set: {1, 2, 3}>"
+    end
+  end
+end

--- a/src/prelude.rb
+++ b/src/prelude.rb
@@ -1,11 +1,11 @@
 autoload :Set, 'set'
 
 module Enumerable
-  def to_set(&block)
+  def to_set(klass = Set, &block)
     if block
-      Set.new(map(&block))
+      klass.new(map(&block))
     else
-      Set.new(self)
+      klass.new(self)
     end
   end
 end

--- a/src/prelude.rb
+++ b/src/prelude.rb
@@ -1,0 +1,1 @@
+autoload :Set, 'set'

--- a/src/prelude.rb
+++ b/src/prelude.rb
@@ -1,1 +1,11 @@
 autoload :Set, 'set'
+
+module Enumerable
+  def to_set(&block)
+    if block
+      Set.new(map(&block))
+    else
+      Set.new(self)
+    end
+  end
+end


### PR DESCRIPTION
At least in theory, in practice this means we always load the Set module. It has been written in a way that is fully compatible with an actual dynamic autoload.
The name `prelude.rb` is based on MRI:
```
$ ruby -e 'p Enumerable.instance_method(:to_set)'
#<UnboundMethod: Enumerable#to_set(klass=..., *args, &block) <internal:prelude>:28>
```

This should resolve all the current spec crashes for Enumerable