### PR TITLE
Apply FIXEDENCODING flag to Regexp with `\x` escapes

### DIFF
--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -120,10 +120,7 @@ public:
         }
     }
 
-    bool operator==(const RegexpObject &other) const {
-        return m_pattern == other.m_pattern && (m_options | RegexOpts::NoEncoding) == (other.m_options | RegexOpts::NoEncoding);
-        // /n encoding option is ignored when doing == in ruby MRI
-    }
+    bool operator==(const RegexpObject &other) const;
 
     bool casefold(Env *env) const {
         assert_initialized(env);

--- a/spec/language/regexp/interpolation_spec.rb
+++ b/spec/language/regexp/interpolation_spec.rb
@@ -53,8 +53,6 @@ describe "Regexps with interpolation" do
 
   it "allows escape sequences in interpolated regexps" do
     escape_seq = %r{"\x80"}n
-    NATFIXME 'it allows escape sequences in interpolated regexps', exception: SpecFailedException do
-      %r{#{escape_seq}}n.should == /(?-mix:"\x80")/n
-    end
+    %r{#{escape_seq}}n.should == /(?-mix:"\x80")/n
   end
 end

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -528,6 +528,14 @@ Value RegexpObject::names() const {
     return names;
 }
 
+bool RegexpObject::operator==(const RegexpObject &other) const {
+    // /n encoding option is ignored when doing == in ruby MRI
+    int our_options = m_options | RegexOpts::NoEncoding;
+    int their_options = other.m_options | RegexOpts::NoEncoding;
+
+    return m_pattern == other.m_pattern && our_options == their_options;
+}
+
 Value RegexpObject::source(Env *env) const {
     assert_initialized(env);
     return new StringObject { pattern() };

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -240,7 +240,7 @@ Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
     return this;
 }
 
-static String prepare_pattern_for_onigmo(const String &pattern) {
+static String prepare_pattern_for_onigmo(const String &pattern, bool *fixed_encoding) {
     String new_pattern;
     auto length = pattern.length();
     size_t index = 0;
@@ -306,6 +306,13 @@ static String prepare_pattern_for_onigmo(const String &pattern) {
                 break;
             }
 
+            case 'x': {
+                *fixed_encoding = true;
+                new_pattern.append_char('\\');
+                new_pattern.append_char('x');
+                break;
+            }
+
             default:
                 new_pattern.append_char('\\');
                 new_pattern.append_char(c);
@@ -327,7 +334,10 @@ void RegexpObject::initialize(Env *env, const String &pattern, int options) {
     OnigErrorInfo einfo;
     m_pattern = pattern;
 
-    auto tweaked_pattern = prepare_pattern_for_onigmo(pattern);
+    bool fixed_encoding = false;
+    auto tweaked_pattern = prepare_pattern_for_onigmo(pattern, &fixed_encoding);
+    if (fixed_encoding)
+        options |= RegexOpts::FixedEncoding;
 
     UChar *pat = (UChar *)tweaked_pattern.c_str();
     // NATFIXME: Fully support character encodings in capture groups

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -67,6 +67,12 @@ describe 'regexp' do
       r2.should be_kind_of(Regexp)
       r1.should == r2
     end
+
+    it 'automatically applies FIXEDENCODING flag' do
+      c = Regexp.new('\x80', Regexp::NOENCODING)
+      c.options.should == Regexp::FIXEDENCODING | Regexp::NOENCODING
+      c.to_s.should == '(?-mix:\x80)'
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
This rabbit hole brought to you by the CI failure here: https://github.com/natalie-lang/natalie/actions/runs/9327001578/job/25676301847

```
Regexps with interpolation
  allows escape sequences in interpolated regexps
    Issue has been fixed, please remove or update the NATFIXME marker
    (spec/language/regexp/interpolation_spec.rb:56:in `block in block in block')
```

The NATFIXME is correct for `bin/natalie` but wrong for the self-hosted `bin/nat`. Does that mean the self-hosted compiler is doing something right?? No! Well, yes, but only by mistake.

Because we pass all Regexps through the hosting Ruby's Regexp constructor [here](https://github.com/natalie-lang/natalie/blob/1760beedea456836896eb64bc5ae3dd942a95045/lib/natalie/compiler/pass1.rb#L1939), the hosting Ruby is responsible for updating the Regexp options. (Ask me how long it took to remember this / figure this out again!)

ANNNNNNNYYYYYYWAYYYYYYYY....

Given the following Ruby file:

```
# wat.rb
escape_seq = %r{"\x80"}n

p(a: escape_seq.options)
p(b: %r{#{escape_seq}}n.options)
p(c: /(?-mix:"\x80")/n.options)

p(d: %r{foo}n.options)
```

We were getting different results:

```
→ diff -W 25 -y <(bin/natalie wat.rb) <(bin/nat wat.rb)
{:a=>48}    |   {:a=>32}
{:b=>32}        {:b=>32}
{:c=>48}    |   {:c=>32}
{:d=>32}        {:d=>32}
```

...but now we are not:

```
→ diff -W 25 -y <(bin/natalie wat.rb) <(bin/nat wat.rb)
{:a=>48}        {:a=>48}
{:b=>48}        {:b=>48}
{:c=>48}        {:c=>48}
{:d=>32}        {:d=>32}
```

Whew! 😅 

And even cooler, this work fixed the `NATFIXME` too! (A darker take on this would be to say I could have saved myself a lot of time if I just focused on fixing the `NATFIXME` directly. 😆😭)