### PR TITLE
Refactor handling of ConstantOrWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -904,22 +904,17 @@ module Natalie
 
           # CONST = value
           transform_expression(node.value, used: true),
-        ]
-        instructions << DupInstruction.new if used
-        instructions.push(
+          DupInstruction.new,
           PushSelfInstruction.new,
           ConstSetInstruction.new(node.name),
-          ElseInstruction.new(:if),
-        )
 
           # else; CONST; end
-        if used
-          instructions.push(
-            PushSelfInstruction.new,
-            ConstFindInstruction.new(node.name, strict: false),
-          )
-        end
-        instructions << EndInstruction.new(:if)
+          ElseInstruction.new(:if),
+          PushSelfInstruction.new,
+          ConstFindInstruction.new(node.name, strict: false),
+          EndInstruction.new(:if),
+        ]
+        instructions << PopInstruction.new unless used
         instructions
       end
 

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -898,23 +898,26 @@ module Natalie
           ConstFindInstruction.new(node.name, strict: false),
           ElseInstruction.new(:if),
           EndInstruction.new(:if),
-
+        ]
+        instructions << DupInstruction.new if used
+        instructions.append(
           # if defined?(CONST) && CONST
           IfInstruction.new,
 
           # CONST
-          PushSelfInstruction.new,
-          ConstFindInstruction.new(node.name, strict: false),
+          # Nothing to do here, return value is on the stack if the result is used
 
           # else; CONST = value; end
           ElseInstruction.new(:if),
-          transform_expression(node.value, used: true),
-          DupInstruction.new,
+        )
+        instructions << PopInstruction.new if used
+        instructions.concat(transform_expression(node.value, used: true))
+        instructions << DupInstruction.new if used
+        instructions.append(
           PushSelfInstruction.new,
           ConstSetInstruction.new(node.name),
           EndInstruction.new(:if),
-        ]
-        instructions << PopInstruction.new unless used
+        )
         instructions
       end
 


### PR DESCRIPTION
The old code worked like this:
```ruby
if !defined?(CONST) || !CONST
  CONST = value
else
  CONST
end
```
With a bit of DeMorgan and flipping the bodies, we can rewrite this as:
```ruby
if defined?(CONST) && CONST
  CONST
else
  CONST = value
end
```
This removes two operations from the resulting code.