### PR TITLE
Allow local variables of LHS in MatchRequiredNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2005,8 +2005,10 @@ module Natalie
       end
 
       def transform_match_required_node(node, used:)
-        match_required_node_compiler = Transformers::MatchRequiredNode.new(self)
-        instructions = match_required_node_compiler.call(node)
+        match_required_node_compiler = Transformers::MatchRequiredNode.new
+        code_str = match_required_node_compiler.call(node)
+        parser = Natalie::Parser.new(code_str, @file.path, locals: current_locals)
+        instructions = transform_expression(parser.ast.statements, used: false)
         instructions << PushNilInstruction.new if used
         instructions
       end

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -109,10 +109,6 @@ module Natalie
         @macro_expander.expand(node, locals: locals, depth: @depth, file: @file)
       end
 
-      def current_locals
-        @locals_stack.last
-      end
-
       def transform_body(body, location:, used:)
         return transform_begin_node(body, used:) if body.is_a?(Prism::BeginNode)
         body = body.body if body.is_a?(Prism::StatementsNode)
@@ -2007,7 +2003,7 @@ module Natalie
       def transform_match_required_node(node, used:)
         match_required_node_compiler = Transformers::MatchRequiredNode.new
         code_str = match_required_node_compiler.call(node)
-        parser = Natalie::Parser.new(code_str, @file.path, locals: current_locals)
+        parser = Natalie::Parser.new(code_str, @file.path, locals: @locals_stack.last)
         instructions = transform_expression(parser.ast.statements, used: false)
         instructions << PushNilInstruction.new if used
         instructions

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -65,7 +65,7 @@ module Natalie
               result
             end.call(#{value.location.slice})
           RUBY
-          parser = Natalie::Parser.new(code_str, compiler.file.path, locals: [node.name])
+          parser = Natalie::Parser.new(code_str, compiler.file.path, locals: compiler.current_locals)
           compiler.transform_expression(parser.ast.statements, used: false)
         end
       end

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -4,23 +4,15 @@ module Natalie
   class Compiler
     module Transformers
       class MatchRequiredNode
-        attr_reader :compiler
-
-        def initialize(compiler)
-          @compiler = compiler
-        end
-
         def call(node)
-          code_str = case node.pattern.type
-                     when :array_pattern_node
-                       transform_array_pattern_node(node.pattern, node.value)
-                     when :local_variable_target_node
-                       transform_local_variable_target_node(node.pattern, node.value)
-                     else
-                       transform_eqeqeq_check(node.pattern, node.value)
-                     end
-          parser = Natalie::Parser.new(code_str, compiler.file.path, locals: compiler.current_locals)
-          compiler.transform_expression(parser.ast.statements, used: false)
+          case node.pattern.type
+          when :array_pattern_node
+            transform_array_pattern_node(node.pattern, node.value)
+          when :local_variable_target_node
+            transform_local_variable_target_node(node.pattern, node.value)
+          else
+            transform_eqeqeq_check(node.pattern, node.value)
+          end
         end
 
         private

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -1,10 +1,30 @@
 require_relative '../spec_helper'
 
+module PatternMatchingHelper
+  def self.one = 1
+end
+
 # NATFIXME: Temprorary file until we can run some things in `language/pattern_matching_spec.rb`
 describe 'pattern matching' do
   it 'can assign a single value' do
     1 => a
     a.should == 1
+  end
+
+  it 'can assign a single value from an expression' do
+    1 + 1 => a
+    a.should == 2
+  end
+
+  it 'can assign a single value from a variable' do
+    a = 1
+    a => b
+    b.should == 1
+  end
+
+  it 'can assign a single value from a method call' do
+   PatternMatchingHelper.one => a
+   a.should == 1
   end
 
   it 'does not define a local variable if the expression fails' do


### PR DESCRIPTION
```ruby
a = 1
a => b
```
This code failed due to the lack of locals information in the code generator. After this bug fix, a few code cleanups/refactors have been done to separate the Ruby code generation from the instruction generation.