### PR TITLE
Make behaviour of SSLContext#verify_mode match the MRI implementation

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -192,10 +192,8 @@ module OpenSSL
       __bind_method__ :security_level, :OpenSSL_SSL_SSLContext_security_level
       __bind_method__ :security_level=, :OpenSSL_SSL_SSLContext_set_security_level
       __bind_method__ :setup, :OpenSSL_SSL_SSLContext_setup
-      __bind_method__ :verify_mode, :OpenSSL_SSL_SSLContext_verify_mode
-      __bind_method__ :verify_mode=, :OpenSSL_SSL_SSLContext_set_verify_mode
 
-      attr_accessor :cert_store
+      attr_accessor :cert_store, :verify_mode
 
       alias freeze setup
     end

--- a/test/natalie/openssl_test.rb
+++ b/test/natalie/openssl_test.rb
@@ -629,6 +629,13 @@ describe "OpenSSL::SSL::SSLContext" do
     end
   end
 
+  describe "#verify_mode=" do
+    it "can be called with any value without verification" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = :foobar
+    end
+  end
+
   describe "#setup" do
     it "freezes the context" do
       context = OpenSSL::SSL::SSLContext.new
@@ -647,6 +654,18 @@ describe "OpenSSL::SSL::SSLContext" do
       context = OpenSSL::SSL::SSLContext.new
       context.setup
       context.setup.should be_nil
+    end
+
+    it "validates the verify mode" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = :foobar
+      -> { context.setup }.should raise_error(TypeError, "no implicit conversion of Symbol into Integer")
+    end
+
+    it "supports a nil value as verify mode to disable it" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = nil
+      -> { context.setup }.should_not raise_error
     end
 
     it "validates the cert_store object" do


### PR DESCRIPTION
Don't use the value until `SSLContext#setup` is called. This might result in a late `TypeError`, I'm not sure why MRI behaves this way, but keeping the behaviour as close as possible makes it easier to find bugs in our implementation.