### PR TITLE
Basic support for regexp in Marshal.dump

### DIFF
--- a/spec/core/marshal/dump_spec.rb
+++ b/spec/core/marshal/dump_spec.rb
@@ -390,15 +390,11 @@ describe "Marshal.dump" do
 
   describe "with a Regexp" do
     it "dumps a Regexp" do
-      NATFIXME 'dumps a Regexp', exception: SpecFailedException do
-        Marshal.dump(/\A.\Z/).should == "\x04\bI/\n\\A.\\Z\x00\x06:\x06EF"
-      end
+      Marshal.dump(/\A.\Z/).should == "\x04\bI/\n\\A.\\Z\x00\x06:\x06EF"
     end
 
     it "dumps a Regexp with flags" do
-      NATFIXME 'dumps a Regexp with flags', exception: SpecFailedException do
-        Marshal.dump(//im).should == "\x04\bI/\x00\x05\x06:\x06EF"
-      end
+      Marshal.dump(//im).should == "\x04\bI/\x00\x05\x06:\x06EF"
     end
 
     it "dumps a Regexp with instance variables" do

--- a/spec/core/marshal/shared/load.rb
+++ b/spec/core/marshal/shared/load.rb
@@ -1068,7 +1068,7 @@ describe :marshal_load, shared: true do
 
     it "preserves Regexp encoding" do
       source_object = Regexp.new("a".encode("utf-32le"))
-      NATFIXME 'Support regexp dump', exception: ArgumentError, message: 'dump format error' do
+      NATFIXME 'Support encoding in regexp dump', exception: SpecFailedException do
         regexp = Marshal.send(@method, Marshal.dump(source_object))
 
         regexp.encoding.should == Encoding::UTF_32LE
@@ -1077,13 +1077,11 @@ describe :marshal_load, shared: true do
     end
 
     it "raises ArgumentError when end of byte sequence reached before source string end" do
-      NATFIXME 'raises ArgumentError when end of byte sequence reached before source string end', exception: SpecFailedException do
-        Marshal.dump(/hello world/).should == "\x04\bI/\x10hello world\x00\x06:\x06EF"
+      Marshal.dump(/hello world/).should == "\x04\bI/\x10hello world\x00\x06:\x06EF"
 
-        -> {
-          Marshal.send(@method, "\x04\bI/\x10hel")
-        }.should raise_error(ArgumentError, "marshal data too short")
-      end
+      -> {
+        Marshal.send(@method, "\x04\bI/\x10hel")
+      }.should raise_error(ArgumentError, "marshal data too short")
     end
   end
 

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -232,6 +232,7 @@ module Marshal
 
     def write_regexp(value)
       write_char('I')
+      write_char('/')
       write_string_bytes(value.source)
       write_byte(value.options)
       write_encoding_bytes(value)


### PR DESCRIPTION
We forgot to output the `/` byte to mark it as a regexp type.