### PR TITLE
Make String#freeze spec-compliant

### DIFF
--- a/lib/natalie/compiler/backends/cpp_backend/transform.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/transform.rb
@@ -158,7 +158,7 @@ module Natalie
 
         def interned_string(str, encoding)
           index = @interned_strings[[str, encoding]] ||= @interned_strings.size
-          "#{interned_strings_var_name}[#{index}]"
+          "#{interned_strings_var_name}[#{index}]/*#{str.inspect.gsub(%r{\*/|\\}, '?')}*/"
         end
 
         def set_file(file)

--- a/lib/natalie/compiler/instructions/push_string_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_string_instruction.rb
@@ -14,6 +14,8 @@ module Natalie
         @frozen = frozen
       end
 
+      attr_accessor :frozen
+
       def to_s
         "push_string #{@string.inspect}, #{@bytesize}, #{@encoding.name}#{@frozen ? ', frozen' : ''}"
       end

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -490,7 +490,14 @@ module Natalie
         if receiver.nil?
           instructions << PushSelfInstruction.new
         else
-          instructions << transform_expression(receiver, used: true)
+          inst = transform_expression(receiver, used: true)
+
+          if node.name == :freeze && !node.safe_navigation? && !with_block && inst.size == 1 && inst.first.is_a?(PushStringInstruction)
+            # "foo".freeze get special treatment so we can intern the string at compile time
+            inst.first.frozen = true
+          end
+
+          instructions << inst
         end
 
         if node.safe_navigation?

--- a/spec/core/string/freeze_spec.rb
+++ b/spec/core/string/freeze_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: false
+require_relative '../../spec_helper'
+
+describe "String#freeze" do
+
+  it "produces the same object whenever called on an instance of a literal in the source" do
+    "abc".freeze.should equal "abc".freeze
+  end
+
+  it "doesn't produce the same object for different instances of literals in the source" do
+    "abc".should_not equal "abc"
+  end
+
+  it "being a special form doesn't change the value of defined?" do
+    defined?("abc".freeze).should == "method"
+  end
+
+end


### PR DESCRIPTION
#217

Today I learned:

```ruby
'foo'.freeze.equal?('foo'.freeze) # => true
```

Interesting to note that it only seems to apply to string literals and doesn't work if you set a variable first:

```ruby
s = 'foo'
s.freeze.equal?('foo'.freeze) # => false
```

(Good thing too, because I have no idea how we'd do that with the compiler! 😅)