### PR TITLE
Support Prism::ConstantOperatorWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -850,6 +850,27 @@ module Natalie
         instructions
       end
 
+      def transform_constant_operator_write_node(node, used:)
+        instructions = [
+          PushSelfInstruction.new,
+          ConstFindInstruction.new(node.name, strict: false),
+          transform_expression(node.value, used: true),
+          PushArgcInstruction.new(1),
+          SendInstruction.new(
+            node.operator,
+            args_array_on_stack: false,
+            receiver_is_self: false,
+            with_block: false,
+            has_keyword_hash: false,
+            file: @file.path,
+            line: node.location.start_line,
+          ),
+          PushSelfInstruction.new,
+          ConstSetInstruction.new(node.name),
+        ]
+        instructions
+      end
+
       def transform_constant_or_write_node(node, used:)
         instructions = [
           IsDefinedInstruction.new(type: 'constant'),

--- a/test/natalie/constant_test.rb
+++ b/test/natalie/constant_test.rb
@@ -119,4 +119,15 @@ describe 'constants' do
       end
     end
   end
+
+  describe 'using += write (Prism::ConstantOperatorWriteNode)' do
+    it 'can change a value' do
+      module ModuleA
+        QUUX = 1
+        suppress_warning { QUUX += 1 }
+        QUUX.should == 2
+        remove_const(:QUUX)
+      end
+    end
+  end
 end

--- a/test/natalie/constant_test.rb
+++ b/test/natalie/constant_test.rb
@@ -110,11 +110,12 @@ describe 'constants' do
         QUUX = nil
         QUUX &&= 1
         QUUX.should be_nil
-
         remove_const(:QUUX)
+
         QUUX = 1
         suppress_warning { QUUX &&= 2 }
         QUUX.should == 2
+        remove_const(:QUUX)
       end
     end
   end


### PR DESCRIPTION
```ruby
Foo += 1
```
This kind of code.

This started as an attempt at getting https://github.com/ruby/spec/blob/master/language/predefined_spec.rb to compile, but that resulted in a bunch of turtles on top of each other.