### PR TITLE
Make Object::is_a faster

### DIFF
--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -117,6 +117,7 @@ public:
     Value public_instance_methods(Env *, Value);
 
     ArrayObject *ancestors(Env *);
+    bool ancestors_includes(Env *, ModuleObject *);
     bool is_subclass_of(ModuleObject *);
 
     bool is_method_defined(Env *, Value) const;

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -663,8 +663,6 @@ ArrayObject *ModuleObject::ancestors(Env *env) {
 }
 
 bool ModuleObject::ancestors_includes(Env *env, ModuleObject *module) {
-    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
-
     ModuleObject *klass = this;
     do {
         if (klass->included_modules().is_empty()) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -662,6 +662,27 @@ ArrayObject *ModuleObject::ancestors(Env *env) {
     return ancestors;
 }
 
+bool ModuleObject::ancestors_includes(Env *env, ModuleObject *module) {
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+
+    ModuleObject *klass = this;
+    do {
+        if (klass->included_modules().is_empty()) {
+            // note: if there are included modules, then they will include this klass
+            if (klass == module) {
+                return true;
+            }
+        }
+        for (ModuleObject *m : klass->included_modules()) {
+            if (m == module) {
+                return true;
+            }
+        }
+        klass = klass->m_superclass;
+    } while (klass);
+    return false;
+}
+
 bool ModuleObject::is_subclass_of(ModuleObject *other) {
     if (other == this) {
         return false;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1107,13 +1107,7 @@ bool Object::is_a(Env *env, Value val) const {
         ClassObject *klass = singleton_class();
         if (!klass)
             klass = m_klass;
-        ArrayObject *ancestors = klass->ancestors(env);
-        for (Value m : *ancestors) {
-            if (module == m->as_module()) {
-                return true;
-            }
-        }
-        return false;
+        return klass->ancestors_includes(env, module);
     }
 }
 


### PR DESCRIPTION
Don't allocate an intermediate ArrayObject.

Fix #1874