### PR TITLE
Don't crash on calls to srand with bigint

### DIFF
--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -47,7 +47,7 @@ public:
             seed = new_seed(env);
         auto default_random = GlobalEnv::the()->Random()->const_fetch("DEFAULT"_s)->as_random();
         auto old_seed = default_random->seed();
-        auto new_seed = seed->to_int(env)->to_nat_int_t();
+        auto new_seed = IntegerObject::convert_to_native_type<nat_int_t>(env, seed);
         default_random->m_seed = new_seed;
         default_random->m_generator = new std::mt19937(new_seed);
         return old_seed;

--- a/include/nathelpers/typeinfo.hpp
+++ b/include/nathelpers/typeinfo.hpp
@@ -30,6 +30,11 @@ struct typeinfo<ssize_t> {
     constexpr const char *name() { return "ssize_t"; }
 };
 
+template <>
+struct typeinfo<long long int> {
+    constexpr const char *name() { return "long long int"; }
+};
+
 #ifdef __APPLE__
 template <>
 struct typeinfo<uint64_t> {

--- a/spec/core/kernel/srand_spec.rb
+++ b/spec/core/kernel/srand_spec.rb
@@ -45,10 +45,11 @@ describe "Kernel#srand" do
     srand.should == -17
   end
 
-  # NATFIXME: Support bigint value
-  xit "accepts an Integer as a seed" do
-    srand(0x12345678901234567890)
-    srand.should == 0x12345678901234567890
+  it "accepts an Integer as a seed" do
+    NATFIXME 'Support bigint value', exception: RangeError, message: "bignum too big to convert into `long long int'" do
+      srand(0x12345678901234567890)
+      srand.should == 0x12345678901234567890
+    end
   end
 
   it "calls #to_int on seed" do


### PR DESCRIPTION
Use convert_to_native_type, which generates a readable error message instead of an assertion failure. We should still support bigint, but at least we can run this spec now without crashing.