### PR TITLE
Implement Method#<< and Method#>>

### DIFF
--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -17,6 +17,8 @@ public:
 
     Value unbind(Env *);
     bool eq(Env *, Value);
+    Value ltlt(Env *, Value);
+    Value gtgt(Env *, Value);
     Value source_location();
 
     Value inspect(Env *env) {

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -51,6 +51,7 @@ public:
     Value call(Env *, Args = {}, Block * = nullptr);
     bool equal_value(Value) const;
     Value ltlt(Env *, Value);
+    Value gtgt(Env *, Value);
     Value ruby2_keywords(Env *);
     Value source_location();
     StringObject *to_s(Env *);

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -50,6 +50,7 @@ public:
 
     Value call(Env *, Args = {}, Block * = nullptr);
     bool equal_value(Value) const;
+    Value ltlt(Env *, Value);
     Value ruby2_keywords(Env *);
     Value source_location();
     StringObject *to_s(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1102,6 +1102,7 @@ gen.binding('Object', 'itself', 'Object', 'itself', argc: 0, pass_env: false, pa
 
 gen.binding('Proc', '==', 'ProcObject', 'equal_value', argc: 1, pass_env: false, pass_block: false, aliases: ['eql?'], return_type: :bool)
 gen.binding('Proc', '<<', 'ProcObject', 'ltlt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Proc', '>>', 'ProcObject', 'gtgt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Proc', 'initialize', 'ProcObject', 'initialize', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Proc', 'arity', 'ProcObject', 'arity', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.binding('Proc', 'call', 'ProcObject', 'call', argc: :any, pass_env: true, pass_block: true, aliases: ['[]', '===', 'yield'], return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1101,6 +1101,7 @@ gen.binding('Object', 'nil?', 'Object', 'is_nil', argc: 0, pass_env: false, pass
 gen.binding('Object', 'itself', 'Object', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 
 gen.binding('Proc', '==', 'ProcObject', 'equal_value', argc: 1, pass_env: false, pass_block: false, aliases: ['eql?'], return_type: :bool)
+gen.binding('Proc', '<<', 'ProcObject', 'ltlt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Proc', 'initialize', 'ProcObject', 'initialize', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Proc', 'arity', 'ProcObject', 'arity', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.binding('Proc', 'call', 'ProcObject', 'call', argc: :any, pass_env: true, pass_block: true, aliases: ['[]', '===', 'yield'], return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1024,6 +1024,8 @@ gen.binding('MatchData', '[]', 'MatchDataObject', 'ref', argc: 1..2, pass_env: t
 
 gen.undefine_singleton_method('Method', 'new')
 gen.binding('Method', '==', 'MethodObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('Method', '<<', 'MethodObject', 'ltlt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Method', '>>', 'MethodObject', 'gtgt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Method', 'inspect', 'MethodObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Method', 'owner', 'MethodObject', 'owner', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Method', 'arity', 'MethodObject', 'arity', argc: 0, pass_env: false, pass_block: false, return_type: :int)

--- a/spec/core/method/compose_spec.rb
+++ b/spec/core/method/compose_spec.rb
@@ -1,0 +1,99 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../proc/shared/compose'
+
+describe "Method#<<" do
+  it "returns a Proc that is the composition of self and the passed Proc" do
+    succ = MethodSpecs::Composition.new.method(:succ)
+    upcase = proc { |s| s.upcase }
+
+    (succ << upcase).call('Ruby').should == "RUBZ"
+  end
+
+  it "calls passed Proc with arguments and then calls self with result" do
+    pow_2_proc = proc { |x| x * x }
+    double_proc = proc { |x| x + x }
+
+    pow_2_method = MethodSpecs::Composition.new.method(:pow_2)
+    double_method = MethodSpecs::Composition.new.method(:double)
+
+    (pow_2_method << double_proc).call(2).should == 16
+    (double_method << pow_2_proc).call(2).should == 8
+  end
+
+  it "accepts any callable object" do
+    inc = MethodSpecs::Composition.new.method(:inc)
+
+    double = Object.new
+    def double.call(n); n * 2; end
+
+    (inc << double).call(3).should == 7
+  end
+
+  it_behaves_like :proc_compose, :<<, -> { MethodSpecs::Composition.new.method(:upcase) }
+
+  describe "composition" do
+    it "is a lambda" do
+      pow_2 = MethodSpecs::Composition.new.method(:pow_2)
+      double = proc { |x| x + x }
+
+      (pow_2 << double).is_a?(Proc).should == true
+      (pow_2 << double).should_not.lambda?
+    end
+
+    it "may accept multiple arguments" do
+      inc = MethodSpecs::Composition.new.method(:inc)
+      mul = proc { |n, m| n * m }
+
+      (inc << mul).call(2, 3).should == 7
+    end
+  end
+end
+
+describe "Method#>>" do
+  it "returns a Proc that is the composition of self and the passed Proc" do
+    upcase = proc { |s| s.upcase }
+    succ = MethodSpecs::Composition.new.method(:succ)
+
+    (succ >> upcase).call('Ruby').should == "RUBZ"
+  end
+
+  it "calls passed Proc with arguments and then calls self with result" do
+    pow_2_proc = proc { |x| x * x }
+    double_proc = proc { |x| x + x }
+
+    pow_2_method = MethodSpecs::Composition.new.method(:pow_2)
+    double_method = MethodSpecs::Composition.new.method(:double)
+
+    (pow_2_method >> double_proc).call(2).should == 8
+    (double_method >> pow_2_proc).call(2).should == 16
+  end
+
+  it "accepts any callable object" do
+    inc = MethodSpecs::Composition.new.method(:inc)
+
+    double = Object.new
+    def double.call(n); n * 2; end
+
+    (inc >> double).call(3).should == 8
+  end
+
+  it_behaves_like :proc_compose, :>>, -> { MethodSpecs::Composition.new.method(:upcase) }
+
+  describe "composition" do
+    it "is a lambda" do
+      pow_2 = MethodSpecs::Composition.new.method(:pow_2)
+      double = proc { |x| x + x }
+
+      (pow_2 >> double).is_a?(Proc).should == true
+      (pow_2 >> double).should.lambda?
+    end
+
+    it "may accept multiple arguments" do
+      mul = MethodSpecs::Composition.new.method(:mul)
+      inc = proc { |n| n + 1 }
+
+      (mul >> inc).call(2, 3).should == 7
+    end
+  end
+end

--- a/spec/core/method/compose_spec.rb
+++ b/spec/core/method/compose_spec.rb
@@ -86,7 +86,9 @@ describe "Method#>>" do
       double = proc { |x| x + x }
 
       (pow_2 >> double).is_a?(Proc).should == true
-      (pow_2 >> double).should.lambda?
+      NATFIXME 'Method#to_proc should return lambda', exception: SpecFailedException do
+        (pow_2 >> double).should.lambda?
+      end
     end
 
     it "may accept multiple arguments" do

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -11,6 +11,14 @@ bool MethodObject::eq(Env *env, Value other_value) {
     }
 }
 
+Value MethodObject::ltlt(Env *env, Value other) {
+    return to_proc(env)->ltlt(env, other);
+}
+
+Value MethodObject::gtgt(Env *env, Value other) {
+    return to_proc(env)->gtgt(env, other);
+}
+
 Value MethodObject::source_location() {
     if (!m_method->get_file())
         return NilObject::the();

--- a/src/proc.rb
+++ b/src/proc.rb
@@ -1,13 +1,3 @@
 class Proc
   public :binding
-
-  def >>(other)
-    raise TypeError, 'callable object is expected' unless other.respond_to?(:call)
-
-    if lambda?
-      ->(*args, **kwargs, &block) { other.call(call(*args, **kwargs, &block)) }
-    else
-      proc { |*args, **kwargs, &block| other.call(call(*args, **kwargs, &block)) }
-    end
-  end
 end

--- a/src/proc.rb
+++ b/src/proc.rb
@@ -1,16 +1,6 @@
 class Proc
   public :binding
 
-  def <<(other)
-    raise TypeError, 'callable object is expected' unless other.respond_to?(:call)
-
-    if other.is_a?(Proc) && other.lambda?
-      ->(*args, **kwargs, &block) { call(other.call(*args, **kwargs, &block)) }
-    else
-      proc { |*args, **kwargs, &block| call(other.call(*args, **kwargs, &block)) }
-    end
-  end
-
   def >>(other)
     raise TypeError, 'callable object is expected' unless other.respond_to?(:call)
 

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -25,6 +25,24 @@ bool ProcObject::equal_value(Value other) const {
     return other->is_proc() && other->as_proc()->m_block == m_block;
 }
 
+static Value compose_ltlt(Env *env, Value self, Args args, Block *block) {
+    auto block_var = ProcObject::from_block_maybe(block);
+    auto call = "call"_s;
+    auto other_call_result = env->outer()->var_get("other", 0)->send(env, call, std::move(args), to_block(env, block_var), self);
+    return self->send(env, call, { other_call_result }, nullptr, self);
+}
+
+Value ProcObject::ltlt(Env *env, Value other) {
+    if (!other->respond_to(env, "call"_s))
+        env->raise("TypeError", "callable object is expected");
+
+    env->var_set("other", 0, true, other);
+    auto block = new Block { env, this, compose_ltlt, -1 };
+    if (other->is_proc() && other->as_proc()->is_lambda())
+        block->set_type(Block::BlockType::Lambda);
+    return new ProcObject { block };
+}
+
 Value ProcObject::ruby2_keywords(Env *env) {
     auto block_wrapper = [](Env *env, Value self, Args args, Block *block) -> Value {
         auto kwargs = args.has_keyword_hash() ? args.pop_keyword_hash() : new HashObject;


### PR DESCRIPTION
By forwarding the calls to `Proc#<<` and `Proc#>>`. These methods have been moved from Ruby to C++ to simplify this call in C++ code.