### PR TITLE
Implement Kernel.select

### DIFF
--- a/spec/core/kernel/select_spec.rb
+++ b/spec/core/kernel/select_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Kernel#select" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:select)
+  end
+end
+
+describe "Kernel.select" do
+  it 'does not block when timeout is 0' do
+    IO.pipe do |read, write|
+      select([read], [], [], 0).should == nil
+      write.write 'data'
+      select([read], [], [], 0).should == [[read], [], []]
+    end
+  end
+end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -56,6 +56,11 @@ module Kernel
     Random::DEFAULT.rand(*args)
   end
 
+  def select(...)
+    IO.select(...)
+  end
+  module_function :select
+
   def warn(*msgs, category: nil, uplevel: nil)
     if !category.nil? && !category.is_a?(Symbol)
       category = category.to_sym if category.respond_to?(:to_sym)


### PR DESCRIPTION
Which is just a proxy to `IO.select`. so I really don't understand why the language has this. Sure, it is three characters shorter to not type the `IO.` prefix, but then we implement a different `select` in `Enumerable` so you're better of using the prefixed version anyway.