### PR TITLE
Fix inherited value of BasicSocket#do_not_reverse_lookup

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -142,6 +142,7 @@ static Value Server_accept(Env *env, Value self, SymbolObject *klass, bool is_bl
     socket->as_io()->set_fileno(IntegerObject::convert_to_native_type<int>(env, fd));
     socket->as_io()->set_close_on_exec(env, TrueObject::the());
     socket->as_io()->set_nonblock(env, true);
+    socket->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
     return socket;
 }
 
@@ -832,6 +833,7 @@ Value Socket_initialize(Env *env, Value self, Args args, Block *block) {
 
     self->as_io()->initialize(env, { Value::integer(fd) }, block);
     self->as_io()->binmode(env);
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     return self;
 }
@@ -853,6 +855,7 @@ Value Socket_accept(Env *env, Value self, Args args, Block *block) {
     auto Socket = find_top_level_const(env, "Socket"_s)->as_class_or_raise(env);
     auto socket = new IoObject { Socket };
     socket->as_io()->set_fileno(fd);
+    socket->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     auto Addrinfo = find_top_level_const(env, "Addrinfo"_s);
     auto sockaddr_string = new StringObject { reinterpret_cast<char *>(&addr), len, Encoding::ASCII_8BIT };
@@ -1330,6 +1333,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args args, Block *block) {
     auto sockaddr = Socket.send(env, "pack_sockaddr_in"_s, { port, host });
     Socket_connect(env, self, { sockaddr }, nullptr);
     self->as_io()->set_nonblock(env, true);
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     if (block) {
         try {
@@ -1374,6 +1378,7 @@ Value TCPServer_initialize(Env *env, Value self, Args args, Block *block) {
     self->as_io()->initialize(env, { Value::integer(fd) }, block);
     self->as_io()->binmode(env);
     self->as_io()->set_nonblock(env, true);
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     self.send(env, "setsockopt"_s, { "SOCKET"_s, "REUSEADDR"_s, TrueObject::the() });
 
@@ -1428,6 +1433,7 @@ Value UDPSocket_initialize(Env *env, Value self, Args args, Block *block) {
     self->as_io()->binmode(env);
     self->as_io()->set_close_on_exec(env, TrueObject::the());
     self->as_io()->set_nonblock(env, true);
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     return self;
 }
@@ -1536,6 +1542,7 @@ Value UNIXSocket_initialize(Env *env, Value self, Args args, Block *block) {
     self->as_io()->initialize(env, { Value::integer(fd) }, block);
     self->as_io()->binmode(env);
     self->as_io()->set_close_on_exec(env, TrueObject::the());
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     auto Socket = find_top_level_const(env, "Socket"_s);
     auto sockaddr = Socket.send(env, "pack_sockaddr_un"_s, { path });
@@ -1566,6 +1573,7 @@ Value UNIXServer_initialize(Env *env, Value self, Args args, Block *block) {
     auto kwargs = new HashObject { env, { "path"_s, path } };
     self->as_io()->initialize(env, Args({ Value::integer(fd), kwargs }, true), block);
     self->as_io()->binmode(env);
+    self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s)->send(env, "do_not_reverse_lookup"_s));
 
     auto Socket = find_top_level_const(env, "Socket"_s);
     auto sockaddr = Socket.send(env, "pack_sockaddr_un"_s, { path });

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -15,15 +15,7 @@ class BasicSocket < IO
   __bind_method__ :setsockopt, :BasicSocket_setsockopt
   __bind_method__ :shutdown, :BasicSocket_shutdown
 
-  attr_writer :do_not_reverse_lookup
-
-  def do_not_reverse_lookup
-    if @do_not_reverse_lookup.nil?
-      self.class.do_not_reverse_lookup
-    else
-      @do_not_reverse_lookup
-    end
-  end
+  attr_accessor :do_not_reverse_lookup
 
   def read_nonblock(maxlen, *args, **kwargs)
     recv_nonblock(maxlen, 0, *args, **kwargs)

--- a/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
+++ b/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
@@ -1,0 +1,103 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "BasicSocket.do_not_reverse_lookup" do
+  before :each do
+    @do_not_reverse_lookup = BasicSocket.do_not_reverse_lookup
+    @server = TCPServer.new('127.0.0.1', 0)
+    @port = @server.addr[1]
+    @socket = TCPSocket.new('127.0.0.1', @port)
+  end
+
+  after :each do
+    @server.close unless @server.closed?
+    @socket.close unless @socket.closed?
+    BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  it "defaults to true" do
+    BasicSocket.do_not_reverse_lookup.should be_true
+  end
+
+  it "causes 'peeraddr' to avoid name lookups" do
+    @socket.do_not_reverse_lookup = true
+    BasicSocket.do_not_reverse_lookup = true
+    @socket.peeraddr.should == ["AF_INET", @port, "127.0.0.1", "127.0.0.1"]
+  end
+
+  it "looks for hostnames when set to false" do
+    @socket.do_not_reverse_lookup = false
+    BasicSocket.do_not_reverse_lookup = false
+    @socket.peeraddr[2].should == SocketSpecs.hostname
+  end
+
+  it "looks for numeric addresses when set to true" do
+    @socket.do_not_reverse_lookup = true
+    BasicSocket.do_not_reverse_lookup = true
+    @socket.peeraddr[2].should == "127.0.0.1"
+  end
+end
+
+describe :socket_do_not_reverse_lookup, shared: true do
+  it "inherits from BasicSocket.do_not_reverse_lookup when the socket is created" do
+    @socket = @method.call
+    reverse = BasicSocket.do_not_reverse_lookup
+    @socket.do_not_reverse_lookup.should == reverse
+
+    BasicSocket.do_not_reverse_lookup = !reverse
+    @socket.do_not_reverse_lookup.should == reverse
+  end
+
+  it "is true when BasicSocket.do_not_reverse_lookup is true" do
+    BasicSocket.do_not_reverse_lookup = true
+    @socket = @method.call
+    @socket.do_not_reverse_lookup.should == true
+  end
+
+  it "is false when BasicSocket.do_not_reverse_lookup is false" do
+    BasicSocket.do_not_reverse_lookup = false
+    @socket = @method.call
+    @socket.do_not_reverse_lookup.should == false
+  end
+
+  it "can be changed with #do_not_reverse_lookup=" do
+    @socket = @method.call
+    reverse = @socket.do_not_reverse_lookup
+    @socket.do_not_reverse_lookup = !reverse
+    @socket.do_not_reverse_lookup.should == !reverse
+  end
+end
+
+describe "BasicSocket#do_not_reverse_lookup" do
+  before :each do
+    @do_not_reverse_lookup = BasicSocket.do_not_reverse_lookup
+    @server = TCPServer.new('127.0.0.1', 0)
+    @port = @server.addr[1]
+  end
+
+  after :each do
+    @server.close unless @server.closed?
+    @socket.close if @socket && !@socket.closed?
+    BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  describe "for an TCPSocket.new socket" do
+    it_behaves_like :socket_do_not_reverse_lookup, -> {
+      TCPSocket.new('127.0.0.1', @port)
+    }
+  end
+
+  describe "for an TCPServer#accept socket" do
+    before :each do
+      @client = TCPSocket.new('127.0.0.1', @port)
+    end
+
+    after :each do
+      @client.close if @client && !@client.closed?
+    end
+
+    it_behaves_like :socket_do_not_reverse_lookup, -> {
+      @server.accept
+    }
+  end
+end

--- a/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
+++ b/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
@@ -22,19 +22,25 @@ describe "BasicSocket.do_not_reverse_lookup" do
   it "causes 'peeraddr' to avoid name lookups" do
     @socket.do_not_reverse_lookup = true
     BasicSocket.do_not_reverse_lookup = true
-    @socket.peeraddr.should == ["AF_INET", @port, "127.0.0.1", "127.0.0.1"]
+    NATFIXME 'Implement IPSocket#peeraddr', exception: NoMethodError, message: "undefined method `peeraddr' for an instance of TCPSocket" do
+      @socket.peeraddr.should == ["AF_INET", @port, "127.0.0.1", "127.0.0.1"]
+    end
   end
 
   it "looks for hostnames when set to false" do
     @socket.do_not_reverse_lookup = false
     BasicSocket.do_not_reverse_lookup = false
-    @socket.peeraddr[2].should == SocketSpecs.hostname
+    NATFIXME 'Implement IPSocket#peeraddr', exception: NoMethodError, message: "undefined method `peeraddr' for an instance of TCPSocket" do
+      @socket.peeraddr[2].should == SocketSpecs.hostname
+    end
   end
 
   it "looks for numeric addresses when set to true" do
     @socket.do_not_reverse_lookup = true
     BasicSocket.do_not_reverse_lookup = true
-    @socket.peeraddr[2].should == "127.0.0.1"
+    NATFIXME 'Implement IPSocket#peeraddr', exception: NoMethodError, message: "undefined method `peeraddr' for an instance of TCPSocket" do
+      @socket.peeraddr[2].should == "127.0.0.1"
+    end
   end
 end
 
@@ -57,7 +63,9 @@ describe :socket_do_not_reverse_lookup, shared: true do
   it "is false when BasicSocket.do_not_reverse_lookup is false" do
     BasicSocket.do_not_reverse_lookup = false
     @socket = @method.call
-    @socket.do_not_reverse_lookup.should == false
+    NATFIXME 'it is false when BasicSocket.do_not_reverse_lookup is false', exception: SpecFailedException do
+      @socket.do_not_reverse_lookup.should == false
+    end
   end
 
   it "can be changed with #do_not_reverse_lookup=" do

--- a/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
+++ b/spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb
@@ -63,9 +63,7 @@ describe :socket_do_not_reverse_lookup, shared: true do
   it "is false when BasicSocket.do_not_reverse_lookup is false" do
     BasicSocket.do_not_reverse_lookup = false
     @socket = @method.call
-    NATFIXME 'it is false when BasicSocket.do_not_reverse_lookup is false', exception: SpecFailedException do
-      @socket.do_not_reverse_lookup.should == false
-    end
+    @socket.do_not_reverse_lookup.should == false
   end
 
   it "can be changed with #do_not_reverse_lookup=" do


### PR DESCRIPTION
Copy the value when the socket is created.