### PR TITLE
Convert heredocs in eval statements to static string where possible

### DIFF
--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -159,6 +159,17 @@ module Natalie
         args = expr.arguments&.arguments || []
         node = args.first
         $stderr.puts 'FIXME: binding passed to eval() will be ignored.' if args.size > 1
+        if node.type == :interpolated_string_node && node.parts.all? { |subnode| subnode.type == :string_node }
+          node = Prism::StringNode.new(
+            nil,
+            nil,
+            node.opening_loc,
+            node.opening_loc,
+            node.closing_loc,
+            node.parts.map(&:unescaped).join,
+            node.location,
+          )
+        end
         if node.type == :string_node
           begin
             Natalie::Parser.new(node.unescaped, current_path, locals: locals).ast

--- a/spec/language/numbered_parameters_spec.rb
+++ b/spec/language/numbered_parameters_spec.rb
@@ -34,14 +34,12 @@ describe "Numbered parameters" do
   end
 
   it "cannot be overwritten with local variable" do
-    NATFIXME 'Eval', exception: SpecFailedException, message: 'eval() only works on static strings' do
-      -> {
-        eval <<~CODE
-          _1 = 0
-          proc { _1 }.call("a").should == 0
-        CODE
-      }.should raise_error(SyntaxError, /_1 is reserved for numbered parameter/)
-    end
+    -> {
+      eval <<~CODE
+        _1 = 0
+        proc { _1 }.call("a").should == 0
+      CODE
+    }.should raise_error(SyntaxError, /_1 is reserved for numbered parameter/)
   end
 
   it "errors when numbered parameter is overwritten with local variable" do

--- a/spec/language/regexp/back-references_spec.rb
+++ b/spec/language/regexp/back-references_spec.rb
@@ -23,7 +23,7 @@ describe "Regexps with back-references" do
   end
 
   it "returns nil for numbered variable with too large index" do
-    NATFIXME 'eval() only works on static strings', exception: TypeError, message: 'eval() only works on static strings' do
+    NATFIXME 'eval() only works on static strings', exception: SpecFailedException do
       -> {
         eval(<<~CODE).should == nil
           "a" =~ /(.)/

--- a/test/natalie/eval_test.rb
+++ b/test/natalie/eval_test.rb
@@ -49,4 +49,11 @@ describe 'eval macro' do
   it 'raises a SyntaxError for invalid parse' do
     -> { eval('())))') }.should raise_error(SyntaxError)
   end
+
+  it 'can handle multiline statements with heredocs' do
+    eval(<<~RUBY).should == 1
+      a = 1
+      a
+    RUBY
+  end
 end


### PR DESCRIPTION
This fixes #2075

Fun fact: the file where I encountered this issue has just been rewritten to get rid of the eval statements. (https://github.com/ruby/spec/pull/1155)