### PR TITLE
Freeze RUBY_* String constants

### DIFF
--- a/spec/core/builtin_constants/builtin_constants_spec.rb
+++ b/spec/core/builtin_constants/builtin_constants_spec.rb
@@ -4,6 +4,10 @@ describe "RUBY_VERSION" do
   it "is a String" do
     RUBY_VERSION.should be_kind_of(String)
   end
+
+  it "is frozen" do
+    RUBY_VERSION.should.frozen?
+  end
 end
 
 describe "RUBY_PATCHLEVEL" do
@@ -16,11 +20,19 @@ describe "RUBY_COPYRIGHT" do
   it "is a String" do
     RUBY_COPYRIGHT.should be_kind_of(String)
   end
+
+  it "is frozen" do
+    RUBY_COPYRIGHT.should.frozen?
+  end
 end
 
 describe "RUBY_DESCRIPTION" do
   it "is a String" do
     RUBY_DESCRIPTION.should be_kind_of(String)
+  end
+
+  it "is frozen" do
+    RUBY_DESCRIPTION.should.frozen?
   end
 end
 
@@ -28,11 +40,19 @@ describe "RUBY_ENGINE" do
   it "is a String" do
     RUBY_ENGINE.should be_kind_of(String)
   end
+
+  it "is frozen" do
+    RUBY_ENGINE.should.frozen?
+  end
 end
 
 describe "RUBY_PLATFORM" do
   it "is a String" do
     RUBY_PLATFORM.should be_kind_of(String)
+  end
+
+  it "is frozen" do
+    RUBY_PLATFORM.should.frozen?
   end
 end
 
@@ -40,10 +60,18 @@ describe "RUBY_RELEASE_DATE" do
   it "is a String" do
     RUBY_RELEASE_DATE.should be_kind_of(String)
   end
+
+  it "is frozen" do
+    RUBY_RELEASE_DATE.should.frozen?
+  end
 end
 
 describe "RUBY_REVISION" do
   it "is a String" do
     RUBY_REVISION.should be_kind_of(String)
+  end
+
+  it "is frozen" do
+    RUBY_REVISION.should.frozen?
   end
 end

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -453,28 +453,36 @@ Env *build_top_env() {
     ENV->extend_once(env, Enumerable);
 
     Value RUBY_VERSION = new StringObject { "3.3.0" };
+    RUBY_VERSION->freeze();
     Object->const_set("RUBY_VERSION"_s, RUBY_VERSION);
 
     Value RUBY_COPYRIGHT = new StringObject { "natalie - Copyright (c) 2023 Tim Morgan and contributors" };
+    RUBY_COPYRIGHT->freeze();
     Object->const_set("RUBY_COPYRIGHT"_s, RUBY_COPYRIGHT);
 
     auto ruby_revision_short = TM::String(ruby_revision, 10);
     StringObject *RUBY_DESCRIPTION = StringObject::format("natalie ({} revision {}) [{}]", ruby_release_date, ruby_revision_short, ruby_platform);
+    RUBY_DESCRIPTION->freeze();
     Object->const_set("RUBY_DESCRIPTION"_s, RUBY_DESCRIPTION);
 
     Value RUBY_ENGINE = new StringObject { "natalie" };
+    RUBY_ENGINE->freeze();
     Object->const_set("RUBY_ENGINE"_s, RUBY_ENGINE);
 
     Value RUBY_PATCHLEVEL = new IntegerObject { -1 };
+    RUBY_PATCHLEVEL->freeze();
     Object->const_set("RUBY_PATCHLEVEL"_s, RUBY_PATCHLEVEL);
 
     StringObject *RUBY_PLATFORM = new StringObject { ruby_platform };
+    RUBY_PLATFORM->freeze();
     Object->const_set("RUBY_PLATFORM"_s, RUBY_PLATFORM);
 
     Value RUBY_RELEASE_DATE = new StringObject { ruby_release_date };
+    RUBY_RELEASE_DATE->freeze();
     Object->const_set("RUBY_RELEASE_DATE"_s, RUBY_RELEASE_DATE);
 
     Value RUBY_REVISION = new StringObject { ruby_revision };
+    RUBY_REVISION->freeze();
     Object->const_set("RUBY_REVISION"_s, RUBY_REVISION);
 
     ModuleObject *GC = new ModuleObject { "GC" };


### PR DESCRIPTION
These are all frozen in MRI, and are not supposed to be changeable. 