### PR TITLE
Handle regexp back references with an index that is too big

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2150,8 +2150,25 @@ module Natalie
       end
 
       def transform_numbered_reference_read_node(node, used:)
+        if node.number == 0
+          instructions = [
+            PushSelfInstruction.new,
+            PushStringInstruction.new("warning: `#{node.location.slice}' is too big for a number variable, always nil"),
+            PushArgcInstruction.new(1),
+            SendInstruction.new(
+              :warn,
+              receiver_is_self: true,
+              with_block: false,
+              file: @file.path,
+              line: node.location.start_line,
+            ),
+            PopInstruction.new,
+          ]
+          instructions << PushNilInstruction.new if used
+          return instructions
+        end
+
         return [] unless used
-        return [PushNilInstruction.new] if node.number == 0
         [
           PushLastMatchInstruction.new,
           DupInstruction.new,

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2151,6 +2151,7 @@ module Natalie
 
       def transform_numbered_reference_read_node(node, used:)
         return [] unless used
+        return [PushNilInstruction.new] if node.number == 0
         [
           PushLastMatchInstruction.new,
           DupInstruction.new,

--- a/spec/language/regexp/back-references_spec.rb
+++ b/spec/language/regexp/back-references_spec.rb
@@ -23,7 +23,7 @@ describe "Regexps with back-references" do
   end
 
   it "returns nil for numbered variable with too large index" do
-    NATFIXME 'eval() only works on static strings', exception: SpecFailedException do
+    NATFIXME 'print warning for numbered variable with too large index', exception: SpecFailedException, message: /but the output was/ do
       -> {
         eval(<<~CODE).should == nil
           "a" =~ /(.)/

--- a/spec/language/regexp/back-references_spec.rb
+++ b/spec/language/regexp/back-references_spec.rb
@@ -23,14 +23,12 @@ describe "Regexps with back-references" do
   end
 
   it "returns nil for numbered variable with too large index" do
-    NATFIXME 'print warning for numbered variable with too large index', exception: SpecFailedException, message: /but the output was/ do
-      -> {
-        eval(<<~CODE).should == nil
-          "a" =~ /(.)/
-          eval('$4294967296')
-        CODE
-      }.should complain(/warning: ('|`)\$4294967296' is too big for a number variable, always nil/)
-    end
+    -> {
+      eval(<<~CODE).should == nil
+        "a" =~ /(.)/
+        eval('$4294967296')
+      CODE
+    }.should complain(/warning: ('|`)\$4294967296' is too big for a number variable, always nil/)
   end
 
   # NATFIXME


### PR DESCRIPTION
Short explanation: Prism uses a 32 bit unsigned int to store the index, indices larger than that are stored as 0. So the check `node.number == 0` actually means `node.number >= 2**32`