### PR TITLE
Handle self nodes in multiple assignment calls

### DIFF
--- a/lib/natalie/compiler/multiple_assignment.rb
+++ b/lib/natalie/compiler/multiple_assignment.rb
@@ -58,7 +58,7 @@ module Natalie
         @instructions << PushArgcInstruction.new(args.size + 1)
         @instructions << SendInstruction.new(
           message,
-          receiver_is_self: false,
+          receiver_is_self: receiver.is_a?(Prism::SelfNode),
           with_block: false,
           file: @file,
           line: @line,

--- a/lib/natalie/compiler/multiple_assignment.rb
+++ b/lib/natalie/compiler/multiple_assignment.rb
@@ -95,7 +95,7 @@ module Natalie
           @instructions << PushArgcInstruction.new(1)
           @instructions << SendInstruction.new(
             arg.name,
-            receiver_is_self: false,
+            receiver_is_self: arg.receiver.is_a?(Prism::SelfNode),
             with_block: false,
             file: @file,
             line: @line,

--- a/spec/language/send_spec.rb
+++ b/spec/language/send_spec.rb
@@ -251,10 +251,8 @@ describe "Invoking a private setter method" do
 
     it "for multiple assignment" do
       receiver = LangSendSpecs::PrivateSetter.new
-      NATFIXME 'it permits self as a receiver', exception: NoMethodError, message: "private method `foo=' called for an instance of LangSendSpecs::PrivateSetter" do
-        receiver.call_self_foo_equals_masgn(42)
-        receiver.foo.should == 42
-      end
+      receiver.call_self_foo_equals_masgn(42)
+      receiver.foo.should == 42
     end
   end
 end

--- a/test/natalie/send_test.rb
+++ b/test/natalie/send_test.rb
@@ -1,8 +1,15 @@
 require_relative '../spec_helper'
 
 class Foo
+  attr_accessor :arr
+  private :arr=
+
   def foo
     'foo'
+  end
+
+  def self_splat_assign(val)
+    *self.arr = val
   end
 end
 
@@ -26,5 +33,13 @@ describe 'calling send from C++ code to an undefined method' do
     obj = Object.new
     obj.singleton_class.undef_method(:==)
     -> { 1 == obj }.should raise_error(NoMethodError)
+  end
+end
+
+describe 'calling multiwrite splat node' do
+  it 'works' do
+    foo = Foo.new
+    foo.self_splat_assign([1, 2])
+    foo.arr.should == [1, 2]
   end
 end


### PR DESCRIPTION
This supports code like:
```ruby
self.foo, * = bar
*self.foo = bar
```