### PR TITLE
Add :turkic support for case mapping methods

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -14,6 +14,14 @@
 
 namespace Natalie {
 
+enum CaseMapType {
+    CaseMapFull = 0,
+    CaseMapAscii = 1,
+    CaseMapTurkicAzeri = 2,
+    CaseMapLithuanian = 4,
+    CaseMapFold = 8,
+};
+
 const int SPECIAL_CASE_LOWER_MAX_SIZE = 2;
 const int SPECIAL_CASE_TITLE_MAX_SIZE = 3;
 const int SPECIAL_CASE_UPPER_MAX_SIZE = 3;
@@ -96,9 +104,9 @@ public:
     static EncodingObject *find_encoding(Env *env, Value encoding);
 
     // must pass a buffer of nat_int_t to this function; uint8_t return is number of codepoints written
-    static uint8_t codepoint_to_lowercase(nat_int_t codepoint, nat_int_t result[], bool ascii_only = false);
-    static uint8_t codepoint_to_uppercase(nat_int_t codepoint, nat_int_t result[], bool ascii_only = false);
-    static uint8_t codepoint_to_titlecase(nat_int_t codepoint, nat_int_t result[], bool ascii_only = false);
+    static uint8_t codepoint_to_lowercase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags = CaseMapFull);
+    static uint8_t codepoint_to_uppercase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags = CaseMapFull);
+    static uint8_t codepoint_to_titlecase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags = CaseMapFull);
 
     static void init_special_casing_map();
     static SpecialCasingEntry find_special_casing_map_entry(nat_int_t codepoint);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -16,20 +16,11 @@ namespace Natalie {
 
 using namespace TM;
 
-enum CaseFoldType {
-    Ascii = 1,
-    FoldTurkicAzeri = 2,
-    FoldLithuanian = 4,
-    Upcase = 8,
-    Downcase = 16,
-    Fold = 32
-};
-
-inline CaseFoldType operator|(CaseFoldType a, CaseFoldType b) {
-    return static_cast<CaseFoldType>(static_cast<int>(a) | static_cast<int>(b));
+inline CaseMapType operator|(CaseMapType a, CaseMapType b) {
+    return static_cast<CaseMapType>(static_cast<int>(a) | static_cast<int>(b));
 }
-inline CaseFoldType operator^(CaseFoldType a, CaseFoldType b) {
-    return static_cast<CaseFoldType>(static_cast<int>(a) ^ static_cast<int>(b));
+inline CaseMapType operator^(CaseMapType a, CaseMapType b) {
+    return static_cast<CaseMapType>(static_cast<int>(a) ^ static_cast<int>(b));
 }
 
 class StringObject : public Object {
@@ -404,7 +395,7 @@ public:
     size_t char_index_to_byte_index(size_t) const;
     size_t byte_index_to_char_index(size_t) const;
 
-    static CaseFoldType check_case_options(Env *env, Value arg1, Value arg2, CaseFoldType flags);
+    static CaseMapType check_case_options(Env *env, Value arg1, Value arg2, bool downcase = false);
 
     unsigned char at(size_t index) const {
         return m_string.at(index);

--- a/spec/core/string/capitalize_spec.rb
+++ b/spec/core/string/capitalize_spec.rb
@@ -44,15 +44,11 @@ describe "String#capitalize" do
 
   describe "full Unicode case mapping adapted for Turkic languages" do
     it "capitalizes ASCII characters according to Turkic semantics" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "iSa".capitalize(:turkic).should == "İsa"
-      end
+      "iSa".capitalize(:turkic).should == "İsa"
     end
 
     it "allows Lithuanian as an extra option" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "iSa".capitalize(:turkic, :lithuanian).should == "İsa"
-      end
+      "iSa".capitalize(:turkic, :lithuanian).should == "İsa"
     end
 
     it "does not allow any other additional option" do
@@ -66,9 +62,7 @@ describe "String#capitalize" do
     end
 
     it "allows Turkic as an extra option (and applies Turkic semantics)" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "iß".capitalize(:lithuanian, :turkic).should == "İß"
-      end
+      "iß".capitalize(:lithuanian, :turkic).should == "İß"
     end
 
     it "does not allow any other additional option" do
@@ -153,19 +147,15 @@ describe "String#capitalize!" do
 
   describe "modifies self in place for full Unicode case mapping adapted for Turkic languages" do
     it "capitalizes ASCII characters according to Turkic semantics" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a = "iSa"
-        a.capitalize!(:turkic)
-        a.should == "İsa"
-      end
+      a = "iSa"
+      a.capitalize!(:turkic)
+      a.should == "İsa"
     end
 
     it "allows Lithuanian as an extra option" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a = "iSa"
-        a.capitalize!(:turkic, :lithuanian)
-        a.should == "İsa"
-      end
+      a = "iSa"
+      a.capitalize!(:turkic, :lithuanian)
+      a.should == "İsa"
     end
 
     it "does not allow any other additional option" do
@@ -181,11 +171,9 @@ describe "String#capitalize!" do
     end
 
     it "allows Turkic as an extra option (and applies Turkic semantics)" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a = "iß"
-        a.capitalize!(:lithuanian, :turkic)
-        a.should == "İß"
-      end
+      a = "iß"
+      a.capitalize!(:lithuanian, :turkic)
+      a.should == "İß"
     end
 
     it "does not allow any other additional option" do

--- a/spec/core/string/upcase_spec.rb
+++ b/spec/core/string/upcase_spec.rb
@@ -39,15 +39,11 @@ describe "String#upcase" do
 
   describe "full Unicode case mapping adapted for Turkic languages" do
     it "upcases ASCII characters according to Turkic semantics" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "i".upcase(:turkic).should == "İ"
-      end
+      "i".upcase(:turkic).should == "İ"
     end
 
     it "allows Lithuanian as an extra option" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "i".upcase(:turkic, :lithuanian).should == "İ"
-      end
+      "i".upcase(:turkic, :lithuanian).should == "İ"
     end
 
     it "does not allow any other additional option" do
@@ -61,9 +57,7 @@ describe "String#upcase" do
     end
 
     it "allows Turkic as an extra option (and applies Turkic semantics)" do
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        "iß".upcase(:lithuanian, :turkic).should == "İSS"
-      end
+      "iß".upcase(:lithuanian, :turkic).should == "İSS"
     end
 
     it "does not allow any other additional option" do
@@ -139,17 +133,13 @@ describe "String#upcase!" do
     it "upcases ASCII characters according to Turkic semantics" do
       a = "i"
       a.upcase!(:turkic)
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a.should == "İ"
-      end
+      a.should == "İ"
     end
 
     it "allows Lithuanian as an extra option" do
       a = "i"
       a.upcase!(:turkic, :lithuanian)
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a.should == "İ"
-      end
+      a.should == "İ"
     end
 
     it "does not allow any other additional option" do
@@ -167,9 +157,7 @@ describe "String#upcase!" do
     it "allows Turkic as an extra option (and applies Turkic semantics)" do
       a = "iß"
       a.upcase!(:lithuanian, :turkic)
-      NATFIXME 'Pending unicode casemap support', exception: SpecFailedException do
-        a.should == "İSS"
-      end
+      a.should == "İSS"
     end
 
     it "does not allow any other additional option" do

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -286,6 +286,11 @@ uint8_t EncodingObject::codepoint_to_uppercase(nat_int_t codepoint, nat_int_t re
         return 1;
     }
 
+    if (flags & CaseMapTurkicAzeri && codepoint == 0x69) {
+        result[0] = 0x130;
+        return 1;
+    }
+
     auto block = codepoint >> 8;
     auto index = ucase_index[block] + (codepoint & 0xff);
     auto delta = ucase_map[index];

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -319,6 +319,11 @@ uint8_t EncodingObject::codepoint_to_titlecase(nat_int_t codepoint, nat_int_t re
     if (flags & CaseMapAscii)
         return codepoint_to_uppercase(codepoint, result, CaseMapAscii);
 
+    if (flags & CaseMapTurkicAzeri && codepoint == 0x69) {
+        result[0] = 0x130;
+        return 1;
+    }
+
     auto block = codepoint >> 8;
     auto index = tcase_index[block] + (codepoint & 0xff);
     auto delta = tcase_map[index];

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -244,8 +244,8 @@ void EncodingObject::initialize_defaults(Env *env) {
     s_filesystem = s_default_external;
 }
 
-uint8_t EncodingObject::codepoint_to_lowercase(nat_int_t codepoint, nat_int_t result[], bool ascii_only) {
-    if (ascii_only) {
+uint8_t EncodingObject::codepoint_to_lowercase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags) {
+    if (flags & CaseMapAscii) {
         if (codepoint >= 'A' && codepoint <= 'Z')
             result[0] = codepoint + 32;
         else
@@ -277,8 +277,8 @@ uint8_t EncodingObject::codepoint_to_lowercase(nat_int_t codepoint, nat_int_t re
     return 1;
 }
 
-uint8_t EncodingObject::codepoint_to_uppercase(nat_int_t codepoint, nat_int_t result[], bool ascii_only) {
-    if (ascii_only) {
+uint8_t EncodingObject::codepoint_to_uppercase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags) {
+    if (flags & CaseMapAscii) {
         if (codepoint >= 'a' && codepoint <= 'z')
             result[0] = codepoint - 32;
         else
@@ -310,8 +310,9 @@ uint8_t EncodingObject::codepoint_to_uppercase(nat_int_t codepoint, nat_int_t re
     return 1;
 }
 
-uint8_t EncodingObject::codepoint_to_titlecase(nat_int_t codepoint, nat_int_t result[], bool ascii_only) {
-    if (ascii_only) return codepoint_to_uppercase(codepoint, result, true);
+uint8_t EncodingObject::codepoint_to_titlecase(nat_int_t codepoint, nat_int_t result[], CaseMapType flags) {
+    if (flags & CaseMapAscii)
+        return codepoint_to_uppercase(codepoint, result, CaseMapAscii);
 
     auto block = codepoint >> 8;
     auto index = tcase_index[block] + (codepoint & 0xff);

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2864,7 +2864,7 @@ StringObject *StringObject::downcase(Env *env, Value arg1, Value arg2) {
                 str->append(m_encoding->encode_codepoint(codepoint));
             }
         } else {
-            auto length = EncodingObject::codepoint_to_lowercase(codepoint, result);
+            auto length = EncodingObject::codepoint_to_lowercase(codepoint, result, flags);
             for (uint8_t i = 0; i < length; i++)
                 str->append(m_encoding->encode_codepoint(result[i]));
         }


### PR DESCRIPTION
#217

Turns out this wasn't quite as hard as I thought. The section from SpecialCasing.txt has several lines, but only a couple of them are implemented in CRuby, and I was able to code that with a couple if statements.