### PR TITLE
Additional targets in for loop

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -192,6 +192,13 @@ module Natalie
       def transform_call_arg(arg)
         @instructions << ArrayShiftInstruction.new
         @instructions.concat(@pass.transform_expression(arg.receiver, used: true))
+        if arg.safe_navigation?
+          @instructions << DupInstruction.new
+          @instructions << IsNilInstruction.new
+          @instructions << IfInstruction.new
+          @instructions << PopInstruction.new
+          @instructions << ElseInstruction.new(:if)
+        end
         @instructions << SwapInstruction.new
         @instructions << PushArgcInstruction.new(1)
         @instructions << SendInstruction.new(
@@ -203,6 +210,9 @@ module Natalie
           file: @pass.file.path,
           line: arg.location.start_line,
         )
+        if arg.safe_navigation?
+          @instructions << EndInstruction.new(:if)
+        end
       end
 
       def transform_rest_arg(arg)

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2681,6 +2681,7 @@ module Natalie
             class_variable_target_node
             constant_target_node
             global_variable_target_node
+            index_target_node
             instance_variable_target_node
             local_variable_target_node
             multi_target_node

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2677,6 +2677,7 @@ module Natalie
 
         args.count do |arg|
           %i[
+            call_target_node
             class_variable_target_node
             constant_target_node
             global_variable_target_node

--- a/spec/language/for_spec.rb
+++ b/spec/language/for_spec.rb
@@ -168,26 +168,22 @@ describe "The for expression" do
     arr = [:a, :b, :c]
     m = [1,2,3]
     n = 0
-    #for arr[1] in m
-      #n += 1
-    #end
-    NATFIXME 'Suppport IndexTargetNode in for loop', exception: SpecFailedException do
-      arr.should == [:a, 3, :c]
-      n.should == 3
+    for arr[1] in m
+      n += 1
     end
+    arr.should == [:a, 3, :c]
+    n.should == 3
   end
 
   it "allows a hash index writer as an iterator name" do
     hash = { a: 10, b: 20, c: 30 }
     m = [1,2,3]
     n = 0
-    #for hash[:b] in m
-      #n += 1
-    #end
-    NATFIXME 'Suppport IndexTargetNode in for loop', exception: SpecFailedException do
-      hash.should == { a: 10, b: 3, c: 30 }
-      n.should == 3
+    for hash[:b] in m
+      n += 1
     end
+    hash.should == { a: 10, b: 3, c: 30 }
+    n.should == 3
   end
 
   # 1.9 behaviour verified by nobu in

--- a/spec/language/for_spec.rb
+++ b/spec/language/for_spec.rb
@@ -116,6 +116,86 @@ describe "The for expression" do
     $var = old_global_var
   end
 
+  it "allows an attribute as an iterator name" do
+    class OFor
+      attr_accessor :target
+    end
+
+    ofor = OFor.new
+    m = [1,2,3]
+    n = 0
+    #for ofor.target in m
+      #n += 1
+    #end
+    NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
+      ofor.target.should == 3
+      n.should == 3
+    end
+  end
+
+  # Segfault in MRI 3.3 and lower: https://bugs.ruby-lang.org/issues/20468
+  ruby_bug "#20468", ""..."3.4" do
+    it "allows an attribute with safe navigation as an iterator name" do
+      class OFor
+        attr_accessor :target
+      end
+
+      ofor = OFor.new
+      m = [1,2,3]
+      n = 0
+      eval <<~RUBY
+        #for ofor&.target in m
+          #n += 1
+        #end
+      RUBY
+      NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
+        ofor.target.should == 3
+        n.should == 3
+      end
+    end
+
+    it "allows an attribute with safe navigation on a nil base as an iterator name" do
+      ofor = nil
+      m = [1,2,3]
+      n = 0
+      eval <<~RUBY
+        #for ofor&.target in m
+          #n += 1
+        #end
+      RUBY
+      NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
+        ofor.should be_nil
+        n.should == 3
+      end
+    end
+  end
+
+  it "allows an array index writer as an iterator name" do
+    arr = [:a, :b, :c]
+    m = [1,2,3]
+    n = 0
+    #for arr[1] in m
+      #n += 1
+    #end
+    NATFIXME 'Suppport IndexTargetNode in for loop', exception: SpecFailedException do
+      arr.should == [:a, 3, :c]
+      n.should == 3
+    end
+  end
+
+  it "allows a hash index writer as an iterator name" do
+    hash = { a: 10, b: 20, c: 30 }
+    m = [1,2,3]
+    n = 0
+    #for hash[:b] in m
+      #n += 1
+    #end
+    NATFIXME 'Suppport IndexTargetNode in for loop', exception: SpecFailedException do
+      hash.should == { a: 10, b: 3, c: 30 }
+      n.should == 3
+    end
+  end
+
   # 1.9 behaviour verified by nobu in
   # http://redmine.ruby-lang.org/issues/show/2053
   it "yields only as many values as there are arguments" do

--- a/spec/language/for_spec.rb
+++ b/spec/language/for_spec.rb
@@ -151,18 +151,16 @@ describe "The for expression" do
     end
 
     it "allows an attribute with safe navigation on a nil base as an iterator name" do
-      NATFIXME 'Suppport CallTargetNode with safe navigation and nil receiver in for loop', exception: NoMethodError, message: "undefined method `target=' for nil" do
-        ofor = nil
-        m = [1,2,3]
-        n = 0
-        eval <<~RUBY
-          for ofor&.target in m
-            n += 1
-          end
-        RUBY
-        ofor.should be_nil
-        n.should == 3
-      end
+      ofor = nil
+      m = [1,2,3]
+      n = 0
+      eval <<~RUBY
+        for ofor&.target in m
+          n += 1
+        end
+      RUBY
+      ofor.should be_nil
+      n.should == 3
     end
   #end
 

--- a/spec/language/for_spec.rb
+++ b/spec/language/for_spec.rb
@@ -124,17 +124,15 @@ describe "The for expression" do
     ofor = OFor.new
     m = [1,2,3]
     n = 0
-    #for ofor.target in m
-      #n += 1
-    #end
-    NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
-      ofor.target.should == 3
-      n.should == 3
+    for ofor.target in m
+      n += 1
     end
+    ofor.target.should == 3
+    n.should == 3
   end
 
   # Segfault in MRI 3.3 and lower: https://bugs.ruby-lang.org/issues/20468
-  ruby_bug "#20468", ""..."3.4" do
+  #ruby_bug "#20468", ""..."3.4" do
     it "allows an attribute with safe navigation as an iterator name" do
       class OFor
         attr_accessor :target
@@ -144,31 +142,29 @@ describe "The for expression" do
       m = [1,2,3]
       n = 0
       eval <<~RUBY
-        #for ofor&.target in m
-          #n += 1
-        #end
+        for ofor&.target in m
+          n += 1
+        end
       RUBY
-      NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
-        ofor.target.should == 3
-        n.should == 3
-      end
+      ofor.target.should == 3
+      n.should == 3
     end
 
     it "allows an attribute with safe navigation on a nil base as an iterator name" do
-      ofor = nil
-      m = [1,2,3]
-      n = 0
-      eval <<~RUBY
-        #for ofor&.target in m
-          #n += 1
-        #end
-      RUBY
-      NATFIXME 'Suppport CallTargetNode in for loop', exception: SpecFailedException do
+      NATFIXME 'Suppport CallTargetNode with safe navigation and nil receiver in for loop', exception: NoMethodError, message: "undefined method `target=' for nil" do
+        ofor = nil
+        m = [1,2,3]
+        n = 0
+        eval <<~RUBY
+          for ofor&.target in m
+            n += 1
+          end
+        RUBY
         ofor.should be_nil
         n.should == 3
       end
     end
-  end
+  #end
 
   it "allows an array index writer as an iterator name" do
     arr = [:a, :b, :c]


### PR DESCRIPTION
The following code is now supported:

```ruby
for foo.bar in [1,2,3]
for nil&.bar in [1,2,3]
for foo[1] in [1,2,3]
for foo[:bar] in [1,2,3]
```

Observation: the `ruby_bug` guard appears to mean we don't run the tests, I had to remove that line from the spec file to run the tests. I think we're interpreting this guard in the wrong way.