### PR TITLE
Improve IPv6 support in TCP sockets

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -586,7 +586,7 @@ Value IPSocket_addr(Env *env, Value self, Args args, Block *) {
         family = new StringObject("AF_INET");
         const auto *in = reinterpret_cast<sockaddr_in *>(&addr);
         char host_buf[INET_ADDRSTRLEN];
-        auto ntop_result = inet_ntop(AF_INET, &in->sin_addr, host_buf, INET_ADDRSTRLEN);
+        auto ntop_result = inet_ntop(addr.ss_family, &in->sin_addr, host_buf, INET_ADDRSTRLEN);
         if (!ntop_result)
             env->raise_errno();
         host = ip = new StringObject { host_buf };
@@ -599,7 +599,7 @@ Value IPSocket_addr(Env *env, Value self, Args args, Block *) {
         family = new StringObject("AF_INET6");
         const auto *in6 = reinterpret_cast<sockaddr_in6 *>(&addr);
         char host_buf[INET6_ADDRSTRLEN];
-        auto ntop_result = inet_ntop(AF_INET, &in6->sin6_addr, host_buf, INET6_ADDRSTRLEN);
+        auto ntop_result = inet_ntop(addr.ss_family, &in6->sin6_addr, host_buf, INET6_ADDRSTRLEN);
         if (!ntop_result)
             env->raise_errno();
         host = ip = new StringObject { host_buf };

--- a/spec/library/socket/shared/address.rb
+++ b/spec/library/socket/shared/address.rb
@@ -72,8 +72,7 @@ describe :socket_local_remote_address, shared: true do
   end
 
   guard -> { SocketSpecs.ipv6_available? } do
-    # NATFIXME: Issues with IPv6
-    xdescribe 'using IPv6' do
+    describe 'using IPv6' do
       before :each do
         @s = TCPServer.new('::1', 0)
         @a = TCPSocket.new('::1', @s.addr[1])
@@ -90,11 +89,15 @@ describe :socket_local_remote_address, shared: true do
       end
 
       it 'uses PF_INET6 as the protocol family' do
-        @addr.pfamily.should == Socket::PF_INET6
+        NATFIXME 'uses PF_INET6 as the protocol family', exception: SpecFailedException do
+          @addr.pfamily.should == Socket::PF_INET6
+        end
       end
 
       it 'uses SOCK_STREAM as the socket type' do
-        @addr.socktype.should == Socket::SOCK_STREAM
+        NATFIXME 'uses SOCK_STREAM as the socket type', exception: SpecFailedException do
+          @addr.socktype.should == Socket::SOCK_STREAM
+        end
       end
 
       it 'uses the correct IP address' do
@@ -127,11 +130,14 @@ describe :socket_local_remote_address, shared: true do
 
       it 'can be used to connect to the server' do
         skip if @method == :local_address
-        b = @addr.connect
-        begin
-          b.remote_address.to_s.should == @addr.to_s
-        ensure
-          b.close
+        # Linux throws Errno::ESOCKTNOSUPPORT, MacOS throws Errno::EPROTONOSUPPORT
+        NATFIXME 'Support IPv6 in Addrinfo#connect', exception: SystemCallError, message: /(Socket type|Protocol) not supported/ do
+          b = @addr.connect
+          begin
+            b.remote_address.to_s.should == @addr.to_s
+          ensure
+            b.close
+          end
         end
       end
     end


### PR DESCRIPTION
Try to autodetect the family type, and remove a few hardcoded occurrences of `AF_INET`