### PR TITLE
Fixes to handling CallOrWriteNode

### DIFF
--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -109,9 +109,7 @@ describe 'Optional variable assignments' do
 
         (ScratchPad << :evaluated; @a).b ||= 10
 
-        NATFIXME 'does evaluate receiver only once when assigns', exception: SpecFailedException do
-          ScratchPad.recorded.should == [:evaluated]
-        end
+        ScratchPad.recorded.should == [:evaluated]
         @a.b.should == 10
       end
 


### PR DESCRIPTION
```ruby
a.foo ||= b
```
This should evaluate `a` only once.

This is just the beginning, there are a lot of calls similar to this. https://kddnewton.com/2023/12/06/advent-of-prism-part-6 and https://kddnewton.com/2023/12/16/advent-of-prism-part-16 describe most (or maybe all) of them.