### PR TITLE
Do less (smartly) with CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,18 @@ env:
   CI: 1
 
 jobs:
+  output:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: diff output
+        run: rake docker_test_output
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        ruby_version:
-          - ruby3.1
-          - ruby3.2
-          - ruby3.3
         compiler:
           - gcc
           - clang
@@ -27,7 +31,7 @@ jobs:
         with:
           submodules: true
       - name: run tests
-        run: rake docker_test_${{ matrix.compiler }} RUBY=${{ matrix.ruby_version }}
+        run: rake docker_test_${{ matrix.compiler }} RUBY=ruby3.3
   macos:
     runs-on: macos-12
     steps:
@@ -61,7 +65,7 @@ jobs:
           export PATH="/usr/local/opt/ruby/bin:$PATH"
           rake test
   self-hosted:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +73,7 @@ jobs:
       - name: build self-hosted binary
         run: rake docker_test_self_hosted
   asan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,6 @@ AllCops:
     - spec/**/*.rb
     - vendor/**/*
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Layout/LeadingCommentSpace:
   Enabled: false
 
@@ -54,6 +51,9 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/FormatString:
   Enabled: false
 
@@ -67,6 +67,9 @@ Style/LambdaCall:
   Enabled: false
 
 Style/NumericPredicate:
+  Enabled: false
+
+Style/Next:
   Enabled: false
 
 Style/OptionalBooleanParameter:

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'minitest-reporters'
 gem 'rake'
 
 group :development do
-  gem 'stackprof'
   gem 'rubocop'
+  gem 'stackprof'
 end
 
 group :run_all_specs, optional: true do

--- a/bin/natalie
+++ b/bin/natalie
@@ -350,8 +350,10 @@ class Runner
       system('batcat', path, '-lcpp')
     else
       puts File.read(path)
-      puts '-' * 80
-      puts path
+      unless ENV['DO_NOT_PRINT_CPP_PATH']
+        puts '-' * 80
+        puts path
+      end
     end
   end
 

--- a/spec/support/cpp_output_all_specs.rb
+++ b/spec/support/cpp_output_all_specs.rb
@@ -1,0 +1,51 @@
+require 'concurrent'
+require 'etc'
+
+Thread.abort_on_exception = true
+
+out_dir = ARGV.first
+raise 'must specify output directory as first argument' unless out_dir
+raise "directory #{out_dir} does not exist" unless File.directory?(out_dir)
+
+pool = Concurrent::ThreadPoolExecutor.new(
+  max_threads: Etc.nprocessors,
+  max_queue: 0 # unbounded work queue
+)
+
+specs = 'spec/**/*_spec.rb'
+env = { 'DO_NOT_PRINT_CPP_PATH' => 'true' }
+
+errors = []
+
+Dir[specs].each do |path|
+  pool.post do
+    begin
+      output_path = File.join(out_dir, path.tr('/.', '_')) + '.cpp'
+      system(
+        env,
+        "bin/natalie -d cpp #{path} 2>/dev/null > #{output_path}",
+        exception: true
+      )
+    rescue Exception => e
+      errors << e.message
+    end
+  end
+end
+
+last_count = 0
+loop do
+  puts "#{pool.queue_length} job(s) remaining" if pool.queue_length != last_count
+  last_count = pool.queue_length
+
+  if errors.any?
+    puts errors
+    exit 1
+  end
+
+  break if last_count.zero?
+
+  sleep 1
+end
+
+pool.shutdown
+pool.wait_for_termination


### PR DESCRIPTION
I thought we might be able to reduce our load on GitHub CI if we do less. Generating CPP from our compiler is relatively fast, so let's compare the output between different **Host** Ruby versions. If they are all the same, then presumably the resulting binaries from GCC and Clang should be the same.

That lets us only do a full build once for Ruby 3.3 on GCC and once on Clang.

This probably won't speed up CI, but it might allow us to run more jobs from more PRs without getting rate limited as much. :crossed_fingers: 