### PR TITLE
Raise SyntaxError for invalid regexp

### DIFF
--- a/spec/language/regexp/character_classes_spec.rb
+++ b/spec/language/regexp/character_classes_spec.rb
@@ -1,0 +1,642 @@
+# coding: utf-8
+require_relative '../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Regexp with character classes" do
+  it "supports \\w (word character)" do
+    /\w/.match("a").to_a.should == ["a"]
+    /\w/.match("1").to_a.should == ["1"]
+    /\w/.match("_").to_a.should == ["_"]
+
+    # Non-matches
+    /\w/.match(LanguageSpecs.white_spaces).should be_nil
+    /\w/.match(LanguageSpecs.non_alphanum_non_space).should be_nil
+    /\w/.match("\0").should be_nil
+  end
+
+  it "supports \\W (non-word character)" do
+    /\W+/.match(LanguageSpecs.white_spaces).to_a.should == [LanguageSpecs.white_spaces]
+    /\W+/.match(LanguageSpecs.non_alphanum_non_space).to_a.should == [LanguageSpecs.non_alphanum_non_space]
+    /\W/.match("\0").to_a.should == ["\0"]
+
+    # Non-matches
+    /\W/.match("a").should be_nil
+    /\W/.match("1").should be_nil
+    /\W/.match("_").should be_nil
+  end
+
+  it "supports \\s (space character)" do
+    /\s+/.match(LanguageSpecs.white_spaces).to_a.should == [LanguageSpecs.white_spaces]
+
+    # Non-matches
+    /\s/.match("a").should be_nil
+    /\s/.match("1").should be_nil
+    /\s/.match(LanguageSpecs.non_alphanum_non_space).should be_nil
+    /\s/.match("\0").should be_nil
+  end
+
+  it "supports \\S (non-space character)" do
+    /\S/.match("a").to_a.should == ["a"]
+    /\S/.match("1").to_a.should == ["1"]
+    /\S+/.match(LanguageSpecs.non_alphanum_non_space).to_a.should == [LanguageSpecs.non_alphanum_non_space]
+    /\S/.match("\0").to_a.should == ["\0"]
+
+    # Non-matches
+    /\S/.match(LanguageSpecs.white_spaces).should be_nil
+  end
+
+  it "supports \\d (numeric digit)" do
+    /\d/.match("1").to_a.should == ["1"]
+
+    # Non-matches
+    /\d/.match("a").should be_nil
+    /\d/.match(LanguageSpecs.white_spaces).should be_nil
+    /\d/.match(LanguageSpecs.non_alphanum_non_space).should be_nil
+    /\d/.match("\0").should be_nil
+  end
+
+  it "supports \\D (non-digit)" do
+    /\D/.match("a").to_a.should == ["a"]
+    /\D+/.match(LanguageSpecs.white_spaces).to_a.should == [LanguageSpecs.white_spaces]
+    /\D+/.match(LanguageSpecs.non_alphanum_non_space).to_a.should == [LanguageSpecs.non_alphanum_non_space]
+    /\D/.match("\0").to_a.should == ["\0"]
+
+    # Non-matches
+    /\D/.match("1").should be_nil
+  end
+
+  it "supports [] (character class)" do
+    /[a-z]+/.match("fooBAR").to_a.should == ["foo"]
+    /[\b]/.match("\b").to_a.should == ["\b"] # \b inside character class is backspace
+  end
+
+  it "supports [[:alpha:][:digit:][:etc:]] (predefined character classes)" do
+    /[[:alnum:]]+/.match("a1").to_a.should == ["a1"]
+    /[[:alpha:]]+/.match("Aa1").to_a.should == ["Aa"]
+    /[[:blank:]]+/.match(LanguageSpecs.white_spaces).to_a.should == [LanguageSpecs.blanks]
+    # /[[:cntrl:]]/.match("").to_a.should == [""] # TODO: what should this match?
+    /[[:digit:]]/.match("1").to_a.should == ["1"]
+    # /[[:graph:]]/.match("").to_a.should == [""] # TODO: what should this match?
+    /[[:lower:]]+/.match("Aa1").to_a.should == ["a"]
+    /[[:print:]]+/.match(LanguageSpecs.white_spaces).to_a.should == [" "]     # include all of multibyte encoded characters
+    /[[:punct:]]+/.match(LanguageSpecs.punctuations).to_a.should == [LanguageSpecs.punctuations]
+    /[[:space:]]+/.match(LanguageSpecs.white_spaces).to_a.should == [LanguageSpecs.white_spaces]
+    /[[:upper:]]+/.match("123ABCabc").to_a.should == ["ABC"]
+    /[[:xdigit:]]+/.match("xyz0123456789ABCDEFabcdefXYZ").to_a.should == ["0123456789ABCDEFabcdef"]
+
+    # Parsing
+    /[[:lower:][:digit:]A-C]+/.match("a1ABCDEF").to_a.should == ["a1ABC"] # can be composed with other constructs in the character class
+    /[^[:lower:]A-C]+/.match("abcABCDEF123def").to_a.should == ["DEF123"] # negated character class
+    /[:alnum:]+/.match("a:l:n:u:m").to_a.should == ["a:l:n:u:m"] # should behave like regular character class composed of the individual letters
+    /[\[:alnum:]+/.match("[:a:l:n:u:m").to_a.should == ["[:a:l:n:u:m"] # should behave like regular character class composed of the individual letters
+    -> { eval('/[[:alpha:]-[:digit:]]/') }.should raise_error(SyntaxError) # can't use character class as a start value of range
+  end
+
+  it "matches ASCII characters with [[:ascii:]]" do
+    "\x00".match(/[[:ascii:]]/).to_a.should == ["\x00"]
+    "\x7F".match(/[[:ascii:]]/).to_a.should == ["\x7F"]
+  end
+
+  not_supported_on :opal do
+    it "doesn't match non-ASCII characters with [[:ascii:]]" do
+      /[[:ascii:]]/.match("\u{80}").should be_nil
+      /[[:ascii:]]/.match("\u{9898}").should be_nil
+    end
+  end
+
+  it "matches Unicode letter characters with [[:alnum:]]" do
+    "à".match(/[[:alnum:]]/).to_a.should == ["à"]
+  end
+
+  it "matches Unicode digits with [[:alnum:]]" do
+    "\u{0660}".match(/[[:alnum:]]/).to_a.should == ["\u{0660}"]
+  end
+
+  it "doesn't matches Unicode marks with [[:alnum:]]" do
+    "\u{36F}".match(/[[:alnum:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:alnum:]]" do
+    "\u{16}".match(/[[:alnum:]]/).to_a.should == []
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:alnum:]]" do
+    "\u{3F}".match(/[[:alnum:]]/).to_a.should == []
+  end
+
+  it "matches Unicode letter characters with [[:alpha:]]" do
+    "à".match(/[[:alpha:]]/).to_a.should == ["à"]
+  end
+
+  it "doesn't match Unicode digits with [[:alpha:]]" do
+    "\u{0660}".match(/[[:alpha:]]/).to_a.should == []
+  end
+
+  it "doesn't matches Unicode marks with [[:alpha:]]" do
+    "\u{36F}".match(/[[:alpha:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:alpha:]]" do
+    "\u{16}".match(/[[:alpha:]]/).to_a.should == []
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:alpha:]]" do
+    "\u{3F}".match(/[[:alpha:]]/).to_a.should == []
+  end
+
+  it "matches Unicode space characters with [[:blank:]]" do
+    "\u{1680}".match(/[[:blank:]]/).to_a.should == ["\u{1680}"]
+  end
+
+  it "doesn't match Unicode control characters with [[:blank:]]" do
+    "\u{16}".match(/[[:blank:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:blank:]]" do
+    "\u{3F}".match(/[[:blank:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode letter characters with [[:blank:]]" do
+    "à".match(/[[:blank:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:blank:]]" do
+    "\u{0660}".match(/[[:blank:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:blank:]]" do
+    "\u{36F}".match(/[[:blank:]]/).should be_nil
+  end
+
+  it "doesn't Unicode letter characters with [[:cntrl:]]" do
+    "à".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:cntrl:]]" do
+    "\u{0660}".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:cntrl:]]" do
+    "\u{36F}".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:cntrl:]]" do
+    "\u{3F}".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "matches Unicode control characters with [[:cntrl:]]" do
+    "\u{16}".match(/[[:cntrl:]]/).to_a.should == ["\u{16}"]
+  end
+
+  it "doesn't match Unicode format characters with [[:cntrl:]]" do
+    "\u{2060}".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:cntrl:]]" do
+    "\u{E001}".match(/[[:cntrl:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode letter characters with [[:digit:]]" do
+    "à".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "matches Unicode digits with [[:digit:]]" do
+    "\u{0660}".match(/[[:digit:]]/).to_a.should == ["\u{0660}"]
+    "\u{FF12}".match(/[[:digit:]]/).to_a.should == ["\u{FF12}"]
+  end
+
+  it "doesn't match Unicode marks with [[:digit:]]" do
+    "\u{36F}".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:digit:]]" do
+    "\u{3F}".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:digit:]]" do
+    "\u{16}".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode format characters with [[:digit:]]" do
+    "\u{2060}".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:digit:]]" do
+    "\u{E001}".match(/[[:digit:]]/).should be_nil
+  end
+
+  it "matches Unicode letter characters with [[:graph:]]" do
+      "à".match(/[[:graph:]]/).to_a.should == ["à"]
+  end
+
+  it "matches Unicode digits with [[:graph:]]" do
+    "\u{0660}".match(/[[:graph:]]/).to_a.should == ["\u{0660}"]
+    "\u{FF12}".match(/[[:graph:]]/).to_a.should == ["\u{FF12}"]
+  end
+
+  it "matches Unicode marks with [[:graph:]]" do
+    "\u{36F}".match(/[[:graph:]]/).to_a.should ==["\u{36F}"]
+  end
+
+  it "matches Unicode punctuation characters with [[:graph:]]" do
+    "\u{3F}".match(/[[:graph:]]/).to_a.should == ["\u{3F}"]
+  end
+
+  it "doesn't match Unicode control characters with [[:graph:]]" do
+    "\u{16}".match(/[[:graph:]]/).should be_nil
+  end
+
+  it "match Unicode format characters with [[:graph:]]" do
+    "\u{2060}".match(/[[:graph:]]/).to_a.should == ["\u2060"]
+  end
+
+  it "match Unicode private-use characters with [[:graph:]]" do
+    "\u{E001}".match(/[[:graph:]]/).to_a.should == ["\u{E001}"]
+  end
+
+  it "matches Unicode lowercase letter characters with [[:lower:]]" do
+    "\u{FF41}".match(/[[:lower:]]/).to_a.should == ["\u{FF41}"]
+    "\u{1D484}".match(/[[:lower:]]/).to_a.should == ["\u{1D484}"]
+    "\u{E8}".match(/[[:lower:]]/).to_a.should == ["\u{E8}"]
+  end
+
+  it "doesn't match Unicode uppercase letter characters with [[:lower:]]" do
+    "\u{100}".match(/[[:lower:]]/).should be_nil
+    "\u{130}".match(/[[:lower:]]/).should be_nil
+    "\u{405}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode title-case characters with [[:lower:]]" do
+    "\u{1F88}".match(/[[:lower:]]/).should be_nil
+    "\u{1FAD}".match(/[[:lower:]]/).should be_nil
+    "\u{01C5}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:lower:]]" do
+    "\u{0660}".match(/[[:lower:]]/).should be_nil
+    "\u{FF12}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:lower:]]" do
+    "\u{36F}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:lower:]]" do
+    "\u{3F}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:lower:]]" do
+    "\u{16}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode format characters with [[:lower:]]" do
+    "\u{2060}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:lower:]]" do
+    "\u{E001}".match(/[[:lower:]]/).should be_nil
+  end
+
+  it "matches Unicode lowercase letter characters with [[:print:]]" do
+    "\u{FF41}".match(/[[:print:]]/).to_a.should == ["\u{FF41}"]
+    "\u{1D484}".match(/[[:print:]]/).to_a.should == ["\u{1D484}"]
+    "\u{E8}".match(/[[:print:]]/).to_a.should == ["\u{E8}"]
+  end
+
+  it "matches Unicode uppercase letter characters with [[:print:]]" do
+    "\u{100}".match(/[[:print:]]/).to_a.should == ["\u{100}"]
+    "\u{130}".match(/[[:print:]]/).to_a.should == ["\u{130}"]
+    "\u{405}".match(/[[:print:]]/).to_a.should == ["\u{405}"]
+  end
+
+  it "matches Unicode title-case characters with [[:print:]]" do
+    "\u{1F88}".match(/[[:print:]]/).to_a.should == ["\u{1F88}"]
+    "\u{1FAD}".match(/[[:print:]]/).to_a.should == ["\u{1FAD}"]
+    "\u{01C5}".match(/[[:print:]]/).to_a.should == ["\u{01C5}"]
+  end
+
+  it "matches Unicode digits with [[:print:]]" do
+    "\u{0660}".match(/[[:print:]]/).to_a.should == ["\u{0660}"]
+    "\u{FF12}".match(/[[:print:]]/).to_a.should == ["\u{FF12}"]
+  end
+
+  it "matches Unicode marks with [[:print:]]" do
+    "\u{36F}".match(/[[:print:]]/).to_a.should == ["\u{36F}"]
+  end
+
+  it "matches Unicode punctuation characters with [[:print:]]" do
+    "\u{3F}".match(/[[:print:]]/).to_a.should == ["\u{3F}"]
+  end
+
+  it "doesn't match Unicode control characters with [[:print:]]" do
+    "\u{16}".match(/[[:print:]]/).should be_nil
+  end
+
+  it "match Unicode format characters with [[:print:]]" do
+    "\u{2060}".match(/[[:print:]]/).to_a.should == ["\u{2060}"]
+  end
+
+  it "match Unicode private-use characters with [[:print:]]" do
+    "\u{E001}".match(/[[:print:]]/).to_a.should == ["\u{E001}"]
+  end
+
+
+  it "doesn't match Unicode lowercase letter characters with [[:punct:]]" do
+    "\u{FF41}".match(/[[:punct:]]/).should be_nil
+    "\u{1D484}".match(/[[:punct:]]/).should be_nil
+    "\u{E8}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode uppercase letter characters with [[:punct:]]" do
+    "\u{100}".match(/[[:punct:]]/).should be_nil
+    "\u{130}".match(/[[:punct:]]/).should be_nil
+    "\u{405}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode title-case characters with [[:punct:]]" do
+    "\u{1F88}".match(/[[:punct:]]/).should be_nil
+    "\u{1FAD}".match(/[[:punct:]]/).should be_nil
+    "\u{01C5}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:punct:]]" do
+    "\u{0660}".match(/[[:punct:]]/).should be_nil
+    "\u{FF12}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:punct:]]" do
+    "\u{36F}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "matches Unicode Pc characters with [[:punct:]]" do
+    "\u{203F}".match(/[[:punct:]]/).to_a.should == ["\u{203F}"]
+  end
+
+  it "matches Unicode Pd characters with [[:punct:]]" do
+    "\u{2E17}".match(/[[:punct:]]/).to_a.should == ["\u{2E17}"]
+  end
+
+  it "matches Unicode Ps characters with [[:punct:]]" do
+    "\u{0F3A}".match(/[[:punct:]]/).to_a.should == ["\u{0F3A}"]
+  end
+
+  it "matches Unicode Pe characters with [[:punct:]]" do
+    "\u{2046}".match(/[[:punct:]]/).to_a.should == ["\u{2046}"]
+  end
+
+  it "matches Unicode Pi characters with [[:punct:]]" do
+    "\u{00AB}".match(/[[:punct:]]/).to_a.should == ["\u{00AB}"]
+  end
+
+  it "matches Unicode Pf characters with [[:punct:]]" do
+    "\u{201D}".match(/[[:punct:]]/).to_a.should == ["\u{201D}"]
+    "\u{00BB}".match(/[[:punct:]]/).to_a.should == ["\u{00BB}"]
+  end
+
+  it "matches Unicode Po characters with [[:punct:]]" do
+    "\u{00BF}".match(/[[:punct:]]/).to_a.should == ["\u{00BF}"]
+  end
+
+  it "doesn't match Unicode format characters with [[:punct:]]" do
+    "\u{2060}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:punct:]]" do
+    "\u{E001}".match(/[[:punct:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode lowercase letter characters with [[:space:]]" do
+    "\u{FF41}".match(/[[:space:]]/).should be_nil
+    "\u{1D484}".match(/[[:space:]]/).should be_nil
+    "\u{E8}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode uppercase letter characters with [[:space:]]" do
+    "\u{100}".match(/[[:space:]]/).should be_nil
+    "\u{130}".match(/[[:space:]]/).should be_nil
+    "\u{405}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode title-case characters with [[:space:]]" do
+    "\u{1F88}".match(/[[:space:]]/).should be_nil
+    "\u{1FAD}".match(/[[:space:]]/).should be_nil
+    "\u{01C5}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:space:]]" do
+    "\u{0660}".match(/[[:space:]]/).should be_nil
+    "\u{FF12}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:space:]]" do
+    "\u{36F}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "matches Unicode Zs characters with [[:space:]]" do
+    "\u{205F}".match(/[[:space:]]/).to_a.should == ["\u{205F}"]
+  end
+
+  it "matches Unicode Zl characters with [[:space:]]" do
+    "\u{2028}".match(/[[:space:]]/).to_a.should == ["\u{2028}"]
+  end
+
+  it "matches Unicode Zp characters with [[:space:]]" do
+    "\u{2029}".match(/[[:space:]]/).to_a.should == ["\u{2029}"]
+  end
+
+  it "doesn't match Unicode format characters with [[:space:]]" do
+    "\u{2060}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:space:]]" do
+    "\u{E001}".match(/[[:space:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode lowercase characters with [[:upper:]]" do
+    "\u{FF41}".match(/[[:upper:]]/).should be_nil
+    "\u{1D484}".match(/[[:upper:]]/).should be_nil
+    "\u{E8}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "matches Unicode uppercase characters with [[:upper:]]" do
+    "\u{100}".match(/[[:upper:]]/).to_a.should == ["\u{100}"]
+    "\u{130}".match(/[[:upper:]]/).to_a.should == ["\u{130}"]
+    "\u{405}".match(/[[:upper:]]/).to_a.should == ["\u{405}"]
+  end
+
+  it "doesn't match Unicode title-case characters with [[:upper:]]" do
+    "\u{1F88}".match(/[[:upper:]]/).should be_nil
+    "\u{1FAD}".match(/[[:upper:]]/).should be_nil
+    "\u{01C5}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode digits with [[:upper:]]" do
+    "\u{0660}".match(/[[:upper:]]/).should be_nil
+    "\u{FF12}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:upper:]]" do
+    "\u{36F}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:upper:]]" do
+    "\u{3F}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:upper:]]" do
+    "\u{16}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode format characters with [[:upper:]]" do
+    "\u{2060}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:upper:]]" do
+    "\u{E001}".match(/[[:upper:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode letter characters [^a-fA-F] with [[:xdigit:]]" do
+    "à".match(/[[:xdigit:]]/).should be_nil
+    "g".match(/[[:xdigit:]]/).should be_nil
+    "X".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "matches Unicode letter characters [a-fA-F] with [[:xdigit:]]" do
+    "a".match(/[[:xdigit:]]/).to_a.should == ["a"]
+    "F".match(/[[:xdigit:]]/).to_a.should == ["F"]
+  end
+
+  it "doesn't match Unicode digits [^0-9] with [[:xdigit:]]" do
+    "\u{0660}".match(/[[:xdigit:]]/).should be_nil
+    "\u{FF12}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode marks with [[:xdigit:]]" do
+    "\u{36F}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode punctuation characters with [[:xdigit:]]" do
+    "\u{3F}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:xdigit:]]" do
+    "\u{16}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode format characters with [[:xdigit:]]" do
+    "\u{2060}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:xdigit:]]" do
+    "\u{E001}".match(/[[:xdigit:]]/).should be_nil
+  end
+
+  it "matches Unicode lowercase characters with [[:word:]]" do
+    "\u{FF41}".match(/[[:word:]]/).to_a.should == ["\u{FF41}"]
+    "\u{1D484}".match(/[[:word:]]/).to_a.should == ["\u{1D484}"]
+    "\u{E8}".match(/[[:word:]]/).to_a.should == ["\u{E8}"]
+  end
+
+  it "matches Unicode uppercase characters with [[:word:]]" do
+    "\u{100}".match(/[[:word:]]/).to_a.should == ["\u{100}"]
+    "\u{130}".match(/[[:word:]]/).to_a.should == ["\u{130}"]
+    "\u{405}".match(/[[:word:]]/).to_a.should == ["\u{405}"]
+  end
+
+  it "matches Unicode title-case characters with [[:word:]]" do
+    "\u{1F88}".match(/[[:word:]]/).to_a.should == ["\u{1F88}"]
+    "\u{1FAD}".match(/[[:word:]]/).to_a.should == ["\u{1FAD}"]
+    "\u{01C5}".match(/[[:word:]]/).to_a.should == ["\u{01C5}"]
+  end
+
+  it "matches Unicode decimal digits with [[:word:]]" do
+    "\u{FF10}".match(/[[:word:]]/).to_a.should == ["\u{FF10}"]
+    "\u{096C}".match(/[[:word:]]/).to_a.should == ["\u{096C}"]
+  end
+
+  it "matches Unicode marks with [[:word:]]" do
+    "\u{36F}".match(/[[:word:]]/).to_a.should == ["\u{36F}"]
+  end
+
+  it "match Unicode Nl characters with [[:word:]]" do
+    "\u{16EE}".match(/[[:word:]]/).to_a.should == ["\u{16EE}"]
+  end
+
+  it "doesn't match Unicode No characters with [[:word:]]" do
+    "\u{17F0}".match(/[[:word:]]/).should be_nil
+  end
+  it "doesn't match Unicode punctuation characters with [[:word:]]" do
+    "\u{3F}".match(/[[:word:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode control characters with [[:word:]]" do
+    "\u{16}".match(/[[:word:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode format characters with [[:word:]]" do
+    "\u{2060}".match(/[[:word:]]/).should be_nil
+  end
+
+  it "doesn't match Unicode private-use characters with [[:word:]]" do
+    "\u{E001}".match(/[[:word:]]/).should be_nil
+  end
+
+  it "matches unicode named character properties" do
+    "a1".match(/\p{Alpha}/).to_a.should == ["a"]
+  end
+
+  it "matches unicode abbreviated character properties" do
+    "a1".match(/\p{L}/).to_a.should == ["a"]
+  end
+
+  it "matches unicode script properties" do
+    "a\u06E9b".match(/\p{Arabic}/).to_a.should == ["\u06E9"]
+  end
+
+  it "matches unicode Han properties" do
+    "松本行弘 Ruby".match(/\p{Han}+/u).to_a.should == ["松本行弘"]
+  end
+
+  it "matches unicode Hiragana properties" do
+    "Ruby（ルビー）、まつもとゆきひろ".match(/\p{Hiragana}+/u).to_a.should == ["まつもとゆきひろ"]
+  end
+
+  it "matches unicode Katakana properties" do
+    "Ruby（ルビー）、まつもとゆきひろ".match(/\p{Katakana}+/u).to_a.should == ["ルビ"]
+  end
+
+  it "matches unicode Hangul properties" do
+    "루비(Ruby)".match(/\p{Hangul}+/u).to_a.should == ["루비"]
+  end
+
+  it "supports negated property condition" do
+    "a".match(eval("/\P{L}/")).should be_nil
+    "1".match(eval("/\P{N}/")).should be_nil
+  end
+
+  it "raises a RegexpError for an unterminated unicode property" do
+    NATFIXME 'it raises a RegexpError for an unterminated unicode property', exception: SpecFailedException do
+      -> { Regexp.new('\p{') }.should raise_error(RegexpError)
+    end
+  end
+
+  it "supports \\X (unicode 9.0 with UTR #51 workarounds)" do
+    # simple emoji without any fancy modifier or ZWJ
+    /\X/.match("\u{1F98A}").to_a.should == ["🦊"]
+
+    # skin tone modifier
+    /\X/.match("\u{1F918}\u{1F3FD}").to_a.should == ["🤘🏽"]
+
+    # emoji joined with ZWJ
+    /\X/.match("\u{1F3F3}\u{FE0F}\u{200D}\u{1F308}").to_a.should == ["🏳️‍🌈"]
+    /\X/.match("\u{1F469}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}").to_a.should == ["👩‍👩‍👧‍👦"]
+
+    # without the ZWJ
+    /\X+/.match("\u{1F3F3}\u{FE0F}\u{1F308}").to_a.should == ["🏳️🌈"]
+    /\X+/.match("\u{1F469}\u{1F469}\u{1F467}\u{1F466}").to_a.should == ["👩👩👧👦"]
+
+    # both of the ZWJ combined
+    /\X+/.match("\u{1F3F3}\u{FE0F}\u{200D}\u{1F308}\u{1F469}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}")
+      .to_a.should == ["🏳️‍🌈👩‍👩‍👧‍👦"]
+  end
+end

--- a/spec/language/regexp/grouping_spec.rb
+++ b/spec/language/regexp/grouping_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Regexps with grouping" do
+  it "support ()" do
+    /(a)/.match("a").to_a.should == ["a", "a"]
+  end
+
+  it "allows groups to be nested" do
+    md = /(hay(st)a)ck/.match('haystack')
+    md.to_a.should == ['haystack','haysta', 'st']
+  end
+
+  it "raises a SyntaxError when parentheses aren't balanced" do
+   -> { eval "/(hay(st)ack/" }.should raise_error(SyntaxError)
+  end
+
+  it "supports (?: ) (non-capturing group)" do
+    /(?:foo)(bar)/.match("foobar").to_a.should == ["foobar", "bar"]
+    # Parsing precedence
+    /(?:xdigit:)/.match("xdigit:").to_a.should == ["xdigit:"]
+  end
+
+  it "group names cannot start with digits or minus" do
+    -> { Regexp.new("(?<1a>a)") }.should raise_error(RegexpError)
+    -> { Regexp.new("(?<-a>a)") }.should raise_error(RegexpError)
+  end
+
+  it "ignore capture groups in line comments" do
+    /^
+     (a) # there is a capture group on this line
+     b   # there is no capture group on this line (not even here)
+     $/x.match("ab").to_a.should == [ "ab", "a" ]
+  end
+
+  it "does not consider # inside a character class as a comment" do
+    # From https://github.com/rubocop/rubocop/blob/39fcf1c568/lib/rubocop/cop/utils/format_string.rb#L18
+    regexp = /
+        % (?<type>%) # line comment
+      | % (?<flags>(?-mix:[ #0+-]|(?-mix:(\d+)\$))*) (?#group comment)
+        (?:
+          (?: (?-mix:(?<width>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:\.(?<precision>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:<(?<name>\w+)>)?
+            | (?-mix:(?<width>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:<(?<name>\w+)>) (?-mix:\.(?<precision>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))?
+            | (?-mix:<(?<name>\w+)>) (?<more_flags>(?-mix:[ #0+-]|(?-mix:(\d+)\$))*) (?-mix:(?<width>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:\.(?<precision>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))?
+          ) (?-mix:(?<type>[bBdiouxXeEfgGaAcps]))
+          | (?-mix:(?<width>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:\.(?<precision>(?-mix:\d+|(?-mix:\*(?-mix:(\d+)\$)?))))? (?-mix:\{(?<name>\w+)\})
+        )
+    /x
+    regexp.named_captures.should == {
+      "type" => [1, 13],
+      "flags" => [2],
+      "width" => [3, 6, 11, 14],
+      "precision" => [4, 8, 12, 15],
+      "name" => [5, 7, 9, 16],
+      "more_flags" => [10]
+    }
+    match = regexp.match("%6.3f")
+    match[:width].should == '6'
+    match[:precision].should == '3'
+    match[:type].should == 'f'
+    match.to_a.should == [ "%6.3f", nil, "", "6", "3"] + [nil] * 8 + ["f"] + [nil] * 3
+  end
+end

--- a/spec/language/regexp/modifiers_spec.rb
+++ b/spec/language/regexp/modifiers_spec.rb
@@ -1,0 +1,119 @@
+require_relative '../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Regexps with modifiers" do
+  it "supports /i (case-insensitive)" do
+    /foo/i.match("FOO").to_a.should == ["FOO"]
+  end
+
+  it "supports /m (multiline)" do
+    /foo.bar/m.match("foo\nbar").to_a.should == ["foo\nbar"]
+    /foo.bar/.match("foo\nbar").should be_nil
+  end
+
+  it "supports /x (extended syntax)" do
+    /\d +/x.match("abc123").to_a.should == ["123"] # Quantifiers can be separated from the expression they apply to
+  end
+
+  it "supports /o (once)" do
+    NATFIXME 'it supports /o (once)', exception: SpecFailedException do
+      2.times do |i|
+        /#{i}/o.should == /0/
+      end
+    end
+  end
+
+  it "invokes substitutions for /o only once" do
+    ScratchPad.record []
+    o = Object.new
+    def o.to_s
+      ScratchPad << :to_s
+      "class_with_to_s"
+    end
+    NATFIXME 'eval() only works on static strings', exception: TypeError, message: 'eval() only works on static strings' do
+      eval "2.times { /#{o}/o }"
+      ScratchPad.recorded.should == [:to_s]
+    end
+  end
+
+  it "supports modifier combinations" do
+    /foo/imox.match("foo").to_a.should == ["foo"]
+    /foo/imoximox.match("foo").to_a.should == ["foo"]
+
+    -> { eval('/foo/a') }.should raise_error(SyntaxError)
+  end
+
+  it "supports (?~) (absent operator)" do
+    Regexp.new("(?~foo)").match("hello").to_a.should == ["hello"]
+    "foo".scan(Regexp.new("(?~foo)")).should == ["fo","o",""]
+  end
+
+  it "supports (?imx-imx) (inline modifiers)" do
+    /(?i)foo/.match("FOO").to_a.should == ["FOO"]
+    /foo(?i)/.match("FOO").should be_nil
+    # Interaction with /i
+    /(?-i)foo/i.match("FOO").should be_nil
+    /foo(?-i)/i.match("FOO").to_a.should == ["FOO"]
+    # Multiple uses
+    /foo (?i)bar (?-i)baz/.match("foo BAR baz").to_a.should == ["foo BAR baz"]
+    /foo (?i)bar (?-i)baz/.match("foo BAR BAZ").should be_nil
+
+    /(?m)./.match("\n").to_a.should == ["\n"]
+    /.(?m)/.match("\n").should be_nil
+    # Interaction with /m
+    /(?-m)./m.match("\n").should be_nil
+    /.(?-m)/m.match("\n").to_a.should == ["\n"]
+    # Multiple uses
+    /. (?m). (?-m)./.match(". \n .").to_a.should == [". \n ."]
+    /. (?m). (?-m)./.match(". \n \n").should be_nil
+
+    /(?x) foo /.match("foo").to_a.should == ["foo"]
+    / foo (?x)/.match("foo").should be_nil
+    # Interaction with /x
+    /(?-x) foo /x.match("foo").should be_nil
+    / foo (?-x)/x.match("foo").to_a.should == ["foo"]
+    # Multiple uses
+    /( foo )(?x)( bar )(?-x)( baz )/.match(" foo bar baz ").to_a.should == [" foo bar baz ", " foo ", "bar", " baz "]
+    /( foo )(?x)( bar )(?-x)( baz )/.match(" foo barbaz").should be_nil
+
+    # Parsing
+    /(?i-i)foo/.match("FOO").should be_nil
+    /(?ii)foo/.match("FOO").to_a.should == ["FOO"]
+    /(?-)foo/.match("foo").to_a.should == ["foo"]
+    -> { eval('/(?o)/') }.should raise_error(SyntaxError)
+  end
+
+  it "supports (?imx-imx:expr) (scoped inline modifiers)" do
+    /foo (?i:bar) baz/.match("foo BAR baz").to_a.should == ["foo BAR baz"]
+    /foo (?i:bar) baz/.match("foo BAR BAZ").should be_nil
+    /foo (?-i:bar) baz/i.match("foo BAR BAZ").should be_nil
+
+    /. (?m:.) ./.match(". \n .").to_a.should == [". \n ."]
+    /. (?m:.) ./.match(". \n \n").should be_nil
+    /. (?-m:.) ./m.match("\n \n \n").should be_nil
+
+    /( foo )(?x: bar )( baz )/.match(" foo bar baz ").to_a.should == [" foo bar baz ", " foo ", " baz "]
+    /( foo )(?x: bar )( baz )/.match(" foo barbaz").should be_nil
+    /( foo )(?-x: bar )( baz )/x.match("foo bar baz").to_a.should == ["foo bar baz", "foo", "baz"]
+
+    # Parsing
+    /(?i-i:foo)/.match("FOO").should be_nil
+    /(?ii:foo)/.match("FOO").to_a.should == ["FOO"]
+    /(?-:)foo/.match("foo").to_a.should == ["foo"]
+    -> { eval('/(?o:)/') }.should raise_error(SyntaxError)
+  end
+
+  it "supports . with /m" do
+    # Basic matching
+    /./m.match("\n").to_a.should == ["\n"]
+  end
+
+  it "supports ASCII/Unicode modifiers" do
+    eval('/(?a)[[:alpha:]]+/').match("a\u3042").to_a.should == ["a"]
+    eval('/(?d)[[:alpha:]]+/').match("a\u3042").to_a.should == ["a\u3042"]
+    eval('/(?u)[[:alpha:]]+/').match("a\u3042").to_a.should == ["a\u3042"]
+    eval('/(?a)\w+/').match("a\u3042").to_a.should == ["a"]
+    eval('/(?d)\w+/').match("a\u3042").to_a.should == ["a"]
+    eval('/(?u)\w+/').match("a\u3042").to_a.should == ["a\u3042"]
+  end
+end

--- a/spec/language/regexp_spec.rb
+++ b/spec/language/regexp_spec.rb
@@ -34,10 +34,9 @@ describe "Literal Regexps" do
     end
   end
 
-  # NATFIXME: Compile error for invalid Regexp syntax
-  #it "throws SyntaxError for malformed literals" do
-    #-> { eval('/(/') }.should raise_error(SyntaxError)
-  #end
+  it "throws SyntaxError for malformed literals" do
+    -> { eval('/(/') }.should raise_error(SyntaxError)
+  end
 
   #############################################################################
   # %r


### PR DESCRIPTION
This is one of those "do we really want this change" cases.

An invalid Regexp literal currently results in either a AOT compile error, or nothing at all in case the Regexp is not used. This changes that behaviour: an invalid Regexp literal will now generate an hardcoded exception in the output.
This fixes the compile issue with 4 language specs. Even though I kind of like the compile time error we're currently raising, I also like the fact that we're able to run more specs.