### PR TITLE
Bytecode VM: Add getbool to the bytecode loader

### DIFF
--- a/lib/natalie/compiler/bytecode_loader.rb
+++ b/lib/natalie/compiler/bytecode_loader.rb
@@ -19,6 +19,10 @@ module Natalie
           @io = io
         end
 
+        def getbool
+          getbyte == 1
+        end
+
         def getbyte
           @io.getbyte
         end

--- a/lib/natalie/compiler/instructions/push_arg_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_arg_instruction.rb
@@ -38,7 +38,7 @@ module Natalie
 
       def self.deserialize(io)
         index = io.read_ber_integer
-        nil_default = io.getbyte == 1
+        nil_default = io.getbool
         new(index, nil_default: nil_default)
       end
     end

--- a/lib/natalie/compiler/instructions/variable_declare_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_declare_instruction.rb
@@ -53,7 +53,7 @@ module Natalie
       def self.deserialize(io)
         size = io.read_ber_integer
         name = io.read(size)
-        local_only = io.getbyte == 1
+        local_only = io.getbool
         new(name, local_only:)
       end
     end

--- a/lib/natalie/compiler/instructions/variable_get_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_get_instruction.rb
@@ -72,7 +72,7 @@ module Natalie
       def self.deserialize(io)
         size = io.read_ber_integer
         name = io.read(size)
-        default_to_nil = io.getbyte == 1
+        default_to_nil = io.getbool
         new(name, default_to_nil: default_to_nil)
       end
     end

--- a/lib/natalie/compiler/instructions/variable_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_set_instruction.rb
@@ -59,7 +59,7 @@ module Natalie
       def self.deserialize(io)
         size = io.read_ber_integer
         name = io.read(size).to_sym
-        local_only = io.getbyte == 1
+        local_only = io.getbool
         new(name, local_only: local_only)
       end
     end


### PR DESCRIPTION
This removes the `getbyte == 1` pattern with something more descriptive. This might prevent issues like  #1909.