### PR TITLE
Bytecode VM: Fix boolean flags in push_and and variable_set

### DIFF
--- a/lib/natalie/compiler/instructions/push_arg_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_arg_instruction.rb
@@ -38,7 +38,7 @@ module Natalie
 
       def self.deserialize(io)
         index = io.read_ber_integer
-        nil_default = io.read(1) == 1
+        nil_default = io.getbyte == 1
         new(index, nil_default: nil_default)
       end
     end

--- a/lib/natalie/compiler/instructions/variable_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_set_instruction.rb
@@ -59,7 +59,7 @@ module Natalie
       def self.deserialize(io)
         size = io.read_ber_integer
         name = io.read(size).to_sym
-        local_only = io.read(1) == 1
+        local_only = io.getbyte == 1
         new(name, local_only: local_only)
       end
     end


### PR DESCRIPTION
`io.read(0)` returns a character "\x00" or "\x01" for a boolean, use getbyte instead to retrieve a 0 or 1.