### PR TITLE
Refresh shared spec for Regexp.quote/Regexp.escape

### DIFF
--- a/spec/core/regexp/shared/quote.rb
+++ b/spec/core/regexp/shared/quote.rb
@@ -2,8 +2,8 @@
 
 describe :regexp_quote, shared: true do
   it "escapes any characters with special meaning in a regular expression" do
-    Regexp.send(@method, '\*?{}.+^[]()- ').should == '\\\\\*\?\{\}\.\+\^\[\]\(\)\-\\ '
-    Regexp.send(@method, "\*?{}.+^[]()- ").should == '\\*\\?\\{\\}\\.\\+\\^\\[\\]\\(\\)\\-\\ '
+    Regexp.send(@method, '\*?{}.+^$[]()- ').should == '\\\\\*\?\{\}\.\+\^\$\[\]\(\)\-\\ '
+    Regexp.send(@method, "\*?{}.+^$[]()- ").should == '\\*\\?\\{\\}\\.\\+\\^\\$\\[\\]\\(\\)\\-\\ '
     Regexp.send(@method, '\n\r\f\t').should == '\\\\n\\\\r\\\\f\\\\t'
     Regexp.send(@method, "\n\r\f\t").should == '\\n\\r\\f\\t'
   end
@@ -18,23 +18,23 @@ describe :regexp_quote, shared: true do
   end
 
   it "works for broken strings" do
-    Regexp.send(@method, "a.\x85b.".force_encoding("US-ASCII")).should =="a\\.\x85b\\.".force_encoding("US-ASCII")
-    Regexp.send(@method, "a.\x80".force_encoding("UTF-8")).should == "a\\.\x80".force_encoding("UTF-8")
+    Regexp.send(@method, "a.\x85b.".dup.force_encoding("US-ASCII")).should =="a\\.\x85b\\.".dup.force_encoding("US-ASCII")
+    Regexp.send(@method, "a.\x80".dup.force_encoding("UTF-8")).should == "a\\.\x80".dup.force_encoding("UTF-8")
   end
 
   it "sets the encoding of the result to US-ASCII if there are only US-ASCII characters present in the input String" do
-    str = "abc".force_encoding("euc-jp")
+    str = "abc".dup.force_encoding("euc-jp")
     Regexp.send(@method, str).encoding.should == Encoding::US_ASCII
   end
 
   it "sets the encoding of the result to the encoding of the String if any non-US-ASCII characters are present in an input String with valid encoding" do
-    str = "ありがとう".force_encoding("utf-8")
+    str = "ありがとう".dup.force_encoding("utf-8")
     str.valid_encoding?.should be_true
     Regexp.send(@method, str).encoding.should == Encoding::UTF_8
   end
 
   it "sets the encoding of the result to BINARY if any non-US-ASCII characters are present in an input String with invalid encoding" do
-    str = "\xff".force_encoding "us-ascii"
+    str = "\xff".dup.force_encoding "us-ascii"
     str.valid_encoding?.should be_false
     Regexp.send(@method, "\xff").encoding.should == Encoding::BINARY
   end

--- a/test/natalie/regexp_test.rb
+++ b/test/natalie/regexp_test.rb
@@ -96,12 +96,6 @@ describe 'regexp' do
     end
   end
 
-  describe '.escape and .quote' do
-    it 'escapes special characters' do
-      Regexp.escape('$').should == '\$'
-    end
-  end
-
   describe '#==' do
     it 'returns true if the regexp source is the same' do
       /foo/.should == /foo/


### PR DESCRIPTION
This includes a spec for the escape of `$`, which means we can remove our local spec for this.

This finishes the leftovers of #2222, which depended on an upstream merge in ruby/spec.