### PR TITLE
Bytecode VM: Fix VariableGetInstruction deserialize

### DIFF
--- a/lib/natalie/compiler/instructions/variable_declare_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_declare_instruction.rb
@@ -39,6 +39,23 @@ module Natalie
       def execute(vm)
         :noop
       end
+
+      def serialize
+        name_string = @name.to_s
+        [
+          instruction_number,
+          name_string.bytesize,
+          name_string,
+          @local_only ? 1 : 0,
+        ].pack("Cwa#{name_string.bytesize}C")
+      end
+
+      def self.deserialize(io)
+        size = io.read_ber_integer
+        name = io.read(size)
+        local_only = io.getbyte == 1
+        new(name, local_only:)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/variable_get_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_get_instruction.rb
@@ -71,7 +71,7 @@ module Natalie
 
       def self.deserialize(io)
         size = io.read_ber_integer
-        var_name = io.read(size)
+        name = io.read(size)
         default_to_nil = io.getbyte == 1
         new(name, default_to_nil: default_to_nil)
       end

--- a/test/bytecode/variable_declare_test.rb
+++ b/test/bytecode/variable_declare_test.rb
@@ -1,0 +1,18 @@
+require_relative '../spec_helper'
+
+describe 'it can run some code with a variable_declare instruction' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run some code with a variable_declar instruction' do
+    code = 'a = 1; puts a'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "1\n"
+  end
+end

--- a/test/bytecode/variable_get_test.rb
+++ b/test/bytecode/variable_get_test.rb
@@ -1,0 +1,18 @@
+require_relative '../spec_helper'
+
+describe 'it can run some code with a variable_get instruction' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can run some code with a variable_get instruction' do
+    code = 'puts ["a", "0"].map { |x| x.ord }'
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "97\n48\n"
+  end
+end


### PR DESCRIPTION
The old code resulted in the following disassembled instruction:
```
variable_get Natalie::Compiler::VariableGetInstruction
```

This fixes it to:
```
variable_get x
```

We can now run the following piece of code
```ruby
puts ['a', '0'].map { |x| x.ord }
```
This one is also included as a unit test.