### PR TITLE
Fix warning for new array with unused block

### DIFF
--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -25,7 +25,7 @@ Value ArrayObject::initialize(Env *env, Value size, Value value, Block *block) {
     this->assert_not_frozen(env);
 
     if (!size && !value && block)
-        env->warn("given block not used");
+        env->verbose_warn("given block not used");
 
     if (!size) {
         ArrayObject new_array;


### PR DESCRIPTION
Only warn in verbose mode.

This is the result of  #2007, but split into a new PR since it started to become a mess.