### PR TITLE
Fix wrong operator used for buffer size check

### DIFF
--- a/src/io.rb
+++ b/src/io.rb
@@ -102,7 +102,7 @@ class IO
 
     buf = String.new('', encoding: Encoding.default_external)
     get_bytes = lambda do |size|
-      buf << read(1024) while !eof? && buf.bytesize << size
+      buf << read(1024) while !eof? && buf.bytesize < size
       return nil if eof? && buf.empty?
       buf.byteslice(0, size).force_encoding(Encoding.default_external)
     end


### PR DESCRIPTION
All tests were passing because we still got the desired result, but it was reading to the end of the IO object in one go instead of a little-at-a-time.