### PR TITLE
Fix mutex usage in ThreadGroupObject::add

### DIFF
--- a/include/natalie/thread_group_object.hpp
+++ b/include/natalie/thread_group_object.hpp
@@ -32,7 +32,7 @@ public:
     virtual void visit_children(Visitor &) override final;
 
 private:
-    std::mutex m_mutex;
+    static inline std::mutex m_mutex;
 
     static inline ThreadGroupObject *m_default { nullptr };
     Vector<ThreadObject *> m_threads;

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -7,7 +7,7 @@ Value ThreadGroupObject::add(Env *env, Value value) {
         env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value->klass()->inspect_str());
     auto thread = value->as_thread();
 
-    std::unique_lock { m_mutex };
+    std::unique_lock lock { m_mutex };
     auto old_thread_group = thread->group();
     if (old_thread_group != this) {
         if (old_thread_group) {


### PR DESCRIPTION
We're updating multiple thread groups, so this mutex should be a class variable, not an instance variable. Save the lock into a variable, so we run the critical section with a lock.