### PR TITLE
Add :xml option to String#encode

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -96,10 +96,17 @@ public:
         Universal,
     };
 
+    enum class EncodeXmlOption {
+        None,
+        Attr,
+        Text,
+    };
+
     struct EncodeOptions {
         EncodeInvalidOption invalid_option = EncodeInvalidOption::Raise;
         EncodeUndefOption undef_option = EncodeUndefOption::Raise;
         EncodeNewlineOption newline_option = EncodeNewlineOption::None;
+        EncodeXmlOption xml_option = EncodeXmlOption::None;
         StringObject *replace_option = nullptr;
         Value fallback_option = nullptr;
     };

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -511,6 +511,7 @@ private:
     using EncodeOptions = EncodingObject::EncodeOptions;
     using EncodeInvalidOption = EncodingObject::EncodeInvalidOption;
     using EncodeNewlineOption = EncodingObject::EncodeNewlineOption;
+    using EncodeXmlOption = EncodingObject::EncodeXmlOption;
     using EncodeUndefOption = EncodingObject::EncodeUndefOption;
 
     String m_string {};

--- a/spec/core/string/shared/encode.rb
+++ b/spec/core/string/shared/encode.rb
@@ -394,71 +394,49 @@ describe :string_encode, shared: true do
 
   describe "given the xml: :text option" do
     it "replaces all instances of '&' with '&amp;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '& and &'.send(@method, "UTF-8", xml: :text).should == '&amp; and &amp;'
-      end
+      '& and &'.send(@method, "UTF-8", xml: :text).should == '&amp; and &amp;'
     end
 
     it "replaces all instances of '<' with '&lt;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '< and <'.send(@method, "UTF-8", xml: :text).should == '&lt; and &lt;'
-      end
+      '< and <'.send(@method, "UTF-8", xml: :text).should == '&lt; and &lt;'
     end
 
     it "replaces all instances of '>' with '&gt;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '> and >'.send(@method, "UTF-8", xml: :text).should == '&gt; and &gt;'
-      end
+      '> and >'.send(@method, "UTF-8", xml: :text).should == '&gt; and &gt;'
     end
 
     it "does not replace '\"'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '" and "'.send(@method, "UTF-8", xml: :text).should == '" and "'
-      end
+      '" and "'.send(@method, "UTF-8", xml: :text).should == '" and "'
     end
 
     it "replaces undefined characters with their upper-case hexadecimal numeric character references" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        'ürst'.send(@method, Encoding::US_ASCII, xml: :text).should == '&#xFC;rst'
-      end
+      'ürst'.send(@method, Encoding::US_ASCII, xml: :text).should == '&#xFC;rst'
     end
   end
 
   describe "given the xml: :attr option" do
     it "surrounds the encoded text with double-quotes" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        'abc'.send(@method, "UTF-8", xml: :attr).should == '"abc"'
-      end
+      'abc'.send(@method, "UTF-8", xml: :attr).should == '"abc"'
     end
 
     it "replaces all instances of '&' with '&amp;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '& and &'.send(@method, "UTF-8", xml: :attr).should == '"&amp; and &amp;"'
-      end
+      '& and &'.send(@method, "UTF-8", xml: :attr).should == '"&amp; and &amp;"'
     end
 
     it "replaces all instances of '<' with '&lt;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '< and <'.send(@method, "UTF-8", xml: :attr).should == '"&lt; and &lt;"'
-      end
+      '< and <'.send(@method, "UTF-8", xml: :attr).should == '"&lt; and &lt;"'
     end
 
     it "replaces all instances of '>' with '&gt;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '> and >'.send(@method, "UTF-8", xml: :attr).should == '"&gt; and &gt;"'
-      end
+      '> and >'.send(@method, "UTF-8", xml: :attr).should == '"&gt; and &gt;"'
     end
 
     it "replaces all instances of '\"' with '&quot;'" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        '" and "'.send(@method, "UTF-8", xml: :attr).should == '"&quot; and &quot;"'
-      end
+      '" and "'.send(@method, "UTF-8", xml: :attr).should == '"&quot; and &quot;"'
     end
 
     it "replaces undefined characters with their upper-case hexadecimal numeric character references" do
-      NATFIXME 'xml option', exception: ArgumentError, message: 'unknown keyword: :xml' do
-        'ürst'.send(@method, Encoding::US_ASCII, xml: :attr).should == '"&#xFC;rst"'
-      end
+      'ürst'.send(@method, Encoding::US_ASCII, xml: :attr).should == '"&#xFC;rst"'
     end
   end
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1172,6 +1172,16 @@ Value StringObject::encode_in_place(Env *env, Value dst_encoding, Value src_enco
         auto fallback = kwargs->remove(env, "fallback"_s);
         if (fallback && !fallback->is_nil())
             options.fallback_option = fallback;
+
+        auto xml = kwargs->remove(env, "xml"_s);
+        if (xml) {
+            if (xml == "attr"_s)
+                options.xml_option = EncodeXmlOption::Attr;
+            else if (xml == "text"_s)
+                options.xml_option = EncodeXmlOption::Text;
+            else
+                env->raise("ArgumentError", "unexpected value for xml option: {}", xml->inspect_str(env));
+        }
     }
 
     auto find_encoding = [&](Value encoding) {


### PR DESCRIPTION
#217

This is the final PR for making `String#encode` and `String#encode!` spec-compliant. There are a few specs skill skipped because of missing encodings, such as `Emacs_Mule` and `ISO_2022_JP` encodings. I don't intend to work on those right now, so I'm calling this spec done for now.