### PR TITLE
Add :invalid and :replace options to String#encode

### DIFF
--- a/include/natalie/encoding/utf8_encoding_object.hpp
+++ b/include/natalie/encoding/utf8_encoding_object.hpp
@@ -23,6 +23,8 @@ public:
         return codepoint >= 0 && codepoint < 0x110000;
     }
 
+    virtual std::tuple<bool, int, nat_int_t> next_codepoint(const String &, size_t *) const override;
+
     virtual std::pair<bool, StringView> prev_char(const String &string, size_t *index) const override;
     virtual std::pair<bool, StringView> next_char(const String &string, size_t *index) const override;
 

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -69,6 +69,8 @@ public:
 
     virtual bool valid_codepoint(nat_int_t codepoint) const = 0;
 
+    virtual std::tuple<bool, int, nat_int_t> next_codepoint(const String &, size_t *) const;
+
     virtual std::pair<bool, StringView> prev_char(const String &, size_t *) const = 0;
     virtual std::pair<bool, StringView> next_char(const String &, size_t *) const = 0;
 

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -77,6 +77,11 @@ public:
         return view;
     }
 
+    enum class EncodeInvalidOption {
+        Raise,
+        Replace,
+    };
+
     enum class EncodeNewlineOption {
         None,
         Cr,
@@ -85,6 +90,7 @@ public:
     };
 
     typedef struct EncodeOptions {
+        EncodeInvalidOption invalid_option = EncodeInvalidOption::Raise;
         EncodeNewlineOption newline_option = EncodeNewlineOption::None;
     } EncodeOptions;
 

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -94,6 +94,7 @@ public:
     typedef struct EncodeOptions {
         EncodeInvalidOption invalid_option = EncodeInvalidOption::Raise;
         EncodeNewlineOption newline_option = EncodeNewlineOption::None;
+        StringObject *replace_option = nullptr;
     } EncodeOptions;
 
     virtual Value encode(Env *, EncodingObject *, StringObject *, EncodeOptions) const;

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -83,7 +83,12 @@ public:
         Crlf,
         Universal,
     };
-    virtual Value encode(Env *, EncodingObject *, StringObject *, EncodeNewlineOption = EncodeNewlineOption::None) const;
+
+    typedef struct EncodeOptions {
+        EncodeNewlineOption newline_option = EncodeNewlineOption::None;
+    } EncodeOptions;
+
+    virtual Value encode(Env *, EncodingObject *, StringObject *, EncodeOptions) const;
 
     virtual bool is_printable_char(const nat_int_t c) const;
     virtual String escaped_char(const nat_int_t c) const = 0;

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -57,7 +57,7 @@ public:
     [[noreturn]] void raise_local_jump_error(Value, LocalJumpErrorType, nat_int_t break_point = 0);
     [[noreturn]] void raise_errno();
     [[noreturn]] void raise_errno(StringObject *);
-    [[noreturn]] void raise_invalid_byte_sequence_error(EncodingObject *);
+    [[noreturn]] void raise_invalid_byte_sequence_error(const EncodingObject *);
     [[noreturn]] void raise_no_method_error(Object *, SymbolObject *, MethodMissingReason);
     [[noreturn]] void raise_name_error(SymbolObject *name, String);
     [[noreturn]] void raise_name_error(StringObject *name, String);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -509,6 +509,7 @@ private:
     using Object::Object;
 
     using EncodeOptions = EncodingObject::EncodeOptions;
+    using EncodeInvalidOption = EncodingObject::EncodeInvalidOption;
     using EncodeNewlineOption = EncodingObject::EncodeNewlineOption;
 
     String m_string {};

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -508,6 +508,7 @@ private:
 
     using Object::Object;
 
+    using EncodeOptions = EncodingObject::EncodeOptions;
     using EncodeNewlineOption = EncodingObject::EncodeNewlineOption;
 
     String m_string {};

--- a/spec/core/string/encode_spec.rb
+++ b/spec/core/string/encode_spec.rb
@@ -56,11 +56,9 @@ describe "String#encode" do
 
   describe "when passed options" do
     it "returns a copy when Encoding.default_internal is nil" do
-      NATFIXME 'encode options' do
-        Encoding.default_internal = nil
-        str = "あ"
-        str.encode(invalid: :replace).should_not equal(str)
-      end
+      Encoding.default_internal = nil
+      str = "あ"
+      str.encode(invalid: :replace).should_not equal(str)
     end
 
     it "normalizes newlines with cr_newline option" do
@@ -185,12 +183,10 @@ describe "String#encode" do
 
   describe "when passed to, from, options" do
     it "returns a copy when both encodings are the same" do
-      NATFIXME 'encode options' do
-        str = "あ"
-        encoded = str.encode("utf-8", "utf-8", invalid: :replace)
-        encoded.should_not equal(str)
-        encoded.should == str
-      end
+      str = "あ"
+      encoded = str.encode("utf-8", "utf-8", invalid: :replace)
+      encoded.should_not equal(str)
+      encoded.should == str
     end
 
     it "returns a copy in the destination encoding when both encodings are the same" do
@@ -244,11 +240,9 @@ describe "String#encode!" do
 
   describe "when passed options" do
     it "returns self for ASCII-only String when Encoding.default_internal is nil" do
-      NATFIXME 'encode options' do
-        Encoding.default_internal = nil
-        str = +"abc"
-        str.encode!(invalid: :replace).should equal(str)
-      end
+      Encoding.default_internal = nil
+      str = +"abc"
+      str.encode!(invalid: :replace).should equal(str)
     end
   end
 

--- a/spec/core/string/encode_spec.rb
+++ b/spec/core/string/encode_spec.rb
@@ -86,11 +86,9 @@ describe "String#encode" do
     end
 
     it "replaces invalid encoding in source with a specified replacement" do
-      NATFIXME 'encode options' do
-        encoded = "ち\xE3\x81\xFF".encode("UTF-16LE", invalid: :replace, replace: "foo")
-        encoded.should == "\u3061foofoo".encode("UTF-16LE")
-        encoded.encode("UTF-8").should == "ちfoofoo"
-      end
+      encoded = "ち\xE3\x81\xFF".encode("UTF-16LE", invalid: :replace, replace: "foo")
+      encoded.should == "\u3061foofoo".encode("UTF-16LE")
+      encoded.encode("UTF-8").should == "ちfoofoo"
     end
 
     it "replace multiple invalid bytes at the end with a single replacement character" do

--- a/spec/core/string/encode_spec.rb
+++ b/spec/core/string/encode_spec.rb
@@ -80,11 +80,9 @@ describe "String#encode" do
     end
 
     it "replaces invalid encoding in source with default replacement" do
-      NATFIXME 'encode options' do
-        encoded = "ち\xE3\x81\xFF".encode("UTF-16LE", invalid: :replace)
-        encoded.should == "\u3061\ufffd\ufffd".encode("UTF-16LE")
-        encoded.encode("UTF-8").should == "ち\ufffd\ufffd"
-      end
+      encoded = "ち\xE3\x81\xFF".encode("UTF-16LE", invalid: :replace)
+      encoded.should == "\u3061\ufffd\ufffd".encode("UTF-16LE")
+      encoded.encode("UTF-8").should == "ち\ufffd\ufffd"
     end
 
     it "replaces invalid encoding in source with a specified replacement" do

--- a/spec/core/string/shared/encode.rb
+++ b/spec/core/string/shared/encode.rb
@@ -105,11 +105,9 @@ describe :string_encode, shared: true do
     end
 
     it "transcodes to Encoding.default_internal when set" do
-      NATFIXME 'encode options' do
-        Encoding.default_internal = Encoding::UTF_8
-        str = [0xA4, 0xA2].pack('CC').force_encoding Encoding::EUC_JP
-        str.send(@method, invalid: :replace).should == "あ"
-      end
+      Encoding.default_internal = Encoding::UTF_8
+      str = [0xA4, 0xA2].pack('CC').force_encoding Encoding::EUC_JP
+      str.send(@method, invalid: :replace).should == "あ"
     end
 
     it "raises an Encoding::ConverterNotFoundError when no conversion is possible despite 'invalid: :replace, undef: :replace'" do

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -239,7 +239,8 @@ String Utf8EncodingObject::encode_codepoint(nat_int_t codepoint) const {
         buf.append_char(0b10000000 | ((codepoint >> 6) & 0x3f));
         buf.append_char(0b10000000 | (codepoint & 0x3f));
     } else {
-        TM_UNREACHABLE();
+        buf.append_char(0xFF);
+        buf.append_char(0xFD);
     }
     return buf;
 }

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -3,6 +3,136 @@
 
 namespace Natalie {
 
+/*
+    Code point ↔ UTF-8 conversion:
+
+    First code point Last code point Byte 1   Byte 2   Byte 3   Byte 4
+    U+0000           U+007F          0xxxxxxx
+    U+0080           U+07FF          110xxxxx 10xxxxxx
+    U+0800           U+FFFF          1110xxxx 10xxxxxx 10xxxxxx
+    U+10000          U+10FFFF        11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+
+    See: https://en.wikipedia.org/wiki/UTF-8
+*/
+std::tuple<bool, int, nat_int_t> Utf8EncodingObject::next_codepoint(const String &string, size_t *index) const {
+    size_t len = string.size();
+
+    if (*index >= len)
+        return { true, 0, -1 };
+
+    size_t i = *index;
+    unsigned char c = string[i];
+
+    nat_int_t codepoint = 0;
+    int bytes = 0;
+    if ((c >> 3) == 0b11110) { // 11110xxx, 4 bytes
+        codepoint = (c ^ 0xF0) << 18;
+        if (i + 1 < len) codepoint += ((unsigned char)string[i + 1] ^ 0x80) << 12;
+        if (i + 2 < len) codepoint += ((unsigned char)string[i + 2] ^ 0x80) << 6;
+        if (i + 3 < len) codepoint += (unsigned char)string[i + 3] ^ 0x80;
+        bytes = 4;
+    } else if ((c >> 4) == 0b1110) { // 1110xxxx, 3 bytes
+        codepoint = (c ^ 0xE0) << 12;
+        if (i + 1 < len) codepoint += ((unsigned char)string[i + 1] ^ 0x80) << 6;
+        if (i + 2 < len) codepoint += (unsigned char)string[i + 2] ^ 0x80;
+        bytes = 3;
+    } else if ((c >> 5) == 0b110) { // 110xxxxx, 2 bytes
+        codepoint = (c ^ 0xC0) << 6;
+        if (i + 1 < len) codepoint += (unsigned char)string[i + 1] ^ 0x80;
+        bytes = 2;
+    } else if ((c >> 7) == 0b0) { // 0xxxxxxx, 1 byte
+        codepoint = c;
+        bytes = 1;
+    } else { // invalid, 1 byte
+        *index += 1;
+        return { false, 1, c };
+    }
+
+    if (codepoint < 0)
+        abort();
+
+    if (*index + bytes > len) {
+        bytes = len - *index;
+        *index = len;
+        return { false, bytes, codepoint };
+    } else {
+        *index += bytes;
+    }
+
+    // All, but the 1st, bytes should match the format 10xxxxxx
+    for (int j = 1; j < bytes; j++) {
+        unsigned char cj = string[i + j];
+        if (cj >> 6 != 0b10)
+            return { false, bytes, codepoint };
+    }
+
+    bool valid = true;
+
+    // Check whether a codepoint is in a valid range
+    switch (bytes) {
+    case 1:
+        // no check
+        // all values that can be represented with 7 bits (0-127) are correct
+        break;
+    case 2: {
+        // Codepoints range: U+0080..U+07FF
+        // Check the highest 4 significant bits of
+        // 110xxxx-	10------
+        unsigned char extra_bits = (unsigned char)string[i] & 0b11110;
+
+        if (extra_bits == 0) {
+            valid = false;
+            bytes = 1;
+        }
+
+        break;
+    }
+    case 3: {
+        // Codepoints range: U+0800..U+FFFF.
+        // Check the highest 5 significant bits of
+        // 1110xxxx	10x-----	10------
+        //
+        // U+D800..U+DFFF - invalid codepoints
+        // xxxx1101 xx1----- xx------
+        unsigned char extra_bits1 = (unsigned char)string[i] & 0b1111;
+        unsigned char extra_bits2 = (unsigned char)string[i + 1] & 0b100000;
+        unsigned char significant_bits1 = (unsigned char)string[i] & 0b1111;
+        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
+
+        if (extra_bits1 == 0 && extra_bits2 == 0) {
+            valid = false;
+            bytes = 1;
+        } else if (significant_bits1 == 0b1101 && (significant_bits2 >> 5) == 1) {
+            valid = false;
+            bytes = 1;
+        }
+
+        break;
+    }
+    case 4: {
+        // Codepoints range: U+10000..U+10FFFF.
+        // 11110xxx	10xxxxxx 10xxxxxx 10xxxxxx
+        unsigned char significant_bits1 = (unsigned char)string[i] & 0b111;
+        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
+        unsigned char significant_bits3 = (unsigned char)string[i + 2] & 0b111111;
+        unsigned char significant_bits4 = (unsigned char)string[i + 3] & 0b111111;
+
+        int codepoint = significant_bits4 | (significant_bits3 << 6) | (significant_bits2 << 12) | (significant_bits1 << 18);
+
+        if (codepoint < 0x10000 || codepoint > 0x10FFFF) {
+            valid = false;
+            bytes = 1; // TODO: Remove?
+        }
+
+        break;
+    }
+    default:
+        NAT_UNREACHABLE();
+    }
+
+    return { valid, bytes, codepoint };
+}
+
 std::pair<bool, StringView> Utf8EncodingObject::prev_char(const String &string, size_t *index) const {
     if (*index == 0)
         return { true, StringView() };
@@ -25,124 +155,18 @@ std::pair<bool, StringView> Utf8EncodingObject::prev_char(const String &string, 
     return { true, StringView(&string, *index, length) };
 }
 
-/*
-    Code point ↔ UTF-8 conversion:
-
-    First code point Last code point Byte 1   Byte 2   Byte 3   Byte 4
-    U+0000           U+007F          0xxxxxxx
-    U+0080           U+07FF          110xxxxx 10xxxxxx
-    U+0800           U+FFFF          1110xxxx 10xxxxxx 10xxxxxx
-    U+10000          U+10FFFF        11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-
-    See: https://en.wikipedia.org/wiki/UTF-8
-*/
 std::pair<bool, StringView> Utf8EncodingObject::next_char(const String &string, size_t *index) const {
-    size_t len = string.size();
-
-    if (*index >= len)
-        return { true, StringView() };
-
     size_t i = *index;
-    int length = 0;
-    unsigned char c = string[i];
-    bool valid = true;
+    auto [valid, length, codepoint] = next_codepoint(string, index);
 
-    // Check the first byte and determine length
-    if ((c >> 3) == 0b11110) { // 11110xxx, 4 bytes
-        if (i + 3 >= len) {
-            *index += 1;
-            return { false, StringView(&string, i, 1) };
-        }
-        length = 4;
-    } else if ((c >> 4) == 0b1110) { // 1110xxxx, 3 bytes
-        if (i + 2 >= len) {
-            *index += 1;
-            return { false, StringView(&string, i, 1) };
-        }
-        length = 3;
-    } else if ((c >> 5) == 0b110) { // 110xxxxx, 2 bytes
-        if (i + 1 >= len) {
-            *index += 1;
-            return { false, StringView(&string, i, 1) };
-        }
-        length = 2;
-    } else if ((c >> 7) == 0b0) { // 0xxxxxxx, 1 byte
+    if (!valid && length > 1) {
+        // next_codepoint is greedy: invalid characters consume as many bytes as possible.
+        // But String#chars and similar methods only want single bytes for invalid characters.
+        // So reset the index and only consume a single byte.
+        *index = i + 1;
         length = 1;
-    } else {
-        *index += 1;
-        return { false, StringView(&string, i, 1) };
     }
 
-    // All, but the 1st, bytes should match the format 10xxxxxx
-    for (size_t j = i + 1; j <= i + length - 1; j++) {
-        unsigned char cj = string[j];
-        if (cj >> 6 != 0b10) {
-            *index += 1;
-            return { false, StringView(&string, i, 1) };
-        }
-    }
-
-    // Check whether a codepoint is in a valid range
-    switch (length) {
-    case 1:
-        // no check
-        // all values that can be represented with 7 bits (0-127) are correct
-        break;
-    case 2: {
-        // Codepoints range: U+0080..U+07FF
-        // Check the highest 4 significant bits of
-        // 110xxxx-	10------
-        unsigned char extra_bits = (unsigned char)string[i] & 0b11110;
-
-        if (extra_bits == 0) {
-            valid = false;
-            length = 1;
-        }
-
-        break;
-    }
-    case 3: {
-        // Codepoints range: U+0800..U+FFFF.
-        // Check the highest 5 significant bits of
-        // 1110xxxx	10x-----	10------
-        //
-        // U+D800..U+DFFF - invalid codepoints
-        // xxxx1101 xx1----- xx------
-        unsigned char extra_bits1 = (unsigned char)string[i] & 0b1111;
-        unsigned char extra_bits2 = (unsigned char)string[i + 1] & 0b100000;
-        unsigned char significant_bits1 = (unsigned char)string[i] & 0b1111;
-        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
-
-        if (extra_bits1 == 0 && extra_bits2 == 0) {
-            valid = false;
-            length = 1;
-        } else if (significant_bits1 == 0b1101 && (significant_bits2 >> 5) == 1) {
-            valid = false;
-            length = 1;
-        }
-
-        break;
-    }
-    case 4: {
-        // Codepoints range: U+10000..U+10FFFF.
-        // 11110xxx	10xxxxxx 10xxxxxx 10xxxxxx
-        unsigned char significant_bits1 = (unsigned char)string[i] & 0b111;
-        unsigned char significant_bits2 = (unsigned char)string[i + 1] & 0b111111;
-        unsigned char significant_bits3 = (unsigned char)string[i + 2] & 0b111111;
-        unsigned char significant_bits4 = (unsigned char)string[i + 3] & 0b111111;
-
-        int codepoint = significant_bits4 | (significant_bits3 << 6) | (significant_bits2 << 12) | (significant_bits1 << 18);
-
-        if (codepoint < 0x10000 || codepoint > 0x10FFFF) {
-            valid = false;
-            length = 1;
-        }
-
-        break;
-    }
-    }
-
-    *index += length;
     return { valid, StringView(&string, i, length) };
 }
 
@@ -265,5 +289,4 @@ nat_int_t Utf8EncodingObject::decode_codepoint(StringView &str) const {
         return -1;
     }
 }
-
 }

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -50,20 +50,20 @@ std::pair<bool, StringView> Utf8EncodingObject::next_char(const String &string, 
     // Check the first byte and determine length
     if ((c >> 3) == 0b11110) { // 11110xxx, 4 bytes
         if (i + 3 >= len) {
-            *index = len;
-            return { false, StringView(&string, i) };
+            *index += 1;
+            return { false, StringView(&string, i, 1) };
         }
         length = 4;
     } else if ((c >> 4) == 0b1110) { // 1110xxxx, 3 bytes
         if (i + 2 >= len) {
-            *index = len;
-            return { false, StringView(&string, i) };
+            *index += 1;
+            return { false, StringView(&string, i, 1) };
         }
         length = 3;
     } else if ((c >> 5) == 0b110) { // 110xxxxx, 2 bytes
         if (i + 1 >= len) {
-            *index = len;
-            return { false, StringView(&string, i) };
+            *index += 1;
+            return { false, StringView(&string, i, 1) };
         }
         length = 2;
     } else if ((c >> 7) == 0b0) { // 0xxxxxxx, 1 byte

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -59,6 +59,11 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
             case EncodeInvalidOption::Raise:
                 env->raise_invalid_byte_sequence_error(this);
             case EncodeInvalidOption::Replace:
+                if (options.replace_option) {
+                    temp_string.append(options.replace_option);
+                    std::tie(valid, length, c) = orig_encoding->next_codepoint(string, &index);
+                    continue;
+                }
                 unicode_codepoint = 0xFFFD;
             }
         } else {

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -12,8 +12,8 @@ EncodingObject::EncodingObject()
 //
 // TODO:
 // * support encoding options
-Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str, EncodeNewlineOption newline_option) const {
-    if (num() == orig_encoding->num() && newline_option == EncodeNewlineOption::None)
+Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObject *str, EncodeOptions options) const {
+    if (num() == orig_encoding->num() && options.newline_option == EncodeNewlineOption::None)
         return str;
 
     StringObject temp_string = StringObject("", (EncodingObject *)this);
@@ -22,7 +22,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
     size_t index = 0;
     auto [valid, c] = str->next_char_result(&index);
     while (!c.is_empty()) {
-        switch (newline_option) {
+        switch (options.newline_option) {
         case EncodeNewlineOption::None:
             break;
         case EncodeNewlineOption::Cr:

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -270,6 +270,14 @@ Value EncodingObject::inspect(Env *env) const {
     return StringObject::format("#<Encoding:{}>", name());
 }
 
+// Default implementation is pretty dumb; we'll need to override this for
+// every multi-byte encoding, I think.
+std::tuple<bool, int, nat_int_t> EncodingObject::next_codepoint(const String &string, size_t *index) const {
+    auto [valid, view] = next_char(string, index);
+    auto codepoint = view.is_empty() ? 0 : decode_codepoint(view);
+    return { valid, view.length(), codepoint };
+}
+
 Value EncodingObject::locale_charmap() {
     auto codeset = ::nl_langinfo(CODESET);
     assert(codeset);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -149,7 +149,7 @@ void Env::raise_errno(StringObject *detail) {
     raise_exception(error);
 }
 
-void Env::raise_invalid_byte_sequence_error(EncodingObject *encoding) {
+void Env::raise_invalid_byte_sequence_error(const EncodingObject *encoding) {
     auto name = encoding->name()->as_string()->string();
     raise("ArgumentError", "invalid byte sequence in {}", name);
 }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1128,20 +1128,20 @@ Value StringObject::encode_in_place(Env *env, Value dst_encoding, Value src_enco
     if (!dst_encoding)
         dst_encoding = EncodingObject::get(Encoding::UTF_8);
 
-    EncodeNewlineOption newline_option = EncodeNewlineOption::None;
+    EncodeOptions options;
     if (kwargs) {
         if (kwargs->remove(env, "universal_newline"_s))
-            newline_option = EncodeNewlineOption::Universal;
+            options.newline_option = EncodeNewlineOption::Universal;
         else if (kwargs->remove(env, "crlf_newline"_s))
-            newline_option = EncodeNewlineOption::Crlf;
+            options.newline_option = EncodeNewlineOption::Crlf;
         else if (kwargs->remove(env, "cr_newline"_s))
-            newline_option = EncodeNewlineOption::Cr;
+            options.newline_option = EncodeNewlineOption::Cr;
     }
 
     env->ensure_no_extra_keywords(kwargs);
     auto orig_encoding = m_encoding;
     EncodingObject *encoding_obj = EncodingObject::find_encoding(env, dst_encoding);
-    return encoding_obj->encode(env, orig_encoding, this, newline_option);
+    return encoding_obj->encode(env, orig_encoding, this, options);
 }
 
 Value StringObject::force_encoding(Env *env, Value encoding) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1153,6 +1153,10 @@ Value StringObject::encode_in_place(Env *env, Value dst_encoding, Value src_enco
             else if (invalid == "replace"_s)
                 options.invalid_option = EncodeInvalidOption::Replace;
         }
+
+        auto replace = kwargs->remove(env, "replace"_s);
+        if (replace && !replace->is_nil())
+            options.replace_option = replace->as_string_or_raise(env)->encode(env, dst_encoding)->as_string_or_raise(env);
     }
 
     env->ensure_no_extra_keywords(kwargs);

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -201,6 +201,22 @@ describe 'string' do
       s.force_encoding 'ascii-8bit'
       s.chars.map { |c| c.ord }.should == [240, 159, 152, 137, 226, 128, 157, 196, 131, 97]
     end
+
+    it 'returns characters from an improperly-encoded string' do
+      "\xF0\x9F\x98\x81".chars.should == ["😁"] # proper four bytes
+      "\xF0\x9F\x98".chars.should == ["\xF0", "\x9F", "\x98"]
+      "\xF0\x9F".chars.should == ["\xF0", "\x9F"]
+      "\xF0".chars.should == ["\xF0"]
+
+      # second byte doesn't match 10xxxxxx
+      "\xF0x\x9F\x81".chars.should == ["\xF0", "x", "\x9F", "\x81"]
+
+      # third byte doesn't match 10xxxxxx
+      "\xF0\x9Fx\x81".chars.should == ["\xF0", "\x9F", "x", "\x81"]
+
+      # fourth byte doesn't match 10xxxxxx
+      "\xF0\x9F\x98x".chars.should == ["\xF0", "\x9F", "\x98", "x"]
+    end
   end
 
   describe '#[]' do


### PR DESCRIPTION
What a yak shave. 😅 Adding `EncodingObject::next_codepoint()` is a big win though.

#217 