### PR TITLE
Fix aliases for methods of stdlib

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -280,6 +280,7 @@ public:
 
     void method_alias(Env *env, Value new_name, Value old_name);
     virtual void method_alias(Env *, SymbolObject *, SymbolObject *);
+    virtual void singleton_method_alias(Env *, SymbolObject *, SymbolObject *);
 
     nat_int_t object_id() const;
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -54,7 +54,12 @@ class BindingGen
         puts "    #{binding.rb_class_as_c_variable}->#{binding.set_visibility_method_name}(env, #{binding.rb_method.inspect}_s);"
       end
       binding.aliases.each do |method|
-        puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
+        define_method_name = binding.define_method_name
+        if define_method_name == 'define_method'
+          puts "    #{binding.rb_class_as_c_variable}->method_alias(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
+        else
+          puts "    #{binding.rb_class_as_c_variable}->#{define_method_name}(env, #{method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
+        end
       end
     end
     @undefine_methods.each { |rb_class, method| puts "    #{rb_class}->undefine_method(env, #{method.inspect}_s);" }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -54,11 +54,11 @@ class BindingGen
         puts "    #{binding.rb_class_as_c_variable}->#{binding.set_visibility_method_name}(env, #{binding.rb_method.inspect}_s);"
       end
       binding.aliases.each do |method|
-        define_method_name = binding.define_method_name
-        if define_method_name == 'define_method'
-          puts "    #{binding.rb_class_as_c_variable}->method_alias(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
+        alias_name = binding.alias_name
+        if alias_name
+          puts "    #{binding.rb_class_as_c_variable}->#{alias_name}(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
         else
-          puts "    #{binding.rb_class_as_c_variable}->#{define_method_name}(env, #{method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
+          puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
         end
       end
     end
@@ -189,6 +189,16 @@ auto return_value = #{cpp_class}::#{cpp_method}(#{args_to_pass});
         'define_singleton_method'
       else
         'define_method'
+      end
+    end
+
+    def alias_name
+      if @module_function
+        'method_alias'
+      elsif @singleton || @static
+        nil
+      else
+        'method_alias'
       end
     end
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -54,12 +54,7 @@ class BindingGen
         puts "    #{binding.rb_class_as_c_variable}->#{binding.set_visibility_method_name}(env, #{binding.rb_method.inspect}_s);"
       end
       binding.aliases.each do |method|
-        alias_name = binding.alias_name
-        if alias_name
-          puts "    #{binding.rb_class_as_c_variable}->#{alias_name}(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
-        else
-          puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
-        end
+        puts "    #{binding.rb_class_as_c_variable}->#{binding.alias_name}(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
       end
     end
     @undefine_methods.each { |rb_class, method| puts "    #{rb_class}->undefine_method(env, #{method.inspect}_s);" }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -196,7 +196,7 @@ auto return_value = #{cpp_class}::#{cpp_method}(#{args_to_pass});
       if @module_function
         'method_alias'
       elsif @singleton || @static
-        nil
+        'singleton_method_alias'
       else
         'method_alias'
       end

--- a/spec/core/kernel/fail_spec.rb
+++ b/spec/core/kernel/fail_spec.rb
@@ -3,9 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "Kernel#fail" do
   it "is a private method" do
-    NATFIXME 'is a private method', exception: SpecFailedException do
-      Kernel.should have_private_instance_method(:fail)
-    end
+    Kernel.should have_private_instance_method(:fail)
   end
 
   it "raises a RuntimeError" do

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -792,6 +792,15 @@ void Object::method_alias(Env *env, SymbolObject *new_name, SymbolObject *old_na
     }
 }
 
+void Object::singleton_method_alias(Env *env, SymbolObject *new_name, SymbolObject *old_name) {
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+
+    ClassObject *klass = singleton_class(env);
+    if (klass->is_frozen())
+        env->raise("FrozenError", "can't modify frozen object: {}", to_s(env)->string());
+    klass->method_alias(env, new_name, old_name);
+}
+
 nat_int_t Object::object_id() const {
     if (is_integer()) {
         const auto i = as_integer();


### PR DESCRIPTION
This is a requirement to fix things like https://github.com/ruby/spec/blob/89175b222f15a7929a4f9a8b11bb67c728fc8830/core/unboundmethod/equal_value_spec.rb#L121