### PR TITLE
Refresh fixtures of Marshal specs

### DIFF
--- a/spec/core/marshal/fixtures/marshal_data.rb
+++ b/spec/core/marshal/fixtures/marshal_data.rb
@@ -1,4 +1,7 @@
 # -*- encoding: binary -*-
+
+require_relative 'marshal_multibyte_data'
+
 class UserDefined
   class Nested
     def ==(other)
@@ -266,18 +269,6 @@ module MarshalSpec
       "Foo"
     end
   end
-
-  # NATFIXME: Support module_eval
-  #module_eval(<<~ruby.dup.force_encoding(Encoding::UTF_8))
-    #class MultibyteぁあぃいClass
-    #end
-
-    #module MultibyteけげこごModule
-    #end
-
-    #class MultibyteぁあぃいTime < Time
-    #end
-  #ruby
 
   class ObjectWithFreezeRaisingException < Object
     def freeze

--- a/spec/core/marshal/fixtures/marshal_multibyte_data.rb
+++ b/spec/core/marshal/fixtures/marshal_multibyte_data.rb
@@ -1,0 +1,12 @@
+# -*- encoding: utf-8 -*-
+
+module MarshalSpec
+  class MultibyteぁあぃいClass
+  end
+
+  module MultibyteけげこごModule
+  end
+
+  class MultibyteぁあぃいTime < Time
+  end
+end


### PR DESCRIPTION
This removes the module_eval call and should resolve the crashes in the nightly specs runner.