### PR TITLE
Support Prism::ConstantPathAndWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -937,17 +937,20 @@ module Natalie
           DupInstruction.new,
           ConstFindInstruction.new(name, strict: true),
           IfInstruction.new,
-          DupInstruction.new,
+        ]
+        instructions << DupInstruction.new if used
+        instructions.append(
           transform_expression(node.value, used: true),
           SwapInstruction.new,
           ConstSetInstruction.new(name),
-          ConstFindInstruction.new(name, strict: true),
+        )
+        instructions << ConstFindInstruction.new(name, strict: true) if used
+        instructions.append(
           ElseInstruction.new(:if),
           PopInstruction.new,
-          PushNilInstruction.new,
-          EndInstruction.new(:if),
-        ]
-        instructions << PopInstruction.new unless used
+        )
+        instructions << PushNilInstruction.new if used
+        instructions << EndInstruction.new(:if)
         instructions
       end
 

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -622,18 +622,19 @@ describe 'Optional variable assignments' do
       Object::A.should == 20
     end
 
-#    NATFIXME: Implement transform_constant_path_and_write_node
-#    it 'with &&= assignments' do
-#      Object::A = 20
-#      -> {
-#        Object::A &&= 10
-#      }.should complain(/already initialized constant/)
-#      Object::A.should == 10
-#    end
-#
-#    it 'with &&= assignments will fail with non-existent constants' do
-#      -> { Object::A &&= 10 }.should raise_error(NameError)
-#    end
+    it 'with &&= assignments' do
+      Object::A = 20
+      NATFIXME 'it should print a warning when reassigning a const', exception: SpecFailedException, message: /should have printed a warning/ do
+        -> {
+          Object::A &&= 10
+        }.should complain(/already initialized constant/)
+      end
+      Object::A.should == 10
+    end
+
+    it 'with &&= assignments will fail with non-existent constants' do
+      -> { Object::A &&= 10 }.should raise_error(NameError)
+    end
 
     it 'with operator assignments' do
       NATFIXME 'it should print a warning when reassigning a const', exception: SpecFailedException, message: /should have printed a warning/ do
@@ -739,40 +740,41 @@ describe 'Optional constant assignment' do
   end
 
   describe "with &&=" do
-#    NATFIXME: Implement transform_constant_path_and_write_node
-#    it "re-assigns a scoped constant if already true" do
-#      module ConstantSpecs
-#        OpAssignTrue = true
-#      end
-#      suppress_warning do
-#        ConstantSpecs::OpAssignTrue &&= 1
-#      end
-#      ConstantSpecs::OpAssignTrue.should == 1
-#      ConstantSpecs.send :remove_const, :OpAssignTrue
-#    end
-#
-#    it "leaves scoped constant if not true" do
-#      module ConstantSpecs
-#        OpAssignFalse = false
-#      end
-#      ConstantSpecs::OpAssignFalse &&= 1
-#      ConstantSpecs::OpAssignFalse.should == false
-#      ConstantSpecs.send :remove_const, :OpAssignFalse
-#    end
-#
-#    it 'causes side-effects of the module part to be applied only once (when assigns)' do
-#      module ConstantSpecs
-#        OpAssignTrue = true
-#      end
-#
-#      suppress_warning do # already initialized constant
-#        x = 0
-#        (x += 1; ConstantSpecs)::OpAssignTrue &&= :assigned
-#        x.should == 1
-#        ConstantSpecs::OpAssignTrue.should == :assigned
-#      end
-#
-#      ConstantSpecs.send :remove_const, :OpAssignTrue
-#    end
+    it "re-assigns a scoped constant if already true" do
+      module ConstantSpecs
+        OpAssignTrue = true
+      end
+      suppress_warning do
+        ConstantSpecs::OpAssignTrue &&= 1
+      end
+      ConstantSpecs::OpAssignTrue.should == 1
+      ConstantSpecs.send :remove_const, :OpAssignTrue
+    end
+
+    it "leaves scoped constant if not true" do
+      module ConstantSpecs
+        OpAssignFalse = false
+      end
+      ConstantSpecs::OpAssignFalse &&= 1
+      ConstantSpecs::OpAssignFalse.should == false
+      ConstantSpecs.send :remove_const, :OpAssignFalse
+    end
+
+    it 'causes side-effects of the module part to be applied only once (when assigns)' do
+      module ConstantSpecs
+        OpAssignTrue = true
+      end
+
+      suppress_warning do # already initialized constant
+        x = 0
+        (x += 1; ConstantSpecs)::OpAssignTrue &&= :assigned
+        NATFIXME 'No side effect for evaluation of path', exception: SpecFailedException do
+          x.should == 1
+        end
+        ConstantSpecs::OpAssignTrue.should == :assigned
+      end
+
+      ConstantSpecs.send :remove_const, :OpAssignTrue
+    end
   end
 end

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -768,9 +768,7 @@ describe 'Optional constant assignment' do
       suppress_warning do # already initialized constant
         x = 0
         (x += 1; ConstantSpecs)::OpAssignTrue &&= :assigned
-        NATFIXME 'No side effect for evaluation of path', exception: SpecFailedException do
-          x.should == 1
-        end
+        x.should == 1
         ConstantSpecs::OpAssignTrue.should == :assigned
       end
 


### PR DESCRIPTION
This supports code like this:
```ruby
FOO::BAR &&= 1
```
This should resolve the compilation issues in `spec/language/optional_assignments_spec.rb`