### PR TITLE
Enable the formerly crashing spec of Regexp#encoding again

### DIFF
--- a/spec/core/regexp/encoding_spec.rb
+++ b/spec/core/regexp/encoding_spec.rb
@@ -20,8 +20,7 @@ describe "Regexp#encoding" do
     end
   end
 
-  # NATFIXME: Crashes with GC unreachable
-  xit "defaults to UTF-8 if \\u escapes appear" do
+  it "defaults to UTF-8 if \\u escapes appear" do
     /\u{9879}/.encoding.should == Encoding::UTF_8
   end
 


### PR DESCRIPTION
This has been fixed somewhere in the past (at least: that what it looks like).