### PR TITLE
Upgrade to Prism 0.29

### DIFF
--- a/lib/natalie/compiler/const_prepper.rb
+++ b/lib/natalie/compiler/const_prepper.rb
@@ -8,8 +8,8 @@ module Natalie
           @name = node.name
           @namespace = PushSelfInstruction.new
         when :constant_path_node, :constant_path_target_node
-          raise 'unexpected child here' if node.child.type != :constant_read_node
-          @name = node.child.name
+          raise 'unexpected child here' if node.name.nil?
+          @name = node.name
           if node.parent
             @namespace = pass.transform_expression(node.parent, used: true)
             @private = false

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -606,7 +606,7 @@ module Natalie
           # stack: [obj, new_value]
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @file.path,
@@ -798,7 +798,7 @@ module Natalie
           transform_expression(node.value, used: true),
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @file.path,
@@ -862,7 +862,7 @@ module Natalie
           transform_expression(node.value, used: true),
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             args_array_on_stack: false,
             receiver_is_self: false,
             with_block: false,
@@ -1210,7 +1210,7 @@ module Natalie
           transform_expression(node.value, used: true),
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @file.path,
@@ -1445,7 +1445,7 @@ module Natalie
           # stack: [obj, *keys, new_value]
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @file.path,
@@ -1576,7 +1576,7 @@ module Natalie
           transform_expression(node.value, used: true),
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @file.path,
@@ -1761,7 +1761,7 @@ module Natalie
           transform_expression(node.value, used: true),
           PushArgcInstruction.new(1),
           SendInstruction.new(
-            node.operator,
+            node.binary_operator,
             receiver_is_self: false,
             with_block: false,
             file: @current_path,


### PR DESCRIPTION
This version got released somewhere during the development cycle of  #2018. The most relevant change for us:

> All fields named `operator` have been renamed to `binary_operator` for `*OperatorWriteNode` nodes. This is to make it easier to provide C++ support. In the Ruby API, the old fields are aliased to the new fields with a deprecation warning.

Since I want to tackle these missing operators to fix some of the current compilation issues, it would be nice to fix that compatibility issue. Everything else seems to work just fine with this upgrade.