### PR TITLE
Support multiple features in with_feature spec guard

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -185,8 +185,8 @@ def with_block_device
   nil
 end
 
-def with_feature(name)
-  yield if MSpec.features[name]
+def with_feature(*names)
+  yield if names.all? { |name| MSpec.features[name] }
 end
 
 def with_timezone(zone, offset = nil)


### PR DESCRIPTION
Example of this being required:: https://github.com/ruby/spec/blob/master/library/socket/ancillarydata/ip_pktinfo_spec.rb#L3

According to https://github.com/ruby/mspec/blob/b8f8f4e4922b88bb5d1641e727c96f606e54669a/lib/mspec/guards/feature.rb#L25, this is an `all` filter, not an `any`.