### PR TITLE
Support safe navigation for special write operations

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -596,7 +596,18 @@ module Natalie
         instructions = [
           # stack: [obj]
           transform_expression(obj, used: true),
+        ]
 
+        if node.safe_navigation?
+          instructions.append(
+            DupInstruction.new,
+            IsNilInstruction.new,
+            IfInstruction.new,
+            ElseInstruction.new(:if),
+          )
+        end
+
+        instructions.append(
           # stack: [obj, value]
           transform_expression(node.value, used: true),
 
@@ -637,7 +648,9 @@ module Natalie
             file: @file.path,
             line: node.location.start_line,
           ),
-        ]
+        )
+
+        instructions << EndInstruction.new(:if) if node.safe_navigation?
 
         instructions << PopInstruction.new unless used
         instructions

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -637,7 +637,18 @@ module Natalie
 
           # duplicate for use in the falsey case, so we only evaluate `a` once
           DupInstruction.new,
+        ]
+        if node.safe_navigation?
+          instructions.append(
+            DupInstruction.new,
+            IsNilInstruction.new,
+            IfInstruction.new,
+            PopInstruction.new,
+            ElseInstruction.new(:if),
+          )
+        end
 
+        instructions.append(
           # .foo
           PushArgcInstruction.new(0),
           SendInstruction.new(
@@ -675,7 +686,9 @@ module Natalie
           ),
 
           EndInstruction.new(:if),
-        ]
+        )
+
+        instructions << EndInstruction.new(:if) if node.safe_navigation?
 
         instructions << PopInstruction.new unless used
         instructions

--- a/spec/language/safe_navigator_spec.rb
+++ b/spec/language/safe_navigator_spec.rb
@@ -83,9 +83,7 @@ describe "Safe navigator" do
     obj.m.should == 3
 
     obj = nil
-    NATFIXME 'nil allows assignment operators', exception: NoMethodError, message: "undefined method `m' for nil" do
-      (obj&.m += 3).should == nil
-    end
+    (obj&.m += 3).should == nil
   end
 
   it "allows ||= operator" do

--- a/spec/language/safe_navigator_spec.rb
+++ b/spec/language/safe_navigator_spec.rb
@@ -108,9 +108,7 @@ describe "Safe navigator" do
     obj.m.should == true
 
     obj = nil
-    NATFIXME 'nil allows ||= operator', exception: NoMethodError, message: "undefined method `m' for nil" do
-      (obj&.m ||= true).should == nil
-    end
+    (obj&.m ||= true).should == nil
     obj.should == nil
   end
 

--- a/spec/language/safe_navigator_spec.rb
+++ b/spec/language/safe_navigator_spec.rb
@@ -127,9 +127,7 @@ describe "Safe navigator" do
     obj.m.should == false
 
     obj = nil
-    NATFIXME 'nil allows &&= operator', exception: NoMethodError, message: "undefined method `m' for nil" do
-      (obj&.m &&= false).should == nil
-    end
+    (obj&.m &&= false).should == nil
     obj.should == nil
   end
 


### PR DESCRIPTION
This means support for code like:
```ruby
foo = nil
foo&.bar += 1
foo&.bar ||= 1
foo&.bar &&= 1
```

This fixes the remaining issues in `spec/language/safe_navigator_spec.rb`