### PR TITLE
Remove Array resize in Encoding::list

### DIFF
--- a/include/natalie/encodings.hpp
+++ b/include/natalie/encodings.hpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 
-const int EncodingCount = 44;
+const size_t EncodingCount = 44;
 
 enum class Encoding {
     ASCII_8BIT = 1,

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -172,7 +172,7 @@ EncodingObject *EncodingObject::find_encoding(Env *env, Value encoding) {
 }
 
 ArrayObject *EncodingObject::list(Env *) {
-    auto ary = new ArrayObject {};
+    auto ary = new ArrayObject { EncodingCount };
     for (auto pair : s_encoding_list)
         ary->push(pair.second);
     // dbg("size {} enccnt {}", ary->size(), EncodingCount);


### PR DESCRIPTION
The output should be exactly EncodingCount items, reserve that space beforehand and get rid of the array resize operations.