### PR TITLE
Various cleanups in socket.cpp related to sockaddr structs

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -858,22 +858,7 @@ Value Socket_pack_sockaddr_in(Env *env, Value self, Args args, Block *block) {
     if (result != 0)
         env->raise("SocketError", "getaddrinfo: {}", gai_strerror(result));
 
-    StringObject *packed = nullptr;
-
-    switch (addr->ai_family) {
-    case AF_INET: {
-        auto in = (struct sockaddr_in *)addr->ai_addr;
-        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in), Encoding::ASCII_8BIT };
-        break;
-    }
-    case AF_INET6: {
-        auto in = (struct sockaddr_in6 *)addr->ai_addr;
-        packed = new StringObject { (const char *)in, sizeof(struct sockaddr_in6), Encoding::ASCII_8BIT };
-        break;
-    }
-    default:
-        NAT_NOT_YET_IMPLEMENTED("unknown getaddrinfo family");
-    }
+    auto packed = new StringObject { reinterpret_cast<const char *>(addr->ai_addr), addr->ai_addrlen, Encoding::ASCII_8BIT };
 
     freeaddrinfo(addr);
 

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -348,7 +348,7 @@ Value BasicSocket_getsockopt(Env *env, Value self, Args args, Block *block) {
     auto result = getsockopt(self->as_io()->fileno(), level, optname, &buf, &len);
     if (result == -1)
         env->raise_errno();
-    auto data = new StringObject { buf, len };
+    auto data = new StringObject { buf, len, Encoding::ASCII_8BIT };
     auto Option = fetch_nested_const({ "Socket"_s, "Option"_s });
     return Option.send(env, "new"_s, { Value::integer(family), Value::integer(level), Value::integer(optname), data });
 }

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -297,53 +297,17 @@ Value BasicSocket_s_for_fd(Env *env, Value self, Args args, Block *block) {
 Value BasicSocket_getpeername(Env *env, Value self, Args args, Block *) {
     args.ensure_argc_is(env, 0);
 
-    struct sockaddr addr { };
+    sockaddr_storage addr {};
     socklen_t addr_len = sizeof(addr);
 
     auto getpeername_result = getpeername(
         self->as_io()->fileno(),
-        &addr,
+        reinterpret_cast<sockaddr *>(&addr),
         &addr_len);
     if (getpeername_result == -1)
         env->raise_errno();
 
-    switch (addr.sa_family) {
-    case AF_INET: {
-        struct sockaddr_in in { };
-        socklen_t len = sizeof(in);
-        auto getpeername_result = getpeername(
-            self->as_io()->fileno(),
-            (struct sockaddr *)&in,
-            &len);
-        if (getpeername_result == -1)
-            env->raise_errno();
-        return new StringObject { (const char *)&in, len, Encoding::ASCII_8BIT };
-    }
-    case AF_INET6: {
-        struct sockaddr_in6 in6 { };
-        socklen_t len = sizeof(in6);
-        auto getpeername_result = getpeername(
-            self->as_io()->fileno(),
-            (struct sockaddr *)&in6,
-            &len);
-        if (getpeername_result == -1)
-            env->raise_errno();
-        return new StringObject { (const char *)&in6, len, Encoding::ASCII_8BIT };
-    }
-    case AF_UNIX: {
-        struct sockaddr_un un { };
-        socklen_t len = sizeof(un);
-        auto getpeername_result = getpeername(
-            self->as_io()->fileno(),
-            (struct sockaddr *)&un,
-            &len);
-        if (getpeername_result == -1)
-            env->raise_errno();
-        return new StringObject { (const char *)&un, len, Encoding::ASCII_8BIT };
-    }
-    default:
-        NAT_NOT_YET_IMPLEMENTED("BasicSocket#getpeername for family %d", addr.sa_family);
-    }
+    return new StringObject { reinterpret_cast<const char *>(&addr), addr_len, Encoding::ASCII_8BIT };
 }
 
 Value BasicSocket_getsockname(Env *env, Value self, Args args, Block *) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1213,10 +1213,10 @@ Value TCPServer_accept(Env *env, Value self, Args args, Block *) {
     if (self->as_io()->is_closed())
         env->raise("IOError", "closed stream");
 
-    socklen_t len = std::max(sizeof(sockaddr_in), sizeof(sockaddr_in6));
-    char buf[len];
+    sockaddr_storage addr {};
+    socklen_t len = sizeof(addr);
 
-    auto fd = blocking_accept(env, self->as_io(), (struct sockaddr *)&buf, &len);
+    auto fd = blocking_accept(env, self->as_io(), reinterpret_cast<sockaddr *>(&addr), &len);
 
     if (fd == -1)
         env->raise_errno();


### PR DESCRIPTION
Sometimes reading the docs is worth the effort. This change removes a little over 100 lines, fixes a few bugs, removes some superfluous method calls and removes a few `NAT_NOT_YET_IMPLEMENTED` lines.