### PR TITLE
Bytecode VM: Support PushLastMatchInstruction

### DIFF
--- a/lib/natalie/compiler/instructions/push_last_match_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_last_match_instruction.rb
@@ -12,7 +12,15 @@ module Natalie
       end
 
       def execute(vm)
-        vm.push($~)
+        vm.push(vm.global_variables[:$~])
+      end
+
+      def serialize(_)
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_, _)
+        new
       end
     end
   end

--- a/test/bytecode/puts_regexp_test.rb
+++ b/test/bytecode/puts_regexp_test.rb
@@ -56,4 +56,24 @@ describe 'puts a regexp match result' do
 
     ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
   end
+
+  it 'can use $1 to access the first match' do
+    code = <<~RUBY
+      /(foo)/ =~ 'foobar'
+      puts $1
+    RUBY
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+  end
+
+  it 'can store matches in local variables' do
+    code = <<~RUBY
+      /(?<foo>bar)/ =~ 'foobar'
+      puts foo
+    RUBY
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "bar\n"
+  end
 end


### PR DESCRIPTION
There are some issues with using references in the interpreter mode (and thus in running the Bytecode VM). Compare:
```
bin/natalie -e '/(?<foo>bar)/ =~ "foobar"; p $~'
#<MatchData "bar" foo:"bar">

bin/natalie -i -e '/(?<foo>bar)/ =~ "foobar"; p $~'
nil
```

I expect the interpreter mode uses some regexp internally and overwrites the global