### PR TITLE
Warn for second argument in Regexp.new being an unsupported type

### DIFF
--- a/spec/core/regexp/shared/new.rb
+++ b/spec/core/regexp/shared/new.rb
@@ -143,7 +143,7 @@ describe :regexp_new_string, shared: true do
       obj = Object.new
       def obj.to_int() ScratchPad.record(:called) end
 
-      NATFIXME 'Support second argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0..1)' do
+      NATFIXME 'does not try to convert the second argument to Integer with #to_int method call', exception: SpecFailedException do
         -> {
           Regexp.send(@method, "Hi", obj)
         }.should complain(/expected true or false as ignorecase/, {verbose: true})
@@ -167,15 +167,15 @@ describe :regexp_new_string, shared: true do
   ruby_version_is "3.2" do
     it "warns any non-Integer, non-nil, non-false second argument" do
       r = nil
-      NATFIXME 'Support second argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0..1)' do
+      NATFIXME 'warns any non-Integer, non-nil, non-false second argument', exception: SpecFailedException do
         -> {
           r = Regexp.send(@method, 'Hi', Object.new)
         }.should complain(/expected true or false as ignorecase/, {verbose: true})
-        (r.options & Regexp::IGNORECASE).should_not == 0
-        (r.options & Regexp::MULTILINE).should == 0
-        not_supported_on :opal do
-          (r.options & Regexp::EXTENDED).should == 0
-        end
+      end
+      (r.options & Regexp::IGNORECASE).should_not == 0
+      (r.options & Regexp::MULTILINE).should == 0
+      not_supported_on :opal do
+        (r.options & Regexp::EXTENDED).should == 0
       end
     end
 

--- a/spec/core/regexp/shared/new.rb
+++ b/spec/core/regexp/shared/new.rb
@@ -143,11 +143,9 @@ describe :regexp_new_string, shared: true do
       obj = Object.new
       def obj.to_int() ScratchPad.record(:called) end
 
-      NATFIXME 'does not try to convert the second argument to Integer with #to_int method call', exception: SpecFailedException do
-        -> {
-          Regexp.send(@method, "Hi", obj)
-        }.should complain(/expected true or false as ignorecase/, {verbose: true})
-      end
+      -> {
+        Regexp.send(@method, "Hi", obj)
+      }.should complain(/expected true or false as ignorecase/, {verbose: true})
 
       ScratchPad.recorded.should == nil
     end
@@ -167,11 +165,9 @@ describe :regexp_new_string, shared: true do
   ruby_version_is "3.2" do
     it "warns any non-Integer, non-nil, non-false second argument" do
       r = nil
-      NATFIXME 'warns any non-Integer, non-nil, non-false second argument', exception: SpecFailedException do
-        -> {
-          r = Regexp.send(@method, 'Hi', Object.new)
-        }.should complain(/expected true or false as ignorecase/, {verbose: true})
-      end
+      -> {
+        r = Regexp.send(@method, 'Hi', Object.new)
+      }.should complain(/expected true or false as ignorecase/, {verbose: true})
       (r.options & Regexp::IGNORECASE).should_not == 0
       (r.options & Regexp::MULTILINE).should == 0
       not_supported_on :opal do

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -226,8 +226,11 @@ Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
                         env->raise("ArgumentError", "unknown regexp option: {}", opts->as_string()->string());
                     }
                 }
-            } else if (opts->is_truthy()) {
-                options = 1;
+            } else {
+                if (!opts->is_true() && !opts->is_false() && env->global_get("$VERBOSE"_s)->is_truthy())
+                    env->warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
+                if (opts->is_truthy())
+                    options = RegexOpts::IgnoreCase;
             }
         }
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -876,9 +876,13 @@ class RaiseErrorExpectation
 end
 
 class ComplainExpectation
-  def initialize(message = nil, verbose: false)
+  def initialize(message = nil, kwargs = {}, verbose: false)
     @message = message
-    @verbose = verbose
+    if kwargs.key?(:verbose)
+      @verbose = kwargs[:verbose]
+    else
+      @verbose = verbose
+    end
   end
 
   def match(subject)
@@ -1425,8 +1429,8 @@ class Object
     RaiseErrorExpectation.new(klass, message, &block)
   end
 
-  def complain(message = nil, verbose: false)
-    ComplainExpectation.new(message, verbose: verbose)
+  def complain(message = nil, kwargs = {}, verbose: false)
+    ComplainExpectation.new(message, kwargs, verbose: verbose)
   end
 
   def match_yaml(expected)


### PR DESCRIPTION
This includes some fixes for the `complain` spec helper