### PR TITLE
Pattern match refactor

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2002,7 +2002,7 @@ module Natalie
 
       def transform_match_required_node(node, used:)
         match_required_node_compiler = Transformers::MatchRequiredNode.new(self)
-        instructions = node.accept(match_required_node_compiler)
+        instructions = match_required_node_compiler.call(node)
         instructions << PushNilInstruction.new if used
         instructions
       end

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -63,8 +63,8 @@ module Natalie
             StringAppendInstruction.new,
             PushSelfInstruction.new, # [msg, self],
             SwapInstruction.new, # [self, msg]
-            PushSelfInstruction.new, # [self, msg, self]
-            ConstFindInstruction.new(:NoMatchingPatternError, strict: false), # [self, msg, NoMatchingPatternError]
+            PushObjectClassInstruction.new, # [self, msg, Object]
+            ConstFindInstruction.new(:NoMatchingPatternError, strict: true), # [self, msg, NoMatchingPatternError]
             SwapInstruction.new, # [self, NoMatchingPatternError, msg]
             PushArgcInstruction.new(2),
             SendInstruction.new(

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -10,6 +10,17 @@ module Natalie
           @compiler = compiler
         end
 
+        def call(node)
+          case node.pattern.type
+          when :array_pattern_node
+            visit_array_pattern_node(node.pattern, node.value)
+          when :local_variable_target_node
+            visit_local_variable_target_node(node.pattern, node.value)
+          else
+            eqeqeq_check(node.pattern, node.value)
+          end
+        end
+
         def eqeqeq_check(node, value)
           [
             compiler.transform_expression(value, used: true),
@@ -74,17 +85,6 @@ module Natalie
             compiler.transform_expression(value, used: true),
             VariableSetInstruction.new(node.name),
           ]
-        end
-
-        def visit_match_required_node(node)
-          case node.pattern.type
-          when :array_pattern_node
-            visit_array_pattern_node(node.pattern, node.value)
-          when :local_variable_target_node
-            visit_local_variable_target_node(node.pattern, node.value)
-          else
-            eqeqeq_check(node.pattern, node.value)
-          end
         end
       end
     end

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -10,7 +10,7 @@ module Natalie
           @compiler = compiler
         end
 
-        def method_missing(_method, node)
+        def eqeqeq_check(node)
           [
             compiler.transform_expression(value, used: true),
             DupInstruction.new, # Required for the error message
@@ -78,7 +78,14 @@ module Natalie
 
         def visit_match_required_node(node)
           @value = node.value
-          node.pattern.accept(self)
+          case node.pattern.type
+          when :array_pattern_node
+            visit_array_pattern_node(node.pattern)
+          when :local_variable_target_node
+            visit_local_variable_target_node(node.pattern)
+          else
+            eqeqeq_check(node.pattern)
+          end
         end
       end
     end

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -13,15 +13,21 @@ module Natalie
         def call(node)
           case node.pattern.type
           when :array_pattern_node
-            visit_array_pattern_node(node.pattern, node.value)
+            transform_array_pattern_node(node.pattern, node.value)
           when :local_variable_target_node
-            visit_local_variable_target_node(node.pattern, node.value)
+            transform_local_variable_target_node(node.pattern, node.value)
           else
-            eqeqeq_check(node.pattern, node.value)
+            transform_eqeqeq_check(node.pattern, node.value)
           end
         end
 
-        def eqeqeq_check(node, value)
+        private
+
+        def transform_array_pattern_node(node, _value)
+          raise SyntaxError, "Pattern not yet supported: #{node.inspect}"
+        end
+
+        def transform_eqeqeq_check(node, value)
           [
             compiler.transform_expression(value, used: true),
             DupInstruction.new, # Required for the error message
@@ -75,11 +81,7 @@ module Natalie
           ]
         end
 
-        def visit_array_pattern_node(node, _value)
-          raise SyntaxError, "Pattern not yet supported: #{node.inspect}"
-        end
-
-        def visit_local_variable_target_node(node, value)
+        def transform_local_variable_target_node(node, value)
           [
             VariableDeclareInstruction.new(node.name),
             compiler.transform_expression(value, used: true),

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -7,6 +7,23 @@ describe 'pattern matching' do
     a.should == 1
   end
 
+  it 'does not define a local variable if the expression fails' do
+    -> {
+      (raise RuntimeError, 'expected error'; 2) => a
+    }.should raise_error(RuntimeError, 'expected error')
+    -> { a }.should raise_error(NameError, /undefined (?:local variable or )?method `a' for main/)
+  end
+
+  it 'does not change an existing variable if the expression fails' do
+    a = 1
+    2 => a
+    a.should == 2
+    -> {
+      (raise RuntimeError, 'expected error'; 3) => a
+    }.should raise_error(RuntimeError, 'expected error')
+    a.should == 2
+  end
+
   it 'has no used mode, always returns nil' do
     # (1 => a).should is a parse error, so use a lambda instead
     l = -> { 1 => a }


### PR DESCRIPTION
Rewrite the `expr => var` statement into Ruby, 

The current construction with the lambda looks like overkill for something that could be written with just an assignment, but will (probably) be useful in the next steps.