### PR TITLE
Refresh specs for StringIO

### DIFF
--- a/spec/library/stringio/read_spec.rb
+++ b/spec/library/stringio/read_spec.rb
@@ -53,7 +53,7 @@ describe "StringIO#read when passed length and a buffer" do
   end
 
   it "reads [length] characters into the buffer" do
-    buf = "foo"
+    buf = +"foo"
     result = @io.read(10, buf)
 
     buf.should == "abcdefghij"

--- a/spec/library/stringio/shared/codepoints.rb
+++ b/spec/library/stringio/shared/codepoints.rb
@@ -31,7 +31,7 @@ describe :stringio_codepoints, shared: true do
     @io.close_read
     -> { @enum.to_a }.should raise_error(IOError)
 
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method).to_a }.should raise_error(IOError)
   end
 

--- a/spec/library/stringio/shared/each.rb
+++ b/spec/library/stringio/shared/each.rb
@@ -96,7 +96,7 @@ end
 
 describe :stringio_each_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("a b c d e", "w")
+    io = StringIO.new(+"a b c d e", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("a b c d e")

--- a/spec/library/stringio/shared/each_byte.rb
+++ b/spec/library/stringio/shared/each_byte.rb
@@ -38,7 +38,7 @@ end
 
 describe :stringio_each_byte_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/spec/library/stringio/shared/each_char.rb
+++ b/spec/library/stringio/shared/each_char.rb
@@ -26,7 +26,7 @@ end
 
 describe :stringio_each_char_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/spec/library/stringio/shared/getc.rb
+++ b/spec/library/stringio/shared/getc.rb
@@ -33,7 +33,7 @@ end
 
 describe :stringio_getc_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/spec/library/stringio/shared/isatty.rb
+++ b/spec/library/stringio/shared/isatty.rb
@@ -1,5 +1,5 @@
 describe :stringio_isatty, shared: true do
   it "returns false" do
-    StringIO.new('tty').send(@method).should be_false
+    StringIO.new("tty").send(@method).should be_false
   end
 end

--- a/spec/library/stringio/shared/read.rb
+++ b/spec/library/stringio/shared/read.rb
@@ -5,19 +5,19 @@ describe :stringio_read, shared: true do
 
   it "returns the passed buffer String" do
     # Note: Rubinius bug:
-    # @io.send(@method, 7, buffer = "").should equal(buffer)
-    ret = @io.send(@method, 7, buffer = "")
+    # @io.send(@method, 7, buffer = +"").should equal(buffer)
+    ret = @io.send(@method, 7, buffer = +"")
     ret.should equal(buffer)
   end
 
   it "reads length bytes and writes them to the buffer String" do
-    @io.send(@method, 7, buffer = "")
+    @io.send(@method, 7, buffer = +"").should.equal?(buffer)
     buffer.should == "example"
   end
 
   it "tries to convert the passed buffer Object to a String using #to_str" do
     obj = mock("to_str")
-    obj.should_receive(:to_str).and_return(buffer = "")
+    obj.should_receive(:to_str).and_return(buffer = +"")
 
     @io.send(@method, 7, obj)
     buffer.should == "example"
@@ -75,7 +75,7 @@ end
 
 describe :stringio_read_no_arguments, shared: true do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "reads the whole content starting from the current position" do
@@ -111,7 +111,7 @@ end
 
 describe :stringio_read_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("test", "w")
+    io = StringIO.new(+"test", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("test")

--- a/spec/library/stringio/shared/readchar.rb
+++ b/spec/library/stringio/shared/readchar.rb
@@ -19,7 +19,7 @@ end
 
 describe :stringio_readchar_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("a b c d e", "w")
+    io = StringIO.new(+"a b c d e", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("a b c d e")

--- a/spec/library/stringio/shared/write.rb
+++ b/spec/library/stringio/shared/write.rb
@@ -1,6 +1,6 @@
 describe :stringio_write, shared: true do
   before :each do
-    @io = StringIO.new('12345')
+    @io = StringIO.new(+'12345')
   end
 
   it "tries to convert the passed Object to a String using #to_s" do
@@ -13,7 +13,7 @@ end
 
 describe :stringio_write_string, shared: true do
   before :each do
-    @io = StringIO.new('12345')
+    @io = StringIO.new(+'12345')
   end
 
   # TODO: RDoc says that #write appends at the current position.
@@ -108,10 +108,10 @@ end
 
 describe :stringio_write_not_writable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.send(@method, "test") }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.send(@method, "test") }.should raise_error(IOError)
   end
@@ -119,7 +119,7 @@ end
 
 describe :stringio_write_append, shared: true do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self" do

--- a/spec/library/stringio/write_nonblock_spec.rb
+++ b/spec/library/stringio/write_nonblock_spec.rb
@@ -10,7 +10,7 @@ describe "StringIO#write_nonblock when passed [String]" do
   it_behaves_like :stringio_write_string, :write_nonblock
 
   it "accepts :exception option" do
-    io = StringIO.new("12345", "a")
+    io = StringIO.new(+"12345", "a")
     io.write_nonblock("67890", exception: true)
     io.string.should == "1234567890"
   end


### PR DESCRIPTION
Prepare for the chilled strings coming in Ruby 3.4.