### PR TITLE
Support global variable target in for loop

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -50,6 +50,8 @@ module Natalie
           transform_instance_variable_arg(arg)
         when ::Prism::ClassVariableTargetNode
           transform_class_variable_arg(arg)
+        when ::Prism::GlobalVariableTargetNode
+          transform_global_variable_arg(arg)
         when ::Prism::ConstantTargetNode
           transform_constant_arg(arg)
         when ::Prism::RequiredParameterNode
@@ -172,6 +174,11 @@ module Natalie
       def transform_class_variable_arg(arg)
         @instructions << ArrayShiftInstruction.new
         @instructions << ClassVariableSetInstruction.new(arg.name)
+      end
+
+      def transform_global_variable_arg(arg)
+        @instructions << ArrayShiftInstruction.new
+        @instructions << GlobalVariableSetInstruction.new(arg.name)
       end
 
       def transform_constant_arg(arg)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2671,6 +2671,7 @@ module Natalie
           %i[
             class_variable_target_node
             constant_target_node
+            global_variable_target_node
             instance_variable_target_node
             local_variable_target_node
             multi_target_node

--- a/spec/language/for_spec.rb
+++ b/spec/language/for_spec.rb
@@ -104,6 +104,18 @@ describe "The for expression" do
     end
   end
 
+  it "allows a global variable as an iterator name" do
+    old_global_var = $var
+    m = [1,2,3]
+    n = 0
+    for $var in m
+      n += 1
+    end
+    $var.should == 3
+    n.should == 3
+    $var = old_global_var
+  end
+
   # 1.9 behaviour verified by nobu in
   # http://redmine.ruby-lang.org/issues/show/2053
   it "yields only as many values as there are arguments" do


### PR DESCRIPTION
This includes the pending spec changes in https://github.com/ruby/spec/pull/1163. I will refresh them if upstream requires any additional changes.