### PR TITLE
Bytecode VM: Support push_int

### DIFF
--- a/lib/natalie/compiler/instructions/push_int_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_int_instruction.rb
@@ -24,6 +24,76 @@ module Natalie
       def execute(vm)
         vm.push(@int)
       end
+
+      def serialize
+        # Use the algorithm of Marshal.dump with a twist: Marshal switches from type `i` to `l` for values >= (1 <<30)
+        # or < -(1 << 30). If this is the case, add a first byte `5` for positive or `-5` for negative numbers, and
+        # encode the absolute value using BER encoding. The bytes `5` and `-5` are impossible in regular Marshal
+        # encoding.
+        bytes = []
+        if @int.zero?
+          bytes << 0
+        elsif @int > 0 && @int < 123
+          bytes << (@int + 5)
+        elsif @int > -124 && @int < 0
+          bytes << ((@int - 5) & 255)
+        elsif @int >= (1 << 30)
+          bytes << 5
+          bytes.concat([@int].pack('w').bytes)
+        elsif @int < -(1 << 30)
+          bytes << -5
+          bytes.concat([@int.abs].pack('w').bytes)
+        else
+          int = @int
+          until int.zero? || int == -1
+            bytes << (int & 255)
+            int >>= 8
+          end
+          if int.zero?
+            bytes.unshift(bytes.size)
+          else
+            bytes.unshift(256 - bytes.size)
+          end
+        end
+        [
+          instruction_number,
+          *bytes
+        ].pack('C*')
+      end
+
+      def self.deserialize(io)
+        # See {serialize} for an explanation of the algorithm.
+        byte = io.read(1).unpack1('c')
+        if byte.zero?
+          return new(0)
+        elsif byte.positive?
+          if byte == 5
+            int = io.read_ber_integer
+            return new(int)
+          elsif byte > 5 && byte < 128
+            return new(byte - 5)
+          end
+          integer = 0
+          byte.times do |i|
+            integer |= io.getbyte << (8 * i)
+          end
+          new(integer)
+        else
+          if byte == -5
+            int = io.read_ber_integer
+            return new(-int)
+          elsif byte > -129 && byte < -4
+            return new(byte + 5)
+          end
+          byte = -byte
+          integer = -1
+          byte.times do |i|
+            integer &= ~(255 << (8 * i))
+            integer |= io.getbyte << (8 * i)
+          end
+          new(integer)
+        end
+      end
     end
   end
 end

--- a/test/bytecode/puts_integer_test.rb
+++ b/test/bytecode/puts_integer_test.rb
@@ -1,0 +1,64 @@
+require_relative '../spec_helper'
+
+describe 'puts an integer' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run a puts with 0' do
+    code = 'puts 0'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "0\n"
+  end
+
+  it 'can run a puts with 1' do
+    code = 'puts 1'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "1\n"
+  end
+
+  it 'can run a puts with -1' do
+    code = 'puts -1'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "-1\n"
+  end
+
+  it 'can run a puts with the extreme positive value for regular int encoding' do
+    num = (1 << 30) - 1
+    code = "puts #{num}"
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+  end
+
+  it 'can run a puts with the extreme negative value for regular int encoding' do
+    num = -(1 << 30)
+    code = "puts #{num}"
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+  end
+
+  it 'can run a puts with a bignum' do
+    num = 1 << 64
+    code = "puts #{num}"
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+  end
+
+  it 'can run a puts with a negative bignum' do
+    num = 1 << 64
+    code = "puts -#{num}"
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "-#{num}\n"
+  end
+end


### PR DESCRIPTION
Well, this one took forever, why are integers only trivial on the surface level?

I didn't think BER encoding to be a suitable format here: it only works for positive values, so that would add a sign byte, which results in different representations of `0` and `-0`, even though it's actually the same value.

Instead, it uses Marshal encoding with a twist. The options for the first byte (interpreted as signed) of the encoded value are:
* `0`, if we encode a `0`
* `6..127`, if we encode a value in the range `1..122`, we can decode that one by subtracting `5` from the encoded value
* `1..4`, if we encode a value in the range `123..((1 << 30) - 1)`. This means we have to read this amount of extra bytes and use some shifts/ors on the binary value to retrieve the original numer

Negative values use in a similar way, but using negative values. This means the encoded value will never start with `5` or `-5`. We use those values as markers for positive or negative values out of the regular range. The number will be encoded as BER encoding of the absolute value.