### PR TITLE
Implement Zlib::ZStream#closed?

### DIFF
--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -60,6 +60,7 @@ Value Zlib_deflate_initialize(Env *env, Value self, Args args, Block *) {
     self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
     self->ivar_set(env, "@out"_s, new VoidPObject(out, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@closed"_s, FalseObject::the());
 
     int ret = deflateInit2(stream,
         (int)level->to_nat_int_t(),
@@ -135,6 +136,7 @@ Value Zlib_deflate_set_dictionary(Env *env, Value self, Args args, Block *) {
 Value Zlib_deflate_close(Env *env, Value self, Args args, Block *) {
     auto *strm = (z_stream *)self->ivar_get(env, "@stream"_s)->as_void_p()->void_ptr();
     deflateEnd(strm);
+    self->ivar_set(env, "@closed"_s, TrueObject::the());
     return self;
 }
 
@@ -154,6 +156,7 @@ Value Zlib_inflate_initialize(Env *env, Value self, Args args, Block *) {
     self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
     self->ivar_set(env, "@out"_s, new VoidPObject(out, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@closed"_s, FalseObject::the());
 
     int ret = inflateInit2(stream, (int)window_bits->to_nat_int_t());
     if (ret != Z_OK)
@@ -223,6 +226,7 @@ Value Zlib_inflate_finish(Env *env, Value self, Args args, Block *) {
 Value Zlib_inflate_close(Env *env, Value self, Args args, Block *) {
     auto *strm = (z_stream *)self->ivar_get(env, "@stream"_s)->as_void_p()->void_ptr();
     inflateEnd(strm);
+    self->ivar_set(env, "@closed"_s, TrueObject::the());
     return self;
 }
 

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -73,6 +73,8 @@ module Zlib
     __bind_method__ :avail_in, :Zlib_ZStream_avail_in, 0
     __bind_method__ :avail_out, :Zlib_ZStream_avail_out, 0
     __bind_method__ :data_type, :Zlib_ZStream_data_type, 0
+
+    def closed? = @closed
   end
   
   class Deflate < ZStream


### PR DESCRIPTION
This resolves the crash in `library/zlib/inflate/append_spec.rb` (even though most of the specs still fail)