### PR TITLE
Implement BasicSocket#recv_nonblock

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -423,9 +423,9 @@ Value BasicSocket_recv_nonblock(Env *env, Value self, Args args, Block *) {
         flags | MSG_DONTWAIT,
         nullptr, nullptr);
     if (recvfrom_result < 0) {
-        if (exception->is_falsey())
-            return "wait_readable"_s;
         if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            if (exception->is_falsey())
+                return "wait_readable"_s;
             auto SystemCallError = find_top_level_const(env, "SystemCallError"_s);
             ExceptionObject *error = SystemCallError.send(env, "exception"_s, { Value::integer(errno) })->as_exception();
             auto WaitReadable = fetch_nested_const({ "IO"_s, "WaitReadable"_s });
@@ -1339,9 +1339,9 @@ Value UDPSocket_recvfrom_nonblock(Env *env, Value self, Args args, Block *) {
         flags | MSG_DONTWAIT,
         reinterpret_cast<struct sockaddr *>(&addr), &addr_len);
     if (recvfrom_result < 0) {
-        if (exception->is_falsey())
-            return "wait_readable"_s;
         if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            if (exception->is_falsey())
+                return "wait_readable"_s;
             auto SystemCallError = find_top_level_const(env, "SystemCallError"_s);
             ExceptionObject *error = SystemCallError.send(env, "exception"_s, { Value::integer(errno) })->as_exception();
             auto WaitReadable = fetch_nested_const({ "IO"_s, "WaitReadable"_s });
@@ -1474,9 +1474,9 @@ Value UNIXServer_sysaccept(Env *env, Value self, bool is_blocking = true, bool e
         fd = accept4(fileno, reinterpret_cast<sockaddr *>(&addr), &len, SOCK_CLOEXEC | SOCK_NONBLOCK);
 #endif
         if (fd == -1) {
-            if (!exception)
-                return "wait_readable"_s;
             if (errno == EWOULDBLOCK || errno == EAGAIN) {
+                if (!exception)
+                    return "wait_readable"_s;
                 auto SystemCallError = find_top_level_const(env, "SystemCallError"_s);
                 ExceptionObject *error = SystemCallError.send(env, "exception"_s, { Value::integer(errno) })->as_exception();
                 auto WaitReadable = fetch_nested_const({ "IO"_s, "WaitReadable"_s });

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -439,6 +439,49 @@ Value BasicSocket_recv(Env *env, Value self, Args args, Block *) {
     return new StringObject { buf, static_cast<size_t>(bytes) };
 }
 
+Value BasicSocket_recv_nonblock(Env *env, Value self, Args args, Block *) {
+    auto kwargs = args.pop_keyword_hash();
+    args.ensure_argc_between(env, 1, 3);
+
+    const auto maxlen = IntegerObject::convert_to_nat_int_t(env, args[0]);
+    const auto flags = IntegerObject::convert_to_nat_int_t(env, args.at(1, Value::integer(0)));
+    auto buffer = args.at(2, new StringObject { "", Encoding::ASCII_8BIT })->to_str(env);
+    auto exception = kwargs ? kwargs->remove(env, "exception"_s) : TrueObject::the();
+    env->ensure_no_extra_keywords(kwargs);
+
+    const auto fileno = self->as_io()->fileno();
+#ifdef __APPLE__
+    const auto fcntlflags = fcntl(fileno, F_GETFL);
+    if (fcntlflags < 0)
+        env->raise_errno();
+    if (!(fcntlflags & O_NONBLOCK))
+        if (fcntl(fileno, F_SETFL, fcntlflags | O_NONBLOCK) < 0)
+            env->raise_errno();
+#endif
+    char charbuf[maxlen];
+    const auto recvfrom_result = recvfrom(
+        fileno,
+        charbuf, maxlen,
+        flags | MSG_DONTWAIT,
+        nullptr, nullptr);
+    if (recvfrom_result < 0) {
+        if (exception->is_falsey())
+            return "wait_readable"_s;
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            auto SystemCallError = find_top_level_const(env, "SystemCallError"_s);
+            ExceptionObject *error = SystemCallError.send(env, "exception"_s, { Value::integer(errno) })->as_exception();
+            auto WaitReadable = fetch_nested_const({ "IO"_s, "WaitReadable"_s });
+            error->extend(env, { WaitReadable });
+            env->raise_exception(error);
+        } else {
+            env->raise_errno();
+        }
+    }
+
+    buffer->set_str(charbuf, recvfrom_result);
+    return buffer;
+}
+
 Value BasicSocket_send(Env *env, Value self, Args args, Block *) {
     // send(mesg, flags [, dest_sockaddr]) => numbytes_sent
     args.ensure_argc_between(env, 2, 3);

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -360,48 +360,6 @@ Value BasicSocket_local_address(Env *env, Value self, Args args, Block *) {
     return Addrinfo.send(env, "new"_s, { packed });
 }
 
-Value BasicSocket_read_nonblock(Env *env, Value self, Args args, Block *) {
-    auto kwargs = args.pop_keyword_hash();
-    args.ensure_argc_between(env, 1, 2);
-
-    const auto maxlen = IntegerObject::convert_to_nat_int_t(env, args[0]);
-    auto buffer = args.at(1, new StringObject { "", Encoding::ASCII_8BIT })->to_str(env);
-    auto exception = kwargs ? kwargs->remove(env, "exception"_s) : TrueObject::the();
-    env->ensure_no_extra_keywords(kwargs);
-
-    const auto fileno = self->as_io()->fileno();
-#ifdef __APPLE__
-    const auto flags = fcntl(fileno, F_GETFL);
-    if (flags < 0)
-        env->raise_errno();
-    if (!(flags & O_NONBLOCK))
-        if (fcntl(fileno, F_SETFL, flags | O_NONBLOCK) < 0)
-            env->raise_errno();
-#endif
-    char charbuf[maxlen];
-    const auto recvfrom_result = recvfrom(
-        fileno,
-        charbuf, maxlen,
-        MSG_DONTWAIT,
-        nullptr, nullptr);
-    if (recvfrom_result < 0) {
-        if (exception->is_falsey())
-            return "wait_readable"_s;
-        if (errno == EWOULDBLOCK || errno == EAGAIN) {
-            auto SystemCallError = find_top_level_const(env, "SystemCallError"_s);
-            ExceptionObject *error = SystemCallError.send(env, "exception"_s, { Value::integer(errno) })->as_exception();
-            auto WaitReadable = fetch_nested_const({ "IO"_s, "WaitReadable"_s });
-            error->extend(env, { WaitReadable });
-            env->raise_exception(error);
-        } else {
-            env->raise_errno();
-        }
-    }
-
-    buffer->set_str(charbuf, recvfrom_result);
-    return buffer;
-}
-
 static ssize_t blocking_recv(Env *env, IoObject *io, char *buf, size_t len, int flags) {
     Defer done_sleeping([] { ThreadObject::set_current_sleeping(false); });
     ThreadObject::set_current_sleeping(true);

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -9,7 +9,6 @@ class BasicSocket < IO
   __bind_method__ :getsockname, :BasicSocket_getsockname
   __bind_method__ :getsockopt, :BasicSocket_getsockopt
   __bind_method__ :local_address, :BasicSocket_local_address
-  __bind_method__ :read_nonblock, :BasicSocket_read_nonblock
   __bind_method__ :recv, :BasicSocket_recv
   __bind_method__ :recv_nonblock, :BasicSocket_recv_nonblock
   __bind_method__ :send, :BasicSocket_send
@@ -24,6 +23,10 @@ class BasicSocket < IO
     else
       @do_not_reverse_lookup
     end
+  end
+
+  def read_nonblock(maxlen, *args, **kwargs)
+    recv_nonblock(maxlen, 0, *args, **kwargs)
   end
 
   class << self

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -11,6 +11,7 @@ class BasicSocket < IO
   __bind_method__ :local_address, :BasicSocket_local_address
   __bind_method__ :read_nonblock, :BasicSocket_read_nonblock
   __bind_method__ :recv, :BasicSocket_recv
+  __bind_method__ :recv_nonblock, :BasicSocket_recv_nonblock
   __bind_method__ :send, :BasicSocket_send
   __bind_method__ :setsockopt, :BasicSocket_setsockopt
   __bind_method__ :shutdown, :BasicSocket_shutdown

--- a/spec/library/socket/basicsocket/recv_nonblock_spec.rb
+++ b/spec/library/socket/basicsocket/recv_nonblock_spec.rb
@@ -1,0 +1,91 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Socket::BasicSocket#recv_nonblock" do
+  SocketSpecs.each_ip_protocol do |family, ip_address|
+    before :each do
+      @s1 = Socket.new(family, :DGRAM)
+      @s2 = Socket.new(family, :DGRAM)
+    end
+
+    after :each do
+      @s1.close unless @s1.closed?
+      @s2.close unless @s2.closed?
+    end
+
+    platform_is_not :windows do
+      describe 'using an unbound socket' do
+        it 'raises an exception extending IO::WaitReadable' do
+          -> { @s1.recv_nonblock(1) }.should raise_error(IO::WaitReadable)
+        end
+      end
+    end
+
+    it "raises an exception extending IO::WaitReadable if there's no data available" do
+      @s1.bind(Socket.pack_sockaddr_in(0, ip_address))
+      -> {
+        @s1.recv_nonblock(5)
+      }.should raise_error(IO::WaitReadable) { |e|
+        platform_is_not :windows do
+          e.should be_kind_of(Errno::EAGAIN)
+        end
+        platform_is :windows do
+          e.should be_kind_of(Errno::EWOULDBLOCK)
+        end
+      }
+    end
+
+    it "returns :wait_readable with exception: false" do
+      @s1.bind(Socket.pack_sockaddr_in(0, ip_address))
+      @s1.recv_nonblock(5, exception: false).should == :wait_readable
+    end
+
+    it "receives data after it's ready" do
+      @s1.bind(Socket.pack_sockaddr_in(0, ip_address))
+      @s2.send("aaa", 0, @s1.getsockname)
+      IO.select([@s1], nil, nil, 2)
+      @s1.recv_nonblock(5).should == "aaa"
+    end
+
+    it "allows an output buffer as third argument" do
+      @s1.bind(Socket.pack_sockaddr_in(0, ip_address))
+      @s2.send("data", 0, @s1.getsockname)
+      IO.select([@s1], nil, nil, 2)
+
+      buf = +"foo"
+      @s1.recv_nonblock(5, 0, buf)
+      buf.should == "data"
+    end
+
+    it "does not block if there's no data available" do
+      @s1.bind(Socket.pack_sockaddr_in(0, ip_address))
+      @s2.send("a", 0, @s1.getsockname)
+      IO.select([@s1], nil, nil, 2)
+      @s1.recv_nonblock(1).should == "a"
+      -> {
+        @s1.recv_nonblock(5)
+      }.should raise_error(IO::WaitReadable)
+    end
+  end
+
+  SocketSpecs.each_ip_protocol do |family, ip_address|
+    describe 'using a connected but not bound socket' do
+      before do
+        @server = Socket.new(family, :STREAM)
+      end
+
+      after do
+        @server.close
+      end
+
+      it "raises Errno::ENOTCONN" do
+        -> { @server.recv_nonblock(1) }.should raise_error { |e|
+          [Errno::ENOTCONN, Errno::EINVAL].should.include?(e.class)
+        }
+        -> { @server.recv_nonblock(1, exception: false) }.should raise_error { |e|
+          [Errno::ENOTCONN, Errno::EINVAL].should.include?(e.class)
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This includes a bug fix for the other nonblock methods: check the errno type before returning a `:wait_readable` symbol, there might be a different issue. The other spec files did not include a check for this situation.