### PR TITLE
Include a header for Bytecode files

### DIFF
--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -52,6 +52,8 @@ module Natalie
     end
 
     def compile_to_bytecode(io)
+      header = ['NatX', 0, 0].pack('a4C2')
+      io.write(header)
       instructions.each do |instruction|
         io.write(instruction.serialize)
       end

--- a/lib/natalie/compiler/bytecode_loader.rb
+++ b/lib/natalie/compiler/bytecode_loader.rb
@@ -9,6 +9,7 @@ module Natalie
 
       def initialize(io)
         @io = IO.new(io)
+        validate_signature
         @instructions = load_instructions
       end
 
@@ -46,6 +47,14 @@ module Natalie
       end
 
       private
+
+      def validate_signature
+        header, major_version, minor_version = @io.read(6).unpack('a4C2')
+        raise 'Invalid header, this is probably not a Natalie bytecode file' if header != 'NatX'
+        # For now, mark the version as 0.0. The bytecode format is unfinished and there is no backwards compatiblity
+        # guarantee.
+        raise "Invalid version, expected 0.0, got #{major_version}.#{minor_version}" if major_version != 0 || minor_version != 0
+      end
 
       def load_instructions
         instructions = []


### PR DESCRIPTION
This header consists of a magic 32 bit value (representing `NatX`), and two bytes for the version. The current version has been set to 0.0, meaning there is zero backwards compatibility guarantee and every git pull can cause your bytecode files to become invalid.