### PR TITLE
Small fixes to Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - spec/**/*.rb
     - vendor/**/*
 
-FrozenStringLiteralComment:
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 Layout/LeadingCommentSpace:
@@ -102,3 +102,7 @@ Style/WhileUntilModifier:
 Lint/Void:
   Exclude:
     - test/**/*.rb
+
+# No autoload in Natalie, so we do need to require pp/set
+Lint/RedundantRequireStatement:
+  Enabled: false

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -326,7 +326,7 @@ class Date
     end
   end
 
-  def strftime(format = '%F') # rubocop:disable Line/UnusedMethodArgument
+  def strftime(format = '%F') # rubocop:disable Lint/UnusedMethodArgument
     __inline__ <<-END
       format_var->assert_type(env, Object::Type::String, "String");
       struct tm time = { 0 };


### PR DESCRIPTION
So we're getting less errors before crashing with an "invalid byte sequence in UTF-8" message