### PR TITLE
Fix String#rstrip with invalid encodings

### DIFF
--- a/spec/core/string/rstrip_spec.rb
+++ b/spec/core/string/rstrip_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/strip'
@@ -11,6 +12,14 @@ describe "String#rstrip" do
     "  hello world \n\r\t\n\v\r".rstrip.should == "  hello world"
     "hello".rstrip.should == "hello"
     "hello\x00".rstrip.should == "hello"
+    "こにちわ ".rstrip.should == "こにちわ"
+  end
+
+  it "works with lazy substrings" do
+    "  hello  "[1...-1].rstrip.should == " hello"
+    "  hello world  "[1...-1].rstrip.should == " hello world"
+    "  hello world \n\r\t\n\v\r"[1...-1].rstrip.should == " hello world"
+    " こにちわ  "[1...-1].rstrip.should == "こにちわ"
   end
 
   it "returns a copy of self with all trailing whitespace and NULL bytes removed" do
@@ -37,6 +46,18 @@ describe "String#rstrip!" do
     a.should == "hello"
   end
 
+  it "makes a string empty if it is only whitespace" do
+    "".rstrip!.should == nil
+    " ".rstrip.should == ""
+    "  ".rstrip.should == ""
+  end
+
+  it "removes trailing NULL bytes and whitespace" do
+    a = "\000 goodbye \000"
+    a.rstrip!
+    a.should == "\000 goodbye"
+  end
+
   it "raises a FrozenError on a frozen instance that is modified" do
     -> { "  hello  ".freeze.rstrip! }.should raise_error(FrozenError)
   end
@@ -45,5 +66,29 @@ describe "String#rstrip!" do
   it "raises a FrozenError on a frozen instance that would not be modified" do
     -> { "hello".freeze.rstrip! }.should raise_error(FrozenError)
     -> { "".freeze.rstrip!      }.should raise_error(FrozenError)
+  end
+
+  ruby_version_is "3.2" do
+    it "raises an Encoding::CompatibilityError if the last non-space codepoint is invalid" do
+      s = "abc\xDF".force_encoding(Encoding::UTF_8)
+      s.valid_encoding?.should be_false
+      -> { s.rstrip! }.should raise_error(Encoding::CompatibilityError)
+
+      s = "abc\xDF   ".force_encoding(Encoding::UTF_8)
+      s.valid_encoding?.should be_false
+      -> { s.rstrip! }.should raise_error(Encoding::CompatibilityError)
+    end
+  end
+
+  ruby_version_is ""..."3.2" do
+    it "raises an ArgumentError if the last non-space codepoint is invalid" do
+      s = "abc\xDF".force_encoding(Encoding::UTF_8)
+      s.valid_encoding?.should be_false
+      -> { s.rstrip! }.should raise_error(ArgumentError)
+
+      s = "abc\xDF   ".force_encoding(Encoding::UTF_8)
+      s.valid_encoding?.should be_false
+      -> { s.rstrip! }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2722,6 +2722,11 @@ Value StringObject::rjust(Env *env, Value length_obj, Value pad_obj) const {
 Value StringObject::rstrip(Env *env) const {
     if (length() == 0)
         return new StringObject { "", m_encoding };
+
+    if (!valid_encoding()) {
+        env->raise(m_encoding->klass()->const_find(env, "CompatibilityError"_s)->as_class(), "invalid byte sequence in {}", m_encoding->name()->as_string()->string());
+    }
+
     assert(length() < NAT_INT_MAX);
     nat_int_t last_char;
     nat_int_t len = static_cast<nat_int_t>(length());
@@ -2742,6 +2747,9 @@ Value StringObject::rstrip_in_place(Env *env) {
     assert_not_frozen(env);
     if (length() == 0)
         return NilObject::the();
+
+    if (!valid_encoding())
+        env->raise(m_encoding->klass()->const_find(env, "CompatibilityError"_s)->as_class(), "invalid byte sequence in {}", m_encoding->name()->as_string()->string());
 
     assert(length() < NAT_INT_MAX);
     nat_int_t last_char;


### PR DESCRIPTION
This changes the behavior of String#rstrip{!} to raise an Encoding::CompatibilityError if it has invalid codepoints.

This also refreshes the spec of String#rstrip to include the new MRI behavior.