### PR TITLE
Scoping fixes for pattern matching

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2003,7 +2003,9 @@ module Natalie
       def transform_match_required_node(node, used:)
         match_required_node_compiler = Transformers::MatchRequiredNode.new
         code_str = match_required_node_compiler.call(node)
-        parser = Natalie::Parser.new(code_str, @file.path, locals: @locals_stack.last)
+        locals = @locals_stack.last
+        locals += [node.value.name] if node.value.is_a?(Prism::LocalVariableReadNode)
+        parser = Natalie::Parser.new(code_str, @file.path, locals:)
         instructions = transform_expression(parser.ast.statements, used: false)
         instructions << PushNilInstruction.new if used
         instructions

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2004,7 +2004,15 @@ module Natalie
         match_required_node_compiler = Transformers::MatchRequiredNode.new
         code_str = match_required_node_compiler.call(node)
         locals = @locals_stack.last
-        locals += [node.value.name] if node.value.is_a?(Prism::LocalVariableReadNode)
+        child_nodes = [node.value]
+        until child_nodes.empty?
+          next_node = child_nodes.shift
+          if next_node.is_a?(Prism::LocalVariableReadNode)
+            locals += [next_node.name]
+          elsif !next_node.nil?
+            child_nodes += next_node.child_nodes
+          end
+        end
         parser = Natalie::Parser.new(code_str, @file.path, locals:)
         instructions = transform_expression(parser.ast.statements, used: false)
         instructions << PushNilInstruction.new if used

--- a/lib/natalie/compiler/transformers/match_required_node.rb
+++ b/lib/natalie/compiler/transformers/match_required_node.rb
@@ -28,7 +28,7 @@ module Natalie
             #{target} = lambda do |result|
               values = result.deconstruct
               if values.size != #{node.requireds.size}
-                raise ::NoMatchingPatternError, "\#{result}: \#{result} length mismatch (given \#{values.size}, expected #{node.requireds.size})"
+                raise ::NoMatchingPatternError, "\#{result}: \#{values} length mismatch (given \#{values.size}, expected #{node.requireds.size})"
               end
               values
             rescue NoMethodError

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -124,8 +124,7 @@ describe 'pattern matching' do
     struct = Struct.new(:a, :b)
     s = struct.new(1, 2)
     -> {
-      s2 = s # NATFIXME: Workaround for scoping issue, we should use `s` directly in the line below
-      s2 => a, b, c
+      s => a, b, c
     }.should raise_error(NoMatchingPatternError, "#{s}: [1, 2] length mismatch (given 2, expected 3)")
   end
 end

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -124,7 +124,8 @@ describe 'pattern matching' do
     struct = Struct.new(:a, :b)
     s = struct.new(1, 2)
     -> {
-      s => a, b, c
+      s2 = s # NATFIXME: Workaround for scoping issue, we should use `s` directly in the line below
+      s2 => a, b, c
     }.should raise_error(NoMatchingPatternError, "#{s}: [1, 2] length mismatch (given 2, expected 3)")
   end
 end

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -100,6 +100,16 @@ describe 'pattern matching' do
     c.should == 3
   end
 
+  it 'can recursively handle local variables' do
+    x = 1
+    y = 2
+    -> {
+      [x, x + y] => a, b
+      a.should == 1
+      b.should == 3
+    }.call
+  end
+
   it 'can handle array targets with any input that implements #deconstruct' do
     deconstruct = mock('deconstruct')
     deconstruct.should_receive(:deconstruct).and_return([1, 2])

--- a/test/natalie/pattern_matching_test.rb
+++ b/test/natalie/pattern_matching_test.rb
@@ -119,6 +119,14 @@ describe 'pattern matching' do
       [1, 2] => a, b, c
     }.should raise_error(NoMatchingPatternError, '[1, 2]: [1, 2] length mismatch (given 2, expected 3)')
   end
+
+  it 'uses both the original input and the result of #deconstruct in the error message' do
+    struct = Struct.new(:a, :b)
+    s = struct.new(1, 2)
+    -> {
+      s => a, b, c
+    }.should raise_error(NoMatchingPatternError, "#{s}: [1, 2] length mismatch (given 2, expected 3)")
+  end
 end
 
 describe 'NoMatchingPatternError' do


### PR DESCRIPTION
This started out as an easy fix for an error message, but spiraled out of control