### PR TITLE
First step to support pattern matching

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1999,6 +1999,20 @@ module Natalie
         instructions
       end
 
+      def transform_match_required_node(node, used:)
+        unless node.pattern.is_a?(Prism::LocalVariableTargetNode)
+          raise SyntaxError, "Pattern not yet supported: #{node.pattern.inspect}"
+        end
+
+        instructions = [
+          VariableDeclareInstruction.new(node.pattern.name),
+          transform_expression(node.value, used: true),
+          VariableSetInstruction.new(node.pattern.name),
+        ]
+        instructions << PushNilInstruction.new if used
+        instructions
+      end
+
       def transform_match_write_node(node, used:)
         instructions = []
         instructions << transform_expression(node.call, used: used)

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -1,0 +1,15 @@
+require_relative '../spec_helper'
+
+# NATFIXME: Temprorary file until we can run some things in `language/pattern_matching_spec.rb`
+describe 'pattern matching' do
+  it 'can assign a single value' do
+    1 => a
+    a.should == 1
+  end
+
+  it 'has no used mode, always returns nil' do
+    # (1 => a).should is a parse error, so use a lambda instead
+    l = -> { 1 => a }
+    l.call.should be_nil
+  end
+end


### PR DESCRIPTION
This supports the following syntax:
```ruby
expression => variable
```
Which is pretty much just an assignment written the other way around.

This is the first step in a very long process to add pattern matching to Natalie