### PR TITLE
Implement END

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2132,6 +2132,25 @@ module Natalie
         end
       end
 
+      def transform_post_execution_node(node, used:)
+        instructions = [
+          DefineBlockInstruction.new(arity: 0),
+          transform_expression(node.statements, used: true),
+          EndInstruction.new(:define_block),
+          PushSelfInstruction.new,
+          PushArgcInstruction.new(0),
+          SendInstruction.new(
+            :at_exit,
+            receiver_is_self: true,
+            with_block: true,
+            file: @file.path,
+            line: node.location.start_line,
+          ),
+        ]
+        instructions << PopInstruction.new unless used
+        instructions
+      end
+
       def transform_range_node(node, used:)
         instructions = [
           transform_expression(node.right || Prism.nil_node(location: node.location), used: true),

--- a/spec/core/kernel/at_exit_spec.rb
+++ b/spec/core/kernel/at_exit_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../../shared/kernel/at_exit'
+
+describe "Kernel.at_exit" do
+  it_behaves_like :kernel_at_exit, :at_exit
+
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:at_exit)
+  end
+
+  it "raises ArgumentError if called without a block" do
+    -> { at_exit }.should raise_error(ArgumentError, "called without a block")
+  end
+end
+
+describe "Kernel#at_exit" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/spec/language/END_spec.rb
+++ b/spec/language/END_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../spec_helper'
+require_relative '../shared/kernel/at_exit'
+
+describe "The END keyword" do
+  it_behaves_like :kernel_at_exit, :END
+
+  it "runs only once for multiple calls" do
+    NATFIXME 'it runs only once for multiple calls', exception: SpecFailedException do
+      ruby_exe("10.times { END { puts 'foo' }; } ").should == "foo\n"
+    end
+  end
+
+  it "is affected by the toplevel assignment" do
+    ruby_exe("foo = 'foo'; END { puts foo }").should == "foo\n"
+  end
+
+  it "warns when END is used in a method" do
+    NATFIXME 'it warns when END is used in a method', exception: SpecFailedException do
+      ruby_exe(<<~ruby, args: "2>&1").should =~ /warning: END in method; use at_exit/
+        def foo
+          END { }
+        end
+      ruby
+    end
+  end
+
+  context "END blocks and at_exit callbacks are mixed" do
+    it "runs them all in reverse order of registration" do
+      ruby_exe(<<~ruby).should == "at_exit#2\nEND#2\nat_exit#1\nEND#1\n"
+        END { puts 'END#1' }
+        at_exit { puts 'at_exit#1' }
+        END { puts 'END#2' }
+        at_exit { puts 'at_exit#2' }
+      ruby
+    end
+  end
+end

--- a/spec/shared/kernel/at_exit.rb
+++ b/spec/shared/kernel/at_exit.rb
@@ -1,0 +1,76 @@
+describe :kernel_at_exit, shared: true do
+  it "runs after all other code" do
+    ruby_exe("#{@method} { print 5 }; print 6").should == "65"
+  end
+
+  it "runs in reverse order of registration" do
+    code = "#{@method} { print 4 }; #{@method} { print 5 }; print 6; #{@method} { print 7 }"
+    ruby_exe(code).should == "6754"
+  end
+
+  it "allows calling exit inside a handler" do
+    code = "#{@method} { print 3 }; #{@method} { print 4; exit; print 5 }; #{@method} { print 6 }"
+    ruby_exe(code).should == "643"
+  end
+
+  it "gives access to the last raised exception - global variables $! and $@" do
+    code = <<-EOC
+      #{@method} {
+        puts "The exception matches: \#{$! == $exception && $@ == $exception.backtrace} (message=\#{$!.message})"
+      }
+
+      begin
+        raise "foo"
+      rescue => $exception
+        raise
+      end
+    EOC
+
+    result = ruby_exe(code, args: "2>&1", exit_status: 1)
+    result.lines.should.include?("The exception matches: true (message=foo)\n")
+  end
+
+  it "gives access to an exception raised in a previous handler" do
+    code = "#{@method} { print '$!.message = ' + $!.message }; #{@method} { raise 'foo' }"
+    result = ruby_exe(code, args: "2>&1", exit_status: 1)
+    result.lines.should.include?("$!.message = foo")
+  end
+
+  it "both exceptions in a handler and in the main script are printed" do
+    code = "#{@method} { raise 'at_exit_error' }; raise 'main_script_error'"
+    result = ruby_exe(code, args: "2>&1", exit_status: 1)
+    result.should.include?('at_exit_error (RuntimeError)')
+    result.should.include?('main_script_error (RuntimeError)')
+  end
+
+  it "decides the exit status if both at_exit and the main script raise SystemExit" do
+    ruby_exe("#{@method} { exit 43 }; exit 42", args: "2>&1", exit_status: 43)
+    $?.exitstatus.should == 43
+  end
+
+  it "runs all handlers even if some raise exceptions" do
+    code = "#{@method} { STDERR.puts 'last' }; #{@method} { exit 43 }; #{@method} { STDERR.puts 'first' }; exit 42"
+    result = ruby_exe(code, args: "2>&1", exit_status: 43)
+    result.should == "first\nlast\n"
+    $?.exitstatus.should == 43
+  end
+
+  it "runs handlers even if the main script fails to parse" do
+    script = fixture(__FILE__, "#{@method}.rb")
+    result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exit_status: 1)
+    $?.should_not.success?
+    result.should.include?("handler ran\n")
+
+    # it's tempting not to rely on error message and rely only on exception class name,
+    # but CRuby before 3.2 doesn't print class name for syntax error
+    result.should include_any_of("syntax error", "SyntaxError")
+  end
+
+  it "calls the nested handler right after the outer one if a handler is nested into another handler" do
+    ruby_exe(<<~ruby).should == "last\nbefore\nafter\nnested\nfirst\n"
+        #{@method} { puts :first }
+        #{@method} { puts :before; #{@method} { puts :nested }; puts :after };
+        #{@method} { puts :last }
+    ruby
+  end
+end

--- a/spec/shared/kernel/at_exit.rb
+++ b/spec/shared/kernel/at_exit.rb
@@ -10,7 +10,9 @@ describe :kernel_at_exit, shared: true do
 
   it "allows calling exit inside a handler" do
     code = "#{@method} { print 3 }; #{@method} { print 4; exit; print 5 }; #{@method} { print 6 }"
-    ruby_exe(code).should == "643"
+    NATFIXME 'it allows calling exit inside a handler', exception: SpecFailedException do
+      ruby_exe(code).should == "643"
+    end
   end
 
   it "gives access to the last raised exception - global variables $! and $@" do
@@ -26,44 +28,56 @@ describe :kernel_at_exit, shared: true do
       end
     EOC
 
-    result = ruby_exe(code, args: "2>&1", exit_status: 1)
-    result.lines.should.include?("The exception matches: true (message=foo)\n")
+    NATFIXME 'it gives access to the last raised exception - global variables $! and $@', exception: SpecFailedException do
+      result = ruby_exe(code, args: "2>&1", exit_status: 1)
+      result.lines.should.include?("The exception matches: true (message=foo)\n")
+    end
   end
 
   it "gives access to an exception raised in a previous handler" do
     code = "#{@method} { print '$!.message = ' + $!.message }; #{@method} { raise 'foo' }"
-    result = ruby_exe(code, args: "2>&1", exit_status: 1)
-    result.lines.should.include?("$!.message = foo")
+    NATFIXME 'it gives access to an exception raised in a previous handler', exception: SpecFailedException do
+      result = ruby_exe(code, args: "2>&1", exit_status: 1)
+      result.lines.should.include?("$!.message = foo")
+    end
   end
 
   it "both exceptions in a handler and in the main script are printed" do
     code = "#{@method} { raise 'at_exit_error' }; raise 'main_script_error'"
-    result = ruby_exe(code, args: "2>&1", exit_status: 1)
-    result.should.include?('at_exit_error (RuntimeError)')
-    result.should.include?('main_script_error (RuntimeError)')
+    NATFIXME 'it both exceptions in a handler and in the main script are printed', exception: SpecFailedException do
+      result = ruby_exe(code, args: "2>&1", exit_status: 1)
+      result.should.include?('at_exit_error (RuntimeError)')
+      result.should.include?('main_script_error (RuntimeError)')
+    end
   end
 
   it "decides the exit status if both at_exit and the main script raise SystemExit" do
-    ruby_exe("#{@method} { exit 43 }; exit 42", args: "2>&1", exit_status: 43)
-    $?.exitstatus.should == 43
+    NATFIXME 'it decides the exit status if both at_exit and the main script raise SystemExit', exception: SpecFailedException do
+      ruby_exe("#{@method} { exit 43 }; exit 42", args: "2>&1", exit_status: 43)
+      $?.exitstatus.should == 43
+    end
   end
 
   it "runs all handlers even if some raise exceptions" do
     code = "#{@method} { STDERR.puts 'last' }; #{@method} { exit 43 }; #{@method} { STDERR.puts 'first' }; exit 42"
-    result = ruby_exe(code, args: "2>&1", exit_status: 43)
-    result.should == "first\nlast\n"
-    $?.exitstatus.should == 43
+    NATFIXME 'it runs all handlers even if some raise exceptions', exception: SpecFailedException do
+      result = ruby_exe(code, args: "2>&1", exit_status: 43)
+      result.should == "first\nlast\n"
+      $?.exitstatus.should == 43
+    end
   end
 
   it "runs handlers even if the main script fails to parse" do
     script = fixture(__FILE__, "#{@method}.rb")
-    result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exit_status: 1)
-    $?.should_not.success?
-    result.should.include?("handler ran\n")
+    NATFIXME 'it runs handlers even if the main script fails to parse', exception: SpecFailedException do
+      result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exit_status: 1)
+      $?.should_not.success?
+      result.should.include?("handler ran\n")
 
-    # it's tempting not to rely on error message and rely only on exception class name,
-    # but CRuby before 3.2 doesn't print class name for syntax error
-    result.should include_any_of("syntax error", "SyntaxError")
+      # it's tempting not to rely on error message and rely only on exception class name,
+      # but CRuby before 3.2 doesn't print class name for syntax error
+      result.should include_any_of("syntax error", "SyntaxError")
+    end
   end
 
   it "calls the nested handler right after the outer one if a handler is nested into another handler" do


### PR DESCRIPTION
Well, kind of, it converts them to `at_exit` calls, which is mostly correct (and our implementation of `at_exit` is not completely spec compliant either). It's good enough for most regular cases.