### PR TITLE
Update NATFIXME in specs of IO#close

### DIFF
--- a/spec/core/io/close_spec.rb
+++ b/spec/core/io/close_spec.rb
@@ -53,7 +53,7 @@ describe "IO#close" do
   it 'raises an IOError with a clear message' do
     matching_exception = nil
 
-    NATFIXME 'IOError message does not match', exception: SpecFailedException do
+    NATFIXME 'it should raise an IOError', exception: SpecFailedException, message: /but instead raised nothing/ do
       -> do
         IOSpecs::THREAD_CLOSE_RETRIES.times do
           read_io, write_io = IO.pipe


### PR DESCRIPTION
The message implied we raised with a different error message, but we don't raise at all. Update the description and add a message check to make sure the description matches with the error.