### PR TITLE
Support some extra targets for rescue statements

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2291,10 +2291,13 @@ module Natalie
           instructions << GlobalVariableSetInstruction.new(node.name)
         when ::Prism::IndexTargetNode
           instructions = [transform_expression(node.receiver, used: true)]
-          # Get rid of the PushArgcInstruction from transform_arguments_node_for_callish
+
+          # transform_arguments_node_for_callish pushes the arguments on the stack and adds an PushArgcInstruction
+          # Remove the PushArgcInstruction, push $!, and add an PushArgcInstruction with the size + 1
           instructions.append(transform_arguments_node_for_callish(node.arguments)[:instructions][...-1])
           instructions << GlobalVariableGetInstruction.new(:$!)
           instructions << PushArgcInstruction.new(node.arguments.arguments.size + 1)
+
           instructions << SendInstruction.new(
             :[]=,
             receiver_is_self: node.receiver.nil? || node.receiver.is_a?(Prism::SelfNode),

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2289,6 +2289,20 @@ module Natalie
           ]
         when ::Prism::GlobalVariableTargetNode
           instructions << GlobalVariableSetInstruction.new(node.name)
+        when ::Prism::IndexTargetNode
+          instructions = [transform_expression(node.receiver, used: true)]
+          # Get rid of the PushArgcInstruction from transform_arguments_node_for_callish
+          instructions.append(transform_arguments_node_for_callish(node.arguments)[:instructions][...-1])
+          instructions << GlobalVariableGetInstruction.new(:$!)
+          instructions << PushArgcInstruction.new(node.arguments.arguments.size + 1)
+          instructions << SendInstruction.new(
+            :[]=,
+            receiver_is_self: node.receiver.nil? || node.receiver.is_a?(Prism::SelfNode),
+            with_block: false,
+            file: @file.path,
+            line: node.location.start_line,
+          )
+          instructions << PopInstruction.new
         when ::Prism::InstanceVariableTargetNode
           instructions << InstanceVariableSetInstruction.new(node.name)
         when ::Prism::LocalVariableTargetNode

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2268,6 +2268,17 @@ module Natalie
         instructions = [GlobalVariableGetInstruction.new(:$!)]
 
         case node
+        when ::Prism::CallTargetNode
+          instructions.prepend(transform_expression(node.receiver, used: true))
+          instructions << PushArgcInstruction.new(1)
+          instructions << SendInstruction.new(
+            :"#{node.message}=",
+            receiver_is_self: node.receiver.nil? || node.receiver.is_a?(Prism::SelfNode),
+            with_block: false,
+            file: @file.path,
+            line: node.location.start_line,
+          )
+          instructions << PopInstruction.new
         when ::Prism::ClassVariableTargetNode
           instructions << ClassVariableSetInstruction.new(node.name)
         when ::Prism::ConstantTargetNode, ::Prism::ConstantPathTargetNode

--- a/spec/language/fixtures/rescue.rb
+++ b/spec/language/fixtures/rescue.rb
@@ -1,0 +1,67 @@
+module RescueSpecs
+  def self.begin_else(raise_exception)
+    begin
+      ScratchPad << :one
+      raise "an error occurred" if raise_exception
+    rescue
+      ScratchPad << :rescue_ran
+      :rescue_val
+    else
+      ScratchPad << :else_ran
+      :val
+    end
+  end
+
+  def self.begin_else_ensure(raise_exception)
+    begin
+      ScratchPad << :one
+      raise "an error occurred" if raise_exception
+    rescue
+      ScratchPad << :rescue_ran
+      :rescue_val
+    else
+      ScratchPad << :else_ran
+      :val
+    ensure
+      ScratchPad << :ensure_ran
+      :ensure_val
+    end
+  end
+
+  def self.begin_else_return(raise_exception)
+    begin
+      ScratchPad << :one
+      raise "an error occurred" if raise_exception
+    rescue
+      ScratchPad << :rescue_ran
+      :rescue_val
+    else
+      ScratchPad << :else_ran
+      :val
+    end
+    ScratchPad << :outside_begin
+    :return_val
+  end
+
+  def self.begin_else_return_ensure(raise_exception)
+    begin
+      ScratchPad << :one
+      raise "an error occurred" if raise_exception
+    rescue
+      ScratchPad << :rescue_ran
+      :rescue_val
+    else
+      ScratchPad << :else_ran
+      :val
+    ensure
+      ScratchPad << :ensure_ran
+      :ensure_val
+    end
+    ScratchPad << :outside_begin
+    :return_val
+  end
+
+  def self.raise_standard_error
+    raise StandardError, "an error occurred"
+  end
+end

--- a/spec/language/fixtures/rescue/top_level.rb
+++ b/spec/language/fixtures/rescue/top_level.rb
@@ -1,0 +1,7 @@
+# capturing in local variable at top-level
+
+begin
+  raise "message"
+rescue => e
+  ScratchPad << e.message
+end

--- a/spec/language/fixtures/rescue_captures.rb
+++ b/spec/language/fixtures/rescue_captures.rb
@@ -1,0 +1,110 @@
+module RescueSpecs
+  class Captor
+    attr_accessor :captured_error
+
+    def self.should_capture_exception
+      captor = new
+      captor.capture('some text').should == :caught # Ensure rescue body still runs
+      captor.captured_error.message.should == 'some text'
+    end
+  end
+
+  class ClassVariableCaptor < Captor
+    def capture(msg)
+      raise msg
+    rescue => @@captured_error
+      :caught
+    end
+
+    def captured_error
+      self.class.remove_class_variable(:@@captured_error)
+    end
+  end
+
+  class ConstantCaptor < Captor
+    # Using lambda gets around the dynamic constant assignment warning
+    CAPTURE = -> msg {
+      begin
+        raise msg
+      rescue => CapturedError
+        :caught
+      end
+    }
+
+    def capture(msg)
+      CAPTURE.call(msg)
+    end
+
+    def captured_error
+      self.class.send(:remove_const, :CapturedError)
+    end
+  end
+
+  class GlobalVariableCaptor < Captor
+    def capture(msg)
+      raise msg
+    rescue => $captured_error
+      :caught
+    end
+
+    def captured_error
+      $captured_error.tap do
+        $captured_error = nil # Can't remove globals, only nil them out
+      end
+    end
+  end
+
+  class InstanceVariableCaptor < Captor
+    def capture(msg)
+      raise msg
+    rescue => @captured_error
+      :caught
+    end
+  end
+
+  class LocalVariableCaptor < Captor
+    def capture(msg)
+      raise msg
+    rescue => captured_error
+      @captured_error = captured_error
+      :caught
+    end
+  end
+
+  class SafeNavigationSetterCaptor < Captor
+    # NATFIXME: Compile error
+    #def capture(msg)
+      #raise msg
+    #rescue => self&.captured_error
+      #:caught
+    #end
+  end
+
+  class SetterCaptor < Captor
+    # NATFIXME: Compile error
+    #def capture(msg)
+      #raise msg
+    #rescue => self.captured_error
+      #:caught
+    #end
+  end
+
+  class SquareBracketsCaptor < Captor
+    # NATFIXME: Compile error
+    #def capture(msg)
+      #@hash = {}
+
+      #raise msg
+    #rescue => self[:error]
+      #:caught
+    #end
+
+    def []=(key, value)
+      @hash[key] = value
+    end
+
+    def captured_error
+      @hash[:error]
+    end
+  end
+end

--- a/spec/language/fixtures/rescue_captures.rb
+++ b/spec/language/fixtures/rescue_captures.rb
@@ -72,21 +72,19 @@ module RescueSpecs
   end
 
   class SafeNavigationSetterCaptor < Captor
-    # NATFIXME: Compile error
-    #def capture(msg)
-      #raise msg
-    #rescue => self&.captured_error
-      #:caught
-    #end
+    def capture(msg)
+      raise msg
+    rescue => self&.captured_error
+      :caught
+    end
   end
 
   class SetterCaptor < Captor
-    # NATFIXME: Compile error
-    #def capture(msg)
-      #raise msg
-    #rescue => self.captured_error
-      #:caught
-    #end
+    def capture(msg)
+      raise msg
+    rescue => self.captured_error
+      :caught
+    end
   end
 
   class SquareBracketsCaptor < Captor

--- a/spec/language/fixtures/rescue_captures.rb
+++ b/spec/language/fixtures/rescue_captures.rb
@@ -88,14 +88,13 @@ module RescueSpecs
   end
 
   class SquareBracketsCaptor < Captor
-    # NATFIXME: Compile error
-    #def capture(msg)
-      #@hash = {}
+    def capture(msg)
+      @hash = {}
 
-      #raise msg
-    #rescue => self[:error]
-      #:caught
-    #end
+      raise msg
+    rescue => self[:error]
+      :caught
+    end
 
     def []=(key, value)
       @hash[key] = value

--- a/spec/language/rescue_spec.rb
+++ b/spec/language/rescue_spec.rb
@@ -1,0 +1,622 @@
+require_relative '../spec_helper'
+require_relative 'fixtures/rescue'
+
+class SpecificExampleException < StandardError
+end
+class OtherCustomException < StandardError
+end
+class ArbitraryException < StandardError
+end
+
+exception_list = [SpecificExampleException, ArbitraryException]
+
+describe "The rescue keyword" do
+  before :each do
+    ScratchPad.record []
+  end
+
+  it "can be used to handle a specific exception" do
+    begin
+      raise SpecificExampleException, "Raising this to be handled below"
+    rescue SpecificExampleException
+      :caught
+    end.should == :caught
+  end
+
+  describe 'can capture the raised exception' do
+    before :all do
+      require_relative 'fixtures/rescue_captures'
+    end
+
+    it 'in a local variable' do
+      RescueSpecs::LocalVariableCaptor.should_capture_exception
+    end
+
+    it 'in a class variable' do
+      RescueSpecs::ClassVariableCaptor.should_capture_exception
+    end
+
+    it 'in a constant' do
+      RescueSpecs::ConstantCaptor.should_capture_exception
+    end
+
+    it 'in a global variable' do
+      RescueSpecs::GlobalVariableCaptor.should_capture_exception
+    end
+
+    it 'in an instance variable' do
+      RescueSpecs::InstanceVariableCaptor.should_capture_exception
+    end
+
+    it 'using a safely navigated setter method' do
+      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SafeNavigationSetterCaptor" do
+        RescueSpecs::SafeNavigationSetterCaptor.should_capture_exception
+      end
+    end
+
+    it 'using a setter method' do
+      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SetterCaptor" do
+        RescueSpecs::SetterCaptor.should_capture_exception
+      end
+    end
+
+    it 'using a square brackets setter' do
+      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SquareBracketsCaptor" do
+        RescueSpecs::SquareBracketsCaptor.should_capture_exception
+      end
+    end
+  end
+
+  describe 'capturing in a local variable (that defines it)' do
+    it 'captures successfully in a method' do
+      ScratchPad.record []
+
+      def a
+        raise "message"
+      rescue => e
+        ScratchPad << e.message
+      end
+
+      a
+      ScratchPad.recorded.should == ["message"]
+    end
+
+    it 'captures successfully in a block' do
+      ScratchPad.record []
+
+      p = proc do
+        raise "message"
+      rescue => e
+        ScratchPad << e.message
+      end
+
+      p.call
+      ScratchPad.recorded.should == ["message"]
+    end
+
+    it 'captures successfully in a class' do
+      ScratchPad.record []
+
+      class RescueSpecs::C
+        raise "message"
+      rescue => e
+        ScratchPad << e.message
+      end
+
+      ScratchPad.recorded.should == ["message"]
+    end
+
+    it 'captures successfully in a module' do
+      ScratchPad.record []
+
+      module RescueSpecs::M
+        raise "message"
+      rescue => e
+        ScratchPad << e.message
+      end
+
+      ScratchPad.recorded.should == ["message"]
+    end
+
+    it 'captures sucpcessfully in a singleton class' do
+      ScratchPad.record []
+
+      class << Object.new
+        raise "message"
+      rescue => e
+        ScratchPad << e.message
+      end
+
+      ScratchPad.recorded.should == ["message"]
+    end
+
+    it 'captures successfully at the top-level' do
+      ScratchPad.record []
+
+      require_relative 'fixtures/rescue/top_level'
+
+      ScratchPad.recorded.should == ["message"]
+    end
+  end
+
+  it "returns value from `rescue` if an exception was raised" do
+    begin
+      raise
+    rescue
+      :caught
+    end.should == :caught
+  end
+
+  it "returns value from `else` section if no exceptions were raised" do
+    result = begin
+      :begin
+    rescue
+      :rescue
+    else
+      :else
+    ensure
+      :ensure
+    end
+
+    result.should == :else
+  end
+
+  it "can rescue multiple raised exceptions with a single rescue block" do
+    [->{raise ArbitraryException}, ->{raise SpecificExampleException}].map do |block|
+      begin
+        block.call
+      rescue SpecificExampleException, ArbitraryException
+        :caught
+      end
+    end.should == [:caught, :caught]
+  end
+
+  it "can rescue a splatted list of exceptions" do
+    caught_it = false
+    NATFIXME 'it can rescue a splatted list of exceptions', exception: SpecificExampleException do
+      begin
+        raise SpecificExampleException, "not important"
+      rescue *exception_list
+        caught_it = true
+      end
+      caught_it.should be_true
+      caught = []
+      [->{raise ArbitraryException}, ->{raise SpecificExampleException}].each do |block|
+        begin
+          block.call
+        rescue *exception_list
+          caught << $!
+        end
+      end
+      caught.size.should == 2
+      exception_list.each do |exception_class|
+        caught.map{|e| e.class}.should include(exception_class)
+      end
+    end
+  end
+
+  it "converts the splatted list of exceptions using #to_a" do
+    exceptions = mock("to_a")
+    NATFIXME 'it converts the splatted list of exceptions using #to_a', exception: SpecificExampleException do
+      exceptions.should_receive(:to_a).and_return(exception_list)
+      caught_it = false
+      begin
+        raise SpecificExampleException, "not important"
+      rescue *exceptions
+        caught_it = true
+      end
+      caught_it.should be_true
+    end
+  end
+
+  it "can combine a splatted list of exceptions with a literal list of exceptions" do
+    caught_it = false
+    NATFIXME 'it can combine a splatted list of exceptions with a literal list of exceptions', exception: SpecificExampleException do
+      begin
+        raise SpecificExampleException, "not important"
+      rescue ArbitraryException, *exception_list
+        caught_it = true
+      end
+      caught_it.should be_true
+      caught = []
+      [->{raise ArbitraryException}, ->{raise SpecificExampleException}].each do |block|
+        begin
+          block.call
+        rescue ArbitraryException, *exception_list
+          caught << $!
+        end
+      end
+      caught.size.should == 2
+      exception_list.each do |exception_class|
+        caught.map{|e| e.class}.should include(exception_class)
+      end
+    end
+  end
+
+  it "will only rescue the specified exceptions when doing a splat rescue" do
+    -> do
+      begin
+        raise OtherCustomException, "not rescued!"
+      rescue *exception_list
+      end
+    end.should raise_error(OtherCustomException)
+  end
+
+  it "can rescue different types of exceptions in different ways" do
+    begin
+      raise Exception
+    rescue RuntimeError
+    rescue StandardError
+    rescue Exception
+      ScratchPad << :exception
+    end
+
+    ScratchPad.recorded.should == [:exception]
+  end
+
+  it "rescues exception within the first suitable section in order of declaration" do
+    begin
+      raise StandardError
+    rescue RuntimeError
+      ScratchPad << :runtime_error
+    rescue StandardError
+      ScratchPad << :standard_error
+    rescue Exception
+      ScratchPad << :exception
+    end
+
+    ScratchPad.recorded.should == [:standard_error]
+  end
+
+  it "rescues the exception in the deepest rescue block declared to handle the appropriate exception type" do
+    begin
+      begin
+        RescueSpecs.raise_standard_error
+      rescue ArgumentError
+      end
+    rescue StandardError => e
+      NATFIXME 'it rescues the exception in the deepest rescue block declared to handle the appropriate exception type', exception: SpecFailedException do
+        e.backtrace.first.should =~ /:in [`'](?:RescueSpecs\.)?raise_standard_error'/
+      end
+    else
+      fail("exception wasn't handled by the correct rescue block")
+    end
+  end
+
+  it "will execute an else block only if no exceptions were raised" do
+    result = begin
+      ScratchPad << :one
+    rescue
+      ScratchPad << :does_not_run
+    else
+      ScratchPad << :two
+      :val
+    end
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :two]
+  end
+
+  it "will execute an else block with ensure only if no exceptions were raised" do
+    result = begin
+      ScratchPad << :one
+    rescue
+      ScratchPad << :does_not_run
+    else
+      ScratchPad << :two
+      :val
+    ensure
+      ScratchPad << :ensure
+      :ensure_val
+    end
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :two, :ensure]
+  end
+
+  it "will execute an else block only if no exceptions were raised in a method" do
+    result = RescueSpecs.begin_else(false)
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :else_ran]
+  end
+
+  it "will execute an else block with ensure only if no exceptions were raised in a method" do
+    result = RescueSpecs.begin_else_ensure(false)
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :else_ran, :ensure_ran]
+  end
+
+  it "will execute an else block but use the outer scope return value in a method" do
+    result = RescueSpecs.begin_else_return(false)
+    result.should == :return_val
+    ScratchPad.recorded.should == [:one, :else_ran, :outside_begin]
+  end
+
+  it "will execute an else block with ensure but use the outer scope return value in a method" do
+    result = RescueSpecs.begin_else_return_ensure(false)
+    result.should == :return_val
+    ScratchPad.recorded.should == [:one, :else_ran, :ensure_ran, :outside_begin]
+  end
+
+  it "raises SyntaxError when else is used without rescue and ensure" do
+    -> {
+      eval <<-ruby
+        begin
+          ScratchPad << :begin
+        else
+          ScratchPad << :else
+        end
+      ruby
+    }.should raise_error(SyntaxError, /else without rescue is useless/)
+  end
+
+  it "will not execute an else block if an exception was raised" do
+    result = begin
+      ScratchPad << :one
+      raise "an error occurred"
+    rescue
+      ScratchPad << :two
+      :val
+    else
+      ScratchPad << :does_not_run
+    end
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :two]
+  end
+
+  it "will not execute an else block with ensure if an exception was raised" do
+    result = begin
+      ScratchPad << :one
+      raise "an error occurred"
+    rescue
+      ScratchPad << :two
+      :val
+    else
+      ScratchPad << :does_not_run
+    ensure
+      ScratchPad << :ensure
+      :ensure_val
+    end
+    result.should == :val
+    ScratchPad.recorded.should == [:one, :two, :ensure]
+  end
+
+  it "will not execute an else block if an exception was raised in a method" do
+    result = RescueSpecs.begin_else(true)
+    result.should == :rescue_val
+    ScratchPad.recorded.should == [:one, :rescue_ran]
+  end
+
+  it "will not execute an else block with ensure if an exception was raised in a method" do
+    result = RescueSpecs.begin_else_ensure(true)
+    result.should == :rescue_val
+    ScratchPad.recorded.should == [:one, :rescue_ran, :ensure_ran]
+  end
+
+  it "will not execute an else block but use the outer scope return value in a method" do
+    result = RescueSpecs.begin_else_return(true)
+    result.should == :return_val
+    ScratchPad.recorded.should == [:one, :rescue_ran, :outside_begin]
+  end
+
+  it "will not execute an else block with ensure but use the outer scope return value in a method" do
+    result = RescueSpecs.begin_else_return_ensure(true)
+    result.should == :return_val
+    ScratchPad.recorded.should == [:one, :rescue_ran, :ensure_ran, :outside_begin]
+  end
+
+  it "will not rescue errors raised in an else block in the rescue block above it" do
+    -> do
+      begin
+        ScratchPad << :one
+      rescue Exception
+        ScratchPad << :does_not_run
+      else
+        ScratchPad << :two
+        raise SpecificExampleException, "an error from else"
+      end
+    end.should raise_error(SpecificExampleException)
+    ScratchPad.recorded.should == [:one, :two]
+  end
+
+  it "parses  'a += b rescue c' as 'a += (b rescue c)'" do
+    a = 'a'
+    c = 'c'
+    a += b rescue c
+    a.should == 'ac'
+  end
+
+  context "without rescue expression" do
+    it "will rescue only StandardError and its subclasses" do
+      begin
+        raise StandardError
+      rescue
+        ScratchPad << :caught
+      end
+
+      ScratchPad.recorded.should == [:caught]
+    end
+
+    it "will not rescue exceptions except StandardError" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        -> {
+          begin
+            raise exception
+          rescue
+            ScratchPad << :caught
+          end
+        }.should raise_error(exception.class)
+      end
+      ScratchPad.recorded.should == []
+    end
+  end
+
+  it "uses === to compare against rescued classes" do
+    rescuer = Class.new
+
+    def rescuer.===(exception)
+      true
+    end
+
+    begin
+      raise Exception
+    rescue rescuer
+      rescued = :success
+    rescue Exception
+      rescued = :failure
+    end
+
+    rescued.should == :success
+  end
+
+  it "only accepts Module or Class in rescue clauses" do
+    rescuer = 42
+    -> {
+      begin
+        raise "error"
+      rescue rescuer
+      end
+    }.should raise_error(TypeError) { |e|
+      NATFIXME 'it only accepts Module or Class in rescue clauses', exception: SpecFailedException do
+        e.message.should =~ /class or module required for rescue clause/
+      end
+    }
+  end
+
+  it "only accepts Module or Class in splatted rescue clauses" do
+    rescuer = [42]
+    -> {
+      begin
+        raise "error"
+      rescue *rescuer
+      end
+    }.should raise_error(TypeError) { |e|
+      NATFIXME 'it only accepts Module or Class in splatted rescue clauses', exception: SpecFailedException do
+        e.message.should =~ /class or module required for rescue clause/
+      end
+    }
+  end
+
+  it "evaluates rescue expressions only when needed" do
+    begin
+      ScratchPad << :foo
+    rescue -> { ScratchPad << :bar; StandardError }.call
+    end
+
+    ScratchPad.recorded.should == [:foo]
+  end
+
+  it "suppresses exception from block when raises one from rescue expression" do
+    -> {
+      begin
+        raise "from block"
+      rescue (raise "from rescue expression")
+      end
+    }.should raise_error(RuntimeError, "from rescue expression") { |e|
+      e.cause.message.should == "from block"
+    }
+  end
+
+  it "should splat the handling Error classes" do
+    begin
+      raise "raise"
+    rescue *(RuntimeError) => e
+      :expected
+    end.should == :expected
+  end
+
+  it "allows rescue in class" do
+    eval <<-ruby
+      class RescueInClassExample
+        raise SpecificExampleException
+      rescue SpecificExampleException
+        ScratchPad << :caught
+      end
+    ruby
+
+    ScratchPad.recorded.should == [:caught]
+  end
+
+  it "does not allow rescue in {} block" do
+    -> {
+      eval <<-ruby
+        lambda {
+          raise SpecificExampleException
+        rescue SpecificExampleException
+          :caught
+        }
+      ruby
+    }.should raise_error(SyntaxError)
+  end
+
+  it "allows rescue in 'do end' block" do
+    lambda = eval <<-ruby
+      lambda do
+        raise SpecificExampleException
+      rescue SpecificExampleException
+        ScratchPad << :caught
+      end.call
+    ruby
+
+    ScratchPad.recorded.should == [:caught]
+  end
+
+  it "allows 'rescue' in method arguments" do
+    two = eval '1.+ (raise("Error") rescue 1)'
+    two.should == 2
+  end
+
+  it "requires the 'rescue' in method arguments to be wrapped in parens" do
+    -> { eval '1.+(1 rescue 1)' }.should raise_error(SyntaxError)
+    eval('1.+((1 rescue 1))').should == 2
+  end
+
+  ruby_version_is "3.4" do
+    it "does not introduce extra backtrace entries" do
+      def foo
+        begin
+          raise "oops"
+        rescue
+          return caller(0, 2)
+        end
+      end
+      line = __LINE__
+      foo.should == [
+        "#{__FILE__}:#{line-3}:in 'foo'",
+        "#{__FILE__}:#{line+1}:in 'block (3 levels) in <top (required)>'"
+      ]
+    end
+  end
+
+  describe "inline form" do
+    it "can be inlined" do
+      a = 1/0 rescue 1
+      a.should == 1
+    end
+
+    it "doesn't except rescue expression" do
+      -> {
+        eval <<-ruby
+          a = 1 rescue RuntimeError 2
+        ruby
+      }.should raise_error(SyntaxError)
+    end
+
+    it "rescues only StandardError and its subclasses" do
+      a = raise(StandardError) rescue 1
+      a.should == 1
+
+      -> {
+        a = raise(Exception) rescue 1
+      }.should raise_error(Exception)
+    end
+
+    it "rescues with multiple assignment" do
+
+      a, b = raise rescue [1, 2]
+
+      a.should == 1
+      b.should == 2
+    end
+  end
+end

--- a/spec/language/rescue_spec.rb
+++ b/spec/language/rescue_spec.rb
@@ -49,15 +49,11 @@ describe "The rescue keyword" do
     end
 
     it 'using a safely navigated setter method' do
-      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SafeNavigationSetterCaptor" do
-        RescueSpecs::SafeNavigationSetterCaptor.should_capture_exception
-      end
+      RescueSpecs::SafeNavigationSetterCaptor.should_capture_exception
     end
 
     it 'using a setter method' do
-      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SetterCaptor" do
-        RescueSpecs::SetterCaptor.should_capture_exception
-      end
+      RescueSpecs::SetterCaptor.should_capture_exception
     end
 
     it 'using a square brackets setter' do

--- a/spec/language/rescue_spec.rb
+++ b/spec/language/rescue_spec.rb
@@ -57,9 +57,7 @@ describe "The rescue keyword" do
     end
 
     it 'using a square brackets setter' do
-      NATFIXME 'Compile errors', exception: NoMethodError, message: "undefined method `capture' for an instance of RescueSpecs::SquareBracketsCaptor" do
-        RescueSpecs::SquareBracketsCaptor.should_capture_exception
-      end
+      RescueSpecs::SquareBracketsCaptor.should_capture_exception
     end
   end
 


### PR DESCRIPTION
This resolves the compilation error in https://github.com/ruby/spec/blob/master/language/rescue_spec.rb

Known bug: we ignore the safe navigation flag, so the following code will fail:
```ruby
rescue => nil&.foo
```
There are no upstream specs for this behaviour, and I'll have to find out what it actually does, so I kept that as a future work.