### PR TITLE
Fix behaviour when for IO#write with empty string

### DIFF
--- a/spec/core/io/write_spec.rb
+++ b/spec/core/io/write_spec.rb
@@ -21,9 +21,7 @@ describe "IO#write on a file" do
   end
 
   it "does not check if the file is writable if writing zero bytes" do
-    NATFIXME 'does not check if the file is writable if writing zero bytes', exception: SpecFailedException do
-      -> { @readonly_file.write("") }.should_not raise_error
-    end
+    -> { @readonly_file.write("") }.should_not raise_error
   end
 
   before :each do

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -463,6 +463,8 @@ int IoObject::write(Env *env, Value obj) {
     raise_if_closed(env);
     obj = obj->to_s(env);
     obj->assert_type(env, Object::Type::String, "String");
+    if (obj->as_string()->is_empty())
+        return 0;
     int result = ::write(m_fileno, obj->as_string()->c_str(), obj->as_string()->bytesize());
     if (result == -1) throw_unless_writable(env, this);
     if (m_sync) ::fsync(m_fileno);


### PR DESCRIPTION
Do not check whether the file is writable.