### PR TITLE
Update comment for disabled spec of File#flock

### DIFF
--- a/spec/core/file/flock_spec.rb
+++ b/spec/core/file/flock_spec.rb
@@ -37,7 +37,8 @@ describe "File#flock" do
     END_OF_CODE
   end
 
-  # NATFIXME: Threads
+  # NATFIXME: Thread gets killed by Errno::EINTR, wrapping in a block works
+  #           in single test mode, but fails when running all tests.
   xit "blocks if trying to lock an exclusively locked file" do
     @file.flock File::LOCK_EX
 


### PR DESCRIPTION
The threads work fine, but something with signal handling fails, so we should keep this spec inactive for now.