### PR TITLE
Update spec in language/break that causes a compile error

### DIFF
--- a/spec/language/break_spec.rb
+++ b/spec/language/break_spec.rb
@@ -260,11 +260,11 @@ end
 
 describe "The break statement in a method" do
   # NATFIXME: unexpected env for break (RuntimeError)
-  #it "is invalid and raises a SyntaxError" do
+  xit "is invalid and raises a SyntaxError" do
     #-> {
       #eval("def m; break; end")
     #}.should raise_error(SyntaxError)
-  #end
+  end
 end
 
 describe "The break statement in a module literal" do


### PR DESCRIPTION
Wrap the commented code in a `xit` block, to make it show up in the skipped tests.