### PR TITLE
Bytecode VM: Very hacky disassembler

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -145,6 +145,7 @@ class Runner
   def run
     load_code
     if options[:ast]
+      raise 'No AST output for bytecode' if options[:bytecode]
       require 'pp'
       pp parser.ast
     elsif options[:compile] && options[:bytecode]

--- a/bin/natalie
+++ b/bin/natalie
@@ -172,7 +172,7 @@ class Runner
     elsif options[:debug] == 'edit'
       edit_compile_run_loop
     elsif options[:bytecode]
-      compile_and_run_bytecode(@source_path)
+      compile_and_run_bytecode(@source_path, options)
     else
       compile_and_run
     end
@@ -254,8 +254,12 @@ class Runner
     end
   end
 
-  def compile_and_run_bytecode(path)
+  def compile_and_run_bytecode(path, options)
     loader = Natalie::Compiler::BytecodeLoader.new(File.open(path, 'rb'))
+    if /\Ap\d\z/.match?(options[:debug])
+      puts loader.instructions
+      exit 0
+    end
     im = Natalie::Compiler::InstructionManager.new(loader.instructions)
     Natalie::VM.new(im, path: path).run
   end

--- a/bin/natalie
+++ b/bin/natalie
@@ -25,7 +25,7 @@ OptionParser.new do |opts|
     '-d [type]', '--debug [type]',
     'Show debug output (specify option below)',
     options: {
-      '{p1,p1,p3,p4}' => 'print intermediate AST from individual compiler pass',
+      '{p1,p2,p3,p4}' => 'print intermediate AST from individual compiler pass',
       'cpp'           => 'print generated C++',
       'transform'     => 'only transform the code to C++ without outputting it (can be used for profiling the compiler)',
       'cc-cmd'        => 'show the gcc/clang compiler command that will be run',

--- a/bin/natalie
+++ b/bin/natalie
@@ -25,7 +25,7 @@ OptionParser.new do |opts|
     '-d [type]', '--debug [type]',
     'Show debug output (specify option below)',
     options: {
-      '{p1,p2,p3,p4}' => 'print intermediate AST from individual compiler pass',
+      '{p1,p2,p3,p4}' => 'print intermediate instructions from individual compiler pass',
       'cpp'           => 'print generated C++',
       'transform'     => 'only transform the code to C++ without outputting it (can be used for profiling the compiler)',
       'cc-cmd'        => 'show the gcc/clang compiler command that will be run',


### PR DESCRIPTION
To turn this:
```
$ xxd hello.bin
00000000: 4849 0548 656c 6c6f 3a01 4f05 7072 696e  HI.Hello:.O.prin
00000010: 7401 3748 4907 2c20 776f 726c 643a 014f  t.7HI., world:.O
00000020: 0470 7574 7301                           .puts.
```
Into this:
```
$ bin/natalie -d p1 --bytecode hello.bin 
push_self
push_string "Hello", 5, UTF-8
push_argc 1
send :print to self
pop
push_self
push_string ", world", 7, UTF-8
push_argc 1
send :puts to self
```

In my ideal version, there should be a strict separation between the input of instructions and the output, so we should be able to compile a bytecode file to cpp too. For now, this is really going to help with development.