### PR TITLE
Bytecode VM: Add support for pushing bools and floats

### DIFF
--- a/lib/natalie/compiler/instructions/push_false_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_false_instruction.rb
@@ -14,6 +14,14 @@ module Natalie
       def execute(vm)
         vm.push(false)
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/push_float_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_float_instruction.rb
@@ -28,6 +28,18 @@ module Natalie
       def execute(vm)
         vm.push(@float)
       end
+
+      def serialize
+        [
+          instruction_number,
+          @float,
+        ].pack('CG')
+      end
+
+      def self.deserialize(io)
+        float = io.read(8).unpack1('G')
+        new(float)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/push_true_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_true_instruction.rb
@@ -14,6 +14,14 @@ module Natalie
       def execute(vm)
         vm.push(true)
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/test/bytecode/puts_bool_test.rb
+++ b/test/bytecode/puts_bool_test.rb
@@ -1,0 +1,18 @@
+require_relative '../spec_helper'
+
+describe 'puts a boolean' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run a puts with booleans' do
+    code = 'puts true; puts false'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "true\nfalse\n"
+  end
+end

--- a/test/bytecode/puts_float_test.rb
+++ b/test/bytecode/puts_float_test.rb
@@ -1,0 +1,18 @@
+require_relative '../spec_helper'
+
+describe 'puts a float' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run a puts with floats' do
+    code = 'puts 1.5'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "1.5\n"
+  end
+end


### PR DESCRIPTION
I'm not sure on how to encode integers, so that's why that type is missing.