### PR TITLE
Remove typedef from struct EncodeOptions

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -91,11 +91,11 @@ public:
         Universal,
     };
 
-    typedef struct EncodeOptions {
+    struct EncodeOptions {
         EncodeInvalidOption invalid_option = EncodeInvalidOption::Raise;
         EncodeNewlineOption newline_option = EncodeNewlineOption::None;
         StringObject *replace_option = nullptr;
-    } EncodeOptions;
+    };
 
     virtual Value encode(Env *, EncodingObject *, StringObject *, EncodeOptions) const;
 


### PR DESCRIPTION
This is not required in C++

A small cleanup for  #2131. We have a few other occurrences of `typedef struct`, but those are all in `extern "C"` sections, I left those the way they are.