### PR TITLE
Bump rexml gem to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.3)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)


### PR DESCRIPTION
This resolves some CVE, but since rexml is only a dependency for Rubocop, this should not affect us. This does silence dependabot though.