### PR TITLE
Cleanup of popen2

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -173,10 +173,10 @@ inline Block *to_block(Env *, Block *block) { return block; }
 
 Value shell_backticks(Env *, Value);
 
-FILE *popen2(const char *, const char *, int &);
+FILE *popen2(const char *, const char *, pid_t &);
 int pclose2(FILE *, pid_t);
 
-void set_status_object(Env *, int, int);
+void set_status_object(Env *, pid_t, int);
 
 Value super(Env *, Value, Args, Block *);
 


### PR DESCRIPTION
* Use `pid_t` instead of `int` for pid, update callers as well.
* Make `is_read` const
* Use `STDOUT_FILENO` and `STDIN_FILENO` instead of numeric values

This one has been extracted from #2200 to split up some dependencies.