### PR TITLE
Choose proper encoding when compiling Regexp

### DIFF
--- a/include/natalie/encoding/utf32le_encoding_object.hpp
+++ b/include/natalie/encoding/utf32le_encoding_object.hpp
@@ -36,6 +36,7 @@ public:
     virtual nat_int_t decode_codepoint(StringView &str) const override;
 
     virtual bool is_single_byte_encoding() const override final { return false; }
+    virtual bool is_ascii_compatible() const override final { return true; }
 };
 
 }

--- a/include/natalie/encodings.hpp
+++ b/include/natalie/encodings.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <stddef.h>
+
 namespace Natalie {
 
 const size_t EncodingCount = 44;
 
 enum class Encoding {
+    NONE = 0,
     ASCII_8BIT = 1,
     US_ASCII = 2,
     UTF_8 = 3,

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1212,7 +1212,7 @@ gen.binding('Regexp', '===', 'RegexpObject', 'eqeqeq', argc: 1, pass_env: true, 
 gen.binding('Regexp', '=~', 'RegexpObject', 'eqtilde', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', '~', 'RegexpObject', 'tilde', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'casefold?', 'RegexpObject', 'casefold', argc: 0, pass_env: true, pass_block: false, return_type: :bool)
-gen.binding('Regexp', 'encoding', 'RegexpObject', 'encoding', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Regexp', 'encoding', 'RegexpObject', 'encoding', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'eql?', 'RegexpObject', 'eq', argc: 1, pass_env: true, pass_block: false, aliases: ['=='], return_type: :bool)
 gen.binding('Regexp', 'hash', 'RegexpObject', 'hash', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Regexp', 'initialize', 'RegexpObject', 'initialize', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)

--- a/spec/core/marshal/dump_spec.rb
+++ b/spec/core/marshal/dump_spec.rb
@@ -136,7 +136,7 @@ describe "Marshal.dump" do
 
     it "dumps the String in multibyte encoding" do
       object = UserDefinedString.new("a".encode("utf-32le"))
-      NATFIXME 'Encoding of output', exception: Encoding::CompatibilityError, message: 'incompatible character encodings: ASCII-8BIT and UTF-32LE' do
+      NATFIXME 'Encoding of output', exception: SpecFailedException, message: /should be == / do
         Marshal.dump(object).should == "\x04\bIu:\x16UserDefinedString\ta\x00\x00\x00\x06:\rencoding\"\rUTF-32LE"
       end
     end

--- a/spec/core/marshal/shared/load.rb
+++ b/spec/core/marshal/shared/load.rb
@@ -383,7 +383,7 @@ describe :marshal_load, shared: true do
 
     it "loads the String in multibyte encoding" do
       source_object = UserDefinedString.new("a".encode("utf-32le"))
-      NATFIXME 'loads the String in multibyte encoding', exception: Encoding::CompatibilityError, message: 'incompatible character encodings: ASCII-8BIT and UTF-32LE' do
+      NATFIXME 'loads the String in multibyte encoding', exception: SpecFailedException, message: '"a" should be == to "a"' do
         object = Marshal.send(@method, Marshal.dump(source_object))
         object.string.should == "a".encode("utf-32le")
       end

--- a/spec/core/regexp/encoding_spec.rb
+++ b/spec/core/regexp/encoding_spec.rb
@@ -26,15 +26,11 @@ describe "Regexp#encoding" do
   end
 
   it "defaults to UTF-8 if a literal UTF-8 character appears" do
-    NATFIXME 'Encoding', exception: SpecFailedException do
-      /¥/.encoding.should == Encoding::UTF_8
-    end
+    /¥/.encoding.should == Encoding::UTF_8
   end
 
   it "returns UTF-8 if the 'u' modifier is supplied" do
-    NATFIXME 'Encoding', exception: SpecFailedException do
-      /ASCII/u.encoding.should == Encoding::UTF_8
-    end
+    /ASCII/u.encoding.should == Encoding::UTF_8
   end
 
   it "returns Windows-31J if the 's' modifier is supplied" do

--- a/spec/core/regexp/shared/new.rb
+++ b/spec/core/regexp/shared/new.rb
@@ -277,9 +277,7 @@ describe :regexp_new_string, shared: true do
     end
 
     it "accepts a one-digit octal value" do
-      NATFIXME "accepts a one-digit octal value", exception: SpecFailedException do
-        Regexp.send(@method, "\0").should == /#{"\x00"}/
-      end
+      Regexp.send(@method, "\0").should == /#{"\x00"}/
     end
 
     it "accepts a two-digit octal value" do
@@ -401,9 +399,7 @@ describe :regexp_new_string, shared: true do
     end
 
     it "accepts \\u{HHHH} for a single Unicode codepoint" do
-      NATFIXME "accepts \\u{HHHH} for a single Unicode codepoint", exception: SpecFailedException do
-        Regexp.send(@method, "\u{0000}").should == /#{"\x00"}/
-      end
+      Regexp.send(@method, "\u{0000}").should == /#{"\x00"}/
     end
 
     it "accepts \\u{HHHHH} for a single Unicode codepoint" do
@@ -411,9 +407,7 @@ describe :regexp_new_string, shared: true do
     end
 
     it "accepts \\u{HHHHHH} for a single Unicode codepoint" do
-      NATFIXME "accepts \\u{HHHHHH} for a single Unicode codepoint", exception: SpecFailedException do
-        Regexp.send(@method, "\u{000000}").should == /#{"\x00"}/
-      end
+      Regexp.send(@method, "\u{000000}").should == /#{"\x00"}/
     end
 
     it "accepts characters followed by \\u{HHHH}" do
@@ -503,9 +497,7 @@ describe :regexp_new_string, shared: true do
     end
 
     it "returns a Regexp with UTF-8 encoding if any UTF-8 escape sequences outside 7-bit ASCII are present" do
-      NATFIXME "returns a Regexp with UTF-8 encoding if any UTF-8 escape sequences outside 7-bit ASCII are present", exception: SpecFailedException do
-        Regexp.send(@method, "\u{ff}").encoding.should == Encoding::UTF_8
-      end
+      Regexp.send(@method, "\u{ff}").encoding.should == Encoding::UTF_8
     end
 
     it "returns a Regexp with source String having UTF-8 encoding if any UTF-8 escape sequences outside 7-bit ASCII are present" do
@@ -514,16 +506,12 @@ describe :regexp_new_string, shared: true do
 
     it "returns a Regexp with the input String's encoding" do
       str = "\x82\xa0".dup.force_encoding(Encoding::Shift_JIS)
-      NATFIXME "returns a Regexp with the input String's encoding", exception: SpecFailedException do
-        Regexp.send(@method, str).encoding.should == Encoding::Shift_JIS
-      end
+      Regexp.send(@method, str).encoding.should == Encoding::Shift_JIS
     end
 
     it "returns a Regexp with source String having the input String's encoding" do
       str = "\x82\xa0".dup.force_encoding(Encoding::Shift_JIS)
-      NATFIXME "returns a Regexp with source String having the input String's encoding", exception: SpecFailedException do
-        Regexp.send(@method, str).source.encoding.should == Encoding::Shift_JIS
-      end
+      Regexp.send(@method, str).source.encoding.should == Encoding::Shift_JIS
     end
   end
 end
@@ -633,9 +621,7 @@ describe :regexp_new_regexp, shared: true do
 
   not_supported_on :opal do
     it "sets the encoding to UTF-8 if the Regexp literal has the 'u' option" do
-      NATFIXME "sets the encoding to UTF-8 if the Regexp literal has the 'u' option", exception: SpecFailedException do
-        Regexp.send(@method, /Hi/u).encoding.should == Encoding::UTF_8
-      end
+      Regexp.send(@method, /Hi/u).encoding.should == Encoding::UTF_8
     end
 
     it "sets the encoding to EUC-JP if the Regexp literal has the 'e' option" do

--- a/spec/core/regexp/union_spec.rb
+++ b/spec/core/regexp/union_spec.rb
@@ -79,9 +79,7 @@ describe "Regexp.union" do
   end
 
   it "returns a Regexp with UTF-8 if one part is UTF-8" do
-    NATFIXME 'Encodings', exception: SpecFailedException do
-      Regexp.union(/probl[éeè]me/i, /help/i).encoding.should == Encoding::UTF_8
-    end
+    Regexp.union(/probl[éeè]me/i, /help/i).encoding.should == Encoding::UTF_8
   end
 
   it "returns a Regexp if an array of string with special characters is passed" do

--- a/spec/language/regexp/character_classes_spec.rb
+++ b/spec/language/regexp/character_classes_spec.rb
@@ -615,9 +615,7 @@ describe "Regexp with character classes" do
   end
 
   it "raises a RegexpError for an unterminated unicode property" do
-    NATFIXME 'it raises a RegexpError for an unterminated unicode property', exception: SpecFailedException do
-      -> { Regexp.new('\p{') }.should raise_error(RegexpError)
-    end
+    -> { Regexp.new('\p{') }.should raise_error(RegexpError)
   end
 
   it "supports \\X (unicode 9.0 with UTR #51 workarounds)" do

--- a/spec/language/regexp/encoding_spec.rb
+++ b/spec/language/regexp/encoding_spec.rb
@@ -31,21 +31,15 @@ describe "Regexps with encoding modifiers" do
   end
 
   it "supports /n (No encoding)" do
-    NATFIXME 'it supports /n (No encoding)', exception: SpecFailedException do
-      /./n.match("\303\251").to_a.should == ["\303"]
-    end
+    /./n.match("\303\251").to_a.should == ["\303"]
   end
 
   it "supports /n (No encoding) with interpolation" do
-    NATFIXME 'it supports /n (No encoding) with interpolation', exception: SpecFailedException do
-      /#{/./}/n.match("\303\251").to_a.should == ["\303"]
-    end
+    /#{/./}/n.match("\303\251").to_a.should == ["\303"]
   end
 
   it "supports /n (No encoding) with interpolation /o" do
-    NATFIXME 'it supports /n (No encoding) with interpolation /o', exception: SpecFailedException do
-      /#{/./}/n.match("\303\251").to_a.should == ["\303"]
-    end
+    /#{/./}/n.match("\303\251").to_a.should == ["\303"]
   end
 
   it "warns when using /n with a match string with non-ASCII characters and an encoding other than ASCII-8BIT" do
@@ -59,9 +53,7 @@ describe "Regexps with encoding modifiers" do
   end
 
   it 'uses BINARY when is not initialized' do
-    NATFIXME 'it uses BINARY when is not initialized', exception: SpecFailedException do
-      Regexp.allocate.encoding.should == Encoding::BINARY
-    end
+    Regexp.allocate.encoding.should == Encoding::BINARY
   end
 
   it 'uses BINARY as /n encoding if not all chars are 7-bit' do
@@ -126,15 +118,11 @@ describe "Regexps with encoding modifiers" do
   end
 
   it 'uses UTF-8 as /u encoding' do
-    NATFIXME 'it uses UTF-8 as /u encoding', exception: SpecFailedException do
-      /./u.encoding.should == Encoding::UTF_8
-    end
+    /./u.encoding.should == Encoding::UTF_8
   end
 
   it 'preserves UTF-8 as /u encoding through interpolation' do
-    NATFIXME 'it preserves UTF-8 as /u encoding through interpolation', exception: SpecFailedException do
-      /#{/./}/u.encoding.should == Encoding::UTF_8
-    end
+    /#{/./}/u.encoding.should == Encoding::UTF_8
   end
 
   it "selects last of multiple encoding specifiers" do
@@ -183,9 +171,7 @@ describe "Regexps with encoding modifiers" do
     NATFIXME 'Implement Regexp#fixed_encoding?', exception: NoMethodError, message: "undefined method `fixed_encoding?' for an instance of Regexp" do
       r.should.fixed_encoding?
     end
-    NATFIXME 'it computes the Regexp Encoding for each interpolated Regexp instance', exception: SpecFailedException do
-      r.encoding.should == Encoding::UTF_8
-    end
+    r.encoding.should == Encoding::UTF_8
 
     r = make_regexp.call("abc".dup.force_encoding(Encoding::UTF_8))
     NATFIXME 'Implement Regexp#fixed_encoding?', exception: NoMethodError, message: "undefined method `fixed_encoding?' for an instance of Regexp" do

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -36,40 +36,40 @@ static StringObject *regexp_stringify(const TM::String &str, const size_t start,
 
 static const auto ruby_encoding_lookup = []() {
     // No constructor with std::initializer_list, use a lambda to make a const value
-    auto map = Hashmap<OnigEncoding, Value>();
+    auto map = Hashmap<OnigEncoding, Encoding>();
 
-    map.put(ONIG_ENCODING_ASCII, EncodingObject::get(Encoding::US_ASCII));
-    map.put(ONIG_ENCODING_ISO_8859_1, EncodingObject::get(Encoding::ISO_8859_1));
-    map.put(ONIG_ENCODING_ISO_8859_2, EncodingObject::get(Encoding::ISO_8859_2));
-    map.put(ONIG_ENCODING_ISO_8859_3, EncodingObject::get(Encoding::ISO_8859_3));
-    map.put(ONIG_ENCODING_ISO_8859_4, EncodingObject::get(Encoding::ISO_8859_4));
-    map.put(ONIG_ENCODING_ISO_8859_5, EncodingObject::get(Encoding::ISO_8859_5));
-    map.put(ONIG_ENCODING_ISO_8859_6, EncodingObject::get(Encoding::ISO_8859_6));
-    map.put(ONIG_ENCODING_ISO_8859_7, EncodingObject::get(Encoding::ISO_8859_7));
-    map.put(ONIG_ENCODING_ISO_8859_8, EncodingObject::get(Encoding::ISO_8859_8));
-    map.put(ONIG_ENCODING_ISO_8859_9, EncodingObject::get(Encoding::ISO_8859_9));
-    map.put(ONIG_ENCODING_ISO_8859_10, EncodingObject::get(Encoding::ISO_8859_10));
-    map.put(ONIG_ENCODING_ISO_8859_11, EncodingObject::get(Encoding::ISO_8859_11));
-    map.put(ONIG_ENCODING_ISO_8859_13, EncodingObject::get(Encoding::ISO_8859_13));
-    map.put(ONIG_ENCODING_ISO_8859_14, EncodingObject::get(Encoding::ISO_8859_14));
-    map.put(ONIG_ENCODING_ISO_8859_15, EncodingObject::get(Encoding::ISO_8859_15));
-    map.put(ONIG_ENCODING_ISO_8859_16, EncodingObject::get(Encoding::ISO_8859_16));
-    map.put(ONIG_ENCODING_UTF_8, EncodingObject::get(Encoding::UTF_8));
-    map.put(ONIG_ENCODING_UTF_16BE, EncodingObject::get(Encoding::UTF_16BE));
-    map.put(ONIG_ENCODING_UTF_16LE, EncodingObject::get(Encoding::UTF_16LE));
-    map.put(ONIG_ENCODING_UTF_32BE, EncodingObject::get(Encoding::UTF_32BE));
-    map.put(ONIG_ENCODING_UTF_32LE, EncodingObject::get(Encoding::UTF_32LE));
-    map.put(ONIG_ENCODING_EUC_JP, EncodingObject::get(Encoding::EUC_JP));
+    map.put(ONIG_ENCODING_ASCII, Encoding::US_ASCII);
+    map.put(ONIG_ENCODING_ISO_8859_1, Encoding::ISO_8859_1);
+    map.put(ONIG_ENCODING_ISO_8859_2, Encoding::ISO_8859_2);
+    map.put(ONIG_ENCODING_ISO_8859_3, Encoding::ISO_8859_3);
+    map.put(ONIG_ENCODING_ISO_8859_4, Encoding::ISO_8859_4);
+    map.put(ONIG_ENCODING_ISO_8859_5, Encoding::ISO_8859_5);
+    map.put(ONIG_ENCODING_ISO_8859_6, Encoding::ISO_8859_6);
+    map.put(ONIG_ENCODING_ISO_8859_7, Encoding::ISO_8859_7);
+    map.put(ONIG_ENCODING_ISO_8859_8, Encoding::ISO_8859_8);
+    map.put(ONIG_ENCODING_ISO_8859_9, Encoding::ISO_8859_9);
+    map.put(ONIG_ENCODING_ISO_8859_10, Encoding::ISO_8859_10);
+    map.put(ONIG_ENCODING_ISO_8859_11, Encoding::ISO_8859_11);
+    map.put(ONIG_ENCODING_ISO_8859_13, Encoding::ISO_8859_13);
+    map.put(ONIG_ENCODING_ISO_8859_14, Encoding::ISO_8859_14);
+    map.put(ONIG_ENCODING_ISO_8859_15, Encoding::ISO_8859_15);
+    map.put(ONIG_ENCODING_ISO_8859_16, Encoding::ISO_8859_16);
+    map.put(ONIG_ENCODING_UTF_8, Encoding::UTF_8);
+    map.put(ONIG_ENCODING_UTF_16BE, Encoding::UTF_16BE);
+    map.put(ONIG_ENCODING_UTF_16LE, Encoding::UTF_16LE);
+    map.put(ONIG_ENCODING_UTF_32BE, Encoding::UTF_32BE);
+    map.put(ONIG_ENCODING_UTF_32LE, Encoding::UTF_32LE);
+    map.put(ONIG_ENCODING_EUC_JP, Encoding::EUC_JP);
     // ONIG_ENCODING_EUC_TW has no local encoding
     // ONIG_ENCODING_EUC_KR has no local encoding
     // ONIG_ENCODING_EUC_CN has no local encoding
-    map.put(ONIG_ENCODING_SHIFT_JIS, EncodingObject::get(Encoding::SHIFT_JIS));
+    map.put(ONIG_ENCODING_SHIFT_JIS, Encoding::SHIFT_JIS);
     // ONIG_ENCODING_WINDOWS_31J has no local encoding
     // ONIG_ENCODING_KOI8_R has no local encoding
     // ONIG_ENCODING_KOI8_U has no local encoding
-    map.put(ONIG_ENCODING_WINDOWS_1250, EncodingObject::get(Encoding::Windows_1250));
-    map.put(ONIG_ENCODING_WINDOWS_1251, EncodingObject::get(Encoding::Windows_1251));
-    map.put(ONIG_ENCODING_WINDOWS_1252, EncodingObject::get(Encoding::Windows_1252));
+    map.put(ONIG_ENCODING_WINDOWS_1250, Encoding::Windows_1250);
+    map.put(ONIG_ENCODING_WINDOWS_1251, Encoding::Windows_1251);
+    map.put(ONIG_ENCODING_WINDOWS_1252, Encoding::Windows_1252);
     // ONIG_ENCODING_WINDOWS_1253 has no local encoding
     // ONIG_ENCODING_WINDOWS_1254 has no local encoding
     // ONIG_ENCODING_WINDOWS_1257 has no local encoding
@@ -80,7 +80,7 @@ static const auto ruby_encoding_lookup = []() {
 }();
 
 static const auto onig_encoding_lookup = []() {
-    auto map = Hashmap<Value, OnigEncoding>();
+    auto map = Hashmap<Encoding, OnigEncoding>();
     for (auto [onig_encoding, ruby_encoding] : ruby_encoding_lookup) {
         map.put(ruby_encoding, onig_encoding);
     }
@@ -89,14 +89,15 @@ static const auto onig_encoding_lookup = []() {
 
 EncodingObject *RegexpObject::onig_encoding_to_ruby_encoding(const OnigEncoding encoding) {
     auto result = ruby_encoding_lookup.get(encoding);
-    if (result) return result->as_encoding();
+    if (result != Encoding::NONE)
+        return EncodingObject::get(result);
 
     // Use US_ASCII as the default
     return EncodingObject::get(Encoding::US_ASCII);
 }
 
-OnigEncoding RegexpObject::ruby_encoding_to_onig_encoding(const Value encoding) {
-    auto result = onig_encoding_lookup.get(encoding);
+OnigEncoding RegexpObject::ruby_encoding_to_onig_encoding(NonNullPtr<const EncodingObject> encoding) {
+    auto result = onig_encoding_lookup.get(encoding->num());
     if (result) return result;
 
     // Use US_ASCII as the default
@@ -202,53 +203,57 @@ Value RegexpObject::regexp_union(Env *env, Args args) {
 
 Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
     assert_not_frozen(env);
+
     if (is_initialized())
         env->raise("TypeError", "already initialized regexp");
+
     if (pattern->is_regexp()) {
         auto other = pattern->as_regexp();
         if (opts && !opts->is_nil())
             env->warn("flags ignored");
-        initialize(env, other->pattern(), other->options());
-    } else {
-        nat_int_t options = 0;
-        if (opts != nullptr) {
-            if (opts.is_fast_integer()) {
-                options = opts.get_fast_integer();
-            } else if (opts->is_integer()) {
-                options = opts->as_integer()->to_nat_int_t();
-            } else if (opts->is_string()) {
-                for (auto c : *opts->as_string()) {
-                    if (c == "i") {
-                        options |= RegexOpts::IgnoreCase;
-                    } else if (c == "m") {
-                        options |= RegexOpts::MultiLine;
-                    } else if (c == "x") {
-                        options |= RegexOpts::Extended;
-                    } else {
-                        env->raise("ArgumentError", "unknown regexp option: {}", opts->as_string()->string());
-                    }
-                }
-            } else {
-                env->verbose_warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
-                if (opts->is_truthy())
-                    options = RegexOpts::IgnoreCase;
-            }
-        }
-
-        initialize(env, pattern->to_str(env)->c_str(), static_cast<int>(options));
+        initialize_internal(env, other->m_pattern, other->options());
+        return this;
     }
+
+    nat_int_t options = 0;
+    if (opts != nullptr) {
+        if (opts.is_fast_integer()) {
+            options = opts.get_fast_integer();
+        } else if (opts->is_integer()) {
+            options = opts->as_integer()->to_nat_int_t();
+        } else if (opts->is_string()) {
+            for (auto c : *opts->as_string()) {
+                if (c == "i") {
+                    options |= RegexOpts::IgnoreCase;
+                } else if (c == "m") {
+                    options |= RegexOpts::MultiLine;
+                } else if (c == "x") {
+                    options |= RegexOpts::Extended;
+                } else {
+                    env->raise("ArgumentError", "unknown regexp option: {}", opts->as_string()->string());
+                }
+            }
+        } else {
+            env->verbose_warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
+            if (opts->is_truthy())
+                options = RegexOpts::IgnoreCase;
+        }
+    }
+
+    initialize_internal(env, pattern->to_str(env), static_cast<int>(options));
+
     return this;
 }
 
-static String prepare_pattern_for_onigmo(const String &pattern, bool *fixed_encoding) {
+static String prepare_pattern_for_onigmo(const StringObject *pattern, bool *fixed_encoding) {
     String new_pattern;
-    auto length = pattern.length();
+    auto length = pattern->bytesize();
     size_t index = 0;
 
     auto next_char = [&length, &index, &pattern]() -> unsigned char {
         if (index >= length)
             return '\0';
-        return pattern[index++];
+        return pattern->string()[index++];
     };
 
     EncodingObject *utf8 = nullptr;
@@ -322,6 +327,8 @@ static String prepare_pattern_for_onigmo(const String &pattern, bool *fixed_enco
         }
 
         default:
+            if (c > 127)
+                *fixed_encoding = true;
             new_pattern.append_char(c);
         }
     }
@@ -329,27 +336,33 @@ static String prepare_pattern_for_onigmo(const String &pattern, bool *fixed_enco
     return new_pattern;
 }
 
-void RegexpObject::initialize(Env *env, const String &pattern, int options) {
+void RegexpObject::initialize_internal(Env *env, const StringObject *pattern, int options) {
     regex_t *regex;
     OnigErrorInfo einfo;
-    m_pattern = pattern;
 
-    bool fixed_encoding = false;
+    bool no_encoding = options & RegexOpts::NoEncoding;
+    bool fixed_encoding = options & RegexOpts::FixedEncoding;
     auto tweaked_pattern = prepare_pattern_for_onigmo(pattern, &fixed_encoding);
+
     if (fixed_encoding)
         options |= RegexOpts::FixedEncoding;
+    m_options = options;
+    m_pattern = pattern;
+
+    // FixedEncoding and NoEncoding are not options that Onigmo understands.
+    options &= ~RegexOpts::FixedEncoding;
+    options &= ~RegexOpts::NoEncoding;
 
     UChar *pat = (UChar *)tweaked_pattern.c_str();
-    // NATFIXME: Fully support character encodings in capture groups
-    int result = onig_new(&regex, pat, pat + tweaked_pattern.length(),
-        options, ONIG_ENCODING_UTF_8, ONIG_SYNTAX_DEFAULT, &einfo);
+    OnigEncoding enc = fixed_encoding && !no_encoding ? ruby_encoding_to_onig_encoding(pattern->encoding()) : ONIG_ENCODING_ASCII;
+    int result = onig_new(&regex, pat, pat + tweaked_pattern.length(), options, enc, ONIG_SYNTAX_DEFAULT, &einfo);
+
     if (result != ONIG_NORMAL) {
         OnigUChar s[ONIG_MAX_ERROR_MESSAGE_LEN];
         onig_error_code_to_str(s, result, &einfo);
-        env->raise("RegexpError", "{}: /{}/", reinterpret_cast<const char *>(s), pattern);
+        env->raise("RegexpError", "{}: /{}/", reinterpret_cast<const char *>(s), pattern->string());
     }
     m_regex = regex;
-    m_options = options;
 }
 
 Value RegexpObject::inspect(Env *env) {
@@ -357,19 +370,14 @@ Value RegexpObject::inspect(Env *env) {
         return KernelModule::inspect(env, this);
     StringObject *out = new StringObject { "/" };
     auto str = pattern();
-    size_t len = str.length();
-    regexp_stringify(str, 0, len, out);
+    size_t len = str->length();
+    regexp_stringify(str->string(), 0, len, out);
     out->append_char('/');
     if (options() & RegexOpts::MultiLine) out->append_char('m');
     if (options() & RegexOpts::IgnoreCase) out->append_char('i');
     if (options() & RegexOpts::Extended) out->append_char('x');
     if (options() & RegexOpts::NoEncoding) out->append_char('n');
     return out;
-}
-
-Value RegexpObject::encoding(Env *env) {
-    // NATFIXME: Implement support for other encodings.
-    return EncodingObject::get(Encoding::US_ASCII);
 }
 
 Value RegexpObject::eqtilde(Env *env, Value other) {
@@ -422,7 +430,7 @@ Value RegexpObject::match_at_byte_offset(Env *env, StringObject *str, size_t byt
     Env *caller_env = env->caller();
 
     OnigRegion *region = onig_region_new();
-    int result = search(str->string(), byte_index, region, ONIG_OPTION_NONE);
+    int result = search(env, str, byte_index, region, ONIG_OPTION_NONE);
 
     if (result >= 0) {
         auto match = new MatchDataObject { region, str, this };
@@ -465,7 +473,7 @@ bool RegexpObject::has_match(Env *env, Value other, Value start) {
     }
 
     OnigRegion *region = onig_region_new();
-    int result = search(str_obj->string(), start_index, region, ONIG_OPTION_NONE);
+    int result = search(env, str_obj, start_index, region, ONIG_OPTION_NONE);
 
     if (result >= 0) {
         return true;
@@ -525,12 +533,29 @@ bool RegexpObject::operator==(const RegexpObject &other) const {
     int our_options = m_options | RegexOpts::NoEncoding;
     int their_options = other.m_options | RegexOpts::NoEncoding;
 
-    return m_pattern == other.m_pattern && our_options == their_options;
+    return m_pattern->string() == other.m_pattern->string() && our_options == their_options;
+}
+
+int RegexpObject::search(Env *env, const StringObject *string_obj, int start, OnigRegion *region, OnigOptionType options) {
+    auto string = string_obj->string();
+    const unsigned char *unsigned_str = (unsigned char *)string.c_str();
+    const unsigned char *char_end = unsigned_str + string.size();
+    const unsigned char *char_start = unsigned_str + start;
+    const unsigned char *char_range = char_end;
+
+    if (string_obj->encoding() != encoding()) {
+        RegexpObject temp_regexp;
+        temp_regexp.initialize_internal(env, m_pattern, m_options | RegexOpts::FixedEncoding);
+        return onig_search(temp_regexp.m_regex, unsigned_str, char_end, char_start, char_range, region, options);
+    }
+
+    return onig_search(m_regex, unsigned_str, char_end, char_start, char_range, region, options);
 }
 
 Value RegexpObject::source(Env *env) const {
     assert_initialized(env);
-    return new StringObject { pattern() };
+    assert(m_pattern);
+    return new StringObject(*m_pattern);
 }
 
 Value RegexpObject::to_s(Env *env) const {
@@ -541,7 +566,7 @@ Value RegexpObject::to_s(Env *env) const {
     auto is_i = options() & RegexOpts::IgnoreCase;
     auto is_x = options() & RegexOpts::Extended;
 
-    auto str = pattern();
+    auto str = m_pattern->string();
     size_t len = str.length();
     size_t start = 0;
 
@@ -619,7 +644,7 @@ Value RegexpObject::to_s(Env *env) const {
 }
 
 String RegexpObject::dbg_inspect() const {
-    return String::format("/{}/", m_pattern);
+    return String::format("/{}/", m_pattern->string());
 }
 
 }

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -308,6 +308,8 @@ static String prepare_pattern_for_onigmo(const StringObject *pattern, bool *fixe
                     new_pattern.append_char(c);
                 }
 
+                *fixed_encoding = true;
+
                 break;
             }
 

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -49,6 +49,11 @@ describe 'regexp' do
     #-> { eval('/\u{111111}/') }.should raise_error(SyntaxError)
   end
 
+  it 'uses the right onigmo encoding' do
+    pattern = Regexp.new("木".encode('EUC-JP'), Regexp::FIXEDENCODING)
+    pattern.encoding.should == Encoding::EUC_JP
+  end
+
   it 'can embed regexp that ignores multiline and comments' do
     r1 = /
     foo

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -74,9 +74,12 @@ describe 'regexp' do
     end
 
     it 'automatically applies FIXEDENCODING flag' do
-      c = Regexp.new('\x80', Regexp::NOENCODING)
-      c.options.should == Regexp::FIXEDENCODING | Regexp::NOENCODING
-      c.to_s.should == '(?-mix:\x80)'
+      r = Regexp.new('\x80', Regexp::NOENCODING)
+      r.options.should == Regexp::FIXEDENCODING | Regexp::NOENCODING
+      r.to_s.should == '(?-mix:\x80)'
+
+      r = Regexp.new('\u1234', 0)
+      r.options.should == Regexp::FIXEDENCODING
     end
   end
 


### PR DESCRIPTION
This was a side quest to get `String#byteindex(regexp)` working like I want.