### PR TITLE
Streamline the verbose warn idiom

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -99,7 +99,7 @@ public:
 
     template <typename... Args>
     void verbose_warn(const char *format, Args... args) {
-        if (GlobalEnv::the()->is_verbose(this))
+        if (GlobalEnv::the()->is_verbose())
             warn(String::format(format, args...));
     }
 

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -97,6 +97,12 @@ public:
         warn(message);
     }
 
+    template <typename... Args>
+    void verbose_warn(const char *format, Args... args) {
+        if (GlobalEnv::the()->is_verbose(this))
+            warn(String::format(format, args...));
+    }
+
     void ensure_block_given(Block *);
     void ensure_no_missing_keywords(HashObject *, std::initializer_list<const String>);
     void ensure_no_extra_keywords(HashObject *);

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -86,6 +86,8 @@ public:
     void global_set_read_hook(Env *, SymbolObject *, bool, GlobalVariableInfo::read_hook_t read_hook);
     void global_set_write_hook(Env *, SymbolObject *, GlobalVariableInfo::write_hook_t);
 
+    bool is_verbose(Env *);
+
     void set_main_env(Env *main_env) { m_main_env = main_env; }
     Env *main_env() { return m_main_env; }
 

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -86,7 +86,8 @@ public:
     void global_set_read_hook(Env *, SymbolObject *, bool, GlobalVariableInfo::read_hook_t read_hook);
     void global_set_write_hook(Env *, SymbolObject *, GlobalVariableInfo::write_hook_t);
 
-    bool is_verbose(Env *);
+    bool is_verbose() const { return m_verbose; }
+    void set_verbose(const bool verbose) { m_verbose = verbose; }
 
     void set_main_env(Env *main_env) { m_main_env = main_env; }
     Env *main_env() { return m_main_env; }
@@ -142,6 +143,7 @@ private:
     MethodMissingReason m_method_missing_reason { MethodMissingReason::Undefined };
     bool m_instance_evaling { false };
     bool m_rescued { false };
+    bool m_verbose { false };
 
     TM::Hashmap<SymbolObject *> m_files {};
 };

--- a/include/natalie/global_variable_info/access_hooks.hpp
+++ b/include/natalie/global_variable_info/access_hooks.hpp
@@ -17,10 +17,10 @@ namespace GlobalVariableAccessHooks::ReadHooks {
 
 namespace GlobalVariableAccessHooks::WriteHooks {
     Object *as_string_or_raise(Env *, Value, GlobalVariableInfo &);
-    Object *to_bool(Env *, Value, GlobalVariableInfo &);
     Object *to_int(Env *, Value, GlobalVariableInfo &);
     Object *last_match(Env *, Value, GlobalVariableInfo &);
     Object *set_stdout(Env *, Value, GlobalVariableInfo &);
+    Object *set_verbose(Env *, Value, GlobalVariableInfo &);
 }
 
 }

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -111,10 +111,6 @@ void GlobalEnv::global_set_write_hook(Env *env, SymbolObject *name, GlobalVariab
     info->set_write_hook(write_hook);
 }
 
-bool GlobalEnv::is_verbose(Env *env) {
-    return global_get(env, "$VERBOSE"_s)->is_truthy();
-}
-
 void GlobalEnv::visit_children(Visitor &visitor) {
     for (auto pair : m_global_variables) {
         visitor.visit(pair.first);

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -111,6 +111,10 @@ void GlobalEnv::global_set_write_hook(Env *env, SymbolObject *name, GlobalVariab
     info->set_write_hook(write_hook);
 }
 
+bool GlobalEnv::is_verbose(Env *env) {
+    return global_get(env, "$VERBOSE"_s)->is_truthy();
+}
+
 void GlobalEnv::visit_children(Visitor &visitor) {
     for (auto pair : m_global_variables) {
         visitor.visit(pair.first);

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -83,6 +83,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
     }
 
     Object *set_verbose(Env *env, Value v, GlobalVariableInfo &) {
+        GlobalEnv::the()->set_verbose(v->is_truthy());
         if (v->is_nil())
             return NilObject::the();
         return bool_object(v->is_truthy()).object();

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -64,12 +64,6 @@ namespace GlobalVariableAccessHooks::WriteHooks {
         return v->as_string_or_raise(env);
     }
 
-    Object *to_bool(Env *env, Value v, GlobalVariableInfo &) {
-        if (v->is_nil())
-            return NilObject::the();
-        return bool_object(v->is_truthy()).object();
-    }
-
     Object *to_int(Env *env, Value v, GlobalVariableInfo &) {
         return v->to_int(env);
     }
@@ -86,6 +80,12 @@ namespace GlobalVariableAccessHooks::WriteHooks {
         if (!v->respond_to(env, "write"_s))
             env->raise("TypeError", "$stdout must have write method, {} given", v->klass()->inspect_str());
         return v.object();
+    }
+
+    Object *set_verbose(Env *env, Value v, GlobalVariableInfo &) {
+        if (v->is_nil())
+            return NilObject::the();
+        return bool_object(v->is_truthy()).object();
     }
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -762,8 +762,7 @@ ArrayObject *ModuleObject::attr(Env *env, Args args) {
     bool accessor = false;
     auto size = args.size();
     if (args.size() > 1 && args[size - 1]->is_boolean()) {
-        if (env->global_get("$VERBOSE"_s)->is_truthy())
-            env->warn("optional boolean argument is obsoleted");
+        env->verbose_warn("optional boolean argument is obsoleted");
         accessor = args[size - 1]->is_truthy();
         size--;
     }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -424,7 +424,7 @@ Env *build_top_env() {
     env->global_alias("$-d"_s, "$DEBUG"_s);
 
     env->global_set("$VERBOSE"_s, FalseObject::the());
-    GlobalEnv::the()->global_set_write_hook(env, "$VERBOSE"_s, GlobalVariableAccessHooks::WriteHooks::to_bool);
+    GlobalEnv::the()->global_set_write_hook(env, "$VERBOSE"_s, GlobalVariableAccessHooks::WriteHooks::set_verbose);
     env->global_alias("$-v"_s, "$VERBOSE"_s);
     env->global_alias("$-w"_s, "$VERBOSE"_s);
 

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -227,8 +227,7 @@ Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
                     }
                 }
             } else {
-                if (!opts->is_true() && !opts->is_false() && env->global_get("$VERBOSE"_s)->is_truthy())
-                    env->warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
+                env->verbose_warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
                 if (opts->is_truthy())
                     options = RegexOpts::IgnoreCase;
             }


### PR DESCRIPTION
This closes #2001.
I'm not completely sure about the `verbose_warn` function name, it might be interpreted as "make your warning extra verbose", I'm open for suggestions on a better name.