### PR TITLE
Implement IntegerObject::convert_to_native_type

### DIFF
--- a/include/nathelpers/typeinfo.hpp
+++ b/include/nathelpers/typeinfo.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Natalie {
+
+template <class T>
+struct typeinfo {
+    constexpr const char *name() = delete;
+};
+
+template <>
+struct typeinfo<int> {
+    constexpr const char *name() { return "int"; }
+};
+
+template <>
+struct typeinfo<std::size_t> {
+    constexpr const char *name() { return "size_t"; }
+};
+
+}

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1498,7 +1498,7 @@ Value UNIXServer_accept(Env *env, Value self, bool is_blocking = true, bool exce
 
     auto Socket = find_top_level_const(env, "UNIXSocket"_s)->as_class_or_raise(env);
     auto socket = new IoObject { Socket };
-    socket->as_io()->set_fileno(IntegerObject::convert_to_nat_int_t(env, fd));
+    socket->as_io()->set_fileno(IntegerObject::convert_to_native_type<int>(env, fd));
     socket->as_io()->set_close_on_exec(env, TrueObject::the());
     socket->as_io()->set_nonblock(env, true);
     return socket;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -346,16 +346,8 @@ Value IoObject::read(Env *env, Value count_value, Value buffer) {
     }
     ssize_t bytes_read;
     if (count_value && !count_value->is_nil()) {
-        count_value->assert_type(env, Object::Type::Integer, "Integer");
-        auto count_value_integer = count_value->as_integer();
-        if (!count_value_integer->is_fixnum())
-            env->raise("RangeError", "bignum too big to convert into `long'");
-        long count = count_value->as_integer()->to_nat_int_t();
-        if (count < 0)
-            env->raise("ArgumentError", "negative length {} given", (long long)count);
-        if (count > std::numeric_limits<off_t>::max())
-            env->raise("RangeError", "bignum too big to convert into `long'");
-        if (m_read_buffer.size() >= static_cast<size_t>(count)) {
+        const auto count = IntegerObject::convert_to_native_type<size_t>(env, count_value);
+        if (m_read_buffer.size() >= count) {
             auto result = new StringObject { m_read_buffer.c_str(), static_cast<size_t>(count), Encoding::ASCII_8BIT };
             m_read_buffer = String { m_read_buffer.c_str() + count, m_read_buffer.size() - count };
             return result;


### PR DESCRIPTION
Add this to IoObject::read to get a user of the new code. We should probably convert most callers of IntegerObject::convert_to_nat_int_t to use this new code.