### PR TITLE
Support Prism::ConstantPathOrWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -986,16 +986,21 @@ module Natalie
           PushFalseInstruction.new,                             # [tmp, false]
           EndInstruction.new(:if),
           IfInstruction.new,                                    # [tmp]                              [tmp]                                           [tmp]
-          ConstFindInstruction.new(name, strict: true),         #                                                                                    [tmp::Const]
-          ElseInstruction.new(:if),
-          DupInstruction.new,                                   # [tmp, tmp]                         [tmp, tmp]
+        ]
+        if used
+          instructions << ConstFindInstruction.new(name, strict: true) #                                                                             [tmp::Const]
+        else
+          instructions << PopInstruction.new                    #                                                                                    []
+        end
+        instructions << ElseInstruction.new(:if)
+        instructions << DupInstruction.new if used              # [tmp, tmp]                         [tmp, tmp]
+        instructions.append(
           transform_expression(node.value, used: true),         # [tmp, tmp, value]                  [tmp, tmp, value]
           SwapInstruction.new,                                  # [tmp, value, tmp]                  [tmp, value, tmp]
           ConstSetInstruction.new(name),                        # [tmp]                              [tmp]
-          ConstFindInstruction.new(name, strict: true),         # [value]                            [value]
-          EndInstruction.new(:if),
-        ]
-        instructions << PopInstruction.new unless used
+        )
+        instructions << ConstFindInstruction.new(name, strict: true) if used # [value]               [value]
+        instructions << EndInstruction.new(:if)
         instructions
       end
 

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -692,9 +692,7 @@ describe 'Optional constant assignment' do
     it 'causes side-effects of the module part to be applied only once (for undefined constant)' do
       x = 0
       (x += 1; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT2 ||= :assigned
-      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
-        x.should == 1
-      end
+      x.should == 1
       NATFIXME "Don't use const_missing in defined?(const)", exception: SpecFailedException do
         ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT2.should == :assigned
       end
@@ -705,9 +703,7 @@ describe 'Optional constant assignment' do
         ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2 = nil
         x = 0
         (x += 1; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT2 ||= :assigned
-        NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
-          x.should == 1
-        end
+        x.should == 1
         ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2.should == :assigned
       end
     end
@@ -720,9 +716,7 @@ describe 'Optional constant assignment' do
         (x += 1; raise Exception; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
       }.should raise_error(Exception)
 
-      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
-        x.should == 1
-      end
+      x.should == 1
       NATFIXME 'it does not evaluate the right-hand side if the module part raises an exception (for undefined constant)', exception: SpecFailedException do
         y.should == 0
         defined?(ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT3).should == nil
@@ -738,13 +732,9 @@ describe 'Optional constant assignment' do
         (x += 1; raise Exception; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
       }.should raise_error(Exception)
 
-      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
-        x.should == 1
-      end
-      NATFIXME 'it does not evaluate the right-hand side if the module part raises an exception (for nil constant)', exception: SpecFailedException do
-        y.should == 0
-        ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3.should == nil
-      end
+      x.should == 1
+      y.should == 0
+      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3.should == nil
     end
   end
 

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -611,17 +611,16 @@ describe 'Optional variable assignments' do
       Object.send(:remove_const, :A) if defined? Object::A
     end
 
-#    NATFIXME: Implement transform_constant_path_or_write_node
-#    it 'with ||= assignments' do
-#      Object::A ||= 10
-#      Object::A.should == 10
-#    end
-#
-#    it 'with ||= do not reassign' do
-#      Object::A = 20
-#      Object::A ||= 10
-#      Object::A.should == 20
-#    end
+    it 'with ||= assignments' do
+      Object::A ||= 10
+      Object::A.should == 10
+    end
+
+    it 'with ||= do not reassign' do
+      Object::A = 20
+      Object::A ||= 10
+      Object::A.should == 20
+    end
 
 #    NATFIXME: Implement transform_constant_path_and_write_node
 #    it 'with &&= assignments' do
@@ -660,83 +659,93 @@ describe 'Optional constant assignment' do
         OpAssignUndefined ||= 42
       end
       ConstantSpecs::OpAssignUndefined.should == 42
-#     NATFIXME: Implement transform_constant_path_or_write_node
-#     ConstantSpecs::OpAssignUndefinedOutside ||= 42
-#     ConstantSpecs::OpAssignUndefinedOutside.should == 42
+      ConstantSpecs::OpAssignUndefinedOutside ||= 42
+      ConstantSpecs::OpAssignUndefinedOutside.should == 42
       ConstantSpecs.send(:remove_const, :OpAssignUndefined)
-#     NATFIXME: Implement transform_constant_path_or_write_node
-#     ConstantSpecs.send(:remove_const, :OpAssignUndefinedOutside)
+      ConstantSpecs.send(:remove_const, :OpAssignUndefinedOutside)
     end
 
     it "assigns a global constant if previously undefined" do
       OpAssignGlobalUndefined ||= 42
-#     NATFIXME: Implement transform_constant_path_or_write_node
-#     ::OpAssignGlobalUndefinedExplicitScope ||= 42
+      ::OpAssignGlobalUndefinedExplicitScope ||= 42
       OpAssignGlobalUndefined.should == 42
-#     NATFIXME: Implement transform_constant_path_or_write_node
-#     ::OpAssignGlobalUndefinedExplicitScope.should == 42
+      ::OpAssignGlobalUndefinedExplicitScope.should == 42
       Object.send :remove_const, :OpAssignGlobalUndefined
-#     NATFIXME: Implement transform_constant_path_or_write_node
-#     Object.send :remove_const, :OpAssignGlobalUndefinedExplicitScope
+      Object.send :remove_const, :OpAssignGlobalUndefinedExplicitScope
     end
 
-#    NATFIXME: Implement transform_constant_path_or_write_node
-#    it 'correctly defines non-existing constants' do
-#      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1 ||= :assigned
-#      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1.should == :assigned
-#    end
-#
-#    it 'correctly overwrites nil constants' do
-#      suppress_warning do # already initialized constant
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1 = nil
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1 ||= :assigned
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1.should == :assigned
-#      end
-#    end
-#
-#    it 'causes side-effects of the module part to be applied only once (for undefined constant)' do
-#      x = 0
-#      (x += 1; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT2 ||= :assigned
-#      x.should == 1
-#      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT2.should == :assigned
-#    end
-#
-#    it 'causes side-effects of the module part to be applied only once (for nil constant)' do
-#      suppress_warning do # already initialized constant
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2 = nil
-#      x = 0
-#      (x += 1; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT2 ||= :assigned
-#      x.should == 1
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2.should == :assigned
-#      end
-#    end
-#
-#    it 'does not evaluate the right-hand side if the module part raises an exception (for undefined constant)' do
-#      x = 0
-#      y = 0
-#
-#      -> {
-#        (x += 1; raise Exception; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
-#      }.should raise_error(Exception)
-#
-#      x.should == 1
-#      y.should == 0
-#      defined?(ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT3).should == nil
-#    end
-#
-#    it 'does not evaluate the right-hand side if the module part raises an exception (for nil constant)' do
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3 = nil
-#      x = 0
-#      y = 0
-#
-#      -> {
-#        (x += 1; raise Exception; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
-#      }.should raise_error(Exception)
-#
-#      x.should == 1
-#      y.should == 0
-#      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3.should == nil
-#    end
+    it 'correctly defines non-existing constants' do
+      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1 ||= :assigned
+      NATFIXME "Don't use const_missing in defined?(const)", exception: SpecFailedException do
+        ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1.should == :assigned
+      end
+    end
+
+    it 'correctly overwrites nil constants' do
+      suppress_warning do # already initialized constant
+      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1 = nil
+      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1 ||= :assigned
+      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT1.should == :assigned
+      end
+    end
+
+    it 'causes side-effects of the module part to be applied only once (for undefined constant)' do
+      x = 0
+      (x += 1; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT2 ||= :assigned
+      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
+        x.should == 1
+      end
+      NATFIXME "Don't use const_missing in defined?(const)", exception: SpecFailedException do
+        ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT2.should == :assigned
+      end
+    end
+
+    it 'causes side-effects of the module part to be applied only once (for nil constant)' do
+      suppress_warning do # already initialized constant
+        ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2 = nil
+        x = 0
+        (x += 1; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT2 ||= :assigned
+        NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
+          x.should == 1
+        end
+        ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT2.should == :assigned
+      end
+    end
+
+    it 'does not evaluate the right-hand side if the module part raises an exception (for undefined constant)' do
+      x = 0
+      y = 0
+
+      -> {
+        (x += 1; raise Exception; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
+      }.should raise_error(Exception)
+
+      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
+        x.should == 1
+      end
+      NATFIXME 'it does not evaluate the right-hand side if the module part raises an exception (for undefined constant)', exception: SpecFailedException do
+        y.should == 0
+        defined?(ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT3).should == nil
+      end
+    end
+
+    it 'does not evaluate the right-hand side if the module part raises an exception (for nil constant)' do
+      ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3 = nil
+      x = 0
+      y = 0
+
+      -> {
+        (x += 1; raise Exception; ConstantSpecs::ClassA)::NIL_OR_ASSIGNED_CONSTANT3 ||= (y += 1; :assigned)
+      }.should raise_error(Exception)
+
+      NATFIXME 'Evaluate LHS only once', exception: SpecFailedException do
+        x.should == 1
+      end
+      NATFIXME 'it does not evaluate the right-hand side if the module part raises an exception (for nil constant)', exception: SpecFailedException do
+        y.should == 0
+        ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3.should == nil
+      end
+    end
   end
 
   describe "with &&=" do


### PR DESCRIPTION
This means code like this:
```ruby
Foo::Bar ||= 1
```