### PR TITLE
Make String#dup spec-compliant

### DIFF
--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -74,6 +74,7 @@ public:
     static bool block_given(Env *env, Block *block) { return !!block; }
 
     Value define_singleton_method(Env *env, Value name, Block *block);
+    Value dup(Env *env);
     Value hash(Env *env);
     Value initialize_copy(Env *env, Value object);
     Value inspect(Env *env);

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -75,6 +75,7 @@ public:
 
     Value define_singleton_method(Env *env, Value name, Block *block);
     Value dup(Env *env);
+    Value dup_better(Env *env); // This will eventually replace `dup`.
     Value hash(Env *env);
     Value initialize_copy(Env *env, Value object);
     Value inspect(Env *env);

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -83,7 +83,7 @@ public:
      * not impacted by those changes.
      */
     void dup_string(Env *env) {
-        m_string = m_string->dup(env)->as_string();
+        m_string = m_string->duplicate(env)->as_string();
     }
 
 private:

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -81,6 +81,8 @@ public:
         m_singleton_class = other.m_singleton_class;
         m_owner = other.m_owner;
         m_flags = other.m_flags;
+        if (m_ivars)
+            delete m_ivars;
         m_ivars = other.m_ivars;
         other.m_type = Type::Nil;
         other.m_singleton_class = nullptr;

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -317,6 +317,8 @@ public:
     Value duplicate(Env *) const;
     Value clone(Env *env, Value freeze = nullptr);
 
+    void copy_instance_variables(Value);
+
     bool is_a(Env *, Value) const;
     bool respond_to(Env *, Value, bool = true);
     bool respond_to_method(Env *, Value, Value);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -313,8 +313,7 @@ public:
     Method *find_method(Env *, SymbolObject *, MethodVisibility, Value) const;
 
     Value dup(Env *) const;
-    Value clone(Env *env);
-    Value clone(Env *env, Value freeze);
+    Value clone(Env *env, Value freeze = nullptr);
 
     bool is_a(Env *, Value) const;
     bool respond_to(Env *, Value, bool = true);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -312,7 +312,7 @@ public:
 
     Method *find_method(Env *, SymbolObject *, MethodVisibility, Value) const;
 
-    Value dup(Env *) const;
+    Value duplicate(Env *) const;
     Value clone(Env *env, Value freeze = nullptr);
 
     bool is_a(Env *, Value) const;

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -58,19 +58,7 @@ public:
             return nullptr;
     }
 
-    bool operator==(Value other) const {
-        if (is_fast_integer()) {
-            if (other.is_fast_integer())
-                return get_fast_integer() == other.get_fast_integer();
-            return false;
-        }
-        if (m_type == Type::Double) {
-            if (other.m_type == Type::Double)
-                return m_double == m_double;
-            return false;
-        }
-        return m_object == other.object();
-    }
+    bool operator==(Value other) const;
 
     bool operator!=(Value other) const {
         return !(*this == other);

--- a/lib/natalie/compiler/instructions/dup_object_instruction.rb
+++ b/lib/natalie/compiler/instructions/dup_object_instruction.rb
@@ -8,7 +8,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:duplicated_value, "#{transform.peek}->dup(env)")
+        transform.exec_and_push(:duplicated_value, "#{transform.peek}->duplicate(env)")
       end
 
       def execute(vm)

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -1216,7 +1216,7 @@ Value OpenSSL_X509_Name_initialize(Env *env, Value self, Args args, Block *) {
         for (auto entry : *args.at(0)->to_ary(env)) {
             ArrayObject *add_entry_args = entry->to_ary(env);
             if (args.size() >= 2 && add_entry_args->size() == 2) {
-                add_entry_args = add_entry_args->dup(env)->as_array();
+                add_entry_args = add_entry_args->duplicate(env)->as_array();
                 add_entry_args->push(lookup->ref(env, add_entry_args->at(0)));
             }
             OpenSSL_X509_Name_add_entry(env, self, Args(add_entry_args), nullptr);

--- a/spec/core/string/dup_spec.rb
+++ b/spec/core/string/dup_spec.rb
@@ -10,9 +10,7 @@ describe "String#dup" do
   it "calls #initialize_copy on the new instance" do
     dup = @obj.dup
     ScratchPad.recorded.should_not == @obj.object_id
-    NATFIXME 'call initialize_copy on the new instance', exception: SpecFailedException do
-      ScratchPad.recorded.should == dup.object_id
-    end
+    ScratchPad.recorded.should == dup.object_id
   end
 
   it "copies instance variables" do

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -63,7 +63,7 @@ ArrayObject *Args::to_array() const {
 
 ArrayObject *Args::to_array_for_block(Env *env, ssize_t min_count, ssize_t max_count, bool spread) const {
     if (m_data.size() == 1 && spread) {
-        auto ary = to_ary(env, m_data[0], true)->dup(env)->as_array();
+        auto ary = to_ary(env, m_data[0], true)->duplicate(env)->as_array();
         ssize_t count = ary->size();
         if (max_count != -1 && count > max_count)
             ary->truncate(max_count);

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -36,7 +36,7 @@ Value DirObject::initialize(Env *env, Value path, Value encoding) {
     } else {
         m_encoding = EncodingObject::filesystem();
     }
-    m_path = path->as_string()->dup(env)->as_string();
+    m_path = path->as_string()->duplicate(env)->as_string();
     assert(m_path);
     return this;
 }
@@ -285,7 +285,7 @@ Value DirObject::home(Env *env, Value username) {
         // no argument version
         Value home_str = new StringObject { "HOME" };
         Value home_dir = GlobalEnv::the()->Object()->const_fetch("ENV"_s).send(env, "fetch"_s, { home_str });
-        return home_dir->dup(env);
+        return home_dir->duplicate(env);
     }
 }
 bool DirObject::is_empty(Env *env, Value dirname) {

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -87,9 +87,9 @@ HashObject *EncodingObject::aliases(Env *env) {
         if (names->size() < 2)
             continue;
 
-        auto original = (*names)[0]->dup(env);
+        auto original = (*names)[0]->duplicate(env);
         for (size_t i = 1; i < names->size(); ++i)
-            aliases->put(env, (*names)[i]->dup(env), original);
+            aliases->put(env, (*names)[i]->duplicate(env), original);
     }
     return aliases;
 }

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -24,7 +24,7 @@ bool HashObject::is_ruby2_keywords_hash(Env *env, Value hash) {
 }
 
 Value HashObject::ruby2_keywords_hash(Env *env, Value hash) {
-    auto result = hash->as_hash_or_raise(env)->dup(env)->as_hash();
+    auto result = hash->as_hash_or_raise(env)->duplicate(env)->as_hash();
     result->m_is_ruby2_keywords_hash = true;
     return result;
 }
@@ -87,7 +87,7 @@ void HashObject::put(Env *env, Value key, Value val) {
     assert_not_frozen(env);
     Key key_container;
     if (!m_is_comparing_by_identity && key->is_string() && !key->is_frozen()) {
-        key = key->as_string()->dup(env);
+        key = key->as_string()->duplicate(env);
     }
     key_container.key = key;
 
@@ -664,7 +664,7 @@ bool HashObject::has_value(Env *env, Value value) {
 }
 
 Value HashObject::merge(Env *env, Args args, Block *block) {
-    return dup(env)->as_hash()->merge_in_place(env, args, block);
+    return duplicate(env)->as_hash()->merge_in_place(env, args, block);
 }
 
 Value HashObject::merge_in_place(Env *env, Args args, Block *block) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -354,13 +354,13 @@ Value KernelModule::hash(Env *env) {
 }
 
 Value KernelModule::initialize_copy(Env *env, Value object) {
-    if (this->send(env, "=="_s, { object })->is_truthy()) {
+    if (object == this)
         return this;
-    }
+
     this->assert_not_frozen(env);
-    if (m_klass != object->klass()) {
+    if (m_klass != object->klass())
         env->raise("TypeError", "initialize_copy should take same class object");
-    }
+
     return this;
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -170,6 +170,7 @@ Value KernelModule::dup(Env *env) {
     // classes that have their own `initialize_copy` method get the `dup_better` code path,
     // while the rest get the old, wrong code path.
     switch (type()) {
+    case Object::Type::Array:
     case Object::Type::String:
         return dup_better(env);
     default:

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -164,6 +164,10 @@ Value KernelModule::define_singleton_method(Env *env, Value name, Block *block) 
     return name_obj;
 }
 
+Value KernelModule::dup(Env *env) {
+    return duplicate(env);
+}
+
 Value KernelModule::exit(Env *env, Value status) {
     if (!status || status->is_true()) {
         status = Value::integer(0);

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -51,7 +51,7 @@ Value Method::call(Env *env, Value self, Args args, Block *block) const {
         }
     } else if (self->is_synthesized()) {
         // Turn this object into a heap-allocated one.
-        self = self->dup(env);
+        self = self->duplicate(env);
     }
 
     return call_fn(args);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -623,12 +623,12 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
 
 Value to_ary_for_masgn(Env *env, Value obj) {
     if (obj->is_array())
-        return obj->dup(env);
+        return obj->duplicate(env);
 
     if (obj->respond_to(env, "to_ary"_s)) {
         auto array = obj.send(env, "to_ary"_s);
         if (array->is_array()) {
-            return array->dup(env);
+            return array->duplicate(env);
         } else if (!array->is_nil()) {
             auto class_name = obj->klass()->inspect_str();
             env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array->klass()->inspect_str());
@@ -707,9 +707,9 @@ std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs, CoerceInvalidRetu
     auto coerce_symbol = "coerce"_s;
     if (lhs->respond_to(env, coerce_symbol)) {
         if (lhs->is_synthesized())
-            lhs = lhs->dup(env);
+            lhs = lhs->duplicate(env);
         if (rhs->is_synthesized())
-            rhs = rhs->dup(env);
+            rhs = rhs->duplicate(env);
         Value coerced = lhs.send(env, coerce_symbol, { rhs });
         if (!coerced->is_array()) {
             if (invalid_return_value_mode == CoerceInvalidReturnValueMode::Raise)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1006,7 +1006,7 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
     return nullptr;
 }
 
-Value Object::dup(Env *env) const {
+Value Object::duplicate(Env *env) const {
     switch (m_type) {
     case Object::Type::Array:
         return new ArrayObject { *as_array() };
@@ -1071,7 +1071,7 @@ Value Object::clone(Env *env, Value freeze) {
         }
     }
 
-    auto duplicate = this->dup(env);
+    auto duplicate = this->duplicate(env);
     if (!duplicate->singleton_class()) {
         auto s_class = singleton_class();
         if (s_class) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1061,10 +1061,6 @@ Value Object::dup(Env *env) const {
     }
 }
 
-Value Object::clone(Env *env) {
-    return this->clone(env, nullptr);
-}
-
 Value Object::clone(Env *env, Value freeze) {
     bool freeze_bool = true;
     if (freeze) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1094,6 +1094,15 @@ Value Object::clone(Env *env, Value freeze) {
     return duplicate;
 }
 
+void Object::copy_instance_variables(const Value other) {
+    auto other_obj = other.object_or_null();
+    assert(other_obj);
+    if (m_ivars)
+        delete m_ivars;
+    if (other_obj->m_ivars)
+        m_ivars = new TM::Hashmap<SymbolObject *, Value> { *other_obj->m_ivars };
+}
+
 bool Object::is_a(Env *env, Value val) const {
     if (!val->is_module()) return false;
     ModuleObject *module = val->as_module();

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -398,7 +398,7 @@ Value StringObject::to_sym(Env *env) const {
 }
 
 Value StringObject::tr(Env *env, Value from_value, Value to_value) const {
-    auto copy = dup(env)->as_string();
+    auto copy = duplicate(env)->as_string();
     copy->tr_in_place(env, from_value, to_value);
     return copy;
 }
@@ -848,7 +848,7 @@ Value StringObject::crypt(Env *env, Value salt) {
 }
 
 Value StringObject::delete_str(Env *env, Args selectors) {
-    auto dup = this->dup(env)->as_string();
+    auto dup = this->duplicate(env)->as_string();
     auto result = dup->delete_in_place(env, std::move(selectors));
     if (result->is_nil())
         return dup;
@@ -1076,7 +1076,7 @@ Value StringObject::size(Env *env) const {
 
 Value StringObject::encode(Env *env, Value encoding) {
     auto orig_encoding = m_encoding;
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     EncodingObject *encoding_obj = EncodingObject::find_encoding(env, encoding);
     return encoding_obj->encode(env, orig_encoding, copy);
 }
@@ -2389,7 +2389,7 @@ Value StringObject::split(Env *env, RegexpObject *splitter, int max_count) {
     OnigRegion *region = onig_region_new();
     int result = splitter->as_regexp()->search(string(), 0, region, ONIG_OPTION_NONE);
     if (result == ONIG_MISMATCH) {
-        ary->push(dup(env));
+        ary->push(duplicate(env));
     } else {
         do {
             index = region->beg[0];
@@ -2416,7 +2416,7 @@ Value StringObject::split(Env *env, StringObject *splitstr, int max_count) {
     assert(splitlen > 0);
     nat_int_t index = index_int(env, splitstr, 0);
     if (index == -1) {
-        ary->push(dup(env));
+        ary->push(duplicate(env));
     } else {
         do {
             size_t u_index = static_cast<size_t>(index);
@@ -2461,7 +2461,7 @@ Value StringObject::split(Env *env, Value splitter, Value max_count_value) {
     if (length() == 0) {
         return ary;
     } else if (max_count == 1 || splitter->is_nil()) {
-        ary->push(dup(env));
+        ary->push(duplicate(env));
     } else if (splitter->is_regexp()) {
         // special empty-split-regexp case, just return characters
         if (splitter->as_regexp()->pattern() == "") {
@@ -2550,7 +2550,7 @@ static Value lines_inner(Value self, EncodingObject *encoding, bool is_each_line
 
     const auto chomp = chomp_value ? chomp_value->is_truthy() : false;
     size_t last_index = 0;
-    auto self_dup = self->dup(env)->as_string();
+    auto self_dup = self->duplicate(env)->as_string();
     auto index = self_dup->index_int(env, separator->as_string(), 0);
 
     auto run_split = [&](auto callback) {
@@ -2616,7 +2616,7 @@ Value StringObject::ljust(Env *env, Value length_obj, Value pad_obj) const {
     if (padstr->string().is_empty())
         env->raise("ArgumentError", "zero width padding");
 
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     while (copy->length() < length) {
         bool truncate = copy->length() + padstr->length() > length;
         copy->append(padstr);
@@ -2726,7 +2726,7 @@ Value StringObject::rjust(Env *env, Value length_obj, Value pad_obj) const {
     }
 
     StringObject *str_with_padding = new StringObject { "", m_encoding };
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     str_with_padding->append(padding);
     str_with_padding->append(copy);
 
@@ -2879,7 +2879,7 @@ StringObject *StringObject::capitalize(Env *env, Value arg1, Value arg2) {
 
 Value StringObject::capitalize_in_place(Env *env, Value arg1, Value arg2) {
     assert_not_frozen(env);
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *capitalize(env, arg1, arg2)->as_string();
     if (*this == *copy) {
         return Value(NilObject::the());
@@ -2918,7 +2918,7 @@ StringObject *StringObject::downcase(Env *env, Value arg1, Value arg2) {
 
 Value StringObject::downcase_in_place(Env *env, Value arg1, Value arg2) {
     assert_not_frozen(env);
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *downcase(env, arg1, arg2)->as_string();
 
     if (*this == *copy) {
@@ -2951,7 +2951,7 @@ StringObject *StringObject::upcase(Env *env, Value arg1, Value arg2) {
 
 Value StringObject::upcase_in_place(Env *env, Value arg1, Value arg2) {
     assert_not_frozen(env);
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *upcase(env, arg1, arg2)->as_string();
 
     if (*this == *copy) {
@@ -2985,7 +2985,7 @@ StringObject *StringObject::swapcase(Env *env, Value arg1, Value arg2) {
 
 Value StringObject::swapcase_in_place(Env *env, Value arg1, Value arg2) {
     assert_not_frozen(env);
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *swapcase(env, arg1, arg2)->as_string();
     if (*this == *copy) {
         return Value(NilObject::the());
@@ -2995,7 +2995,7 @@ Value StringObject::swapcase_in_place(Env *env, Value arg1, Value arg2) {
 
 Value StringObject::uplus(Env *env) {
     if (this->is_frozen()) {
-        return this->dup(env);
+        return this->duplicate(env);
     } else {
         return this;
     }
@@ -3005,7 +3005,7 @@ Value StringObject::uminus(Env *env) {
     if (this->is_frozen()) {
         return this;
     }
-    auto duplicate = this->dup(env);
+    auto duplicate = this->duplicate(env);
     duplicate->freeze();
     return duplicate;
 }
@@ -3399,13 +3399,13 @@ Value StringObject::delete_prefix(Env *env, Value val) {
         return after_delete;
     }
 
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     return copy;
 }
 
 Value StringObject::delete_prefix_in_place(Env *env, Value val) {
     assert_not_frozen(env);
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *delete_prefix(env, val)->as_string();
 
     if (*this == *copy) {
@@ -3424,13 +3424,13 @@ Value StringObject::delete_suffix(Env *env, Value val) {
         return new StringObject { c_str(), length() - arg_len, m_encoding };
     }
 
-    return dup(env)->as_string();
+    return duplicate(env)->as_string();
 }
 
 Value StringObject::delete_suffix_in_place(Env *env, Value val) {
     assert_not_frozen(env);
 
-    StringObject *copy = dup(env)->as_string();
+    StringObject *copy = duplicate(env)->as_string();
     *this = *delete_suffix(env, val)->as_string();
 
     if (*this == *copy) {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -114,6 +114,44 @@ nat_int_t Value::as_fast_integer() const {
     return m_object->as_integer()->to_nat_int_t();
 }
 
+bool Value::operator==(Value other) const {
+    switch (m_type) {
+    case Type::Integer: {
+        switch (other.m_type) {
+        case Type::Integer:
+            return m_integer == other.m_integer;
+        case Type::Double:
+            return false;
+        default: {
+            if (other && other->is_integer()) {
+                auto i = other->as_integer();
+                if (i->is_fixnum())
+                    return m_integer == i->to_nat_int_t();
+            }
+            return false;
+        }
+        }
+    }
+    case Type::Double: {
+        switch (other.m_type) {
+        case Type::Integer:
+            return false;
+        case Type::Double:
+            return m_double == other.m_double;
+        default: {
+            if (other && other->is_float()) {
+                auto f = other->as_float();
+                return m_double == f->to_double();
+            }
+            return false;
+        }
+        }
+    }
+    default:
+        return m_object == other.m_object;
+    }
+}
+
 #undef PROFILED_SEND
 
 }

--- a/test/ruby/ruby_specs_test.rb
+++ b/test/ruby/ruby_specs_test.rb
@@ -31,7 +31,7 @@ describe 'ruby/spec' do
         out_nat = Timeout.timeout(spec_timeout, nil, "execution expired running: #{path}") do
           `#{NAT_BINARY} #{path} 2>&1`
         end
-        puts out_nat unless $?.success?
+        puts out_nat if ENV['DEBUG'] || !$?.success?
         expect($?).must_be :success?
         expect(out_nat).wont_match(/traceback|error/i)
       end


### PR DESCRIPTION
#217

I had to go down a rabbit trail on this one to figure out how `Kernel#dup` works along with `initialize_dup` and `initialize_copy`. This blog post was helpful: https://jonleighton.name/2011/initialize_clone-initialize_dup-and-initialize_copy-in-ruby/