### PR TITLE
Support Prism::NoKeywordsParameterNode

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -59,6 +59,8 @@ module Natalie
           transform_required_keyword_arg(arg)
         when ::Prism::OptionalKeywordParameterNode
           transform_optional_keyword_arg(arg)
+        when ::Prism::NoKeywordsParameterNode
+          transform_no_keyword_arg(arg)
         when ::Prism::ImplicitRestNode
           clean_up_keyword_args
           transform_implicit_rest_arg(arg)
@@ -140,6 +142,10 @@ module Natalie
         @instructions << @pass.transform_expression(arg.value, used: true)
         @instructions << HashDeleteWithDefaultInstruction.new(arg.name)
         @instructions << variable_set(arg.name)
+      end
+
+      def transform_no_keyword_arg(arg)
+        move_keyword_arg_hash_from_args_array_to_stack
       end
 
       def transform_destructured_arg(arg)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2402,7 +2402,8 @@ module Natalie
         args.any? do |arg|
           arg.is_a?(::Prism::RequiredKeywordParameterNode) ||
             arg.is_a?(::Prism::OptionalKeywordParameterNode) ||
-            arg.is_a?(::Prism::KeywordRestParameterNode)
+            arg.is_a?(::Prism::KeywordRestParameterNode) ||
+            arg.is_a?(::Prism::NoKeywordsParameterNode)
         end
       end
 

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -439,6 +439,14 @@ def method_with_kwargs14(a = '', **kwargs)
   [a, kwargs]
 end
 
+def method_implicit_kwargs(*args)
+  args
+end
+
+def method_no_kwargs(*args, **nil)
+  args
+end
+
 describe 'method with keyword args' do
   it 'accepts keyword args' do
     method_with_kwargs1(1, b: 2).should == [1, 2]
@@ -535,6 +543,15 @@ describe 'method with keyword args' do
     -> { method_with_kwargs12(1, b: 2, c: 3) }.should raise_error(ArgumentError, 'unknown keyword: :c')
     -> { method_with_kwargs13(1, 2, c: 3) }.should_not raise_error
     -> { method_with_kwargs14(1, b: 2, c: 3) }.should_not raise_error
+  end
+
+  it 'adds keyword arguments to args splat if no keywords are mentioned in the method signature' do
+    method_implicit_kwargs(1, 2, a: 3).should == [1, 2, { a: 3 }]
+  end
+
+  it 'raises an error when keyword arguments are provided, but not allowed' do
+    -> { method_no_kwargs(1, 2, a: 3) }.should raise_error(ArgumentError)
+    -> { method_no_kwargs(1, 2, **{}) }.should_not raise_error
   end
 
   ruby_version_is ''...'3.3' do
@@ -644,6 +661,8 @@ describe 'Method' do
       method(:method_with_kwargs7).arity.should == 1
       method(:method_with_kwargs8).arity.should == 1
       method(:method_with_kwargs9).arity.should == -1
+      method(:method_implicit_kwargs).arity.should == -1
+      method(:method_no_kwargs).arity.should == -1
     end
   end
 end


### PR DESCRIPTION
This supports method definitions like this:
```ruby
def foo(*args, **nil) = args
```
Without the `**nil`, the keywords would sneakily end up in the `args` array.

Ruby uses a separate error message for this, this change uses the generic error message for extra keywords:
```
$ ruby -e 'def foo(*a, **nil) = a; foo(1, a: 1)
> '
-e:1:in `<main>': no keywords accepted (ArgumentError)

def foo(*a, **nil) = a; foo(1, a: 1)
                            ^^^^^^^
$ bin/natalie -e 'def foo(*a, **nil) = a; foo(1, a: 1)'
Traceback (most recent call last):
        1: from -e:1:in `<main>'
-e:1:in `foo': unknown keyword: :a (ArgumentError)
```

This resolves the compile error in https://github.com/ruby/spec/blob/master/core/method/parameters_spec.rb (which causes a bunch of extra errors in the specs, since we have not implemented that method)