### PR TITLE
Fixes to optional assignments to self

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1678,7 +1678,7 @@ module Natalie
           PushArgcInstruction.new(key_args.size),
           SendInstruction.new(
             :[],
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -1726,7 +1726,7 @@ module Natalie
           PushArgcInstruction.new(key_args.size + 1),
           SendInstruction.new(
             :[]=,
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -558,7 +558,7 @@ module Natalie
           PushArgcInstruction.new(0),
           SendInstruction.new(
             node.read_name,
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -579,7 +579,7 @@ module Natalie
           PushArgcInstruction.new(1),
           SendInstruction.new(
             node.write_name,
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -692,7 +692,7 @@ module Natalie
           PushArgcInstruction.new(0),
           SendInstruction.new(
             node.read_name,
-            receiver_is_self: false,
+            receiver_is_self: node.receiver.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -718,7 +718,7 @@ module Natalie
           PushArgcInstruction.new(1),
           SendInstruction.new(
             node.write_name,
-            receiver_is_self: false,
+            receiver_is_self: node.receiver.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1533,7 +1533,7 @@ module Natalie
           PushArgcInstruction.new(key_args.size),
           SendInstruction.new(
             :[],
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -1562,7 +1562,7 @@ module Natalie
           PushArgcInstruction.new(key_args.size + 1),
           SendInstruction.new(
             :[]=,
-            receiver_is_self: false,
+            receiver_is_self: obj.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file.path,
             line: node.location.start_line,

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -221,10 +221,8 @@ describe 'Optional variable assignments' do
           def []=(k, v) @a[k] = v; 42 end
         end
 
-        NATFIXME 'ignores method visibility when receiver is self', exception: NoMethodError, message: "private method `[]' called" do
-          a = klass_with_private_methods.new(k: false)
-          a.public_method(:k, 10).should == 10
-        end
+        a = klass_with_private_methods.new(k: false)
+        a.public_method(:k, 10).should == 10
       end
 
       context 'splatted argument' do

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -524,10 +524,8 @@ describe 'Optional variable assignments' do
           def []=(k, v) @a[k] = v; 42 end
         end
 
-        NATFIXME 'ignores method visibility when receiver is self', exception: NoMethodError, message: "private method `[]' called" do
-          a = klass_with_private_methods.new(k: true)
-          a.public_method(:k, 10).should == 10
-        end
+        a = klass_with_private_methods.new(k: true)
+        a.public_method(:k, 10).should == 10
       end
 
       context 'splatted argument' do

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -141,10 +141,8 @@ describe 'Optional variable assignments' do
           def a=(v) @a = v; 42 end
         end
 
-        NATFIXME 'ignores method visibility when receiver is self', exception: NoMethodError, message: "private method `a' called" do
-          a = klass_with_private_methods.new(false)
-          a.public_method(10).should == 10
-        end
+        a = klass_with_private_methods.new(false)
+        a.public_method(10).should == 10
       end
     end
 

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -395,10 +395,8 @@ describe 'Optional variable assignments' do
           def a=(v) @a = v; 42 end
         end
 
-        NATFIXME 'ignores method visibility when receiver is self', exception: NoMethodError, message: "private method `a' called" do
-          a = klass_with_private_methods.new(true)
-          a.public_method(10).should == 10
-        end
+        a = klass_with_private_methods.new(true)
+        a.public_method(10).should == 10
       end
     end
 

--- a/spec/language/send_spec.rb
+++ b/spec/language/send_spec.rb
@@ -262,10 +262,8 @@ end
 describe "Invoking a private getter method" do
   it "permits self as a receiver" do
     receiver = LangSendSpecs::PrivateGetter.new
-    NATFIXME 'it permits self as a receiver', exception: NoMethodError, message: "private method `foo' called for an instance of LangSendSpecs::PrivateGetter" do
-      receiver.call_self_foo_or_equals(6)
-      receiver.call_self_foo.should == 6
-    end
+    receiver.call_self_foo_or_equals(6)
+    receiver.call_self_foo.should == 6
   end
 end
 


### PR DESCRIPTION
This fixes the following code patterns:
```ruby
self.foo ||= bar
self.foo &&= bar
self[foo] ||= bar
self[foo] &&= bar
```