### PR TITLE
Bytecode VM: Save encoding object in RoData section

### DIFF
--- a/lib/natalie/compiler/bytecode/ro_data.rb
+++ b/lib/natalie/compiler/bytecode/ro_data.rb
@@ -2,6 +2,10 @@ module Natalie
   class Compiler
     module Bytecode
       class RoData
+        CONVERSIONS = {
+          to_sym: ->(str) { str.to_sym },
+        }.freeze
+
         def initialize
           @buffer = ''.b
           @add_lookup = {}
@@ -30,7 +34,7 @@ module Natalie
           size = @buffer[position..].unpack1('w')
           result = @buffer[position + 1, size]
           if convert
-            result = result.send(convert)
+            result = CONVERSIONS.fetch(convert).call(result)
             @get_lookup[[convert, position]] = result
           end
           result

--- a/lib/natalie/compiler/bytecode/ro_data.rb
+++ b/lib/natalie/compiler/bytecode/ro_data.rb
@@ -3,6 +3,7 @@ module Natalie
     module Bytecode
       class RoData
         CONVERSIONS = {
+          to_encoding: ->(str) { Encoding.find(str) },
           to_sym: ->(str) { str.to_sym },
         }.freeze
 

--- a/lib/natalie/compiler/instructions/push_string_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_string_instruction.rb
@@ -36,18 +36,20 @@ module Natalie
 
       def serialize(rodata)
         position = rodata.add(@string)
+        encoding = rodata.add(@encoding.to_s)
 
         [
           instruction_number,
           position,
-          Encoding.list.index(@encoding),
-        ].pack("CwC")
+          encoding,
+        ].pack("Cww")
       end
 
       def self.deserialize(io, rodata)
-        position = io.read_ber_integer
-        string = rodata.get(position)
-        encoding = Encoding.list.at(io.getbyte)
+        string_position = io.read_ber_integer
+        encoding_position = io.read_ber_integer
+        string = rodata.get(string_position)
+        encoding = rodata.get(encoding_position, convert: :to_encoding)
         new(string, bytesize: string.bytesize, encoding: encoding)
       end
     end

--- a/test/bytecode/rodata_test.rb
+++ b/test/bytecode/rodata_test.rb
@@ -60,5 +60,13 @@ describe 'Bytecode::RoData' do
         @rodata.get(4)
       }.should raise_error(NoMethodError, "undefined method `unpack1' for nil")
     end
+
+    it 'can convert results to Encoding objects' do
+      utf8_index = @rodata.add(Encoding::UTF_8.to_s)
+      binary_index = @rodata.add(Encoding::BINARY.to_s)
+
+      @rodata.get(utf8_index, convert: :to_encoding).should == Encoding::UTF_8
+      @rodata.get(binary_index, convert: :to_encoding).should == Encoding::BINARY
+    end
   end
 end


### PR DESCRIPTION
It turns out the output of Encoding.list differs between MRI and
Natalie. This means that bytecode generated with one platform is not
compatible with the other one.