### PR TITLE
Implement Addrinfo.getaddrinfo

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -175,13 +175,13 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
         service = servicename->to_str(env)->c_str();
     }
     if (family && !family->is_nil())
-        hints.ai_family = IntegerObject::convert_to_native_type<int>(env, family);
+        hints.ai_family = IntegerObject::convert_to_native_type<decltype(hints.ai_family)>(env, family);
     if (socktype && !socktype->is_nil())
-        hints.ai_socktype = IntegerObject::convert_to_native_type<int>(env, socktype);
+        hints.ai_socktype = IntegerObject::convert_to_native_type<decltype(hints.ai_socktype)>(env, socktype);
     if (protocol && !protocol->is_nil())
-        hints.ai_protocol = IntegerObject::convert_to_native_type<int>(env, protocol);
+        hints.ai_protocol = IntegerObject::convert_to_native_type<decltype(hints.ai_protocol)>(env, protocol);
     if (flags && !flags->is_nil())
-        hints.ai_flags = IntegerObject::convert_to_native_type<int>(env, flags);
+        hints.ai_flags = IntegerObject::convert_to_native_type<decltype(hints.ai_flags)>(env, flags);
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -153,12 +153,13 @@ static int Addrinfo_sockaddr_family(Env *env, StringObject *sockaddr) {
 
 Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_between(env, 2, 6);
-    if (args.size() > 4)
+    if (args.size() > 5)
         env->raise("NotImplementedError", "NATFIXME: More arguments for Addrinfo.getaddrinfo");
     auto nodename = args[0];
     auto servicename = args[1];
     auto family = args.at(2, nullptr);
     auto socktype = args.at(3, nullptr);
+    auto protocol = args.at(4, nullptr);
 
     const char *node = nullptr;
     const char *service = nullptr;
@@ -178,6 +179,8 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
         hints.ai_family = IntegerObject::convert_to_native_type<int>(env, family);
     if (socktype && !socktype->is_nil())
         hints.ai_socktype = IntegerObject::convert_to_native_type<int>(env, socktype);
+    if (protocol && !protocol->is_nil())
+        hints.ai_protocol = IntegerObject::convert_to_native_type<int>(env, protocol);
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -192,8 +192,12 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     Defer freeinfo { [&res] { freeaddrinfo(res); } };
 
     auto output = new ArrayObject {};
-    for (addrinfo *rp = res; rp != nullptr; rp = rp->ai_next)
-        output->push(self->send(env, "new"_s, { new StringObject { reinterpret_cast<const char *>(rp->ai_addr), rp->ai_addrlen } }));
+    for (addrinfo *rp = res; rp != nullptr; rp = rp->ai_next) {
+        auto entry = self->send(env, "new"_s, { new StringObject { reinterpret_cast<const char *>(rp->ai_addr), rp->ai_addrlen } });
+        if (rp->ai_canonname)
+            entry->ivar_set(env, "@canonname"_s, new StringObject { rp->ai_canonname });
+        output->push(entry);
+    }
     return output;
 }
 

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -153,13 +153,12 @@ static int Addrinfo_sockaddr_family(Env *env, StringObject *sockaddr) {
 
 Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_between(env, 2, 6);
-    if (args.size() > 5)
-        env->raise("NotImplementedError", "NATFIXME: More arguments for Addrinfo.getaddrinfo");
     auto nodename = args[0];
     auto servicename = args[1];
     auto family = args.at(2, nullptr);
     auto socktype = args.at(3, nullptr);
     auto protocol = args.at(4, nullptr);
+    auto flags = args.at(5, nullptr);
 
     const char *node = nullptr;
     const char *service = nullptr;
@@ -181,6 +180,8 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
         hints.ai_socktype = IntegerObject::convert_to_native_type<int>(env, socktype);
     if (protocol && !protocol->is_nil())
         hints.ai_protocol = IntegerObject::convert_to_native_type<int>(env, protocol);
+    if (flags && !flags->is_nil())
+        hints.ai_flags = IntegerObject::convert_to_native_type<int>(env, flags);
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -153,10 +153,11 @@ static int Addrinfo_sockaddr_family(Env *env, StringObject *sockaddr) {
 
 Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_between(env, 2, 6);
-    if (args.size() > 2)
+    if (args.size() > 3)
         env->raise("NotImplementedError", "NATFIXME: More arguments for Addrinfo.getaddrinfo");
     auto nodename = args[0];
     auto servicename = args[1];
+    auto family = args.at(2, nullptr);
 
     const char *node = nullptr;
     const char *service = nullptr;
@@ -172,6 +173,8 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     } else if (!servicename->is_nil()) {
         service = servicename->to_str(env)->c_str();
     }
+    if (family && !family->is_nil())
+        hints.ai_family = IntegerObject::convert_to_native_type<int>(env, family);
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -153,11 +153,12 @@ static int Addrinfo_sockaddr_family(Env *env, StringObject *sockaddr) {
 
 Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     args.ensure_argc_between(env, 2, 6);
-    if (args.size() > 3)
+    if (args.size() > 4)
         env->raise("NotImplementedError", "NATFIXME: More arguments for Addrinfo.getaddrinfo");
     auto nodename = args[0];
     auto servicename = args[1];
     auto family = args.at(2, nullptr);
+    auto socktype = args.at(3, nullptr);
 
     const char *node = nullptr;
     const char *service = nullptr;
@@ -175,6 +176,8 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     }
     if (family && !family->is_nil())
         hints.ai_family = IntegerObject::convert_to_native_type<int>(env, family);
+    if (socktype && !socktype->is_nil())
+        hints.ai_socktype = IntegerObject::convert_to_native_type<int>(env, socktype);
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -174,14 +174,22 @@ Value Addrinfo_getaddrinfo(Env *env, Value self, Args args, Block *block) {
     } else if (!servicename->is_nil()) {
         service = servicename->to_str(env)->c_str();
     }
-    if (family && !family->is_nil())
+    if (family && !family->is_nil()) {
+        family = Socket_const_name_to_i(env, self, { family }, nullptr);
         hints.ai_family = IntegerObject::convert_to_native_type<decltype(hints.ai_family)>(env, family);
-    if (socktype && !socktype->is_nil())
+    }
+    if (socktype && !socktype->is_nil()) {
+        socktype = Socket_const_name_to_i(env, self, { socktype }, nullptr);
         hints.ai_socktype = IntegerObject::convert_to_native_type<decltype(hints.ai_socktype)>(env, socktype);
-    if (protocol && !protocol->is_nil())
+    }
+    if (protocol && !protocol->is_nil()) {
+        protocol = Socket_const_name_to_i(env, self, { protocol }, nullptr);
         hints.ai_protocol = IntegerObject::convert_to_native_type<decltype(hints.ai_protocol)>(env, protocol);
-    if (flags && !flags->is_nil())
+    }
+    if (flags && !flags->is_nil()) {
+        flags = Socket_const_name_to_i(env, self, { flags }, nullptr);
         hints.ai_flags = IntegerObject::convert_to_native_type<decltype(hints.ai_flags)>(env, flags);
+    }
 
     const auto s = getaddrinfo(node, service, &hints, &res);
     if (s != 0) {

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -248,6 +248,8 @@ class Addrinfo
   attr_reader :afamily, :family, :pfamily, :protocol, :socktype
 
   class << self
+    __bind_method__ :getaddrinfo, :Addrinfo_getaddrinfo
+
     def ip(ip)
       Addrinfo.new(Socket.pack_sockaddr_in(0, ip), nil, nil, Socket::IPPROTO_IP)
     end

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -245,7 +245,7 @@ class Socket < BasicSocket
 end
 
 class Addrinfo
-  attr_reader :afamily, :family, :pfamily, :protocol, :socktype
+  attr_reader :afamily, :family, :pfamily, :protocol, :socktype, :canonname
 
   class << self
     __bind_method__ :getaddrinfo, :Addrinfo_getaddrinfo

--- a/spec/library/socket/addrinfo/canonname_spec.rb
+++ b/spec/library/socket/addrinfo/canonname_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Addrinfo#canonname" do
+
+  before :each do
+    @addrinfos = Addrinfo.getaddrinfo("localhost", 80, :INET, :STREAM, nil, Socket::AI_CANONNAME)
+  end
+
+  it "returns the canonical name for a host" do
+    canonname = @addrinfos.map { |a| a.canonname }.find { |name| name and name.include?("localhost") }
+    if canonname
+      canonname.should include("localhost")
+    else
+      canonname.should == nil
+    end
+  end
+
+  describe 'when the canonical name is not available' do
+    it 'returns nil' do
+      addr = Addrinfo.new(Socket.sockaddr_in(0, '127.0.0.1'))
+
+      addr.canonname.should be_nil
+    end
+  end
+
+end

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -1,0 +1,91 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe 'Addrinfo.getaddrinfo' do
+  it 'returns an Array of Addrinfo instances' do
+    array = Addrinfo.getaddrinfo('127.0.0.1', 80)
+
+    array.should be_an_instance_of(Array)
+    array[0].should be_an_instance_of(Addrinfo)
+  end
+
+  SocketSpecs.each_ip_protocol do |family, ip_address|
+    it 'sets the IP address of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo(ip_address, 80)
+
+      array[0].ip_address.should == ip_address
+    end
+
+    it 'sets the port of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo(ip_address, 80)
+
+      array[0].ip_port.should == 80
+    end
+
+    it 'sets the address family of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo(ip_address, 80)
+
+      array[0].afamily.should == family
+    end
+
+    it 'sets the protocol family of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo(ip_address, 80)
+
+      array[0].pfamily.should == family
+    end
+  end
+
+  guard -> { SocketSpecs.ipv6_available? } do
+    it 'sets a custom protocol family of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+
+      array[0].pfamily.should == Socket::PF_INET6
+    end
+
+    it 'sets a corresponding address family based on a custom protocol family' do
+      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+
+      array[0].afamily.should == Socket::AF_INET6
+    end
+  end
+
+  platform_is_not :windows do
+    it 'sets the default socket type of the Addrinfo instances' do
+      array    = Addrinfo.getaddrinfo('127.0.0.1', 80)
+      possible = [Socket::SOCK_STREAM, Socket::SOCK_DGRAM]
+
+      possible.should include(array[0].socktype)
+    end
+  end
+
+  it 'sets a custom socket type of the Addrinfo instances' do
+    array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, Socket::SOCK_DGRAM)
+
+    array[0].socktype.should == Socket::SOCK_DGRAM
+  end
+
+  platform_is_not :windows do
+    it 'sets the default socket protocol of the Addrinfo instances' do
+      array    = Addrinfo.getaddrinfo('127.0.0.1', 80)
+      possible = [Socket::IPPROTO_TCP, Socket::IPPROTO_UDP]
+
+      possible.should include(array[0].protocol)
+    end
+  end
+
+  platform_is_not :'solaris2.10' do # i386-solaris
+    it 'sets a custom socket protocol of the Addrinfo instances' do
+      array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
+
+      array[0].protocol.should == Socket::IPPROTO_UDP
+    end
+  end
+
+  platform_is_not :solaris do
+    it 'sets the canonical name when AI_CANONNAME is given as a flag' do
+      array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
+
+      array[0].canonname.should be_an_instance_of(String)
+    end
+  end
+end

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -85,7 +85,7 @@ describe 'Addrinfo.getaddrinfo' do
 
   platform_is_not :'solaris2.10' do # i386-solaris
     it 'sets a custom socket protocol of the Addrinfo instances' do
-      NATFIXME 'Support protocol argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+      NATFIXME 'it sets a custom socket protocol of the Addrinfo instances', exception: SpecFailedException do
         array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
 
         array[0].protocol.should == Socket::IPPROTO_UDP

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -39,19 +39,17 @@ describe 'Addrinfo.getaddrinfo' do
 
   guard -> { SocketSpecs.ipv6_available? } do
     it 'sets a custom protocol family of the Addrinfo instances' do
-      NATFIXME 'Support protocol family argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
-        array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
 
+      NATFIXME 'it sets a custom protocol family of the Addrinfo instances', exception: SpecFailedException do
         array[0].pfamily.should == Socket::PF_INET6
       end
     end
 
     it 'sets a corresponding address family based on a custom protocol family' do
-      NATFIXME 'Support address family argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
-        array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
 
-        array[0].afamily.should == Socket::AF_INET6
-      end
+      array[0].afamily.should == Socket::AF_INET6
     end
   end
 

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -31,21 +31,27 @@ describe 'Addrinfo.getaddrinfo' do
     it 'sets the protocol family of the Addrinfo instances' do
       array = Addrinfo.getaddrinfo(ip_address, 80)
 
-      array[0].pfamily.should == family
+      NATFIXME 'it sets the protocol family of the Addrinfo instances', exception: SpecFailedException do
+        array[0].pfamily.should == family
+      end
     end
   end
 
   guard -> { SocketSpecs.ipv6_available? } do
     it 'sets a custom protocol family of the Addrinfo instances' do
-      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+      NATFIXME 'Support protocol family argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+        array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
 
-      array[0].pfamily.should == Socket::PF_INET6
+        array[0].pfamily.should == Socket::PF_INET6
+      end
     end
 
     it 'sets a corresponding address family based on a custom protocol family' do
-      array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
+      NATFIXME 'Support address family argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+        array = Addrinfo.getaddrinfo('::1', 80, Socket::PF_INET6)
 
-      array[0].afamily.should == Socket::AF_INET6
+        array[0].afamily.should == Socket::AF_INET6
+      end
     end
   end
 
@@ -54,14 +60,18 @@ describe 'Addrinfo.getaddrinfo' do
       array    = Addrinfo.getaddrinfo('127.0.0.1', 80)
       possible = [Socket::SOCK_STREAM, Socket::SOCK_DGRAM]
 
-      possible.should include(array[0].socktype)
+      NATFIXME 'it sets the default socket type of the Addrinfo instances', exception: SpecFailedException do
+        possible.should include(array[0].socktype)
+      end
     end
   end
 
   it 'sets a custom socket type of the Addrinfo instances' do
-    array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, Socket::SOCK_DGRAM)
+    NATFIXME 'Support socket type argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+      array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, Socket::SOCK_DGRAM)
 
-    array[0].socktype.should == Socket::SOCK_DGRAM
+      array[0].socktype.should == Socket::SOCK_DGRAM
+    end
   end
 
   platform_is_not :windows do
@@ -69,23 +79,29 @@ describe 'Addrinfo.getaddrinfo' do
       array    = Addrinfo.getaddrinfo('127.0.0.1', 80)
       possible = [Socket::IPPROTO_TCP, Socket::IPPROTO_UDP]
 
-      possible.should include(array[0].protocol)
+      NATFIXME 'it sets the default socket protocol of the Addrinfo instances', exception: SpecFailedException do
+        possible.should include(array[0].protocol)
+      end
     end
   end
 
   platform_is_not :'solaris2.10' do # i386-solaris
     it 'sets a custom socket protocol of the Addrinfo instances' do
-      array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
+      NATFIXME 'Support protocol argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+        array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
 
-      array[0].protocol.should == Socket::IPPROTO_UDP
+        array[0].protocol.should == Socket::IPPROTO_UDP
+      end
     end
   end
 
   platform_is_not :solaris do
     it 'sets the canonical name when AI_CANONNAME is given as a flag' do
-      array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
+      NATFIXME 'Support flags argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
+        array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
 
-      array[0].canonname.should be_an_instance_of(String)
+        array[0].canonname.should be_an_instance_of(String)
+      end
     end
   end
 end

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -95,9 +95,9 @@ describe 'Addrinfo.getaddrinfo' do
 
   platform_is_not :solaris do
     it 'sets the canonical name when AI_CANONNAME is given as a flag' do
-      NATFIXME 'Support flags argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
-        array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
+      array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
 
+      NATFIXME 'Implement Addrinfo#canonname', exception: NoMethodError, message: "undefined method `canonname' for an instance of Addrinfo" do
         array[0].canonname.should be_an_instance_of(String)
       end
     end

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -65,9 +65,9 @@ describe 'Addrinfo.getaddrinfo' do
   end
 
   it 'sets a custom socket type of the Addrinfo instances' do
-    NATFIXME 'Support socket type argument', exception: NotImplementedError, message: "NATFIXME: More arguments for Addrinfo.getaddrinfo" do
-      array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, Socket::SOCK_DGRAM)
+    array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, Socket::SOCK_DGRAM)
 
+    NATFIXME 'it sets a custom socket type of the Addrinfo instances', exception: SpecFailedException do
       array[0].socktype.should == Socket::SOCK_DGRAM
     end
   end

--- a/spec/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/spec/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -97,9 +97,7 @@ describe 'Addrinfo.getaddrinfo' do
     it 'sets the canonical name when AI_CANONNAME is given as a flag' do
       array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
 
-      NATFIXME 'Implement Addrinfo#canonname', exception: NoMethodError, message: "undefined method `canonname' for an instance of Addrinfo" do
-        array[0].canonname.should be_an_instance_of(String)
-      end
+      array[0].canonname.should be_an_instance_of(String)
     end
   end
 end


### PR DESCRIPTION
Most of the failing specs are caused by generic issues in Addrinfo (like the pfamily attribute that currently fails in a lot of specs).