### PR TITLE
Use correct sockaddr type in Server_sysaccept

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -99,7 +99,7 @@ static Value Server_sysaccept(Env *env, Value self, bool is_blocking = true, boo
     if (self->as_io()->is_closed())
         env->raise("IOError", "closed stream");
 
-    sockaddr_un addr;
+    sockaddr_storage addr;
     socklen_t len = sizeof(addr);
     int fd;
     if (is_blocking) {


### PR DESCRIPTION
This code started as a copy-paste from UNIXserver_accept, but has been changed into a generic function. This means it should use a generic socket type instead of sockaddr_un.