### PR TITLE
Add Socket::UDP short constant

### DIFF
--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -130,6 +130,7 @@ class Socket < BasicSocket
     TCP: IPPROTO_TCP,
     TTL: IP_TTL,
     TYPE: SO_TYPE,
+    UDP: IPPROTO_UDP,
     UNIX: AF_UNIX,
     V6ONLY: IPV6_V6ONLY,
   }.freeze


### PR DESCRIPTION
This resolves the first issue with the nightly specs of `BasicSocket#getsockopt`, which says `Socket::UDP` is not defined.

The next issue in this test will be `Socket::Cork` being not defined. This one is a bit harder to fix, since we have choose between `UDP_CORK` and `TCP_CORK`.