### PR TITLE
Bytecode VM: Add with_singleton instruction

### DIFF
--- a/lib/natalie/compiler/instructions/with_singleton_instruction.rb
+++ b/lib/natalie/compiler/instructions/with_singleton_instruction.rb
@@ -33,6 +33,14 @@ module Natalie
         vm.with_self(singleton) { vm.run }
         :no_halt
       end
+
+      def serialize(_)
+        [instruction_number].pack('C')
+      end
+
+      def self.deserialize(_, _)
+        new
+      end
     end
   end
 end

--- a/test/bytecode/with_singleton_test.rb
+++ b/test/bytecode/with_singleton_test.rb
@@ -1,0 +1,25 @@
+require_relative '../spec_helper'
+
+describe 'it can define a class with a singleton part' do
+  before :each do
+    @bytecode_file = tmp('bytecode')
+  end
+
+  after :each do
+    rm_r @bytecode_file
+  end
+
+  it 'can define a class with a singleton part' do
+    code = <<~RUBY
+      class Foo
+        class << self
+          def foo = "foo"
+        end
+      end
+      puts Foo.foo
+    RUBY
+    ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
+
+    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+  end
+end


### PR DESCRIPTION
So, I had no idea what this instruction did, so I had to look up the usage of it in `pass1.rb`, then convert that method name back to the Prism class, and look in the Prism documentation to find an example :D