### PR TITLE
Implement SSLSocket#verify_hostname

### DIFF
--- a/examples/sslsocket.rb
+++ b/examples/sslsocket.rb
@@ -14,6 +14,7 @@ TCPSocket.open('natalie-lang.org', 443) do |sock|
   ssl_context.max_version = :TLS1_3
   ssl_context.security_level = 2
   ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  ssl_context.verify_hostname = true
   ssl_context.cert_store = cert_store
 
   ssl_sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -193,7 +193,7 @@ module OpenSSL
       __bind_method__ :security_level=, :OpenSSL_SSL_SSLContext_set_security_level
       __bind_method__ :setup, :OpenSSL_SSL_SSLContext_setup
 
-      attr_accessor :cert_store, :verify_mode
+      attr_accessor :cert_store, :verify_hostname, :verify_mode
 
       alias freeze setup
     end


### PR DESCRIPTION
Changing the line `ssl_sock.hostname = 'natalie-lang.org'` in the SSL example script to some other hostname now results in a certificate validation failure