### PR TITLE
Fixes to handling of ConstantOrWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -904,17 +904,22 @@ module Natalie
 
           # CONST = value
           transform_expression(node.value, used: true),
-          DupInstruction.new,
+        ]
+        instructions << DupInstruction.new if used
+        instructions.push(
           PushSelfInstruction.new,
           ConstSetInstruction.new(node.name),
+          ElseInstruction.new(:if),
+        )
 
           # else; CONST; end
-          ElseInstruction.new(:if),
-          PushSelfInstruction.new,
-          ConstFindInstruction.new(node.name, strict: false),
-          EndInstruction.new(:if),
-        ]
-        instructions << PopInstruction.new unless used
+        if used
+          instructions.push(
+            PushSelfInstruction.new,
+            ConstFindInstruction.new(node.name, strict: false),
+          )
+        end
+        instructions << EndInstruction.new(:if)
         instructions
       end
 

--- a/test/natalie/constant_test.rb
+++ b/test/natalie/constant_test.rb
@@ -131,6 +131,48 @@ describe 'constants' do
     end
   end
 
+  describe 'using ||= assignment (Prism::ConstantOrWriteNode)' do
+    it 'can create and assign a value' do
+      module ModuleA
+        -> { QUUX }.should raise_error(NameError, /uninitialized constant ModuleA::QUUX/)
+
+        QUUX ||= nil
+        QUUX.should be_nil
+
+        suppress_warning { QUUX ||= false }
+        QUUX.should be_false
+
+        suppress_warning { QUUX ||= 1 }
+        QUUX.should == 1
+
+        suppress_warning { QUUX ||= 2 }
+        QUUX.should == 1
+
+        remove_const(:QUUX)
+      end
+    end
+
+    it 'has the correct return values' do
+      module ModuleA
+        (QUUX ||= nil).should be_nil
+
+        suppress_warning do
+          (QUUX ||= false).should be_false
+        end
+
+        suppress_warning do
+          (QUUX ||= 1).should == 1
+        end
+
+        suppress_warning do
+          (QUUX ||= 2).should == 1
+        end
+
+        remove_const(:QUUX)
+      end
+    end
+  end
+
   describe 'using += write (Prism::ConstantPathOperatorWriteNode)' do
     it 'can change a value' do
       module ModuleA

--- a/test/natalie/constant_test.rb
+++ b/test/natalie/constant_test.rb
@@ -102,7 +102,7 @@ describe 'constants' do
     -> { UnknownConst; nil }.should raise_error(NameError, /uninitialized constant UnknownConst/)
   end
 
-  describe 'using &&= assignment' do
+  describe 'using &&= assignment (Prism::ConstantAndWriteNode)' do
     it 'can assign a value' do
       module ModuleA
         -> { QUUX &&= nil }.should raise_error(NameError, /uninitialized constant ModuleA::QUUX/)


### PR DESCRIPTION
My old implementation was very much based on https://kddnewton.com/2023/12/06/advent-of-prism-part-6#constantorwritenode, which only checks if the constant is defined. Turns out we have to check the value for being falsey too.

This was not caught in the rubyspecs, it might not be tested in the specs, but I wouldn't be surprised if the specs that tried to test it fail with a compilation error in Natalie. The `nil` does get tested in the specs for `ConstantPathOrWriteNode`, which we don't support yet.