### PR TITLE
Fix Regexp.escape/quote not escaping dollar signs

### DIFF
--- a/spec/core/regexp/shared/new.rb
+++ b/spec/core/regexp/shared/new.rb
@@ -56,9 +56,7 @@ describe :regexp_new_string, shared: true do
   end
 
   it "raises a RegexpError when passed an incorrect regexp" do
-      NATFIXME 'Update error message', exception: SpecFailedException, message: /but the message was/ do
-      -> { Regexp.send(@method, "^[$", 0) }.should raise_error(RegexpError, Regexp.new(Regexp.escape("premature end of char-class: /^[$/")))
-    end
+    -> { Regexp.send(@method, "^[$", 0) }.should raise_error(RegexpError, Regexp.new(Regexp.escape("premature end of char-class: /^[$/")))
   end
 
   it "does not set Regexp options if only given one argument" do

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -128,6 +128,7 @@ Value RegexpObject::quote(Env *env, Value string) {
         case '.':
         case '+':
         case '^':
+        case '$':
         case '[':
         case ']':
         case '(':

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -96,6 +96,12 @@ describe 'regexp' do
     end
   end
 
+  describe '.escape and .quote' do
+    it 'escapes special characters' do
+      Regexp.escape('$').should == '\$'
+    end
+  end
+
   describe '#==' do
     it 'returns true if the regexp source is the same' do
       /foo/.should == /foo/


### PR DESCRIPTION
Dollar signs should be escaped/quoted:

    $ irb
    irb(main):001> Regexp.escape '$'
    => "\\$"
