### PR TITLE
Extract transform_match_required_node into its own class

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -3,6 +3,7 @@ require_relative './arity'
 require_relative './base_pass'
 require_relative './const_prepper'
 require_relative './multiple_assignment'
+require_relative './transformers/match_required_node'
 
 module Natalie
   class Compiler
@@ -2000,72 +2001,10 @@ module Natalie
       end
 
       def transform_match_required_node(node, used:)
-        case node.pattern.type
-        when :local_variable_target_node
-          instructions = [
-            VariableDeclareInstruction.new(node.pattern.name),
-            transform_expression(node.value, used: true),
-            VariableSetInstruction.new(node.pattern.name),
-          ]
-          instructions << PushNilInstruction.new if used
-          instructions
-        when :constant_path_node, :constant_read_node
-          instructions = [
-            transform_expression(node.value, used: true),
-            DupInstruction.new, # Required for the error message
-            transform_constant_path_node(node.pattern, used: true),
-            SwapInstruction.new,
-            PushArgcInstruction.new(1),
-            SendInstruction.new(
-              :===,
-              args_array_on_stack: false,
-              receiver_is_self: false,
-              with_block: false,
-              has_keyword_hash: false,
-              file: @file.path,
-              line: node.location.start_line,
-            ),
-            IfInstruction.new,
-            PopInstruction.new,
-            ElseInstruction.new(:if),
-            # Comments are for stack of `1 => String`
-            DupInstruction.new, # [1, 1]
-            PushStringInstruction.new(''), # [1, 1, '']
-            SwapInstruction.new, # [1, '', 1']
-            StringAppendInstruction.new, # [1, '1'],
-            PushStringInstruction.new(': '), # [1, '1', ': ']
-            StringAppendInstruction.new, # [1, '1: ']
-            transform_constant_path_node(node.pattern, used: true), # [1, '1: ', String]
-            StringAppendInstruction.new, # [1, '1: String']
-            PushStringInstruction.new(' === '), # [1, '1: String', ' === ']
-            StringAppendInstruction.new, # [1, '1: String === ']
-            SwapInstruction.new, # ['1: String === ', 1]
-            StringAppendInstruction.new, # ['1: String === 1']
-            PushStringInstruction.new(' does not return true'),
-            StringAppendInstruction.new,
-            PushSelfInstruction.new, # [msg, self],
-            SwapInstruction.new, # [self, msg]
-            PushSelfInstruction.new, # [self, msg, self]
-            ConstFindInstruction.new(:NoMatchingPatternError, strict: false), # [self, msg, NoMatchingPatternError]
-            SwapInstruction.new, # [self, NoMatchingPatternError, msg]
-            PushArgcInstruction.new(2),
-            SendInstruction.new(
-              :raise,
-              args_array_on_stack: false,
-              receiver_is_self: true,
-              with_block: false,
-              has_keyword_hash: false,
-              file: @file.path,
-              line: node.location.start_line,
-            ),
-            EndInstruction.new(:if),
-            PopInstruction.new,
-          ]
-          instructions << PushNilInstruction.new if used
-          instructions
-        else
-          raise SyntaxError, "Pattern not yet supported: #{node.pattern.inspect}"
-        end
+        match_required_node_compiler = Transformers::MatchRequiredNode.new(self)
+        instructions = node.accept(match_required_node_compiler)
+        instructions << PushNilInstruction.new if used
+        instructions
       end
 
       def transform_match_write_node(node, used:)

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -10,7 +10,7 @@ module Natalie
           @compiler = compiler
         end
 
-        def visit_constant_path_node(node)
+        def method_missing(_method, node)
           [
             compiler.transform_expression(value, used: true),
             DupInstruction.new, # Required for the error message
@@ -63,7 +63,10 @@ module Natalie
             PopInstruction.new,
           ]
         end
-        alias visit_constant_read_node visit_constant_path_node
+
+        def visit_array_pattern_node(node)
+          raise SyntaxError, "Pattern not yet supported: #{node.inspect}"
+        end
 
         def visit_local_variable_target_node(node)
           [
@@ -76,10 +79,6 @@ module Natalie
         def visit_match_required_node(node)
           @value = node.value
           node.pattern.accept(self)
-        end
-
-        def method_missing(_method, node)
-          raise SyntaxError, "Pattern not yet supported: #{node.inspect}"
         end
       end
     end

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Natalie
+  class Compiler
+    module Transformers
+      class MatchRequiredNode
+        attr_reader :compiler, :value
+
+        def initialize(compiler)
+          @compiler = compiler
+        end
+
+        def visit_constant_path_node(node)
+          [
+            compiler.transform_expression(value, used: true),
+            DupInstruction.new, # Required for the error message
+            compiler.transform_expression(node, used: true),
+            SwapInstruction.new,
+            PushArgcInstruction.new(1),
+            SendInstruction.new(
+              :===,
+              args_array_on_stack: false,
+              receiver_is_self: false,
+              with_block: false,
+              has_keyword_hash: false,
+              file: compiler.file.path,
+              line: node.location.start_line,
+            ),
+            IfInstruction.new,
+            PopInstruction.new,
+            ElseInstruction.new(:if),
+            # Comments are for stack of `1 => String`
+            DupInstruction.new, # [1, 1]
+            PushStringInstruction.new(''), # [1, 1, '']
+            SwapInstruction.new, # [1, '', 1']
+            StringAppendInstruction.new, # [1, '1'],
+            PushStringInstruction.new(': '), # [1, '1', ': ']
+            StringAppendInstruction.new, # [1, '1: ']
+            compiler.transform_expression(node, used: true), # [1, '1: ', String]
+            StringAppendInstruction.new, # [1, '1: String']
+            PushStringInstruction.new(' === '), # [1, '1: String', ' === ']
+            StringAppendInstruction.new, # [1, '1: String === ']
+            SwapInstruction.new, # ['1: String === ', 1]
+            StringAppendInstruction.new, # ['1: String === 1']
+            PushStringInstruction.new(' does not return true'),
+            StringAppendInstruction.new,
+            PushSelfInstruction.new, # [msg, self],
+            SwapInstruction.new, # [self, msg]
+            PushSelfInstruction.new, # [self, msg, self]
+            ConstFindInstruction.new(:NoMatchingPatternError, strict: false), # [self, msg, NoMatchingPatternError]
+            SwapInstruction.new, # [self, NoMatchingPatternError, msg]
+            PushArgcInstruction.new(2),
+            SendInstruction.new(
+              :raise,
+              args_array_on_stack: false,
+              receiver_is_self: true,
+              with_block: false,
+              has_keyword_hash: false,
+              file: compiler.file.path,
+              line: node.location.start_line,
+            ),
+            EndInstruction.new(:if),
+            PopInstruction.new,
+          ]
+        end
+        alias visit_constant_read_node visit_constant_path_node
+
+        def visit_local_variable_target_node(node)
+          [
+            VariableDeclareInstruction.new(node.name),
+            compiler.transform_expression(@value, used: true),
+            VariableSetInstruction.new(node.name),
+          ]
+        end
+
+        def visit_match_required_node(node)
+          @value = node.value
+          node.pattern.accept(self)
+        end
+
+        def method_missing(_method, node)
+          raise SyntaxError, "Pattern not yet supported: #{node.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -21,6 +21,14 @@ describe 'pattern matching' do
     -> { 1.0 / 0.0 => Float::INFINITY }.should_not raise_error(NoMatchingPatternError)
   end
 
+  it 'can match against anything that implements #===' do
+    1 => 1
+    -> { 1 => 2 }.should raise_error(NoMatchingPatternError, '1: 2 === 1 does not return true')
+
+    1 => (1..10)
+    -> { 1 => (2..10) }.should raise_error(NoMatchingPatternError, '1: 2..10 === 1 does not return true')
+  end
+
   it 'has no used mode, always returns nil' do
     # (1 => a).should is a parse error, so use a lambda instead
     l = -> { 1 => Integer }


### PR DESCRIPTION
This will make it easier to rewrite this code, especially since we might be rewriting this code into something that works on a different level.

This is in preparation of the plans to generate Ruby code. Since that code will work at a totally different level than the instructions generated in Pass1, it will be cleaner to split that up. This would make it easier to add tests for the transformer as well.