### PR TITLE
Refresh specs for Date#month and Date#mon

### DIFF
--- a/spec/library/date/mon_spec.rb
+++ b/spec/library/date/mon_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'shared/month'
+require 'date'
+
+describe "Date#mon" do
+  it_behaves_like :date_month, :mon
+end

--- a/spec/library/date/month_spec.rb
+++ b/spec/library/date/month_spec.rb
@@ -1,9 +1,7 @@
 require_relative '../../spec_helper'
+require_relative 'shared/month'
 require 'date'
 
 describe "Date#month" do
-  it "returns the month" do
-    m = Date.new(2000, 7, 1).month
-    m.should == 7
-  end
+  it_behaves_like :date_month, :month
 end

--- a/spec/library/date/shared/month.rb
+++ b/spec/library/date/shared/month.rb
@@ -1,0 +1,6 @@
+describe :date_month, shared: true do
+  it "returns the month" do
+    m = Date.new(2000, 7, 1).send(@method)
+    m.should == 7
+  end
+end


### PR DESCRIPTION
Upstream changes in https://github.com/ruby/spec/pull/1195 which adds specs for `Date#mon`