### PR TITLE
Add some motivation to the CI job on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
       - name: install ruby
         run: |
           brew update
-          brew uninstall -f ruby
-          brew uninstall -f ruby@3.0
+          brew uninstall -f --ignore-dependencies ruby
+          brew uninstall -f --ignore-dependencies ruby@3.0
           rm -rf /usr/local/lib/ruby/gems/3.0.0 /usr/local/opt/ruby@3.0
           brew install ruby@3.3
       - name: check ruby


### PR DESCRIPTION
It currently fails with this message:

    Error: Refusing to uninstall /usr/local/Cellar/ruby/3.3.5
    because it is required by asciidoctor, which is currently installed.
    You can override this and force removal with:
      brew uninstall --ignore-dependencies ruby