### PR TITLE
Bytecode VM: Support method definitions

### DIFF
--- a/lib/natalie/compiler/instructions/array_shift_instruction.rb
+++ b/lib/natalie/compiler/instructions/array_shift_instruction.rb
@@ -20,6 +20,14 @@ module Natalie
         end
         vm.push(ary.shift)
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/array_shift_with_default_instruction.rb
+++ b/lib/natalie/compiler/instructions/array_shift_with_default_instruction.rb
@@ -19,6 +19,14 @@ module Natalie
         ary = vm.peek
         vm.push(ary.empty? ? default : ary.shift)
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/check_args_instruction.rb
+++ b/lib/natalie/compiler/instructions/check_args_instruction.rb
@@ -49,15 +49,18 @@ module Natalie
       def serialize
         raise NotImplementedError, 'Support keyword arguments' if @keywords.any?
 
+        positional = @positional.is_a?(Range) ? [@positional.first, @positional.last] : [@positional, @positional]
         [
           instruction_number,
-          @positional,
+          *positional,
           @args_array_on_stack ? 1 : 0,
-        ].pack('CwC')
+        ].pack('CwwC')
       end
 
       def self.deserialize(io)
         positional = io.read_ber_integer
+        positional2 = io.read_ber_integer
+        positional = Range.new(positional, positional2) if positional != positional2
         keywords = [] # NATFIXME: Support keyword arguments
         args_array_on_stack = io.getbool
         new(positional:, keywords:, args_array_on_stack:)

--- a/lib/natalie/compiler/instructions/check_args_instruction.rb
+++ b/lib/natalie/compiler/instructions/check_args_instruction.rb
@@ -46,6 +46,23 @@ module Natalie
         end
       end
 
+      def serialize
+        raise NotImplementedError, 'Support keyword arguments' if @keywords.any?
+
+        [
+          instruction_number,
+          @positional,
+          @args_array_on_stack ? 1 : 0,
+        ].pack('CwC')
+      end
+
+      def self.deserialize(io)
+        positional = io.read_ber_integer
+        keywords = [] # NATFIXME: Support keyword arguments
+        args_array_on_stack = io.getbool
+        new(positional:, keywords:, args_array_on_stack:)
+      end
+
       private
 
       def cpp_keywords

--- a/lib/natalie/compiler/instructions/check_extra_keywords_instruction.rb
+++ b/lib/natalie/compiler/instructions/check_extra_keywords_instruction.rb
@@ -21,6 +21,14 @@ module Natalie
           raise ArgumentError, "unknown keywords: #{unknown.map(&:inspect).join ', '}"
         end
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/check_required_keywords_instruction.rb
+++ b/lib/natalie/compiler/instructions/check_required_keywords_instruction.rb
@@ -25,6 +25,24 @@ module Natalie
           raise ArgumentError, "missing keywords: #{missing.map(&:inspect).join ', '}"
         end
       end
+
+      def serialize
+        bytecode = [instruction_number, @keywords.size].pack('Cw')
+        @keywords.each do |keyword|
+          keyword_string = keyword.to_s
+          bytecode << [keyword_string.bytesize, keyword_string].pack("wa#{keyword_string.bytesize}")
+        end
+        bytecode
+      end
+
+      def self.deserialize(io)
+        keywords = []
+        io.read_ber_integer.times do
+          size = io.read_ber_integer
+          keywords << io.read(size).to_sym
+        end
+        new(keywords)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/define_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_method_instruction.rb
@@ -65,6 +65,30 @@ module Natalie
           klass.send(:protected, @name)
         end
       end
+
+      def serialize
+        raise NotImplementedError, 'Support optional arguments' if @arity.negative?
+
+        name_string = @name.to_s
+        [
+          instruction_number,
+          name_string.bytesize,
+          name_string,
+          @arity
+        ].pack("Cwa#{name_string.bytesize}w")
+      end
+
+      def self.deserialize(io)
+        size = io.read_ber_integer
+        name = io.read(size)
+        arity = io.read_ber_integer
+        new(
+          name:,
+          arity:,
+          file: '', # FIXME
+          line: 0 # FIXME
+        )
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/define_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_method_instruction.rb
@@ -67,7 +67,7 @@ module Natalie
       end
 
       def serialize
-        raise NotImplementedError, 'Support optional arguments' if @arity.negative?
+        raise NotImplementedError, 'Methods with more than 127 arguments are not supported' if @arity > 127
 
         name_string = @name.to_s
         [
@@ -75,13 +75,13 @@ module Natalie
           name_string.bytesize,
           name_string,
           @arity
-        ].pack("Cwa#{name_string.bytesize}w")
+        ].pack("Cwa#{name_string.bytesize}c")
       end
 
       def self.deserialize(io)
         size = io.read_ber_integer
         name = io.read(size)
-        arity = io.read_ber_integer
+        arity = io.read(1).unpack1('c')
         new(
           name:,
           arity:,

--- a/lib/natalie/compiler/instructions/hash_delete_instruction.rb
+++ b/lib/natalie/compiler/instructions/hash_delete_instruction.rb
@@ -20,6 +20,21 @@ module Natalie
         hash = vm.peek
         vm.push(hash.delete(@name))
       end
+
+      def serialize
+        name_string = @name.to_s
+        [
+          instruction_number,
+          name_string.bytesize,
+          name_string,
+        ].pack("Cwa#{name_string.bytesize}")
+      end
+
+      def self.deserialize(io)
+        size = io.read_ber_integer
+        name = io.read(size).to_sym
+        new(name)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/hash_delete_with_default_instruction.rb
+++ b/lib/natalie/compiler/instructions/hash_delete_with_default_instruction.rb
@@ -24,6 +24,21 @@ module Natalie
         hash = vm.peek
         vm.push(hash.key?(@name) ? hash.delete(@name) : default)
       end
+
+      def serialize
+        name_string = @name.to_s
+        [
+          instruction_number,
+          name_string.bytesize,
+          name_string,
+        ].pack("Cwa#{name_string.bytesize}")
+      end
+
+      def self.deserialize(io)
+        size = io.read_ber_integer
+        name = io.read(size).to_sym
+        new(name)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/pop_keyword_args_instruction.rb
+++ b/lib/natalie/compiler/instructions/pop_keyword_args_instruction.rb
@@ -18,6 +18,14 @@ module Natalie
           vm.push vm.args.pop
         end
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/push_args_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_args_instruction.rb
@@ -42,6 +42,31 @@ module Natalie
           vm.push(vm.args)
         end
       end
+
+      def serialize
+        raise NotImplementedError, 'Support special ... syntax' if @min_count.nil? || @max_count.nil?
+
+        flags = 0
+        [@for_block, @spread, @to_array].each_with_index do |flag, index|
+          flags |= (1 << index) if flag
+        end
+        [
+          instruction_number,
+          flags,
+          @min_count,
+          @max_count,
+        ].pack('CCww')
+      end
+
+      def self.deserialize(io)
+        flags = io.getbyte
+        min_count = io.read_ber_integer
+        max_count = io.read_ber_integer
+        for_block = flags[0] == 1
+        spread = flags[1] == 1
+        to_array = flags[2] == 1
+        new(for_block:, min_count:, max_count:, spread:, to_array:)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/push_block_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_block_instruction.rb
@@ -24,6 +24,18 @@ module Natalie
       def execute(vm)
         vm.push(vm.block)
       end
+
+      def serialize
+        [
+          instruction_number,
+          @from_nearest_env ? 1 : 0,
+        ].pack('CC')
+      end
+
+      def self.deserialize(io)
+        from_nearest_env = io.getbool
+        new(from_nearest_env:)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/instructions/swap_instruction.rb
+++ b/lib/natalie/compiler/instructions/swap_instruction.rb
@@ -20,6 +20,14 @@ module Natalie
         vm.push(top)
         vm.push(one)
       end
+
+      def serialize
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_)
+        new
+      end
     end
   end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -108,4 +108,16 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "false\ntrue\n"
   end
+
+  it 'can define a method with forwarding for everything (...)' do
+    code = <<~RUBY
+      def foo(*args, **kwargs) = (args + kwargs.keys).join
+      def bar(...) = foo(...)
+      puts bar('bar', baz: 'quux')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -30,4 +30,15 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can define a method with optional arguments' do
+    code = <<~RUBY
+      def foo(a, b = 'baz') = a + b
+      puts foo('bar')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -96,4 +96,16 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can handle a block argument' do
+    code = <<~RUBY
+      def foo(&block) = block.nil?
+      puts foo { 1 }
+      puts foo
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "false\ntrue\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+
+require_relative '../spec_helper'
+
+describe 'define a method' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can define a method without arguments' do
+    code = <<~RUBY
+      def foo = 'foo'
+      puts foo
+    RUBY
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+  end
+
+  it 'can define a method with required positional arguments' do
+    code = <<~RUBY
+      def foo(a, b) = a + b
+      puts foo('bar', 'baz')
+    RUBY
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
+end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -41,4 +41,15 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can define a method with required keyword arguments' do
+    code = <<~RUBY
+      def foo(a, b:) = a + b
+      puts foo('bar', b: 'baz')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -63,4 +63,15 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can define a method with splat positional arguments' do
+    code = <<~RUBY
+      def foo(*args) = args.join
+      puts foo('bar', 'baz')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -74,4 +74,26 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can define a method with splat keyword arguments' do
+    code = <<~RUBY
+      def foo(**kwargs) = kwargs.keys.join
+      puts foo(bar: 'bar', baz: 'quux')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
+
+  it 'can define a method with splat positional and keyword arguments' do
+    code = <<~RUBY
+      def foo(*args, **kwargs) = (args + kwargs.keys).join
+      puts foo('bar', baz: 'quux')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -52,4 +52,15 @@ describe 'define a method' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
   end
+
+  it 'can define a method with optional keyword arguments' do
+    code = <<~RUBY
+      def foo(a, b: 'baz') = a + b
+      puts foo('bar')
+    RUBY
+
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+  end
 end


### PR DESCRIPTION
Well, that one took forever, since there are so many options for argument passing. And this doesn't even add support for things like `def foo(*) = bar(*)`, but that's not supported in Natalie anyway.

We can now compile and run the fib.rb example in bytecode.