### PR TITLE
Import the CGI module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | file(s)          | copyright                         | license           |
 | ---------------- | --------------------------------- | ----------------- |
 | `bigint.*`       | 983                               | Unlicense         |
+| `cgi.rb`         | Wakou Aoyama                      | BSD               |
+| `cgi/*`          | Wakou Aoyama                      | BSD               |
 | `delegate.rb`    | Yukihiro Matsumoto                | BSD               |
 | `dtoa.c`         | David M. Gay, Lucent Technologies | custom permissive |
 | `ipaddr.rb`      | Hajimu Umemoto and Akinori Musha  | BSD               |

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -44,6 +44,7 @@ public:
     static Value catch_method(Env *, Value = nullptr, Block * = nullptr);
     static Value Complex(Env *env, Value real, Value imaginary, Value exception);
     static Value Complex(Env *env, Value real, Value imaginary, bool exception = true);
+    static Value cur_callee(Env *env);
     static Value cur_dir(Env *env);
     static Value exit(Env *env, Value status);
     static Value exit_bang(Env *env, Value status);

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -53,6 +53,16 @@ public:
     Method(const TM::String &name, ModuleObject *owner, Block *block)
         : Method(TM::String(name), owner, block) { }
 
+    static Method *from_other(const TM::String &name, Method *other) {
+        auto method = new Method { name, other->owner(), other->fn(), other->arity() };
+        method->m_self = other->m_self;
+        method->m_env = other->m_env;
+        method->m_file = other->m_file;
+        method->m_line = other->m_line;
+        method->set_original_method(other);
+        return method;
+    }
+
     MethodFnPtr fn() { return m_fn; }
     void set_fn(MethodFnPtr fn) { m_fn = fn; }
 
@@ -67,6 +77,14 @@ public:
     String name() const { return m_name; }
     ModuleObject *owner() const { return m_owner; }
 
+    String original_name() const {
+        if (m_original_method)
+            return m_original_method->name();
+        return name();
+    }
+    void set_original_method(Method *method) { m_original_method = method; }
+    Method *original_method() const { return m_original_method; }
+
     int arity() const { return m_arity; }
 
     const Optional<String> &get_file() const { return m_file; }
@@ -76,6 +94,7 @@ public:
         visitor.visit(m_owner);
         visitor.visit(m_env);
         visitor.visit(m_self);
+        visitor.visit(m_original_method);
     }
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -84,6 +103,7 @@ public:
 
 private:
     String m_name {};
+    Method *m_original_method = nullptr;
     ModuleObject *m_owner;
     MethodFnPtr m_fn;
     Value m_self { nullptr };

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -19,6 +19,7 @@ public:
     bool eq(Env *, Value);
     Value ltlt(Env *, Value);
     Value gtgt(Env *, Value);
+    Value hash() const;
     Value source_location();
 
     Value inspect(Env *env) {

--- a/lib/cgi.rb
+++ b/lib/cgi.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+#
+# cgi.rb - cgi support library
+#
+# Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
+#
+# Copyright (C) 2000  Information-technology Promotion Agency, Japan
+#
+# Author: Wakou Aoyama <wakou@ruby-lang.org>
+#
+# Documentation: Wakou Aoyama (RDoc'd and embellished by William Webber)
+#
+
+# == Overview
+#
+# The Common Gateway Interface (CGI) is a simple protocol for passing an HTTP
+# request from a web server to a standalone program, and returning the output
+# to the web browser.  Basically, a CGI program is called with the parameters
+# of the request passed in either in the environment (GET) or via $stdin
+# (POST), and everything it prints to $stdout is returned to the client.
+#
+# This file holds the CGI class.  This class provides functionality for
+# retrieving HTTP request parameters, managing cookies, and generating HTML
+# output.
+#
+# The file CGI::Session provides session management functionality; see that
+# class for more details.
+#
+# See http://www.w3.org/CGI/ for more information on the CGI protocol.
+#
+# == Introduction
+#
+# CGI is a large class, providing several categories of methods, many of which
+# are mixed in from other modules.  Some of the documentation is in this class,
+# some in the modules CGI::QueryExtension and CGI::HtmlExtension.  See
+# CGI::Cookie for specific information on handling cookies, and cgi/session.rb
+# (CGI::Session) for information on sessions.
+#
+# For queries, CGI provides methods to get at environmental variables,
+# parameters, cookies, and multipart request data.  For responses, CGI provides
+# methods for writing output and generating HTML.
+#
+# Read on for more details.  Examples are provided at the bottom.
+#
+# == Queries
+#
+# The CGI class dynamically mixes in parameter and cookie-parsing
+# functionality,  environmental variable access, and support for
+# parsing multipart requests (including uploaded files) from the
+# CGI::QueryExtension module.
+#
+# === Environmental Variables
+#
+# The standard CGI environmental variables are available as read-only
+# attributes of a CGI object.  The following is a list of these variables:
+#
+#
+#   AUTH_TYPE               HTTP_HOST          REMOTE_IDENT
+#   CONTENT_LENGTH          HTTP_NEGOTIATE     REMOTE_USER
+#   CONTENT_TYPE            HTTP_PRAGMA        REQUEST_METHOD
+#   GATEWAY_INTERFACE       HTTP_REFERER       SCRIPT_NAME
+#   HTTP_ACCEPT             HTTP_USER_AGENT    SERVER_NAME
+#   HTTP_ACCEPT_CHARSET     PATH_INFO          SERVER_PORT
+#   HTTP_ACCEPT_ENCODING    PATH_TRANSLATED    SERVER_PROTOCOL
+#   HTTP_ACCEPT_LANGUAGE    QUERY_STRING       SERVER_SOFTWARE
+#   HTTP_CACHE_CONTROL      REMOTE_ADDR
+#   HTTP_FROM               REMOTE_HOST
+#
+#
+# For each of these variables, there is a corresponding attribute with the
+# same name, except all lower case and without a preceding HTTP_.
+# +content_length+ and +server_port+ are integers; the rest are strings.
+#
+# === Parameters
+#
+# The method #params() returns a hash of all parameters in the request as
+# name/value-list pairs, where the value-list is an Array of one or more
+# values.  The CGI object itself also behaves as a hash of parameter names
+# to values, but only returns a single value (as a String) for each
+# parameter name.
+#
+# For instance, suppose the request contains the parameter
+# "favourite_colours" with the multiple values "blue" and "green".  The
+# following behavior would occur:
+#
+#   cgi.params["favourite_colours"]  # => ["blue", "green"]
+#   cgi["favourite_colours"]         # => "blue"
+#
+# If a parameter does not exist, the former method will return an empty
+# array, the latter an empty string.  The simplest way to test for existence
+# of a parameter is by the #has_key? method.
+#
+# === Cookies
+#
+# HTTP Cookies are automatically parsed from the request.  They are available
+# from the #cookies() accessor, which returns a hash from cookie name to
+# CGI::Cookie object.
+#
+# === Multipart requests
+#
+# If a request's method is POST and its content type is multipart/form-data,
+# then it may contain uploaded files.  These are stored by the QueryExtension
+# module in the parameters of the request.  The parameter name is the name
+# attribute of the file input field, as usual.  However, the value is not
+# a string, but an IO object, either an IOString for small files, or a
+# Tempfile for larger ones.  This object also has the additional singleton
+# methods:
+#
+# #local_path():: the path of the uploaded file on the local filesystem
+# #original_filename():: the name of the file on the client computer
+# #content_type():: the content type of the file
+#
+# == Responses
+#
+# The CGI class provides methods for sending header and content output to
+# the HTTP client, and mixes in methods for programmatic HTML generation
+# from CGI::HtmlExtension and CGI::TagMaker modules.  The precise version of HTML
+# to use for HTML generation is specified at object creation time.
+#
+# === Writing output
+#
+# The simplest way to send output to the HTTP client is using the #out() method.
+# This takes the HTTP headers as a hash parameter, and the body content
+# via a block.  The headers can be generated as a string using the #http_header()
+# method.  The output stream can be written directly to using the #print()
+# method.
+#
+# === Generating HTML
+#
+# Each HTML element has a corresponding method for generating that
+# element as a String.  The name of this method is the same as that
+# of the element, all lowercase.  The attributes of the element are
+# passed in as a hash, and the body as a no-argument block that evaluates
+# to a String.  The HTML generation module knows which elements are
+# always empty, and silently drops any passed-in body.  It also knows
+# which elements require matching closing tags and which don't.  However,
+# it does not know what attributes are legal for which elements.
+#
+# There are also some additional HTML generation methods mixed in from
+# the CGI::HtmlExtension module.  These include individual methods for the
+# different types of form inputs, and methods for elements that commonly
+# take particular attributes where the attributes can be directly specified
+# as arguments, rather than via a hash.
+#
+# === Utility HTML escape and other methods like a function.
+#
+# There are some utility tool defined in cgi/util.rb .
+# And when include, you can use utility methods like a function.
+#
+# == Examples of use
+#
+# === Get form values
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   value = cgi['field_name']   # <== value string for 'field_name'
+#     # if not 'field_name' included, then return "".
+#   fields = cgi.keys            # <== array of field names
+#
+#   # returns true if form has 'field_name'
+#   cgi.has_key?('field_name')
+#   cgi.has_key?('field_name')
+#   cgi.include?('field_name')
+#
+# CAUTION! <code>cgi['field_name']</code> returned an Array with the old
+# cgi.rb(included in Ruby 1.6)
+#
+# === Get form values as hash
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   params = cgi.params
+#
+# cgi.params is a hash.
+#
+#   cgi.params['new_field_name'] = ["value"]  # add new param
+#   cgi.params['field_name'] = ["new_value"]  # change value
+#   cgi.params.delete('field_name')           # delete param
+#   cgi.params.clear                          # delete all params
+#
+#
+# === Save form values to file
+#
+#   require "pstore"
+#   db = PStore.new("query.db")
+#   db.transaction do
+#     db["params"] = cgi.params
+#   end
+#
+#
+# === Restore form values from file
+#
+#   require "pstore"
+#   db = PStore.new("query.db")
+#   db.transaction do
+#     cgi.params = db["params"]
+#   end
+#
+#
+# === Get multipart form values
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   value = cgi['field_name']   # <== value string for 'field_name'
+#   value.read                  # <== body of value
+#   value.local_path            # <== path to local file of value
+#   value.original_filename     # <== original filename of value
+#   value.content_type          # <== content_type of value
+#
+# and value has StringIO or Tempfile class methods.
+#
+# === Get cookie values
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   values = cgi.cookies['name']  # <== array of 'name'
+#     # if not 'name' included, then return [].
+#   names = cgi.cookies.keys      # <== array of cookie names
+#
+# and cgi.cookies is a hash.
+#
+# === Get cookie objects
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   for name, cookie in cgi.cookies
+#     cookie.expires = Time.now + 30
+#   end
+#   cgi.out("cookie" => cgi.cookies) {"string"}
+#
+#   cgi.cookies # { "name1" => cookie1, "name2" => cookie2, ... }
+#
+#   require "cgi"
+#   cgi = CGI.new
+#   cgi.cookies['name'].expires = Time.now + 30
+#   cgi.out("cookie" => cgi.cookies['name']) {"string"}
+#
+# === Print http header and html string to $DEFAULT_OUTPUT ($>)
+#
+#   require "cgi"
+#   cgi = CGI.new("html4")  # add HTML generation methods
+#   cgi.out do
+#     cgi.html do
+#       cgi.head do
+#         cgi.title { "TITLE" }
+#       end +
+#       cgi.body do
+#         cgi.form("ACTION" => "uri") do
+#           cgi.p do
+#             cgi.textarea("get_text") +
+#             cgi.br +
+#             cgi.submit
+#           end
+#         end +
+#         cgi.pre do
+#           CGI.escapeHTML(
+#             "params: #{cgi.params.inspect}\n" +
+#             "cookies: #{cgi.cookies.inspect}\n" +
+#             ENV.collect do |key, value|
+#               "#{key} --> #{value}\n"
+#             end.join("")
+#           )
+#         end
+#       end
+#     end
+#   end
+#
+#   # add HTML generation methods
+#   CGI.new("html3")    # html3.2
+#   CGI.new("html4")    # html4.01 (Strict)
+#   CGI.new("html4Tr")  # html4.01 Transitional
+#   CGI.new("html4Fr")  # html4.01 Frameset
+#   CGI.new("html5")    # html5
+#
+# === Some utility methods
+#
+#   require 'cgi/util'
+#   CGI.escapeHTML('Usage: foo "bar" <baz>')
+#
+#
+# === Some utility methods like a function
+#
+#   require 'cgi/util'
+#   include CGI::Util
+#   escapeHTML('Usage: foo "bar" <baz>')
+#   h('Usage: foo "bar" <baz>') # alias
+#
+#
+
+class CGI
+  VERSION = "0.4.1"
+end
+
+require 'cgi/core'
+require 'cgi/cookie'
+require 'cgi/util'
+# TODO: Implement autoload
+require 'cgi/html'
+# CGI.autoload(:HtmlExtension, 'cgi/html')

--- a/lib/cgi/cookie.rb
+++ b/lib/cgi/cookie.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+require_relative 'util'
+class CGI
+  # Class representing an HTTP cookie.
+  #
+  # In addition to its specific fields and methods, a Cookie instance
+  # is a delegator to the array of its values.
+  #
+  # See RFC 2965.
+  #
+  # == Examples of use
+  #   cookie1 = CGI::Cookie.new("name", "value1", "value2", ...)
+  #   cookie1 = CGI::Cookie.new("name" => "name", "value" => "value")
+  #   cookie1 = CGI::Cookie.new('name'     => 'name',
+  #                             'value'    => ['value1', 'value2', ...],
+  #                             'path'     => 'path',   # optional
+  #                             'domain'   => 'domain', # optional
+  #                             'expires'  => Time.now, # optional
+  #                             'secure'   => true,     # optional
+  #                             'httponly' => true      # optional
+  #                             )
+  #
+  #   cgi.out("cookie" => [cookie1, cookie2]) { "string" }
+  #
+  #   name     = cookie1.name
+  #   values   = cookie1.value
+  #   path     = cookie1.path
+  #   domain   = cookie1.domain
+  #   expires  = cookie1.expires
+  #   secure   = cookie1.secure
+  #   httponly = cookie1.httponly
+  #
+  #   cookie1.name     = 'name'
+  #   cookie1.value    = ['value1', 'value2', ...]
+  #   cookie1.path     = 'path'
+  #   cookie1.domain   = 'domain'
+  #   cookie1.expires  = Time.now + 30
+  #   cookie1.secure   = true
+  #   cookie1.httponly = true
+  class Cookie < Array
+    @@accept_charset="UTF-8" unless defined?(@@accept_charset)
+
+    TOKEN_RE = %r"\A[[!-~]&&[^()<>@,;:\\\"/?=\[\]{}]]+\z"
+    PATH_VALUE_RE = %r"\A[[ -~]&&[^;]]*\z"
+    DOMAIN_VALUE_RE = %r"\A\.?(?<label>(?!-)[-A-Za-z0-9]+(?<!-))(?:\.\g<label>)*\z"
+
+    # Create a new CGI::Cookie object.
+    #
+    # :call-seq:
+    #   Cookie.new(name_string,*value)
+    #   Cookie.new(options_hash)
+    #
+    # +name_string+::
+    #   The name of the cookie; in this form, there is no #domain or
+    #   #expiration.  The #path is gleaned from the +SCRIPT_NAME+ environment
+    #   variable, and #secure is false.
+    # <tt>*value</tt>::
+    #   value or list of values of the cookie
+    # +options_hash+::
+    #   A Hash of options to initialize this Cookie.  Possible options are:
+    #
+    #   name:: the name of the cookie.  Required.
+    #   value:: the cookie's value or list of values.
+    #   path:: the path for which this cookie applies.  Defaults to
+    #          the value of the +SCRIPT_NAME+ environment variable.
+    #   domain:: the domain for which this cookie applies.
+    #   expires:: the time at which this cookie expires, as a +Time+ object.
+    #   secure:: whether this cookie is a secure cookie or not (default to
+    #            false).  Secure cookies are only transmitted to HTTPS
+    #            servers.
+    #   httponly:: whether this cookie is a HttpOnly cookie or not (default to
+    #            false).  HttpOnly cookies are not available to javascript.
+    #
+    #   These keywords correspond to attributes of the cookie object.
+    def initialize(name = "", *value)
+      @domain = nil
+      @expires = nil
+      if name.kind_of?(String)
+        self.name = name
+        self.path = (%r|\A(.*/)| =~ ENV["SCRIPT_NAME"] ? $1 : "")
+        @secure = false
+        @httponly = false
+        return super(value)
+      end
+
+      options = name
+      unless options.has_key?("name")
+        raise ArgumentError, "`name' required"
+      end
+
+      self.name = options["name"]
+      value = Array(options["value"])
+      # simple support for IE
+      self.path = options["path"] || (%r|\A(.*/)| =~ ENV["SCRIPT_NAME"] ? $1 : "")
+      self.domain = options["domain"]
+      @expires = options["expires"]
+      @secure = options["secure"] == true
+      @httponly = options["httponly"] == true
+
+      super(value)
+    end
+
+    # Name of this cookie, as a +String+
+    attr_reader :name
+    # Set name of this cookie
+    def name=(str)
+      if str and !TOKEN_RE.match?(str)
+        raise ArgumentError, "invalid name: #{str.dump}"
+      end
+      @name = str
+    end
+
+    # Path for which this cookie applies, as a +String+
+    attr_reader :path
+    # Set path for which this cookie applies
+    def path=(str)
+      if str and !PATH_VALUE_RE.match?(str)
+        raise ArgumentError, "invalid path: #{str.dump}"
+      end
+      @path = str
+    end
+
+    # Domain for which this cookie applies, as a +String+
+    attr_reader :domain
+    # Set domain for which this cookie applies
+    def domain=(str)
+      if str and ((str = str.b).bytesize > 255 or !DOMAIN_VALUE_RE.match?(str))
+        raise ArgumentError, "invalid domain: #{str.dump}"
+      end
+      @domain = str
+    end
+
+    # Time at which this cookie expires, as a +Time+
+    attr_accessor :expires
+    # True if this cookie is secure; false otherwise
+    attr_reader :secure
+    # True if this cookie is httponly; false otherwise
+    attr_reader :httponly
+
+    # Returns the value or list of values for this cookie.
+    def value
+      self
+    end
+
+    # Replaces the value of this cookie with a new value or list of values.
+    def value=(val)
+      replace(Array(val))
+    end
+
+    # Set whether the Cookie is a secure cookie or not.
+    #
+    # +val+ must be a boolean.
+    def secure=(val)
+      @secure = val if val == true or val == false
+      @secure
+    end
+
+    # Set whether the Cookie is a httponly cookie or not.
+    #
+    # +val+ must be a boolean.
+    def httponly=(val)
+      @httponly = !!val
+    end
+
+    # Convert the Cookie to its string representation.
+    def to_s
+      val = collect{|v| CGI.escape(v) }.join("&")
+      buf = "#{@name}=#{val}".dup
+      buf << "; domain=#{@domain}" if @domain
+      buf << "; path=#{@path}"     if @path
+      buf << "; expires=#{CGI.rfc1123_date(@expires)}" if @expires
+      buf << "; secure"            if @secure
+      buf << "; HttpOnly"          if @httponly
+      buf
+    end
+
+    # Parse a raw cookie string into a hash of cookie-name=>Cookie
+    # pairs.
+    #
+    #   cookies = CGI::Cookie.parse("raw_cookie_string")
+    #     # { "name1" => cookie1, "name2" => cookie2, ... }
+    #
+    def self.parse(raw_cookie)
+      cookies = Hash.new([])
+      return cookies unless raw_cookie
+
+      raw_cookie.split(/;\s?/).each do |pairs|
+        name, values = pairs.split('=',2)
+        next unless name and values
+        values ||= ""
+        values = values.split('&').collect{|v| CGI.unescape(v,@@accept_charset) }
+        if cookies.has_key?(name)
+          values = cookies[name].value + values
+        end
+        cookies[name] = Cookie.new(name, *values)
+      end
+
+      cookies
+    end
+
+    # A summary of cookie string.
+    def inspect
+      "#<CGI::Cookie: #{self.to_s.inspect}>"
+    end
+
+  end # class Cookie
+end
+
+

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -1,0 +1,900 @@
+# frozen_string_literal: true
+#--
+# Methods for generating HTML, parsing CGI-related parameters, and
+# generating HTTP responses.
+#++
+class CGI
+  unless const_defined?(:Util)
+    module Util
+      @@accept_charset = "UTF-8" # :nodoc:
+    end
+    include Util
+    extend Util
+  end
+
+  $CGI_ENV = ENV    # for FCGI support
+
+  # String for carriage return
+  CR  = "\015"
+
+  # String for linefeed
+  LF  = "\012"
+
+  # Standard internet newline sequence
+  EOL = CR + LF
+
+  REVISION = '$Id$' #:nodoc:
+
+  # Whether processing will be required in binary vs text
+  NEEDS_BINMODE = File::BINARY != 0
+
+  # Path separators in different environments.
+  PATH_SEPARATOR = {'UNIX'=>'/', 'WINDOWS'=>'\\', 'MACINTOSH'=>':'}
+
+  # HTTP status codes.
+  HTTP_STATUS = {
+    "OK"                  => "200 OK",
+    "PARTIAL_CONTENT"     => "206 Partial Content",
+    "MULTIPLE_CHOICES"    => "300 Multiple Choices",
+    "MOVED"               => "301 Moved Permanently",
+    "REDIRECT"            => "302 Found",
+    "NOT_MODIFIED"        => "304 Not Modified",
+    "BAD_REQUEST"         => "400 Bad Request",
+    "AUTH_REQUIRED"       => "401 Authorization Required",
+    "FORBIDDEN"           => "403 Forbidden",
+    "NOT_FOUND"           => "404 Not Found",
+    "METHOD_NOT_ALLOWED"  => "405 Method Not Allowed",
+    "NOT_ACCEPTABLE"      => "406 Not Acceptable",
+    "LENGTH_REQUIRED"     => "411 Length Required",
+    "PRECONDITION_FAILED" => "412 Precondition Failed",
+    "SERVER_ERROR"        => "500 Internal Server Error",
+    "NOT_IMPLEMENTED"     => "501 Method Not Implemented",
+    "BAD_GATEWAY"         => "502 Bad Gateway",
+    "VARIANT_ALSO_VARIES" => "506 Variant Also Negotiates"
+  }
+
+  # :startdoc:
+
+  # Synonym for ENV.
+  def env_table
+    ENV
+  end
+
+  # Synonym for $stdin.
+  def stdinput
+    $stdin
+  end
+
+  # Synonym for $stdout.
+  def stdoutput
+    $stdout
+  end
+
+  private :env_table, :stdinput, :stdoutput
+
+  # Create an HTTP header block as a string.
+  #
+  # :call-seq:
+  #   http_header(content_type_string="text/html")
+  #   http_header(headers_hash)
+  #
+  # Includes the empty line that ends the header block.
+  #
+  # +content_type_string+::
+  #   If this form is used, this string is the <tt>Content-Type</tt>
+  # +headers_hash+::
+  #   A Hash of header values. The following header keys are recognized:
+  #
+  #   type:: The Content-Type header.  Defaults to "text/html"
+  #   charset:: The charset of the body, appended to the Content-Type header.
+  #   nph:: A boolean value.  If true, prepend protocol string and status
+  #         code, and date; and sets default values for "server" and
+  #         "connection" if not explicitly set.
+  #   status::
+  #     The HTTP status code as a String, returned as the Status header.  The
+  #     values are:
+  #
+  #     OK:: 200 OK
+  #     PARTIAL_CONTENT:: 206 Partial Content
+  #     MULTIPLE_CHOICES:: 300 Multiple Choices
+  #     MOVED:: 301 Moved Permanently
+  #     REDIRECT:: 302 Found
+  #     NOT_MODIFIED:: 304 Not Modified
+  #     BAD_REQUEST:: 400 Bad Request
+  #     AUTH_REQUIRED:: 401 Authorization Required
+  #     FORBIDDEN:: 403 Forbidden
+  #     NOT_FOUND:: 404 Not Found
+  #     METHOD_NOT_ALLOWED:: 405 Method Not Allowed
+  #     NOT_ACCEPTABLE:: 406 Not Acceptable
+  #     LENGTH_REQUIRED:: 411 Length Required
+  #     PRECONDITION_FAILED:: 412 Precondition Failed
+  #     SERVER_ERROR:: 500 Internal Server Error
+  #     NOT_IMPLEMENTED:: 501 Method Not Implemented
+  #     BAD_GATEWAY:: 502 Bad Gateway
+  #     VARIANT_ALSO_VARIES:: 506 Variant Also Negotiates
+  #
+  #   server:: The server software, returned as the Server header.
+  #   connection:: The connection type, returned as the Connection header (for
+  #                instance, "close".
+  #   length:: The length of the content that will be sent, returned as the
+  #            Content-Length header.
+  #   language:: The language of the content, returned as the Content-Language
+  #              header.
+  #   expires:: The time on which the current content expires, as a +Time+
+  #             object, returned as the Expires header.
+  #   cookie::
+  #     A cookie or cookies, returned as one or more Set-Cookie headers.  The
+  #     value can be the literal string of the cookie; a CGI::Cookie object;
+  #     an Array of literal cookie strings or Cookie objects; or a hash all of
+  #     whose values are literal cookie strings or Cookie objects.
+  #
+  #     These cookies are in addition to the cookies held in the
+  #     @output_cookies field.
+  #
+  #   Other headers can also be set; they are appended as key: value.
+  #
+  # Examples:
+  #
+  #   http_header
+  #     # Content-Type: text/html
+  #
+  #   http_header("text/plain")
+  #     # Content-Type: text/plain
+  #
+  #   http_header("nph"        => true,
+  #               "status"     => "OK",  # == "200 OK"
+  #                 # "status"     => "200 GOOD",
+  #               "server"     => ENV['SERVER_SOFTWARE'],
+  #               "connection" => "close",
+  #               "type"       => "text/html",
+  #               "charset"    => "iso-2022-jp",
+  #                 # Content-Type: text/html; charset=iso-2022-jp
+  #               "length"     => 103,
+  #               "language"   => "ja",
+  #               "expires"    => Time.now + 30,
+  #               "cookie"     => [cookie1, cookie2],
+  #               "my_header1" => "my_value",
+  #               "my_header2" => "my_value")
+  #
+  # This method does not perform charset conversion.
+  def http_header(options='text/html')
+    if options.is_a?(String)
+      content_type = options
+      buf = _header_for_string(content_type)
+    elsif options.is_a?(Hash)
+      if options.size == 1 && options.has_key?('type')
+        content_type = options['type']
+        buf = _header_for_string(content_type)
+      else
+        buf = _header_for_hash(options.dup)
+      end
+    else
+      raise ArgumentError.new("expected String or Hash but got #{options.class}")
+    end
+    if defined?(MOD_RUBY)
+      _header_for_modruby(buf)
+      return ''
+    else
+      buf << EOL    # empty line of separator
+      return buf
+    end
+  end # http_header()
+
+  # This method is an alias for #http_header, when HTML5 tag maker is inactive.
+  #
+  # NOTE: use #http_header to create HTTP header blocks, this alias is only
+  # provided for backwards compatibility.
+  #
+  # Using #header with the HTML5 tag maker will create a <header> element.
+  alias :header :http_header
+
+  def _no_crlf_check(str)
+    if str
+      str = str.to_s
+      raise "A HTTP status or header field must not include CR and LF" if str =~ /[\r\n]/
+      str
+    else
+      nil
+    end
+  end
+  private :_no_crlf_check
+
+  def _header_for_string(content_type) #:nodoc:
+    buf = ''.dup
+    if nph?()
+      buf << "#{_no_crlf_check($CGI_ENV['SERVER_PROTOCOL']) || 'HTTP/1.0'} 200 OK#{EOL}"
+      buf << "Date: #{CGI.rfc1123_date(Time.now)}#{EOL}"
+      buf << "Server: #{_no_crlf_check($CGI_ENV['SERVER_SOFTWARE'])}#{EOL}"
+      buf << "Connection: close#{EOL}"
+    end
+    buf << "Content-Type: #{_no_crlf_check(content_type)}#{EOL}"
+    if @output_cookies
+      @output_cookies.each {|cookie| buf << "Set-Cookie: #{_no_crlf_check(cookie)}#{EOL}" }
+    end
+    return buf
+  end # _header_for_string
+  private :_header_for_string
+
+  def _header_for_hash(options)  #:nodoc:
+    buf = ''.dup
+    ## add charset to option['type']
+    options['type'] ||= 'text/html'
+    charset = options.delete('charset')
+    options['type'] += "; charset=#{charset}" if charset
+    ## NPH
+    options.delete('nph') if defined?(MOD_RUBY)
+    if options.delete('nph') || nph?()
+      protocol = _no_crlf_check($CGI_ENV['SERVER_PROTOCOL']) || 'HTTP/1.0'
+      status = options.delete('status')
+      status = HTTP_STATUS[status] || _no_crlf_check(status) || '200 OK'
+      buf << "#{protocol} #{status}#{EOL}"
+      buf << "Date: #{CGI.rfc1123_date(Time.now)}#{EOL}"
+      options['server'] ||= $CGI_ENV['SERVER_SOFTWARE'] || ''
+      options['connection'] ||= 'close'
+    end
+    ## common headers
+    status = options.delete('status')
+    buf << "Status: #{HTTP_STATUS[status] || _no_crlf_check(status)}#{EOL}" if status
+    server = options.delete('server')
+    buf << "Server: #{_no_crlf_check(server)}#{EOL}" if server
+    connection = options.delete('connection')
+    buf << "Connection: #{_no_crlf_check(connection)}#{EOL}" if connection
+    type = options.delete('type')
+    buf << "Content-Type: #{_no_crlf_check(type)}#{EOL}" #if type
+    length = options.delete('length')
+    buf << "Content-Length: #{_no_crlf_check(length)}#{EOL}" if length
+    language = options.delete('language')
+    buf << "Content-Language: #{_no_crlf_check(language)}#{EOL}" if language
+    expires = options.delete('expires')
+    buf << "Expires: #{CGI.rfc1123_date(expires)}#{EOL}" if expires
+    ## cookie
+    if cookie = options.delete('cookie')
+      case cookie
+      when String, Cookie
+        buf << "Set-Cookie: #{_no_crlf_check(cookie)}#{EOL}"
+      when Array
+        arr = cookie
+        arr.each {|c| buf << "Set-Cookie: #{_no_crlf_check(c)}#{EOL}" }
+      when Hash
+        hash = cookie
+        hash.each_value {|c| buf << "Set-Cookie: #{_no_crlf_check(c)}#{EOL}" }
+      end
+    end
+    if @output_cookies
+      @output_cookies.each {|c| buf << "Set-Cookie: #{_no_crlf_check(c)}#{EOL}" }
+    end
+    ## other headers
+    options.each do |key, value|
+      buf << "#{_no_crlf_check(key)}: #{_no_crlf_check(value)}#{EOL}"
+    end
+    return buf
+  end # _header_for_hash
+  private :_header_for_hash
+
+  def nph?  #:nodoc:
+    return /IIS\/(\d+)/ =~ $CGI_ENV['SERVER_SOFTWARE'] && $1.to_i < 5
+  end
+
+  def _header_for_modruby(buf)  #:nodoc:
+    request = Apache::request
+    buf.scan(/([^:]+): (.+)#{EOL}/o) do |name, value|
+      $stderr.printf("name:%s value:%s\n", name, value) if $DEBUG
+      case name
+      when 'Set-Cookie'
+        request.headers_out.add(name, value)
+      when /^status$/i
+        request.status_line = value
+        request.status = value.to_i
+      when /^content-type$/i
+        request.content_type = value
+      when /^content-encoding$/i
+        request.content_encoding = value
+      when /^location$/i
+        request.status = 302 if request.status == 200
+        request.headers_out[name] = value
+      else
+        request.headers_out[name] = value
+      end
+    end
+    request.send_http_header
+    return ''
+  end
+  private :_header_for_modruby
+
+  # Print an HTTP header and body to $DEFAULT_OUTPUT ($>)
+  #
+  # :call-seq:
+  #   cgi.out(content_type_string='text/html')
+  #   cgi.out(headers_hash)
+  #
+  # +content_type_string+::
+  #   If a string is passed, it is assumed to be the content type.
+  # +headers_hash+::
+  #   This is a Hash of headers, similar to that used by #http_header.
+  # +block+::
+  #   A block is required and should evaluate to the body of the response.
+  #
+  # <tt>Content-Length</tt> is automatically calculated from the size of
+  # the String returned by the content block.
+  #
+  # If <tt>ENV['REQUEST_METHOD'] == "HEAD"</tt>, then only the header
+  # is output (the content block is still required, but it is ignored).
+  #
+  # If the charset is "iso-2022-jp" or "euc-jp" or "shift_jis" then the
+  # content is converted to this charset, and the language is set to "ja".
+  #
+  # Example:
+  #
+  #   cgi = CGI.new
+  #   cgi.out{ "string" }
+  #     # Content-Type: text/html
+  #     # Content-Length: 6
+  #     #
+  #     # string
+  #
+  #   cgi.out("text/plain") { "string" }
+  #     # Content-Type: text/plain
+  #     # Content-Length: 6
+  #     #
+  #     # string
+  #
+  #   cgi.out("nph"        => true,
+  #           "status"     => "OK",  # == "200 OK"
+  #           "server"     => ENV['SERVER_SOFTWARE'],
+  #           "connection" => "close",
+  #           "type"       => "text/html",
+  #           "charset"    => "iso-2022-jp",
+  #             # Content-Type: text/html; charset=iso-2022-jp
+  #           "language"   => "ja",
+  #           "expires"    => Time.now + (3600 * 24 * 30),
+  #           "cookie"     => [cookie1, cookie2],
+  #           "my_header1" => "my_value",
+  #           "my_header2" => "my_value") { "string" }
+  #      # HTTP/1.1 200 OK
+  #      # Date: Sun, 15 May 2011 17:35:54 GMT
+  #      # Server: Apache 2.2.0
+  #      # Connection: close
+  #      # Content-Type: text/html; charset=iso-2022-jp
+  #      # Content-Length: 6
+  #      # Content-Language: ja
+  #      # Expires: Tue, 14 Jun 2011 17:35:54 GMT
+  #      # Set-Cookie: foo
+  #      # Set-Cookie: bar
+  #      # my_header1: my_value
+  #      # my_header2: my_value
+  #      #
+  #      # string
+  def out(options = "text/html") # :yield:
+
+    options = { "type" => options } if options.kind_of?(String)
+    content = yield
+    options["length"] = content.bytesize.to_s
+    output = stdoutput
+    output.binmode if defined? output.binmode
+    output.print http_header(options)
+    output.print content unless "HEAD" == env_table['REQUEST_METHOD']
+  end
+
+
+  # Print an argument or list of arguments to the default output stream
+  #
+  #   cgi = CGI.new
+  #   cgi.print    # default:  cgi.print == $DEFAULT_OUTPUT.print
+  def print(*options)
+    stdoutput.print(*options)
+  end
+
+  # Parse an HTTP query string into a hash of key=>value pairs.
+  #
+  #   params = CGI.parse("query_string")
+  #     # {"name1" => ["value1", "value2", ...],
+  #     #  "name2" => ["value1", "value2", ...], ... }
+  #
+  def self.parse(query)
+    params = {}
+    query.split(/[&;]/).each do |pairs|
+      key, value = pairs.split('=',2).collect{|v| CGI.unescape(v) }
+
+      next unless key
+
+      params[key] ||= []
+      params[key].push(value) if value
+    end
+
+    params.default=[].freeze
+    params
+  end
+
+  # Maximum content length of post data
+  ##MAX_CONTENT_LENGTH  = 2 * 1024 * 1024
+
+  # Maximum number of request parameters when multipart
+  MAX_MULTIPART_COUNT = 128
+
+  # Mixin module that provides the following:
+  #
+  # 1. Access to the CGI environment variables as methods.  See
+  #    documentation to the CGI class for a list of these variables.  The
+  #    methods are exposed by removing the leading +HTTP_+ (if it exists) and
+  #    downcasing the name.  For example, +auth_type+ will return the
+  #    environment variable +AUTH_TYPE+, and +accept+ will return the value
+  #    for +HTTP_ACCEPT+.
+  #
+  # 2. Access to cookies, including the cookies attribute.
+  #
+  # 3. Access to parameters, including the params attribute, and overloading
+  #    #[] to perform parameter value lookup by key.
+  #
+  # 4. The initialize_query method, for initializing the above
+  #    mechanisms, handling multipart forms, and allowing the
+  #    class to be used in "offline" mode.
+  #
+  module QueryExtension
+
+    %w[ CONTENT_LENGTH SERVER_PORT ].each do |env|
+      define_method(env.delete_prefix('HTTP_').downcase) do
+        (val = env_table[env]) && Integer(val)
+      end
+    end
+
+    %w[ AUTH_TYPE CONTENT_TYPE GATEWAY_INTERFACE PATH_INFO
+        PATH_TRANSLATED QUERY_STRING REMOTE_ADDR REMOTE_HOST
+        REMOTE_IDENT REMOTE_USER REQUEST_METHOD SCRIPT_NAME
+        SERVER_NAME SERVER_PROTOCOL SERVER_SOFTWARE
+
+        HTTP_ACCEPT HTTP_ACCEPT_CHARSET HTTP_ACCEPT_ENCODING
+        HTTP_ACCEPT_LANGUAGE HTTP_CACHE_CONTROL HTTP_FROM HTTP_HOST
+        HTTP_NEGOTIATE HTTP_PRAGMA HTTP_REFERER HTTP_USER_AGENT ].each do |env|
+      define_method(env.delete_prefix('HTTP_').downcase) do
+        env_table[env]
+      end
+    end
+
+    # Get the raw cookies as a string.
+    def raw_cookie
+      env_table["HTTP_COOKIE"]
+    end
+
+    # Get the raw RFC2965 cookies as a string.
+    def raw_cookie2
+      env_table["HTTP_COOKIE2"]
+    end
+
+    # Get the cookies as a hash of cookie-name=>Cookie pairs.
+    attr_accessor :cookies
+
+    # Get the parameters as a hash of name=>values pairs, where
+    # values is an Array.
+    attr_reader :params
+
+    # Get the uploaded files as a hash of name=>values pairs
+    attr_reader :files
+
+    # Set all the parameters.
+    def params=(hash)
+      @params.clear
+      @params.update(hash)
+    end
+
+    ##
+    # Parses multipart form elements according to
+    #   http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
+    #
+    # Returns a hash of multipart form parameters with bodies of type StringIO or
+    # Tempfile depending on whether the multipart form element exceeds 10 KB
+    #
+    #   params[name => body]
+    #
+    def read_multipart(boundary, content_length)
+      ## read first boundary
+      stdin = stdinput
+      first_line = "--#{boundary}#{EOL}"
+      content_length -= first_line.bytesize
+      status = stdin.read(first_line.bytesize)
+      raise EOFError.new("no content body")  unless status
+      raise EOFError.new("bad content body") unless first_line == status
+      ## parse and set params
+      params = {}
+      @files = {}
+      boundary_rexp = /--#{Regexp.quote(boundary)}(#{EOL}|--)/
+      boundary_size = "#{EOL}--#{boundary}#{EOL}".bytesize
+      buf = ''.dup
+      bufsize = 10 * 1024
+      max_count = MAX_MULTIPART_COUNT
+      n = 0
+      tempfiles = []
+      while true
+        (n += 1) < max_count or raise StandardError.new("too many parameters.")
+        ## create body (StringIO or Tempfile)
+        body = create_body(bufsize < content_length)
+        tempfiles << body if defined?(Tempfile) && body.kind_of?(Tempfile)
+        class << body
+          if method_defined?(:path)
+            alias local_path path
+          else
+            def local_path
+              nil
+            end
+          end
+          attr_reader :original_filename, :content_type
+        end
+        ## find head and boundary
+        head = nil
+        separator = EOL * 2
+        until head && matched = boundary_rexp.match(buf)
+          if !head && pos = buf.index(separator)
+            len  = pos + EOL.bytesize
+            head = buf[0, len]
+            buf  = buf[(pos+separator.bytesize)..-1]
+          else
+            if head && buf.size > boundary_size
+              len = buf.size - boundary_size
+              body.print(buf[0, len])
+              buf[0, len] = ''
+            end
+            c = stdin.read(bufsize < content_length ? bufsize : content_length)
+            raise EOFError.new("bad content body") if c.nil? || c.empty?
+            buf << c
+            content_length -= c.bytesize
+          end
+        end
+        ## read to end of boundary
+        m = matched
+        len = m.begin(0)
+        s = buf[0, len]
+        if s =~ /(\r?\n)\z/
+          s = buf[0, len - $1.bytesize]
+        end
+        body.print(s)
+        buf = buf[m.end(0)..-1]
+        boundary_end = m[1]
+        content_length = -1 if boundary_end == '--'
+        ## reset file cursor position
+        body.rewind
+        ## original filename
+        /Content-Disposition:.* filename=(?:"(.*?)"|([^;\r\n]*))/i.match(head)
+        filename = $1 || $2 || ''.dup
+        filename = CGI.unescape(filename) if unescape_filename?()
+        body.instance_variable_set(:@original_filename, filename)
+        ## content type
+        /Content-Type: (.*)/i.match(head)
+        (content_type = $1 || ''.dup).chomp!
+        body.instance_variable_set(:@content_type, content_type)
+        ## query parameter name
+        /Content-Disposition:.* name=(?:"(.*?)"|([^;\r\n]*))/i.match(head)
+        name = $1 || $2 || ''
+        if body.original_filename.empty?
+          value=body.read.dup.force_encoding(@accept_charset)
+          body.close! if defined?(Tempfile) && body.kind_of?(Tempfile)
+          (params[name] ||= []) << value
+          unless value.valid_encoding?
+            if @accept_charset_error_block
+              @accept_charset_error_block.call(name,value)
+            else
+              raise InvalidEncoding,"Accept-Charset encoding error"
+            end
+          end
+          class << params[name].last;self;end.class_eval do
+            define_method(:read){self}
+            define_method(:original_filename){""}
+            define_method(:content_type){""}
+          end
+        else
+          (params[name] ||= []) << body
+          @files[name]=body
+        end
+        ## break loop
+        break if content_length == -1
+      end
+      raise EOFError, "bad boundary end of body part" unless boundary_end =~ /--/
+      params.default = []
+      params
+    rescue Exception
+      if tempfiles
+        tempfiles.each {|t|
+          if t.path
+            t.close!
+          end
+        }
+      end
+      raise
+    end # read_multipart
+    private :read_multipart
+    def create_body(is_large)  #:nodoc:
+      if is_large
+        require 'tempfile'
+        body = Tempfile.new('CGI', encoding: Encoding::ASCII_8BIT)
+      else
+        begin
+          require 'stringio'
+          body = StringIO.new("".b)
+        rescue LoadError
+          require 'tempfile'
+          body = Tempfile.new('CGI', encoding: Encoding::ASCII_8BIT)
+        end
+      end
+      body.binmode if defined? body.binmode
+      return body
+    end
+    def unescape_filename?  #:nodoc:
+      user_agent = $CGI_ENV['HTTP_USER_AGENT']
+      return false unless user_agent
+      return /Mac/i.match(user_agent) && /Mozilla/i.match(user_agent) && !/MSIE/i.match(user_agent)
+    end
+
+    # offline mode. read name=value pairs on standard input.
+    def read_from_cmdline
+      require "shellwords"
+
+      string = unless ARGV.empty?
+        ARGV.join(' ')
+      else
+        if STDIN.tty?
+          STDERR.print(
+            %|(offline mode: enter name=value pairs on standard input)\n|
+          )
+        end
+        array = readlines rescue nil
+        if not array.nil?
+            array.join(' ').gsub(/\n/n, '')
+        else
+            ""
+        end
+      end.gsub(/\\=/n, '%3D').gsub(/\\&/n, '%26')
+
+      words = Shellwords.shellwords(string)
+
+      if words.find{|x| /=/n.match(x) }
+        words.join('&')
+      else
+        words.join('+')
+      end
+    end
+    private :read_from_cmdline
+
+    # A wrapper class to use a StringIO object as the body and switch
+    # to a TempFile when the passed threshold is passed.
+    # Initialize the data from the query.
+    #
+    # Handles multipart forms (in particular, forms that involve file uploads).
+    # Reads query parameters in the @params field, and cookies into @cookies.
+    def initialize_query()
+      if ("POST" == env_table['REQUEST_METHOD']) and
+        %r|\Amultipart/form-data.*boundary=\"?([^\";,]+)\"?| =~ env_table['CONTENT_TYPE']
+        current_max_multipart_length = @max_multipart_length.respond_to?(:call) ? @max_multipart_length.call : @max_multipart_length
+        raise StandardError.new("too large multipart data.") if env_table['CONTENT_LENGTH'].to_i > current_max_multipart_length
+        boundary = $1.dup
+        @multipart = true
+        @params = read_multipart(boundary, Integer(env_table['CONTENT_LENGTH']))
+      else
+        @multipart = false
+        @params = CGI.parse(
+                    case env_table['REQUEST_METHOD']
+                    when "GET", "HEAD"
+                      if defined?(MOD_RUBY)
+                        Apache::request.args or ""
+                      else
+                        env_table['QUERY_STRING'] or ""
+                      end
+                    when "POST"
+                      stdinput.binmode if defined? stdinput.binmode
+                      stdinput.read(Integer(env_table['CONTENT_LENGTH'])) or ''
+                    else
+                      read_from_cmdline
+                    end.dup.force_encoding(@accept_charset)
+                  )
+        unless Encoding.find(@accept_charset) == Encoding::ASCII_8BIT
+          @params.each do |key,values|
+            values.each do |value|
+              unless value.valid_encoding?
+                if @accept_charset_error_block
+                  @accept_charset_error_block.call(key,value)
+                else
+                  raise InvalidEncoding,"Accept-Charset encoding error"
+                end
+              end
+            end
+          end
+        end
+      end
+
+      @cookies = CGI::Cookie.parse((env_table['HTTP_COOKIE'] or env_table['COOKIE']))
+    end
+    private :initialize_query
+
+    # Returns whether the form contained multipart/form-data
+    def multipart?
+      @multipart
+    end
+
+    # Get the value for the parameter with a given key.
+    #
+    # If the parameter has multiple values, only the first will be
+    # retrieved; use #params to get the array of values.
+    def [](key)
+      params = @params[key]
+      return '' unless params
+      value = params[0]
+      if @multipart
+        if value
+          return value
+        elsif defined? StringIO
+          StringIO.new("".b)
+        else
+          Tempfile.new("CGI",encoding: Encoding::ASCII_8BIT)
+        end
+      else
+        str = if value then value.dup else "" end
+        str
+      end
+    end
+
+    # Return all query parameter names as an array of String.
+    def keys(*args)
+      @params.keys(*args)
+    end
+
+    # Returns true if a given query string parameter exists.
+    def has_key?(*args)
+      @params.has_key?(*args)
+    end
+    alias key? has_key?
+    alias include? has_key?
+
+  end # QueryExtension
+
+  # Exception raised when there is an invalid encoding detected
+  class InvalidEncoding < Exception; end
+
+  # @@accept_charset is default accept character set.
+  # This default value default is "UTF-8"
+  # If you want to change the default accept character set
+  # when create a new CGI instance, set this:
+  #
+  #   CGI.accept_charset = "EUC-JP"
+  #
+  @@accept_charset="UTF-8" if false # needed for rdoc?
+
+  # Return the accept character set for all new CGI instances.
+  def self.accept_charset
+    @@accept_charset
+  end
+
+  # Set the accept character set for all new CGI instances.
+  def self.accept_charset=(accept_charset)
+    @@accept_charset=accept_charset
+  end
+
+  # Return the accept character set for this CGI instance.
+  attr_reader :accept_charset
+
+  # @@max_multipart_length is the maximum length of multipart data.
+  # The default value is 128 * 1024 * 1024 bytes
+  #
+  # The default can be set to something else in the CGI constructor,
+  # via the :max_multipart_length key in the option hash.
+  #
+  # See CGI.new documentation.
+  #
+  @@max_multipart_length= 128 * 1024 * 1024
+
+  # Create a new CGI instance.
+  #
+  # :call-seq:
+  #   CGI.new(tag_maker) { block }
+  #   CGI.new(options_hash = {}) { block }
+  #
+  #
+  # <tt>tag_maker</tt>::
+  #   This is the same as using the +options_hash+ form with the value <tt>{
+  #   :tag_maker => tag_maker }</tt> Note that it is recommended to use the
+  #   +options_hash+ form, since it also allows you specify the charset you
+  #   will accept.
+  # <tt>options_hash</tt>::
+  #   A Hash that recognizes three options:
+  #
+  #   <tt>:accept_charset</tt>::
+  #     specifies encoding of received query string.  If omitted,
+  #     <tt>@@accept_charset</tt> is used.  If the encoding is not valid, a
+  #     CGI::InvalidEncoding will be raised.
+  #
+  #     Example. Suppose <tt>@@accept_charset</tt> is "UTF-8"
+  #
+  #     when not specified:
+  #
+  #         cgi=CGI.new      # @accept_charset # => "UTF-8"
+  #
+  #     when specified as "EUC-JP":
+  #
+  #         cgi=CGI.new(:accept_charset => "EUC-JP") # => "EUC-JP"
+  #
+  #   <tt>:tag_maker</tt>::
+  #     String that specifies which version of the HTML generation methods to
+  #     use.  If not specified, no HTML generation methods will be loaded.
+  #
+  #     The following values are supported:
+  #
+  #     "html3":: HTML 3.x
+  #     "html4":: HTML 4.0
+  #     "html4Tr":: HTML 4.0 Transitional
+  #     "html4Fr":: HTML 4.0 with Framesets
+  #     "html5":: HTML 5
+  #
+  #   <tt>:max_multipart_length</tt>::
+  #     Specifies maximum length of multipart data. Can be an Integer scalar or
+  #     a lambda, that will be evaluated when the request is parsed. This
+  #     allows more complex logic to be set when determining whether to accept
+  #     multipart data (e.g. consult a registered users upload allowance)
+  #
+  #     Default is 128 * 1024 * 1024 bytes
+  #
+  #         cgi=CGI.new(:max_multipart_length => 268435456) # simple scalar
+  #
+  #         cgi=CGI.new(:max_multipart_length => -> {check_filesystem}) # lambda
+  #
+  # <tt>block</tt>::
+  #   If provided, the block is called when an invalid encoding is
+  #   encountered. For example:
+  #
+  #     encoding_errors={}
+  #     cgi=CGI.new(:accept_charset=>"EUC-JP") do |name,value|
+  #       encoding_errors[name] = value
+  #     end
+  #
+  # Finally, if the CGI object is not created in a standard CGI call
+  # environment (that is, it can't locate REQUEST_METHOD in its environment),
+  # then it will run in "offline" mode.  In this mode, it reads its parameters
+  # from the command line or (failing that) from standard input.  Otherwise,
+  # cookies and other parameters are parsed automatically from the standard
+  # CGI locations, which varies according to the REQUEST_METHOD.
+  def initialize(options = {}, &block) # :yields: name, value
+    @accept_charset_error_block = block_given? ? block : nil
+    @options={
+      :accept_charset=>@@accept_charset,
+      :max_multipart_length=>@@max_multipart_length
+    }
+    case options
+    when Hash
+      @options.merge!(options)
+    when String
+      @options[:tag_maker]=options
+    end
+    @accept_charset=@options[:accept_charset]
+    @max_multipart_length=@options[:max_multipart_length]
+    if defined?(MOD_RUBY) && !ENV.key?("GATEWAY_INTERFACE")
+      Apache.request.setup_cgi_env
+    end
+
+    extend QueryExtension
+    @multipart = false
+
+    initialize_query()  # set @params, @cookies
+    @output_cookies = nil
+    @output_hidden = nil
+
+    case @options[:tag_maker]
+    when "html3"
+      require_relative 'html'
+      extend Html3
+      extend HtmlExtension
+    when "html4"
+      require_relative 'html'
+      extend Html4
+      extend HtmlExtension
+    when "html4Tr"
+      require_relative 'html'
+      extend Html4Tr
+      extend HtmlExtension
+    when "html4Fr"
+      require_relative 'html'
+      extend Html4Tr
+      extend Html4Fr
+      extend HtmlExtension
+    when "html5"
+      require_relative 'html'
+      extend Html5
+      extend HtmlExtension
+    end
+  end
+
+end   # class CGI

--- a/lib/cgi/html.rb
+++ b/lib/cgi/html.rb
@@ -1,0 +1,1035 @@
+# frozen_string_literal: true
+class CGI
+  # Base module for HTML-generation mixins.
+  #
+  # Provides methods for code generation for tags following
+  # the various DTD element types.
+  module TagMaker # :nodoc:
+
+    # Generate code for an element with required start and end tags.
+    #
+    #   - -
+    def nn_element(element, attributes = {})
+      s = nOE_element(element, attributes)
+      if block_given?
+        s << yield.to_s
+      end
+      s << "</#{element.upcase}>"
+    end
+
+    def nn_element_def(attributes = {}, &block)
+      nn_element(__callee__, attributes, &block)
+    end
+
+    # Generate code for an empty element.
+    #
+    #   - O EMPTY
+    def nOE_element(element, attributes = {})
+      attributes={attributes=>nil} if attributes.kind_of?(String)
+      s = "<#{element.upcase}".dup
+      attributes.each do|name, value|
+        next unless value
+        s << " "
+        s << CGI.escapeHTML(name.to_s)
+        if value != true
+          s << '="'
+          s << CGI.escapeHTML(value.to_s)
+          s << '"'
+        end
+      end
+      s << ">"
+    end
+
+    def nOE_element_def(attributes = {}, &block)
+      nOE_element(__callee__, attributes, &block)
+    end
+
+
+    # Generate code for an element for which the end (and possibly the
+    # start) tag is optional.
+    #
+    #   O O or - O
+    def nO_element(element, attributes = {})
+      s = nOE_element(element, attributes)
+      if block_given?
+        s << yield.to_s
+        s << "</#{element.upcase}>"
+      end
+      s
+    end
+
+    def nO_element_def(attributes = {}, &block)
+      nO_element(__callee__, attributes, &block)
+    end
+
+  end # TagMaker
+
+
+  # Mixin module providing HTML generation methods.
+  #
+  # For example,
+  #   cgi.a("http://www.example.com") { "Example" }
+  #     # => "<A HREF=\"http://www.example.com\">Example</A>"
+  #
+  # Modules Html3, Html4, etc., contain more basic HTML-generation methods
+  # (+#title+, +#h1+, etc.).
+  #
+  # See class CGI for a detailed example.
+  #
+  module HtmlExtension
+
+
+    # Generate an Anchor element as a string.
+    #
+    # +href+ can either be a string, giving the URL
+    # for the HREF attribute, or it can be a hash of
+    # the element's attributes.
+    #
+    # The body of the element is the string returned by the no-argument
+    # block passed in.
+    #
+    #   a("http://www.example.com") { "Example" }
+    #     # => "<A HREF=\"http://www.example.com\">Example</A>"
+    #
+    #   a("HREF" => "http://www.example.com", "TARGET" => "_top") { "Example" }
+    #     # => "<A HREF=\"http://www.example.com\" TARGET=\"_top\">Example</A>"
+    #
+    def a(href = "") # :yield:
+      attributes = if href.kind_of?(String)
+                     { "HREF" => href }
+                   else
+                     href
+                   end
+      super(attributes)
+    end
+
+    # Generate a Document Base URI element as a String.
+    #
+    # +href+ can either by a string, giving the base URL for the HREF
+    # attribute, or it can be a has of the element's attributes.
+    #
+    # The passed-in no-argument block is ignored.
+    #
+    #   base("http://www.example.com/cgi")
+    #     # => "<BASE HREF=\"http://www.example.com/cgi\">"
+    def base(href = "") # :yield:
+      attributes = if href.kind_of?(String)
+                     { "HREF" => href }
+                   else
+                     href
+                   end
+      super(attributes)
+    end
+
+    # Generate a BlockQuote element as a string.
+    #
+    # +cite+ can either be a string, give the URI for the source of
+    # the quoted text, or a hash, giving all attributes of the element,
+    # or it can be omitted, in which case the element has no attributes.
+    #
+    # The body is provided by the passed-in no-argument block
+    #
+    #   blockquote("http://www.example.com/quotes/foo.html") { "Foo!" }
+    #     #=> "<BLOCKQUOTE CITE=\"http://www.example.com/quotes/foo.html\">Foo!</BLOCKQUOTE>
+    def blockquote(cite = {})  # :yield:
+      attributes = if cite.kind_of?(String)
+                     { "CITE" => cite }
+                   else
+                     cite
+                   end
+      super(attributes)
+    end
+
+
+    # Generate a Table Caption element as a string.
+    #
+    # +align+ can be a string, giving the alignment of the caption
+    # (one of top, bottom, left, or right).  It can be a hash of
+    # all the attributes of the element.  Or it can be omitted.
+    #
+    # The body of the element is provided by the passed-in no-argument block.
+    #
+    #   caption("left") { "Capital Cities" }
+    #     # => <CAPTION ALIGN=\"left\">Capital Cities</CAPTION>
+    def caption(align = {}) # :yield:
+      attributes = if align.kind_of?(String)
+                     { "ALIGN" => align }
+                   else
+                     align
+                   end
+      super(attributes)
+    end
+
+
+    # Generate a Checkbox Input element as a string.
+    #
+    # The attributes of the element can be specified as three arguments,
+    # +name+, +value+, and +checked+.  +checked+ is a boolean value;
+    # if true, the CHECKED attribute will be included in the element.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   checkbox("name")
+    #     # = checkbox("NAME" => "name")
+    #
+    #   checkbox("name", "value")
+    #     # = checkbox("NAME" => "name", "VALUE" => "value")
+    #
+    #   checkbox("name", "value", true)
+    #     # = checkbox("NAME" => "name", "VALUE" => "value", "CHECKED" => true)
+    def checkbox(name = "", value = nil, checked = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "checkbox", "NAME" => name,
+                       "VALUE" => value, "CHECKED" => checked }
+                   else
+                     name["TYPE"] = "checkbox"
+                     name
+                   end
+      input(attributes)
+    end
+
+    # Generate a sequence of checkbox elements, as a String.
+    #
+    # The checkboxes will all have the same +name+ attribute.
+    # Each checkbox is followed by a label.
+    # There will be one checkbox for each value.  Each value
+    # can be specified as a String, which will be used both
+    # as the value of the VALUE attribute and as the label
+    # for that checkbox.  A single-element array has the
+    # same effect.
+    #
+    # Each value can also be specified as a three-element array.
+    # The first element is the VALUE attribute; the second is the
+    # label; and the third is a boolean specifying whether this
+    # checkbox is CHECKED.
+    #
+    # Each value can also be specified as a two-element
+    # array, by omitting either the value element (defaults
+    # to the same as the label), or the boolean checked element
+    # (defaults to false).
+    #
+    #   checkbox_group("name", "foo", "bar", "baz")
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="foo">foo
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="bar">bar
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="baz">baz
+    #
+    #   checkbox_group("name", ["foo"], ["bar", true], "baz")
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="foo">foo
+    #     # <INPUT TYPE="checkbox" CHECKED NAME="name" VALUE="bar">bar
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="baz">baz
+    #
+    #   checkbox_group("name", ["1", "Foo"], ["2", "Bar", true], "Baz")
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="1">Foo
+    #     # <INPUT TYPE="checkbox" CHECKED NAME="name" VALUE="2">Bar
+    #     # <INPUT TYPE="checkbox" NAME="name" VALUE="Baz">Baz
+    #
+    #   checkbox_group("NAME" => "name",
+    #                    "VALUES" => ["foo", "bar", "baz"])
+    #
+    #   checkbox_group("NAME" => "name",
+    #                    "VALUES" => [["foo"], ["bar", true], "baz"])
+    #
+    #   checkbox_group("NAME" => "name",
+    #                    "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"])
+    def checkbox_group(name = "", *values)
+      if name.kind_of?(Hash)
+        values = name["VALUES"]
+        name = name["NAME"]
+      end
+      values.collect{|value|
+        if value.kind_of?(String)
+          checkbox(name, value) + value
+        else
+          if value[-1] == true || value[-1] == false
+            checkbox(name, value[0],  value[-1]) +
+            value[-2]
+          else
+            checkbox(name, value[0]) +
+            value[-1]
+          end
+        end
+      }.join
+    end
+
+
+    # Generate an File Upload Input element as a string.
+    #
+    # The attributes of the element can be specified as three arguments,
+    # +name+, +size+, and +maxlength+.  +maxlength+ is the maximum length
+    # of the file's _name_, not of the file's _contents_.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    # See #multipart_form() for forms that include file uploads.
+    #
+    #   file_field("name")
+    #     # <INPUT TYPE="file" NAME="name" SIZE="20">
+    #
+    #   file_field("name", 40)
+    #     # <INPUT TYPE="file" NAME="name" SIZE="40">
+    #
+    #   file_field("name", 40, 100)
+    #     # <INPUT TYPE="file" NAME="name" SIZE="40" MAXLENGTH="100">
+    #
+    #   file_field("NAME" => "name", "SIZE" => 40)
+    #     # <INPUT TYPE="file" NAME="name" SIZE="40">
+    def file_field(name = "", size = 20, maxlength = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "file", "NAME" => name,
+                       "SIZE" => size.to_s }
+                   else
+                     name["TYPE"] = "file"
+                     name
+                   end
+      attributes["MAXLENGTH"] = maxlength.to_s if maxlength
+      input(attributes)
+    end
+
+
+    # Generate a Form element as a string.
+    #
+    # +method+ should be either "get" or "post", and defaults to the latter.
+    # +action+ defaults to the current CGI script name.  +enctype+
+    # defaults to "application/x-www-form-urlencoded".
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    # See also #multipart_form() for forms that include file uploads.
+    #
+    #   form{ "string" }
+    #     # <FORM METHOD="post" ENCTYPE="application/x-www-form-urlencoded">string</FORM>
+    #
+    #   form("get") { "string" }
+    #     # <FORM METHOD="get" ENCTYPE="application/x-www-form-urlencoded">string</FORM>
+    #
+    #   form("get", "url") { "string" }
+    #     # <FORM METHOD="get" ACTION="url" ENCTYPE="application/x-www-form-urlencoded">string</FORM>
+    #
+    #   form("METHOD" => "post", "ENCTYPE" => "enctype") { "string" }
+    #     # <FORM METHOD="post" ENCTYPE="enctype">string</FORM>
+    def form(method = "post", action = script_name, enctype = "application/x-www-form-urlencoded")
+      attributes = if method.kind_of?(String)
+                     { "METHOD" => method, "ACTION" => action,
+                       "ENCTYPE" => enctype }
+                   else
+                     unless method.has_key?("METHOD")
+                       method["METHOD"] = "post"
+                     end
+                     unless method.has_key?("ENCTYPE")
+                       method["ENCTYPE"] = enctype
+                     end
+                     method
+                   end
+      if block_given?
+        body = yield
+      else
+        body = ""
+      end
+      if @output_hidden
+        body << @output_hidden.collect{|k,v|
+          "<INPUT TYPE=\"HIDDEN\" NAME=\"#{k}\" VALUE=\"#{v}\">"
+        }.join
+      end
+      super(attributes){body}
+    end
+
+    # Generate a Hidden Input element as a string.
+    #
+    # The attributes of the element can be specified as two arguments,
+    # +name+ and +value+.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   hidden("name")
+    #     # <INPUT TYPE="hidden" NAME="name">
+    #
+    #   hidden("name", "value")
+    #     # <INPUT TYPE="hidden" NAME="name" VALUE="value">
+    #
+    #   hidden("NAME" => "name", "VALUE" => "reset", "ID" => "foo")
+    #     # <INPUT TYPE="hidden" NAME="name" VALUE="value" ID="foo">
+    def hidden(name = "", value = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "hidden", "NAME" => name, "VALUE" => value }
+                   else
+                     name["TYPE"] = "hidden"
+                     name
+                   end
+      input(attributes)
+    end
+
+    # Generate a top-level HTML element as a string.
+    #
+    # The attributes of the element are specified as a hash.  The
+    # pseudo-attribute "PRETTY" can be used to specify that the generated
+    # HTML string should be indented.  "PRETTY" can also be specified as
+    # a string as the sole argument to this method.  The pseudo-attribute
+    # "DOCTYPE", if given, is used as the leading DOCTYPE SGML tag; it
+    # should include the entire text of this tag, including angle brackets.
+    #
+    # The body of the html element is supplied as a block.
+    #
+    #   html{ "string" }
+    #     # <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><HTML>string</HTML>
+    #
+    #   html("LANG" => "ja") { "string" }
+    #     # <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><HTML LANG="ja">string</HTML>
+    #
+    #   html("DOCTYPE" => false) { "string" }
+    #     # <HTML>string</HTML>
+    #
+    #   html("DOCTYPE" => '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">') { "string" }
+    #     # <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><HTML>string</HTML>
+    #
+    #   html("PRETTY" => "  ") { "<BODY></BODY>" }
+    #     # <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+    #     # <HTML>
+    #     #   <BODY>
+    #     #   </BODY>
+    #     # </HTML>
+    #
+    #   html("PRETTY" => "\t") { "<BODY></BODY>" }
+    #     # <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+    #     # <HTML>
+    #     #         <BODY>
+    #     #         </BODY>
+    #     # </HTML>
+    #
+    #   html("PRETTY") { "<BODY></BODY>" }
+    #     # = html("PRETTY" => "  ") { "<BODY></BODY>" }
+    #
+    #   html(if $VERBOSE then "PRETTY" end) { "HTML string" }
+    #
+    def html(attributes = {}) # :yield:
+      if nil == attributes
+        attributes = {}
+      elsif "PRETTY" == attributes
+        attributes = { "PRETTY" => true }
+      end
+      pretty = attributes.delete("PRETTY")
+      pretty = "  " if true == pretty
+      buf = "".dup
+
+      if attributes.has_key?("DOCTYPE")
+        if attributes["DOCTYPE"]
+          buf << attributes.delete("DOCTYPE")
+        else
+          attributes.delete("DOCTYPE")
+        end
+      else
+        buf << doctype
+      end
+
+      buf << super(attributes)
+
+      if pretty
+        CGI.pretty(buf, pretty)
+      else
+        buf
+      end
+
+    end
+
+    # Generate an Image Button Input element as a string.
+    #
+    # +src+ is the URL of the image to use for the button.  +name+
+    # is the input name.  +alt+ is the alternative text for the image.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   image_button("url")
+    #     # <INPUT TYPE="image" SRC="url">
+    #
+    #   image_button("url", "name", "string")
+    #     # <INPUT TYPE="image" SRC="url" NAME="name" ALT="string">
+    #
+    #   image_button("SRC" => "url", "ALT" => "string")
+    #     # <INPUT TYPE="image" SRC="url" ALT="string">
+    def image_button(src = "", name = nil, alt = nil)
+      attributes = if src.kind_of?(String)
+                     { "TYPE" => "image", "SRC" => src, "NAME" => name,
+                       "ALT" => alt }
+                   else
+                     src["TYPE"] = "image"
+                     src["SRC"] ||= ""
+                     src
+                   end
+      input(attributes)
+    end
+
+
+    # Generate an Image element as a string.
+    #
+    # +src+ is the URL of the image.  +alt+ is the alternative text for
+    # the image.  +width+ is the width of the image, and +height+ is
+    # its height.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   img("src", "alt", 100, 50)
+    #     # <IMG SRC="src" ALT="alt" WIDTH="100" HEIGHT="50">
+    #
+    #   img("SRC" => "src", "ALT" => "alt", "WIDTH" => 100, "HEIGHT" => 50)
+    #     # <IMG SRC="src" ALT="alt" WIDTH="100" HEIGHT="50">
+    def img(src = "", alt = "", width = nil, height = nil)
+      attributes = if src.kind_of?(String)
+                     { "SRC" => src, "ALT" => alt }
+                   else
+                     src
+                   end
+      attributes["WIDTH"] = width.to_s if width
+      attributes["HEIGHT"] = height.to_s if height
+      super(attributes)
+    end
+
+
+    # Generate a Form element with multipart encoding as a String.
+    #
+    # Multipart encoding is used for forms that include file uploads.
+    #
+    # +action+ is the action to perform.  +enctype+ is the encoding
+    # type, which defaults to "multipart/form-data".
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   multipart_form{ "string" }
+    #     # <FORM METHOD="post" ENCTYPE="multipart/form-data">string</FORM>
+    #
+    #   multipart_form("url") { "string" }
+    #     # <FORM METHOD="post" ACTION="url" ENCTYPE="multipart/form-data">string</FORM>
+    def multipart_form(action = nil, enctype = "multipart/form-data")
+      attributes = if action == nil
+                     { "METHOD" => "post", "ENCTYPE" => enctype }
+                   elsif action.kind_of?(String)
+                     { "METHOD" => "post", "ACTION" => action,
+                       "ENCTYPE" => enctype }
+                   else
+                     unless action.has_key?("METHOD")
+                       action["METHOD"] = "post"
+                     end
+                     unless action.has_key?("ENCTYPE")
+                       action["ENCTYPE"] = enctype
+                     end
+                     action
+                   end
+      if block_given?
+        form(attributes){ yield }
+      else
+        form(attributes)
+      end
+    end
+
+
+    # Generate a Password Input element as a string.
+    #
+    # +name+ is the name of the input field.  +value+ is its default
+    # value.  +size+ is the size of the input field display.  +maxlength+
+    # is the maximum length of the inputted password.
+    #
+    # Alternatively, attributes can be specified as a hash.
+    #
+    #   password_field("name")
+    #     # <INPUT TYPE="password" NAME="name" SIZE="40">
+    #
+    #   password_field("name", "value")
+    #     # <INPUT TYPE="password" NAME="name" VALUE="value" SIZE="40">
+    #
+    #   password_field("password", "value", 80, 200)
+    #     # <INPUT TYPE="password" NAME="name" VALUE="value" SIZE="80" MAXLENGTH="200">
+    #
+    #   password_field("NAME" => "name", "VALUE" => "value")
+    #     # <INPUT TYPE="password" NAME="name" VALUE="value">
+    def password_field(name = "", value = nil, size = 40, maxlength = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "password", "NAME" => name,
+                       "VALUE" => value, "SIZE" => size.to_s }
+                   else
+                     name["TYPE"] = "password"
+                     name
+                   end
+      attributes["MAXLENGTH"] = maxlength.to_s if maxlength
+      input(attributes)
+    end
+
+    # Generate a Select element as a string.
+    #
+    # +name+ is the name of the element.  The +values+ are the options that
+    # can be selected from the Select menu.  Each value can be a String or
+    # a one, two, or three-element Array.  If a String or a one-element
+    # Array, this is both the value of that option and the text displayed for
+    # it.  If a three-element Array, the elements are the option value, displayed
+    # text, and a boolean value specifying whether this option starts as selected.
+    # The two-element version omits either the option value (defaults to the same
+    # as the display text) or the boolean selected specifier (defaults to false).
+    #
+    # The attributes and options can also be specified as a hash.  In this
+    # case, options are specified as an array of values as described above,
+    # with the hash key of "VALUES".
+    #
+    #   popup_menu("name", "foo", "bar", "baz")
+    #     # <SELECT NAME="name">
+    #     #   <OPTION VALUE="foo">foo</OPTION>
+    #     #   <OPTION VALUE="bar">bar</OPTION>
+    #     #   <OPTION VALUE="baz">baz</OPTION>
+    #     # </SELECT>
+    #
+    #   popup_menu("name", ["foo"], ["bar", true], "baz")
+    #     # <SELECT NAME="name">
+    #     #   <OPTION VALUE="foo">foo</OPTION>
+    #     #   <OPTION VALUE="bar" SELECTED>bar</OPTION>
+    #     #   <OPTION VALUE="baz">baz</OPTION>
+    #     # </SELECT>
+    #
+    #   popup_menu("name", ["1", "Foo"], ["2", "Bar", true], "Baz")
+    #     # <SELECT NAME="name">
+    #     #   <OPTION VALUE="1">Foo</OPTION>
+    #     #   <OPTION SELECTED VALUE="2">Bar</OPTION>
+    #     #   <OPTION VALUE="Baz">Baz</OPTION>
+    #     # </SELECT>
+    #
+    #   popup_menu("NAME" => "name", "SIZE" => 2, "MULTIPLE" => true,
+    #               "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"])
+    #     # <SELECT NAME="name" MULTIPLE SIZE="2">
+    #     #   <OPTION VALUE="1">Foo</OPTION>
+    #     #   <OPTION SELECTED VALUE="2">Bar</OPTION>
+    #     #   <OPTION VALUE="Baz">Baz</OPTION>
+    #     # </SELECT>
+    def popup_menu(name = "", *values)
+
+      if name.kind_of?(Hash)
+        values   = name["VALUES"]
+        size     = name["SIZE"].to_s if name["SIZE"]
+        multiple = name["MULTIPLE"]
+        name     = name["NAME"]
+      else
+        size = nil
+        multiple = nil
+      end
+
+      select({ "NAME" => name, "SIZE" => size,
+               "MULTIPLE" => multiple }){
+        values.collect{|value|
+          if value.kind_of?(String)
+            option({ "VALUE" => value }){ value }
+          else
+            if value[value.size - 1] == true
+              option({ "VALUE" => value[0], "SELECTED" => true }){
+                value[value.size - 2]
+              }
+            else
+              option({ "VALUE" => value[0] }){
+                value[value.size - 1]
+              }
+            end
+          end
+        }.join
+      }
+
+    end
+
+    # Generates a radio-button Input element.
+    #
+    # +name+ is the name of the input field.  +value+ is the value of
+    # the field if checked.  +checked+ specifies whether the field
+    # starts off checked.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   radio_button("name", "value")
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="value">
+    #
+    #   radio_button("name", "value", true)
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="value" CHECKED>
+    #
+    #   radio_button("NAME" => "name", "VALUE" => "value", "ID" => "foo")
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="value" ID="foo">
+    def radio_button(name = "", value = nil, checked = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "radio", "NAME" => name,
+                       "VALUE" => value, "CHECKED" => checked }
+                   else
+                     name["TYPE"] = "radio"
+                     name
+                   end
+      input(attributes)
+    end
+
+    # Generate a sequence of radio button Input elements, as a String.
+    #
+    # This works the same as #checkbox_group().  However, it is not valid
+    # to have more than one radiobutton in a group checked.
+    #
+    #   radio_group("name", "foo", "bar", "baz")
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="foo">foo
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="bar">bar
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="baz">baz
+    #
+    #   radio_group("name", ["foo"], ["bar", true], "baz")
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="foo">foo
+    #     # <INPUT TYPE="radio" CHECKED NAME="name" VALUE="bar">bar
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="baz">baz
+    #
+    #   radio_group("name", ["1", "Foo"], ["2", "Bar", true], "Baz")
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="1">Foo
+    #     # <INPUT TYPE="radio" CHECKED NAME="name" VALUE="2">Bar
+    #     # <INPUT TYPE="radio" NAME="name" VALUE="Baz">Baz
+    #
+    #   radio_group("NAME" => "name",
+    #                 "VALUES" => ["foo", "bar", "baz"])
+    #
+    #   radio_group("NAME" => "name",
+    #                 "VALUES" => [["foo"], ["bar", true], "baz"])
+    #
+    #   radio_group("NAME" => "name",
+    #                 "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"])
+    def radio_group(name = "", *values)
+      if name.kind_of?(Hash)
+        values = name["VALUES"]
+        name = name["NAME"]
+      end
+      values.collect{|value|
+        if value.kind_of?(String)
+          radio_button(name, value) + value
+        else
+          if value[-1] == true || value[-1] == false
+            radio_button(name, value[0],  value[-1]) +
+            value[-2]
+          else
+            radio_button(name, value[0]) +
+            value[-1]
+          end
+        end
+      }.join
+    end
+
+    # Generate a reset button Input element, as a String.
+    #
+    # This resets the values on a form to their initial values.  +value+
+    # is the text displayed on the button. +name+ is the name of this button.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   reset
+    #     # <INPUT TYPE="reset">
+    #
+    #   reset("reset")
+    #     # <INPUT TYPE="reset" VALUE="reset">
+    #
+    #   reset("VALUE" => "reset", "ID" => "foo")
+    #     # <INPUT TYPE="reset" VALUE="reset" ID="foo">
+    def reset(value = nil, name = nil)
+      attributes = if (not value) or value.kind_of?(String)
+                     { "TYPE" => "reset", "VALUE" => value, "NAME" => name }
+                   else
+                     value["TYPE"] = "reset"
+                     value
+                   end
+      input(attributes)
+    end
+
+    alias scrolling_list popup_menu
+
+    # Generate a submit button Input element, as a String.
+    #
+    # +value+ is the text to display on the button.  +name+ is the name
+    # of the input.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   submit
+    #     # <INPUT TYPE="submit">
+    #
+    #   submit("ok")
+    #     # <INPUT TYPE="submit" VALUE="ok">
+    #
+    #   submit("ok", "button1")
+    #     # <INPUT TYPE="submit" VALUE="ok" NAME="button1">
+    #
+    #   submit("VALUE" => "ok", "NAME" => "button1", "ID" => "foo")
+    #     # <INPUT TYPE="submit" VALUE="ok" NAME="button1" ID="foo">
+    def submit(value = nil, name = nil)
+      attributes = if (not value) or value.kind_of?(String)
+                     { "TYPE" => "submit", "VALUE" => value, "NAME" => name }
+                   else
+                     value["TYPE"] = "submit"
+                     value
+                   end
+      input(attributes)
+    end
+
+    # Generate a text field Input element, as a String.
+    #
+    # +name+ is the name of the input field.  +value+ is its initial
+    # value.  +size+ is the size of the input area.  +maxlength+
+    # is the maximum length of input accepted.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    #   text_field("name")
+    #     # <INPUT TYPE="text" NAME="name" SIZE="40">
+    #
+    #   text_field("name", "value")
+    #     # <INPUT TYPE="text" NAME="name" VALUE="value" SIZE="40">
+    #
+    #   text_field("name", "value", 80)
+    #     # <INPUT TYPE="text" NAME="name" VALUE="value" SIZE="80">
+    #
+    #   text_field("name", "value", 80, 200)
+    #     # <INPUT TYPE="text" NAME="name" VALUE="value" SIZE="80" MAXLENGTH="200">
+    #
+    #   text_field("NAME" => "name", "VALUE" => "value")
+    #     # <INPUT TYPE="text" NAME="name" VALUE="value">
+    def text_field(name = "", value = nil, size = 40, maxlength = nil)
+      attributes = if name.kind_of?(String)
+                     { "TYPE" => "text", "NAME" => name, "VALUE" => value,
+                       "SIZE" => size.to_s }
+                   else
+                     name["TYPE"] = "text"
+                     name
+                   end
+      attributes["MAXLENGTH"] = maxlength.to_s if maxlength
+      input(attributes)
+    end
+
+    # Generate a TextArea element, as a String.
+    #
+    # +name+ is the name of the textarea.  +cols+ is the number of
+    # columns and +rows+ is the number of rows in the display.
+    #
+    # Alternatively, the attributes can be specified as a hash.
+    #
+    # The body is provided by the passed-in no-argument block
+    #
+    #   textarea("name")
+    #      # = textarea("NAME" => "name", "COLS" => 70, "ROWS" => 10)
+    #
+    #   textarea("name", 40, 5)
+    #      # = textarea("NAME" => "name", "COLS" => 40, "ROWS" => 5)
+    def textarea(name = "", cols = 70, rows = 10)  # :yield:
+      attributes = if name.kind_of?(String)
+                     { "NAME" => name, "COLS" => cols.to_s,
+                       "ROWS" => rows.to_s }
+                   else
+                     name
+                   end
+      super(attributes)
+    end
+
+  end # HtmlExtension
+
+
+  # Mixin module for HTML version 3 generation methods.
+  module Html3 # :nodoc:
+    include TagMaker
+
+    # The DOCTYPE declaration for this version of HTML
+    def doctype
+      %|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">|
+    end
+
+    instance_method(:nn_element_def).tap do |m|
+      # - -
+      for element in %w[ A TT I B U STRIKE BIG SMALL SUB SUP EM STRONG
+          DFN CODE SAMP KBD VAR CITE FONT ADDRESS DIV CENTER MAP
+          APPLET PRE XMP LISTING DL OL UL DIR MENU SELECT TABLE TITLE
+          STYLE SCRIPT H1 H2 H3 H4 H5 H6 TEXTAREA FORM BLOCKQUOTE
+          CAPTION ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    instance_method(:nOE_element_def).tap do |m|
+      # - O EMPTY
+      for element in %w[ IMG BASE BASEFONT BR AREA LINK PARAM HR INPUT
+          ISINDEX META ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    instance_method(:nO_element_def).tap do |m|
+      # O O or - O
+      for element in %w[ HTML HEAD BODY P PLAINTEXT DT DD LI OPTION TR
+          TH TD ]
+        define_method(element.downcase, m)
+      end
+    end
+
+  end # Html3
+
+
+  # Mixin module for HTML version 4 generation methods.
+  module Html4 # :nodoc:
+    include TagMaker
+
+    # The DOCTYPE declaration for this version of HTML
+    def doctype
+      %|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">|
+    end
+
+    # Initialize the HTML generation methods for this version.
+    # - -
+    instance_method(:nn_element_def).tap do |m|
+      for element in %w[ TT I B BIG SMALL EM STRONG DFN CODE SAMP KBD
+        VAR CITE ABBR ACRONYM SUB SUP SPAN BDO ADDRESS DIV MAP OBJECT
+        H1 H2 H3 H4 H5 H6 PRE Q INS DEL DL OL UL LABEL SELECT OPTGROUP
+        FIELDSET LEGEND BUTTON TABLE TITLE STYLE SCRIPT NOSCRIPT
+        TEXTAREA FORM A BLOCKQUOTE CAPTION ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # - O EMPTY
+    instance_method(:nOE_element_def).tap do |m|
+      for element in %w[ IMG BASE BR AREA LINK PARAM HR INPUT COL META ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # O O or - O
+    instance_method(:nO_element_def).tap do |m|
+      for element in %w[ HTML BODY P DT DD LI OPTION THEAD TFOOT TBODY
+          COLGROUP TR TH TD HEAD ]
+        define_method(element.downcase, m)
+      end
+    end
+
+  end # Html4
+
+
+  # Mixin module for HTML version 4 transitional generation methods.
+  module Html4Tr # :nodoc:
+    include TagMaker
+
+    # The DOCTYPE declaration for this version of HTML
+    def doctype
+      %|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">|
+    end
+
+    # Initialise the HTML generation methods for this version.
+    # - -
+    instance_method(:nn_element_def).tap do |m|
+      for element in %w[ TT I B U S STRIKE BIG SMALL EM STRONG DFN
+          CODE SAMP KBD VAR CITE ABBR ACRONYM FONT SUB SUP SPAN BDO
+          ADDRESS DIV CENTER MAP OBJECT APPLET H1 H2 H3 H4 H5 H6 PRE Q
+          INS DEL DL OL UL DIR MENU LABEL SELECT OPTGROUP FIELDSET
+          LEGEND BUTTON TABLE IFRAME NOFRAMES TITLE STYLE SCRIPT
+          NOSCRIPT TEXTAREA FORM A BLOCKQUOTE CAPTION ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # - O EMPTY
+    instance_method(:nOE_element_def).tap do |m|
+      for element in %w[ IMG BASE BASEFONT BR AREA LINK PARAM HR INPUT
+          COL ISINDEX META ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # O O or - O
+    instance_method(:nO_element_def).tap do |m|
+      for element in %w[ HTML BODY P DT DD LI OPTION THEAD TFOOT TBODY
+          COLGROUP TR TH TD HEAD ]
+        define_method(element.downcase, m)
+      end
+    end
+
+  end # Html4Tr
+
+
+  # Mixin module for generating HTML version 4 with framesets.
+  module Html4Fr # :nodoc:
+    include TagMaker
+
+    # The DOCTYPE declaration for this version of HTML
+    def doctype
+      %|<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">|
+    end
+
+    # Initialise the HTML generation methods for this version.
+    # - -
+    instance_method(:nn_element_def).tap do |m|
+      for element in %w[ FRAMESET ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # - O EMPTY
+    instance_method(:nOE_element_def).tap do |m|
+      for element in %w[ FRAME ]
+        define_method(element.downcase, m)
+      end
+    end
+
+  end # Html4Fr
+
+
+  # Mixin module for HTML version 5 generation methods.
+  module Html5 # :nodoc:
+    include TagMaker
+
+    # The DOCTYPE declaration for this version of HTML
+    def doctype
+      %|<!DOCTYPE HTML>|
+    end
+
+    # Initialise the HTML generation methods for this version.
+    # - -
+    instance_method(:nn_element_def).tap do |m|
+      for element in %w[ SECTION NAV ARTICLE ASIDE HGROUP HEADER
+        FOOTER FIGURE FIGCAPTION S TIME U MARK RUBY BDI IFRAME
+        VIDEO AUDIO CANVAS DATALIST OUTPUT PROGRESS METER DETAILS
+        SUMMARY MENU DIALOG I B SMALL EM STRONG DFN CODE SAMP KBD
+        VAR CITE ABBR SUB SUP SPAN BDO ADDRESS DIV MAP OBJECT
+        H1 H2 H3 H4 H5 H6 PRE Q INS DEL DL OL UL LABEL SELECT
+        FIELDSET LEGEND BUTTON TABLE TITLE STYLE SCRIPT NOSCRIPT
+        TEXTAREA FORM A BLOCKQUOTE CAPTION ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # - O EMPTY
+    instance_method(:nOE_element_def).tap do |m|
+      for element in %w[ IMG BASE BR AREA LINK PARAM HR INPUT COL META
+        COMMAND EMBED KEYGEN SOURCE TRACK WBR ]
+        define_method(element.downcase, m)
+      end
+    end
+
+    # O O or - O
+    instance_method(:nO_element_def).tap do |m|
+      for element in %w[ HTML HEAD BODY P DT DD LI OPTION THEAD TFOOT TBODY
+          OPTGROUP COLGROUP RT RP TR TH TD ]
+        define_method(element.downcase, m)
+      end
+    end
+
+  end # Html5
+
+  class HTML3
+    include Html3
+    include HtmlExtension
+  end
+
+  class HTML4
+    include Html4
+    include HtmlExtension
+  end
+
+  class HTML4Tr
+    include Html4Tr
+    include HtmlExtension
+  end
+
+  class HTML4Fr
+    include Html4Tr
+    include Html4Fr
+    include HtmlExtension
+  end
+
+  class HTML5
+    include Html5
+    include HtmlExtension
+  end
+
+end

--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+# NATALIE
+require 'natalie/inline'
+# END NATALIE
+
+class CGI
+  module Util; end
+  include Util
+  extend Util
+end
+module CGI::Util
+  @@accept_charset = Encoding::UTF_8 unless defined?(@@accept_charset)
+
+  # URL-encode a string into application/x-www-form-urlencoded.
+  # Space characters (+" "+) are encoded with plus signs (+"+"+)
+  #   url_encoded_string = CGI.escape("'Stop!' said Fred")
+  #      # => "%27Stop%21%27+said+Fred"
+  def escape(string)
+    encoding = string.encoding
+    buffer = string.b
+    buffer.gsub!(/([^ a-zA-Z0-9_.\-~]+)/) do |m|
+      '%' + m.unpack('H2' * m.bytesize).join('%').upcase
+    end
+    buffer.tr!(' ', '+')
+    buffer.force_encoding(encoding)
+  end
+
+  # URL-decode an application/x-www-form-urlencoded string with encoding(optional).
+  #   string = CGI.unescape("%27Stop%21%27+said+Fred")
+  #      # => "'Stop!' said Fred"
+  def unescape(string, encoding = @@accept_charset)
+    str = string.tr('+', ' ')
+    str = str.b
+    str.gsub!(/((?:%[0-9a-fA-F]{2})+)/) do |m|
+      [m.delete('%')].pack('H*')
+    end
+    str.force_encoding(encoding)
+    str.valid_encoding? ? str : str.force_encoding(string.encoding)
+  end
+
+  # URL-encode a string following RFC 3986
+  # Space characters (+" "+) are encoded with (+"%20"+)
+  #   url_encoded_string = CGI.escapeURIComponent("'Stop!' said Fred")
+  #      # => "%27Stop%21%27%20said%20Fred"
+  def escapeURIComponent(string)
+    # NATALIE ruby converts this in a c extension
+    __inline__ 'string_var = string_var->to_str2(env)'
+    # END NATALIE
+    encoding = string.encoding
+    buffer = string.b
+    buffer.gsub!(/([^a-zA-Z0-9_.\-~]+)/) do |m|
+      '%' + m.unpack('H2' * m.bytesize).join('%').upcase
+    end
+    buffer.force_encoding(encoding)
+  end
+  alias escape_uri_component escapeURIComponent
+
+  # URL-decode a string following RFC 3986 with encoding(optional).
+  #   string = CGI.unescapeURIComponent("%27Stop%21%27+said%20Fred")
+  #      # => "'Stop!'+said Fred"
+  def unescapeURIComponent(string, encoding = @@accept_charset)
+    str = string.b
+    str.gsub!(/((?:%[0-9a-fA-F]{2})+)/) do |m|
+      [m.delete('%')].pack('H*')
+    end
+    str.force_encoding(encoding)
+    str.valid_encoding? ? str : str.force_encoding(string.encoding)
+  end
+
+  alias unescape_uri_component unescapeURIComponent
+
+  # The set of special characters and their escaped values
+  TABLE_FOR_ESCAPE_HTML__ = {
+    "'" => '&#39;',
+    '&' => '&amp;',
+    '"' => '&quot;',
+    '<' => '&lt;',
+    '>' => '&gt;',
+  }
+
+  # Escape special characters in HTML, namely '&\"<>
+  #   CGI.escapeHTML('Usage: foo "bar" <baz>')
+  #      # => "Usage: foo &quot;bar&quot; &lt;baz&gt;"
+  def escapeHTML(string)
+    enc = string.encoding
+    unless enc.ascii_compatible?
+      if enc.dummy?
+        origenc = enc
+        enc = Encoding::Converter.asciicompat_encoding(enc)
+        string = enc ? string.encode(enc) : string.b
+      end
+      table = Hash[TABLE_FOR_ESCAPE_HTML__.map {|pair|pair.map {|s|s.encode(enc)}}]
+      string = string.gsub(/#{"['&\"<>]".encode(enc)}/, table)
+      string.encode!(origenc) if origenc
+      string
+    else
+      string = string.b
+      string.gsub!(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
+      string.force_encoding(enc)
+    end
+  end
+
+  # TruffleRuby runs the pure-Ruby variant faster, do not use the C extension there
+  unless RUBY_ENGINE == 'truffleruby'
+    begin
+      require 'cgi/escape'
+    rescue LoadError
+    end
+  end
+
+  # Unescape a string that has been HTML-escaped
+  #   CGI.unescapeHTML("Usage: foo &quot;bar&quot; &lt;baz&gt;")
+  #      # => "Usage: foo \"bar\" <baz>"
+  def unescapeHTML(string)
+    enc = string.encoding
+    unless enc.ascii_compatible?
+      if enc.dummy?
+        origenc = enc
+        enc = Encoding::Converter.asciicompat_encoding(enc)
+        string = enc ? string.encode(enc) : string.b
+      end
+      string = string.gsub(Regexp.new('&(apos|amp|quot|gt|lt|#[0-9]+|#x[0-9A-Fa-f]+);'.encode(enc))) do
+        case $1.encode(Encoding::US_ASCII)
+        when 'apos'                then "'".encode(enc)
+        when 'amp'                 then '&'.encode(enc)
+        when 'quot'                then '"'.encode(enc)
+        when 'gt'                  then '>'.encode(enc)
+        when 'lt'                  then '<'.encode(enc)
+        when /\A#0*(\d+)\z/        then $1.to_i.chr(enc)
+        when /\A#x([0-9a-f]+)\z/i  then $1.hex.chr(enc)
+        end
+      end
+      string.encode!(origenc) if origenc
+      return string
+    end
+    return string unless string.include? '&'
+    charlimit = case enc
+                when Encoding::UTF_8; 0x10ffff
+                when Encoding::ISO_8859_1; 256
+                else 128
+                end
+    string = string.b
+    string.gsub!(/&(apos|amp|quot|gt|lt|\#[0-9]+|\#[xX][0-9A-Fa-f]+);/) do
+      match = $1.dup
+      case match
+      when 'apos'                then "'"
+      when 'amp'                 then '&'
+      when 'quot'                then '"'
+      when 'gt'                  then '>'
+      when 'lt'                  then '<'
+      when /\A#0*(\d+)\z/
+        n = $1.to_i
+        if n < charlimit
+          n.chr(enc)
+        else
+          "&##{$1};"
+        end
+      when /\A#x([0-9a-f]+)\z/i
+        n = $1.hex
+        if n < charlimit
+          n.chr(enc)
+        else
+          "&#x#{$1};"
+        end
+      else
+        "&#{match};"
+      end
+    end
+    string.force_encoding enc
+  end
+
+  # Synonym for CGI.escapeHTML(str)
+  alias escape_html escapeHTML
+
+  # Synonym for CGI.unescapeHTML(str)
+  alias unescape_html unescapeHTML
+
+  # Escape only the tags of certain HTML elements in +string+.
+  #
+  # Takes an element or elements or array of elements.  Each element
+  # is specified by the name of the element, without angle brackets.
+  # This matches both the start and the end tag of that element.
+  # The attribute list of the open tag will also be escaped (for
+  # instance, the double-quotes surrounding attribute values).
+  #
+  #   print CGI.escapeElement('<BR><A HREF="url"></A>', "A", "IMG")
+  #     # "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt"
+  #
+  #   print CGI.escapeElement('<BR><A HREF="url"></A>', ["A", "IMG"])
+  #     # "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt"
+  def escapeElement(string, *elements)
+    elements = elements[0] if elements[0].kind_of?(Array)
+    unless elements.empty?
+      string.gsub(/<\/?(?:#{elements.join("|")})(?!\w)(?:.|\n)*?>/i) do
+        CGI.escapeHTML($&)
+      end
+    else
+      string
+    end
+  end
+
+  # Undo escaping such as that done by CGI.escapeElement()
+  #
+  #   print CGI.unescapeElement(
+  #           CGI.escapeHTML('<BR><A HREF="url"></A>'), "A", "IMG")
+  #     # "&lt;BR&gt;<A HREF="url"></A>"
+  #
+  #   print CGI.unescapeElement(
+  #           CGI.escapeHTML('<BR><A HREF="url"></A>'), ["A", "IMG"])
+  #     # "&lt;BR&gt;<A HREF="url"></A>"
+  def unescapeElement(string, *elements)
+    elements = elements[0] if elements[0].kind_of?(Array)
+    unless elements.empty?
+      string.gsub(/&lt;\/?(?:#{elements.join("|")})(?!\w)(?:.|\n)*?&gt;/i) do
+        unescapeHTML($&)
+      end
+    else
+      string
+    end
+  end
+
+  # Synonym for CGI.escapeElement(str)
+  alias escape_element escapeElement
+
+  # Synonym for CGI.unescapeElement(str)
+  alias unescape_element unescapeElement
+
+  # Format a +Time+ object as a String using the format specified by RFC 1123.
+  #
+  #   CGI.rfc1123_date(Time.now)
+  #     # Sat, 01 Jan 2000 00:00:00 GMT
+  def rfc1123_date(time)
+    time.getgm.strftime("%a, %d %b %Y %T GMT")
+  end
+
+  # Prettify (indent) an HTML string.
+  #
+  # +string+ is the HTML string to indent.  +shift+ is the indentation
+  # unit to use; it defaults to two spaces.
+  #
+  #   print CGI.pretty("<HTML><BODY></BODY></HTML>")
+  #     # <HTML>
+  #     #   <BODY>
+  #     #   </BODY>
+  #     # </HTML>
+  #
+  #   print CGI.pretty("<HTML><BODY></BODY></HTML>", "\t")
+  #     # <HTML>
+  #     #         <BODY>
+  #     #         </BODY>
+  #     # </HTML>
+  #
+  def pretty(string, shift = "  ")
+    lines = string.gsub(/(?!\A)<.*?>/m, "\n\\0").gsub(/<.*?>(?!\n)/m, "\\0\n")
+    end_pos = 0
+    while end_pos = lines.index(/^<\/(\w+)/, end_pos)
+      element = $1.dup
+      start_pos = lines.rindex(/^\s*<#{element}/i, end_pos)
+      lines[start_pos ... end_pos] = "__" + lines[start_pos ... end_pos].gsub(/\n(?!\z)/, "\n" + shift) + "__"
+    end
+    lines.gsub(/^((?:#{Regexp::quote(shift)})*)__(?=<\/?\w)/, '\1')
+  end
+
+  alias h escapeHTML
+end

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -942,6 +942,7 @@ gen.binding('IO', 'write_nonblock', 'IoObject', 'write_nonblock', argc: 1, kwarg
 
 gen.module_function_binding('Kernel', '`', 'KernelModule', 'backtick', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'Array', 'KernelModule', 'Array', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
+gen.module_function_binding('Kernel', '__callee__', 'KernelModule', 'cur_callee', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'abort', 'KernelModule', 'abort_method', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.module_function_binding('Kernel', 'at_exit', 'KernelModule', 'at_exit', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.module_function_binding('Kernel', 'binding', 'KernelModule', 'binding', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1043,6 +1043,7 @@ gen.binding('Method', 'inspect', 'MethodObject', 'inspect', argc: 0, pass_env: t
 gen.binding('Method', 'owner', 'MethodObject', 'owner', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Method', 'arity', 'MethodObject', 'arity', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.binding('Method', 'call', 'MethodObject', 'call', argc: :any, pass_env: true, pass_block: true, aliases: ['[]', '==='], return_type: :Object)
+gen.binding('Method', 'hash', 'MethodObject', 'hash', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Method', 'source_location', 'MethodObject', 'source_location', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Method', 'to_proc', 'MethodObject', 'to_proc', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Method', 'unbind', 'MethodObject', 'unbind', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/kernel/__callee___spec.rb
+++ b/spec/core/kernel/__callee___spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/__callee__'
+
+describe "Kernel.__callee__" do
+  it "returns the current method, even when aliased" do
+    KernelSpecs::CalleeTest.new.f.should == :f
+  end
+
+  it "returns the aliased name when aliased method" do
+    KernelSpecs::CalleeTest.new.g.should == :g
+  end
+
+  it "returns the caller from blocks too" do
+    KernelSpecs::CalleeTest.new.in_block.should == [:in_block, :in_block]
+  end
+
+  it "returns the caller from define_method too" do
+    KernelSpecs::CalleeTest.new.dm.should == :dm
+  end
+
+  it "returns the caller from block inside define_method too" do
+    KernelSpecs::CalleeTest.new.dm_block.should == [:dm_block, :dm_block]
+  end
+
+  it "returns method name even from send" do
+    KernelSpecs::CalleeTest.new.from_send.should == :from_send
+  end
+
+  it "returns method name even from eval" do
+    KernelSpecs::CalleeTest.new.from_eval.should == :from_eval
+  end
+
+  it "returns nil from inside a class body" do
+    KernelSpecs::CalleeTest.new.from_class_body.should == nil
+  end
+
+  it "returns nil when not called from a method" do
+    __callee__.should == nil
+  end
+
+  it "returns the caller from a define_method called from the same class" do
+    c = Class.new do
+      define_method(:f) { 1.times{ break __callee__ } }
+      def g; f end
+    end
+    c.new.g.should == :f
+  end
+end

--- a/spec/core/kernel/__method___spec.rb
+++ b/spec/core/kernel/__method___spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/__method__'
+
+describe "Kernel.__method__" do
+  it "returns the current method, even when aliased" do
+    KernelSpecs::MethodTest.new.f.should == :f
+  end
+
+  it "returns the original name when aliased method" do
+    KernelSpecs::MethodTest.new.g.should == :f
+  end
+
+  it "returns the caller from blocks too" do
+    KernelSpecs::MethodTest.new.in_block.should == [:in_block, :in_block]
+  end
+
+  it "returns the caller from define_method too" do
+    KernelSpecs::MethodTest.new.dm.should == :dm
+  end
+
+  it "returns the caller from block inside define_method too" do
+    KernelSpecs::MethodTest.new.dm_block.should == [:dm_block, :dm_block]
+  end
+
+  it "returns method name even from send" do
+    KernelSpecs::MethodTest.new.from_send.should == :from_send
+  end
+
+  it "returns method name even from eval" do
+    KernelSpecs::MethodTest.new.from_eval.should == :from_eval
+  end
+
+  it "returns nil from inside a class body" do
+    KernelSpecs::MethodTest.new.from_class_body.should == nil
+  end
+
+  it "returns nil when not called from a method" do
+    __method__.should == nil
+  end
+end

--- a/spec/library/cgi/cookie/domain_spec.rb
+++ b/spec/library/cgi/cookie/domain_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#domain" do
+  it "returns self's domain" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.domain.should be_nil
+
+    cookie = CGI::Cookie.new("name" => "test-cookie", "domain" => "example.com")
+    cookie.domain.should == "example.com"
+  end
+end
+
+describe "CGI::Cookie#domain=" do
+  it "sets self's domain" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.domain = "test.com"
+    cookie.domain.should == "test.com"
+
+    cookie.domain = "example.com"
+    cookie.domain.should == "example.com"
+  end
+end

--- a/spec/library/cgi/cookie/expires_spec.rb
+++ b/spec/library/cgi/cookie/expires_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#expires" do
+  it "returns self's expiration date" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.expires.should be_nil
+
+    cookie = CGI::Cookie.new("name" => "test-cookie", "expires" => Time.at(1196524602))
+    cookie.expires.should == Time.at(1196524602)
+  end
+end
+
+describe "CGI::Cookie#expires=" do
+  it "sets self's expiration date" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.expires = Time.at(1196524602)
+    cookie.expires.should == Time.at(1196524602)
+
+    cookie.expires = Time.at(1196525000)
+    cookie.expires.should == Time.at(1196525000)
+  end
+end

--- a/spec/library/cgi/cookie/initialize_spec.rb
+++ b/spec/library/cgi/cookie/initialize_spec.rb
@@ -1,0 +1,147 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#initialize when passed String" do
+  before :each do
+    @cookie = CGI::Cookie.allocate
+  end
+
+  it "sets the self's name to the passed String" do
+    @cookie.send(:initialize, "test-cookie")
+    @cookie.name.should == "test-cookie"
+  end
+
+  it "sets the self's value to an empty Array" do
+    @cookie.send(:initialize, "test-cookie")
+    @cookie.value.should == []
+  end
+
+  it "sets self to a non-secure cookie" do
+    @cookie.send(:initialize, "test")
+    @cookie.secure.should be_false
+  end
+
+  it "does set self's path to an empty String when ENV[\"SCRIPT_NAME\"] is not set" do
+    @cookie.send(:initialize, "test-cookie")
+    @cookie.path.should == ""
+  end
+
+  it "does set self's path based on ENV[\"SCRIPT_NAME\"] when ENV[\"SCRIPT_NAME\"] is set" do
+    old_script_name = ENV["SCRIPT_NAME"]
+
+    begin
+      ENV["SCRIPT_NAME"] = "some/path/script.rb"
+      @cookie.send(:initialize, "test-cookie")
+      @cookie.path.should == "some/path/"
+
+      ENV["SCRIPT_NAME"] = "script.rb"
+      @cookie.send(:initialize, "test-cookie")
+      @cookie.path.should == ""
+
+      ENV["SCRIPT_NAME"] = nil
+      @cookie.send(:initialize, "test-cookie")
+      @cookie.path.should == ""
+    ensure
+      ENV["SCRIPT_NAME"] = old_script_name
+    end
+  end
+
+  it "does not set self's expiration date" do
+    @cookie.expires.should be_nil
+  end
+
+  it "does not set self's domain" do
+    @cookie.domain.should be_nil
+  end
+end
+
+describe "CGI::Cookie#initialize when passed Hash" do
+  before :each do
+    @cookie = CGI::Cookie.allocate
+  end
+
+  it "sets self's contents based on the passed Hash" do
+    @cookie.send(:initialize,
+      'name'    => 'test-cookie',
+      'value'   => ["one", "two", "three"],
+      'path'    => 'some/path/',
+      'domain'  => 'example.com',
+      'expires' => Time.at(1196524602),
+      'secure'  => true)
+
+    @cookie.name.should == "test-cookie"
+    @cookie.value.should == ["one", "two", "three"]
+    @cookie.path.should == "some/path/"
+    @cookie.domain.should == "example.com"
+    @cookie.expires.should == Time.at(1196524602)
+    @cookie.secure.should be_true
+  end
+
+  it "does set self's path based on ENV[\"SCRIPT_NAME\"] when the Hash has no 'path' entry" do
+    old_script_name = ENV["SCRIPT_NAME"]
+
+    begin
+      ENV["SCRIPT_NAME"] = "some/path/script.rb"
+      @cookie.send(:initialize, 'name' => 'test-cookie')
+      @cookie.path.should == "some/path/"
+
+      ENV["SCRIPT_NAME"] = "script.rb"
+      @cookie.send(:initialize, 'name' => 'test-cookie')
+      @cookie.path.should == ""
+
+      ENV["SCRIPT_NAME"] = nil
+      @cookie.send(:initialize, 'name' => 'test-cookie')
+      @cookie.path.should == ""
+    ensure
+      ENV["SCRIPT_NAME"] = old_script_name
+    end
+  end
+
+  it "tries to convert the Hash's 'value' to an Array using #Array" do
+    obj = mock("Converted To Array")
+    obj.should_receive(:to_ary).and_return(["1", "2", "3"])
+    @cookie.send(:initialize,
+      'name'  => 'test-cookie',
+      'value' => obj)
+    @cookie.value.should == [ "1", "2", "3" ]
+
+    obj = mock("Converted To Array")
+    obj.should_receive(:to_a).and_return(["one", "two", "three"])
+    @cookie.send(:initialize,
+      'name'  => 'test-cookie',
+      'value' => obj)
+    @cookie.value.should == [ "one", "two", "three" ]
+
+    obj = mock("Put into an Array")
+    @cookie.send(:initialize,
+      'name'  => 'test-cookie',
+      'value' => obj)
+    @cookie.value.should == [ obj ]
+  end
+
+  it "raises a ArgumentError when the passed Hash has no 'name' entry" do
+    -> { @cookie.send(:initialize, {}) }.should raise_error(ArgumentError)
+    -> { @cookie.send(:initialize, "value" => "test") }.should raise_error(ArgumentError)
+  end
+end
+
+describe "CGI::Cookie#initialize when passed String, values ..." do
+  before :each do
+    @cookie = CGI::Cookie.allocate
+  end
+
+  it "sets the self's name to the passed String" do
+    @cookie.send(:initialize, "test-cookie", "one", "two", "three")
+    @cookie.name.should == "test-cookie"
+  end
+
+  it "sets the self's value to an Array containing all passed values" do
+    @cookie.send(:initialize, "test-cookie", "one", "two", "three")
+    @cookie.value.should == ["one", "two", "three"]
+  end
+
+  it "sets self to a non-secure cookie" do
+    @cookie.send(:initialize, "test", "one", "two", "three")
+    @cookie.secure.should be_false
+  end
+end

--- a/spec/library/cgi/cookie/name_spec.rb
+++ b/spec/library/cgi/cookie/name_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#name" do
+  it "returns self's name" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.name.should == "test-cookie"
+
+    cookie = CGI::Cookie.new("name" => "another-cookie")
+    cookie.name.should == "another-cookie"
+  end
+end
+
+describe "CGI::Cookie#name=" do
+  it "sets self's expiration date" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.name = "another-name"
+    cookie.name.should == "another-name"
+
+    cookie.name = "and-one-more"
+    cookie.name.should == "and-one-more"
+  end
+end

--- a/spec/library/cgi/cookie/parse_spec.rb
+++ b/spec/library/cgi/cookie/parse_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie.parse" do
+  it "parses a raw cookie string into a hash of Cookies" do
+    expected = { "test-cookie" => ["one", "two", "three"] }
+    CGI::Cookie.parse("test-cookie=one&two&three").should == expected
+
+    expected = { "second-cookie" => ["three", "four"], "first-cookie" => ["one", "two"] }
+    CGI::Cookie.parse("first-cookie=one&two;second-cookie=three&four").should == expected
+  end
+
+  it "does not use , for cookie separators" do
+    expected = {
+      "first-cookie" => ["one", "two"],
+      "second-cookie" => ["three", "four,third_cookie=five", "six"]
+    }
+    CGI::Cookie.parse("first-cookie=one&two;second-cookie=three&four,third_cookie=five&six").should == expected
+  end
+
+  it "unescapes the Cookie values" do
+    cookie = "test-cookie=+%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D%7E"
+    expected = { "test-cookie" => [ " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~" ] }
+    CGI::Cookie.parse(cookie).should == expected
+  end
+end

--- a/spec/library/cgi/cookie/path_spec.rb
+++ b/spec/library/cgi/cookie/path_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#path" do
+  it "returns self's path" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.path.should == ""
+
+    cookie = CGI::Cookie.new("name" => "test-cookie", "path" => "/some/path/")
+    cookie.path.should == "/some/path/"
+  end
+end
+
+describe "CGI::Cookie#path=" do
+  it "sets self's path" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.path = "/some/path/"
+    cookie.path.should == "/some/path/"
+
+    cookie.path = "/another/path/"
+    cookie.path.should == "/another/path/"
+  end
+end

--- a/spec/library/cgi/cookie/secure_spec.rb
+++ b/spec/library/cgi/cookie/secure_spec.rb
@@ -1,0 +1,70 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#secure" do
+  before :each do
+    @cookie = CGI::Cookie.new("test-cookie")
+  end
+
+  it "returns whether self is a secure cookie or not" do
+    @cookie.secure = true
+    @cookie.secure.should be_true
+
+    @cookie.secure = false
+    @cookie.secure.should be_false
+  end
+end
+
+describe "CGI::Cookie#secure= when passed true" do
+  before :each do
+    @cookie = CGI::Cookie.new("test-cookie")
+  end
+
+  it "returns true" do
+    (@cookie.secure = true).should be_true
+  end
+
+  it "sets self to a secure cookie" do
+    @cookie.secure = true
+    @cookie.secure.should be_true
+  end
+end
+
+describe "CGI::Cookie#secure= when passed false" do
+  before :each do
+    @cookie = CGI::Cookie.new("test-cookie")
+  end
+
+  it "returns false" do
+    (@cookie.secure = false).should be_false
+  end
+
+  it "sets self to a non-secure cookie" do
+    @cookie.secure = false
+    @cookie.secure.should be_false
+  end
+end
+
+describe "CGI::Cookie#secure= when passed Object" do
+  before :each do
+    @cookie = CGI::Cookie.new("test-cookie")
+  end
+
+  it "does not change self's secure value" do
+    @cookie.secure = false
+
+    @cookie.secure = Object.new
+    @cookie.secure.should be_false
+
+    @cookie.secure = "Test"
+    @cookie.secure.should be_false
+
+    @cookie.secure = true
+
+    @cookie.secure = Object.new
+    @cookie.secure.should be_true
+
+    @cookie.secure = "Test"
+    @cookie.secure.should be_true
+  end
+end

--- a/spec/library/cgi/cookie/to_s_spec.rb
+++ b/spec/library/cgi/cookie/to_s_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#to_s" do
+  it "returns a String representation of self" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.to_s.should == "test-cookie=; path="
+
+    cookie = CGI::Cookie.new("test-cookie", "value")
+    cookie.to_s.should == "test-cookie=value; path="
+
+    cookie = CGI::Cookie.new("test-cookie", "one", "two", "three")
+    cookie.to_s.should == "test-cookie=one&two&three; path="
+
+    cookie = CGI::Cookie.new(
+      'name'    => 'test-cookie',
+      'value'   => ["one", "two", "three"],
+      'path'    => 'some/path/',
+      'domain'  => 'example.com',
+      'expires' => Time.at(1196524602),
+      'secure'  => true)
+    cookie.to_s.should == "test-cookie=one&two&three; domain=example.com; path=some/path/; expires=Sat, 01 Dec 2007 15:56:42 GMT; secure"
+  end
+
+  it "escapes the self's values" do
+    cookie = CGI::Cookie.new("test-cookie", " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}")
+    cookie.to_s.should == "test-cookie=+%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D; path="
+  end
+
+  it "does not escape tilde" do
+    cookie = CGI::Cookie.new("test-cookie", "~").to_s.should == "test-cookie=~; path="
+  end
+end

--- a/spec/library/cgi/cookie/value_spec.rb
+++ b/spec/library/cgi/cookie/value_spec.rb
@@ -1,0 +1,76 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::Cookie#value" do
+  it "returns self's value" do
+    cookie = CGI::Cookie.new("test-cookie")
+    cookie.value.should == []
+
+    cookie = CGI::Cookie.new("test-cookie", "one")
+    cookie.value.should == ["one"]
+
+    cookie = CGI::Cookie.new("test-cookie", "one", "two", "three")
+    cookie.value.should == ["one", "two", "three"]
+
+    cookie = CGI::Cookie.new("name" => "test-cookie", "value" => ["one", "two", "three"])
+    cookie.value.should == ["one", "two", "three"]
+  end
+
+  it "is in synch with self" do
+    fail = []
+    [
+      :pop,
+      :shift,
+      [:<<, "Hello"],
+      [:push, "Hello"],
+      [:unshift, "World"],
+      [:replace, ["A", "B"]],
+      [:[]=, 1, "Set"],
+      [:delete, "first"],
+      [:delete_at, 0],
+    ].each do |method, *args|
+      cookie1 = CGI::Cookie.new("test-cookie", "first", "second")
+      cookie2 = CGI::Cookie.new("test-cookie", "first", "second")
+      cookie1.send(method, *args)
+      cookie2.value.send(method, *args)
+      fail << method unless cookie1.value == cookie2.value
+    end
+    fail.should be_empty
+  end
+end
+
+describe "CGI::Cookie#value=" do
+  before :each do
+    @cookie = CGI::Cookie.new("test-cookie")
+  end
+
+  it "sets self's value" do
+    @cookie.value = ["one"]
+    @cookie.value.should == ["one"]
+
+    @cookie.value = ["one", "two", "three"]
+    @cookie.value.should == ["one", "two", "three"]
+  end
+
+  it "automatically converts the passed Object to an Array using #Array" do
+    @cookie.value = "test"
+    @cookie.value.should == ["test"]
+
+    obj = mock("to_a")
+    obj.should_receive(:to_a).and_return(["1", "2"])
+    @cookie.value = obj
+    @cookie.value.should == ["1", "2"]
+
+    obj = mock("to_ary")
+    obj.should_receive(:to_ary).and_return(["1", "2"])
+    @cookie.value = obj
+    @cookie.value.should == ["1", "2"]
+  end
+
+  it "does keep self and the values in sync" do
+    @cookie.value = ["one", "two", "three"]
+    @cookie[0].should == "one"
+    @cookie[1].should == "two"
+    @cookie[2].should == "three"
+  end
+end

--- a/spec/library/cgi/escapeElement_spec.rb
+++ b/spec/library/cgi/escapeElement_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.escapeElement when passed String, elements, ..." do
+  it "escapes only the tags of the passed elements in the passed String" do
+    res = CGI.escapeElement('<BR><A HREF="url"></A>', "A", "IMG")
+    res.should == "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;"
+
+    res = CGI.escapeElement('<BR><A HREF="url"></A>', ["A", "IMG"])
+    res.should == "<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;"
+  end
+
+  it "is case-insensitive" do
+    res = CGI.escapeElement('<BR><A HREF="url"></A>', "a", "img")
+    res.should == '<BR>&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;'
+
+    res = CGI.escapeElement('<br><a href="url"></a>', "A", "IMG")
+    res.should == '<br>&lt;a href=&quot;url&quot;&gt;&lt;/a&gt;'
+  end
+end

--- a/spec/library/cgi/escapeHTML_spec.rb
+++ b/spec/library/cgi/escapeHTML_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.escapeHTML" do
+  it "escapes special HTML characters (&\"<>') in the passed argument" do
+    CGI.escapeHTML(%[& < > " ']).should == '&amp; &lt; &gt; &quot; &#39;'
+  end
+
+  it "escapes invalid encoding" do
+    CGI.escapeHTML(%[<\xA4??>]).should == "&lt;\xA4??&gt;"
+  end
+
+  it "does not escape any other characters" do
+    chars = " !\#$%()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    CGI.escapeHTML(chars).should == chars
+  end
+end

--- a/spec/library/cgi/escapeURIComponent_spec.rb
+++ b/spec/library/cgi/escapeURIComponent_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+ruby_version_is "3.2" do
+  describe "CGI.escapeURIComponent" do
+    it "escapes whitespace" do
+      string = "&<>\" \xE3\x82\x86\xE3\x82\x93\xE3\x82\x86\xE3\x82\x93"
+      CGI.escapeURIComponent(string).should == '%26%3C%3E%22%20%E3%82%86%E3%82%93%E3%82%86%E3%82%93'
+    end
+
+    it "does not escape with unreserved characters" do
+      string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+      CGI.escapeURIComponent(string).should == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    end
+
+    it "supports String with invalid encoding" do
+      string = "\xC0\<\<".dup.force_encoding("UTF-8")
+      CGI.escapeURIComponent(string).should == "%C0%3C%3C"
+    end
+
+    it "processes String bytes one by one, not characters" do
+      CGI.escapeURIComponent("β").should == "%CE%B2" # "β" bytes representation is CE B2
+    end
+
+    it "raises a TypeError with nil" do
+      -> {
+        CGI.escapeURIComponent(nil)
+      }.should raise_error(TypeError, 'no implicit conversion of nil into String')
+    end
+
+    it "encodes empty string" do
+      CGI.escapeURIComponent("").should == ""
+    end
+
+    it "encodes single whitespace" do
+      CGI.escapeURIComponent(" ").should == "%20"
+    end
+
+    it "encodes double whitespace" do
+      CGI.escapeURIComponent("  ").should == "%20%20"
+    end
+
+    it "preserves encoding" do
+      string = "whatever".encode("ASCII-8BIT")
+      CGI.escapeURIComponent(string).encoding.should == Encoding::ASCII_8BIT
+    end
+
+    it "uses implicit type conversion to String" do
+      object = Object.new
+      def object.to_str
+        "a b"
+      end
+
+      CGI.escapeURIComponent(object).should == "a%20b"
+    end
+  end
+end

--- a/spec/library/cgi/escape_spec.rb
+++ b/spec/library/cgi/escape_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.escape" do
+  it "url-encodes the passed argument" do
+    input    = " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"
+    expected = "+%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D"
+    CGI.escape(input).should == expected
+
+    input = "https://ja.wikipedia.org/wiki/\343\203\255\343\203\240\343\202\271\343\202\253\343\203\273\343\203\221\343\203\255\343\203\273\343\202\246\343\203\253\343\203\273\343\203\251\343\203\224\343\203\245\343\202\277"
+    expected = 'https%3A%2F%2Fja.wikipedia.org%2Fwiki%2F%E3%83%AD%E3%83%A0%E3%82%B9%E3%82%AB%E3%83%BB%E3%83%91%E3%83%AD%E3%83%BB%E3%82%A6%E3%83%AB%E3%83%BB%E3%83%A9%E3%83%94%E3%83%A5%E3%82%BF'
+    CGI.escape(input).should == expected
+  end
+
+  it "does not escape tilde" do
+    CGI.escape("~").should == "~"
+  end
+end

--- a/spec/library/cgi/htmlextension/a_spec.rb
+++ b/spec/library/cgi/htmlextension/a_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#a" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed a String" do
+    it "returns an 'a'-element, using the passed String as the 'href'-attribute" do
+      output = @html.a("http://www.example.com")
+      output.should equal_element("A", "HREF" => "http://www.example.com")
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      output = @html.a("http://www.example.com") { "Example" }
+      output.should equal_element("A", { "HREF" => "http://www.example.com" }, "Example")
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns an 'a'-element, using the passed Hash for attributes" do
+      attributes = {"HREF" => "http://www.example.com", "TARGET" => "_top"}
+      @html.a(attributes).should equal_element("A", attributes)
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      attributes = {"HREF" => "http://www.example.com", "TARGET" => "_top"}
+      @html.a(attributes) { "Example" }.should equal_element("A", attributes, "Example")
+    end
+  end
+
+  describe "when each HTML generation" do
+    it "returns the doctype declaration for HTML3" do
+      CGISpecs.cgi_new("html3").a.should == %(<A HREF=""></A>)
+      CGISpecs.cgi_new("html3").a { "link text" }.should == %(<A HREF="">link text</A>)
+    end
+
+    it "returns the doctype declaration for HTML4" do
+      CGISpecs.cgi_new("html4").a.should == %(<A HREF=""></A>)
+      CGISpecs.cgi_new("html4").a { "link text" }.should == %(<A HREF="">link text</A>)
+    end
+    it "returns the doctype declaration for the Transitional version of HTML4" do
+      CGISpecs.cgi_new("html4Tr").a.should == %(<A HREF=""></A>)
+      CGISpecs.cgi_new("html4Tr").a { "link text" }.should == %(<A HREF="">link text</A>)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/base_spec.rb
+++ b/spec/library/cgi/htmlextension/base_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#base" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when bassed a String" do
+    it "returns a 'base'-element, using the passed String as the 'href'-attribute" do
+      output = @html.base("http://www.example.com")
+      output.should equal_element("BASE", {"HREF" => "http://www.example.com"}, nil, not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.base("http://www.example.com") { "Example" }
+      output.should equal_element("BASE", {"HREF" => "http://www.example.com"}, nil, not_closed: true)
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns a 'base'-element, using the passed Hash for attributes" do
+      output = @html.base("HREF" => "http://www.example.com", "ID" => "test")
+      output.should equal_element("BASE", {"HREF" => "http://www.example.com", "ID" => "test"}, nil, not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.base("HREF" => "http://www.example.com", "ID" => "test") { "Example" }
+      output.should equal_element("BASE", {"HREF" => "http://www.example.com", "ID" => "test"}, nil, not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/blockquote_spec.rb
+++ b/spec/library/cgi/htmlextension/blockquote_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#blockquote" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed a String" do
+    it "returns a 'blockquote'-element, using the passed String for the 'cite'-attribute" do
+      output = @html.blockquote("http://www.example.com/quotes/foo.html")
+      output.should equal_element("BLOCKQUOTE", "CITE" => "http://www.example.com/quotes/foo.html")
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      output = @html.blockquote("http://www.example.com/quotes/foo.html") { "Foo!" }
+      output.should equal_element("BLOCKQUOTE", { "CITE" => "http://www.example.com/quotes/foo.html" }, "Foo!")
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns a 'blockquote'-element, using the passed Hash for attributes" do
+      output = @html.blockquote("CITE" => "http://www.example.com/quotes/foo.html", "ID" => "test")
+      output.should equal_element("BLOCKQUOTE", "CITE" => "http://www.example.com/quotes/foo.html", "ID" => "test")
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      output = @html.blockquote("CITE" => "http://www.example.com/quotes/foo.html", "ID" => "test") { "Foo!" }
+      output.should equal_element("BLOCKQUOTE", {"CITE" => "http://www.example.com/quotes/foo.html", "ID" => "test"}, "Foo!")
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/br_spec.rb
+++ b/spec/library/cgi/htmlextension/br_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#br" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when each HTML generation" do
+    it "returns the doctype declaration for HTML3" do
+      CGISpecs.cgi_new("html3").br.should == "<BR>"
+    end
+
+    it "returns the doctype declaration for HTML4" do
+      CGISpecs.cgi_new("html4").br.should == "<BR>"
+    end
+    it "returns the doctype declaration for the Transitional version of HTML4" do
+      CGISpecs.cgi_new("html4Tr").br.should == "<BR>"
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/caption_spec.rb
+++ b/spec/library/cgi/htmlextension/caption_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#caption" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed a String" do
+    it "returns a 'caption'-element, using the passed String for the 'align'-attribute" do
+      output = @html.caption("left")
+      output.should equal_element("CAPTION", "ALIGN" => "left")
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      output = @html.caption("left") { "Capital Cities" }
+      output.should equal_element("CAPTION", {"ALIGN" => "left"}, "Capital Cities")
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns a 'caption'-element, using the passed Hash for attributes" do
+      output = @html.caption("ALIGN" => "left", "ID" => "test")
+      output.should equal_element("CAPTION", "ALIGN" => "left", "ID" => "test")
+    end
+
+    it "includes the passed block's return value when passed a block" do
+      output = @html.caption("ALIGN" => "left", "ID" => "test") { "Capital Cities" }
+      output.should equal_element("CAPTION", {"ALIGN" => "left", "ID" => "test"}, "Capital Cities")
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/checkbox_group_spec.rb
+++ b/spec/library/cgi/htmlextension/checkbox_group_spec.rb
@@ -1,0 +1,76 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#checkbox_group" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed name, values ..." do
+    it "returns a sequence of 'checkbox'-elements with the passed name and the passed values" do
+      output = CGISpecs.split(@html.checkbox_group("test", "foo", "bar", "baz"))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+
+    it "allows passing a value inside an Array" do
+      output = CGISpecs.split(@html.checkbox_group("test", ["foo"], "bar", ["baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+
+    it "allows passing a value as an Array containing the value and the checked state or a label" do
+      output = CGISpecs.split(@html.checkbox_group("test", ["foo"], ["bar", true], ["baz", "label for baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "baz"}, "label for baz", not_closed: true)
+    end
+
+    it "allows passing a value as an Array containing the value, a label and the checked state" do
+      output = CGISpecs.split(@html.checkbox_group("test", ["foo", "label for foo", true], ["bar", "label for bar", false], ["baz", "label for baz", true]))
+      output[0].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "checkbox", "VALUE" => "foo"}, "label for foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "bar"}, "label for bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "checkbox", "VALUE" => "baz"}, "label for baz", not_closed: true)
+    end
+
+    it "returns an empty String when passed no values" do
+      @html.checkbox_group("test").should == ""
+    end
+
+    it "ignores a passed block" do
+      output = CGISpecs.split(@html.checkbox_group("test", "foo", "bar", "baz") { "test" })
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "uses the passed Hash to generate the checkbox sequence" do
+      output = CGISpecs.split(@html.checkbox_group("NAME" => "name", "VALUES" => ["foo", "bar", "baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+
+      output = CGISpecs.split(@html.checkbox_group("NAME" => "name", "VALUES" => [["foo"], ["bar", true], "baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "name", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+
+      output = CGISpecs.split(@html.checkbox_group("NAME" => "name", "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "1"}, "Foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "name", "TYPE" => "checkbox", "VALUE" => "2"}, "Bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "Baz"}, "Baz", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = CGISpecs.split(@html.checkbox_group("NAME" => "name", "VALUES" => ["foo", "bar", "baz"]) { "test" })
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "checkbox", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/checkbox_spec.rb
+++ b/spec/library/cgi/htmlextension/checkbox_spec.rb
@@ -1,0 +1,77 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#checkbox" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns a checkbox-'input'-element without a name" do
+      output = @html.checkbox
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "checkbox"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.checkbox { "test" }
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "checkbox"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns a checkbox-'input'-element with the passed name" do
+      output = @html.checkbox("test")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.checkbox("test") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox"}, "", not_closed: true)
+    end
+  end
+
+  describe "CGI::HtmlExtension#checkbox when passed name, value" do
+    it "returns a checkbox-'input'-element with the passed name and value" do
+      output = @html.checkbox("test", "test-value")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.checkbox("test", "test-value") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, checked" do
+    it "returns a checked checkbox-'input'-element with the passed name and value when checked is true" do
+      output = @html.checkbox("test", "test-value", true)
+      output.should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+
+      output = @html.checkbox("test", "test-value", false)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+
+      output = @html.checkbox("test", "test-value", nil)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.checkbox("test", "test-value", nil) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "checkbox", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a checkbox-'input'-element using the passed Hash for attributes" do
+      attributes = {"NAME" => "test", "VALUE" => "test-value", "CHECKED" => true}
+      output = @html.checkbox(attributes)
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      attributes = {"NAME" => "test", "VALUE" => "test-value", "CHECKED" => true}
+      output = @html.checkbox(attributes) { "test" }
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/doctype_spec.rb
+++ b/spec/library/cgi/htmlextension/doctype_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#doctype" do
+  describe "when each HTML generation" do
+    it "returns the doctype declaration for HTML3" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">'
+      CGISpecs.cgi_new("html3").doctype.should == expect
+    end
+
+    it "returns the doctype declaration for HTML4" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'
+      CGISpecs.cgi_new("html4").doctype.should == expect
+    end
+
+    it "returns the doctype declaration for the Frameset version of HTML4" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">'
+      CGISpecs.cgi_new("html4Fr").doctype.should == expect
+    end
+
+    it "returns the doctype declaration for the Transitional version of HTML4" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'
+      CGISpecs.cgi_new("html4Tr").doctype.should == expect
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/file_field_spec.rb
+++ b/spec/library/cgi/htmlextension/file_field_spec.rb
@@ -1,0 +1,72 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#file_field" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns a file-'input'-element without a name and a size of 20" do
+      output = @html.file_field
+      output.should equal_element("INPUT", {"SIZE" => 20, "NAME" => "", "TYPE" => "file"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.file_field { "test" }
+      output.should equal_element("INPUT", {"SIZE" => 20, "NAME" => "", "TYPE" => "file"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns a checkbox-'input'-element with the passed name" do
+      output = @html.file_field("Example")
+      output.should equal_element("INPUT", {"SIZE" => 20, "NAME" => "Example", "TYPE" => "file"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.file_field("Example") { "test" }
+      output.should equal_element("INPUT", {"SIZE" => 20, "NAME" => "Example", "TYPE" => "file"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, size" do
+    it "returns a checkbox-'input'-element with the passed name and size" do
+      output = @html.file_field("Example", 40)
+      output.should equal_element("INPUT", {"SIZE" => 40, "NAME" => "Example", "TYPE" => "file"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.file_field("Example", 40) { "test" }
+      output.should equal_element("INPUT", {"SIZE" => 40, "NAME" => "Example", "TYPE" => "file"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, size, maxlength" do
+    it "returns a checkbox-'input'-element with the passed name, size and maxlength" do
+      output = @html.file_field("Example", 40, 100)
+      output.should equal_element("INPUT", {"SIZE" => 40, "NAME" => "Example", "TYPE" => "file", "MAXLENGTH" => 100}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.file_field("Example", 40, 100) { "test" }
+      output.should equal_element("INPUT", {"SIZE" => 40, "NAME" => "Example", "TYPE" => "file", "MAXLENGTH" => 100}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns a file-'input'-element using the passed Hash for attributes" do
+      output = @html.file_field("NAME" => "test", "SIZE" => 40)
+      output.should equal_element("INPUT", {"NAME" => "test", "SIZE" => 40}, "", not_closed: true)
+
+      output = @html.file_field("NAME" => "test", "MAXLENGTH" => 100)
+      output.should equal_element("INPUT", {"NAME" => "test", "MAXLENGTH" => 100}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.file_field("NAME" => "test", "SIZE" => 40) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "SIZE" => 40}, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/fixtures/common.rb
+++ b/spec/library/cgi/htmlextension/fixtures/common.rb
@@ -1,0 +1,15 @@
+module CGISpecs
+  def self.cgi_new(html = "html4")
+    old_request_method = ENV['REQUEST_METHOD']
+    ENV['REQUEST_METHOD'] = "GET"
+    begin
+      CGI.new(tag_maker: html)
+    ensure
+      ENV['REQUEST_METHOD'] = old_request_method
+    end
+  end
+
+  def self.split(string)
+    string.split("<").reject { |x| x.empty? }.map { |x| "<#{x}" }
+  end
+end

--- a/spec/library/cgi/htmlextension/form_spec.rb
+++ b/spec/library/cgi/htmlextension/form_spec.rb
@@ -1,0 +1,58 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#form" do
+  before :each do
+    @html = CGISpecs.cgi_new
+    @html.stub!(:script_name).and_return("/path/to/some/script")
+  end
+
+  describe "when passed no arguments" do
+    it "returns a 'form'-element" do
+      output = @html.form
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "post", "ACTION" => "/path/to/some/script"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.form { "test" }
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "post", "ACTION" => "/path/to/some/script"}, "test")
+    end
+  end
+
+  describe "when passed method" do
+    it "returns a 'form'-element with the passed method" do
+      output = @html.form("get")
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ACTION" => "/path/to/some/script"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.form("get") { "test" }
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ACTION" => "/path/to/some/script"}, "test")
+    end
+  end
+
+  describe "when passed method, action" do
+    it "returns a 'form'-element with the passed method and the passed action" do
+      output = @html.form("get", "/some/other/script")
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ACTION" => "/some/other/script"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.form("get", "/some/other/script") { "test" }
+      output.should equal_element("FORM", {"ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ACTION" => "/some/other/script"}, "test")
+    end
+  end
+
+  describe "when passed method, action, enctype" do
+    it "returns a 'form'-element with the passed method, action and enctype" do
+      output = @html.form("get", "/some/other/script", "multipart/form-data")
+      output.should equal_element("FORM", {"ENCTYPE" => "multipart/form-data", "METHOD" => "get", "ACTION" => "/some/other/script"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.form("get", "/some/other/script", "multipart/form-data") { "test" }
+      output.should equal_element("FORM", {"ENCTYPE" => "multipart/form-data", "METHOD" => "get", "ACTION" => "/some/other/script"}, "test")
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/frame_spec.rb
+++ b/spec/library/cgi/htmlextension/frame_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require_relative 'fixtures/common'
+require 'cgi'
+
+describe "CGI::HtmlExtension#frame" do
+  before :each do
+    @html = CGISpecs.cgi_new("html4Fr")
+  end
+
+  it "initializes the HTML Generation methods for the Frameset version of HTML4" do
+    @html.frameset.should == "<FRAMESET></FRAMESET>"
+    @html.frameset { "link text" }.should == "<FRAMESET>link text</FRAMESET>"
+  end
+end

--- a/spec/library/cgi/htmlextension/frameset_spec.rb
+++ b/spec/library/cgi/htmlextension/frameset_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../spec_helper'
+require_relative 'fixtures/common'
+require 'cgi'
+
+describe "CGI::HtmlExtension#frameset" do
+  before :each do
+    @html = CGISpecs.cgi_new("html4Fr")
+  end
+
+  it "initializes the HTML Generation methods for the Frameset version of HTML4" do
+    @html.frameset.should == "<FRAMESET></FRAMESET>"
+    @html.frameset { "link text" }.should == "<FRAMESET>link text</FRAMESET>"
+  end
+end

--- a/spec/library/cgi/htmlextension/hidden_spec.rb
+++ b/spec/library/cgi/htmlextension/hidden_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#hidden" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an hidden-'input'-element without a name" do
+      output = @html.hidden
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "hidden"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.hidden { "test" }
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "hidden"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns an hidden-'input'-element with the passed name" do
+      output = @html.hidden("test")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "hidden"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.hidden("test") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "hidden"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value" do
+    it "returns an hidden-'input'-element with the passed name and value" do
+      output = @html.hidden("test", "some value")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "hidden", "VALUE" => "some value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.hidden("test", "some value") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "hidden", "VALUE" => "some value"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a checkbox-'input'-element using the passed Hash for attributes" do
+      attributes = { "NAME" => "test", "VALUE" => "some value" }
+      output = @html.hidden("test", "some value")
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      attributes = { "NAME" => "test", "VALUE" => "some value" }
+      output = @html.hidden("test", "some value") { "test" }
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/html_spec.rb
+++ b/spec/library/cgi/htmlextension/html_spec.rb
@@ -1,0 +1,66 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#html" do
+  before :each do
+    @html = CGISpecs.cgi_new
+    @html.stub!(:doctype).and_return("<!DOCTYPE SUPA-FUNKAY-RUBYSPEC-DOCTYPE>")
+  end
+
+  describe "when passed no arguments" do
+    it "returns a self's doctype and an 'html'-element" do
+      expected = '<!DOCTYPE SUPA-FUNKAY-RUBYSPEC-DOCTYPE><HTML>'
+      @html.html.should == expected
+    end
+
+    it "includes the passed block when passed a block" do
+      expected = '<!DOCTYPE SUPA-FUNKAY-RUBYSPEC-DOCTYPE><HTML>test</HTML>'
+      @html.html { "test" }.should == expected
+    end
+  end
+
+  describe "when passed 'PRETTY'" do
+    it "returns pretty output when the passed String is 'PRETTY" do
+      expected = "<!DOCTYPE SUPA-FUNKAY-RUBYSPEC-DOCTYPE>\n<HTML>\n"
+      @html.html("PRETTY").should == expected
+    end
+
+    it "includes the passed block when passed a block" do
+      expected = "<!DOCTYPE SUPA-FUNKAY-RUBYSPEC-DOCTYPE>\n<HTML>\n  test\n</HTML>\n"
+      @html.html("PRETTY") { "test" }.should == expected
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "returns an 'html'-element using the passed Hash for attributes" do
+      expected = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><HTML BLA="TEST">'
+      @html.html("DOCTYPE" => '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">', "BLA" => "TEST").should == expected
+    end
+
+    it "omits the doctype when the Hash contains a 'DOCTYPE' entry that's false or nil" do
+      @html.html("DOCTYPE" => false).should == "<HTML>"
+      @html.html("DOCTYPE" => nil).should == "<HTML>"
+    end
+  end
+
+  describe "when each HTML generation" do
+    it "returns the doctype declaration for HTML3" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">'
+      CGISpecs.cgi_new("html3").html.should == expect + "<HTML>"
+      CGISpecs.cgi_new("html3").html { "html body" }.should == expect + "<HTML>html body</HTML>"
+    end
+
+    it "returns the doctype declaration for HTML4" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'
+      CGISpecs.cgi_new("html4").html.should == expect + "<HTML>"
+      CGISpecs.cgi_new("html4").html { "html body" }.should == expect + "<HTML>html body</HTML>"
+    end
+
+    it "returns the doctype declaration for the Transitional version of HTML4" do
+      expect = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'
+      CGISpecs.cgi_new("html4Tr").html.should == expect + "<HTML>"
+      CGISpecs.cgi_new("html4Tr").html { "html body" }.should == expect + "<HTML>html body</HTML>"
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/image_button_spec.rb
+++ b/spec/library/cgi/htmlextension/image_button_spec.rb
@@ -1,0 +1,69 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#image_button" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an image-'input'-element without a source image" do
+      output = @html.image_button
+      output.should equal_element("INPUT", {"SRC" => "", "TYPE" => "image"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.image_button { "test" }
+      output.should equal_element("INPUT", {"SRC" => "", "TYPE" => "image"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src" do
+    it "returns an image-'input'-element with the passed src" do
+      output = @html.image_button("/path/to/image.png")
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.image_button("/path/to/image.png") { "test" }
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src, name" do
+    it "returns an image-'input'-element with the passed src and name" do
+      output = @html.image_button("/path/to/image.png", "test")
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image", "NAME" => "test"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.image_button("/path/to/image.png", "test") { "test" }
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image", "NAME" => "test"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src, name, alt" do
+    it "returns an image-'input'-element with the passed src, name and alt" do
+      output = @html.image_button("/path/to/image.png", "test", "alternative")
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image", "NAME" => "test", "ALT" => "alternative"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.image_button("/path/to/image.png", "test", "alternative") { "test" }
+      output.should equal_element("INPUT", {"SRC" => "/path/to/image.png", "TYPE" => "image", "NAME" => "test", "ALT" => "alternative"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a image-'input'-element using the passed Hash for attributes" do
+      output = @html.image_button("NAME" => "test", "VALUE" => "test-value")
+      output.should equal_element("INPUT", {"SRC" => "", "TYPE" => "image", "NAME" => "test", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.image_button("NAME" => "test", "VALUE" => "test-value") { "test" }
+      output.should equal_element("INPUT", {"SRC" => "", "TYPE" => "image", "NAME" => "test", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/img_spec.rb
+++ b/spec/library/cgi/htmlextension/img_spec.rb
@@ -1,0 +1,83 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#img" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an 'img'-element without an src-url or alt-text" do
+      output = @html.img
+      output.should equal_element("IMG", { "SRC" => "", "ALT" => "" }, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.img { "test" }
+      output.should equal_element("IMG", { "SRC" => "", "ALT" => "" }, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src" do
+    it "returns an 'img'-element with the passed src-url" do
+      output = @html.img("/path/to/some/image.png")
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "" }, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.img("/path/to/some/image.png")
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "" }, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src, alt" do
+    it "returns an 'img'-element with the passed src-url and the passed alt-text" do
+      output = @html.img("/path/to/some/image.png", "Alternative")
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "Alternative" }, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.img("/path/to/some/image.png", "Alternative") { "test" }
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "Alternative" }, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src, alt, width" do
+    it "returns an 'img'-element with the passed src-url, the passed alt-text and the passed width" do
+      output = @html.img("/path/to/some/image.png", "Alternative", 40)
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "Alternative", "WIDTH" => "40" }, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.img("/path/to/some/image.png", "Alternative", 40) { "test" }
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "Alternative", "WIDTH" => "40" }, "", not_closed: true)
+    end
+  end
+
+  describe "when passed src, alt, width, height" do
+    it "returns an 'img'-element with the passed src-url, the passed alt-text, the passed width and the passed height" do
+      output = @html.img("/path/to/some/image.png", "Alternative", 40, 60)
+      output.should equal_element("IMG", { "SRC" => "/path/to/some/image.png", "ALT" => "Alternative", "WIDTH" => "40", "HEIGHT" => "60" }, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.img { "test" }
+      output.should equal_element("IMG", { "SRC" => "", "ALT" => "" }, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns an 'img'-element with the passed Hash as attributes" do
+      attributes = { "SRC" => "src", "ALT" => "alt", "WIDTH" => 100, "HEIGHT" => 50 }
+      output = @html.img(attributes)
+      output.should equal_element("IMG", attributes, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      attributes = { "SRC" => "src", "ALT" => "alt", "WIDTH" => 100, "HEIGHT" => 50 }
+      output = @html.img(attributes) { "test" }
+      output.should equal_element("IMG", attributes, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/multipart_form_spec.rb
+++ b/spec/library/cgi/htmlextension/multipart_form_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#multipart_form" do
+  before :each do
+    @html = CGISpecs.cgi_new
+    @html.stub!(:script_name).and_return("/path/to/some/script.rb")
+  end
+
+  describe "when passed no arguments" do
+    it "returns a 'form'-element with it's enctype set to multipart" do
+      output = @html.multipart_form
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post" }, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.multipart_form { "test" }
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post" }, "test")
+    end
+  end
+
+  describe "when passed action" do
+    it "returns a 'form'-element with the passed action" do
+      output = @html.multipart_form("/some/other/script.rb")
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post", "ACTION" => "/some/other/script.rb" }, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.multipart_form("/some/other/script.rb") { "test" }
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post", "ACTION" => "/some/other/script.rb" }, "test")
+    end
+  end
+
+  describe "when passed action, enctype" do
+    it "returns a 'form'-element with the passed action and enctype" do
+      output = @html.multipart_form("/some/other/script.rb", "application/x-www-form-urlencoded")
+      output.should equal_element("FORM", { "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "post", "ACTION" => "/some/other/script.rb" }, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.multipart_form("/some/other/script.rb", "application/x-www-form-urlencoded") { "test" }
+      output.should equal_element("FORM", { "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "post", "ACTION" => "/some/other/script.rb" }, "test")
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a 'form'-element with the passed Hash as attributes" do
+      output = @html.multipart_form("ID" => "test")
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post", "ID" => "test" }, "")
+
+      output = @html.multipart_form("ID" => "test", "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get")
+      output.should equal_element("FORM", { "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ID" => "test" }, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.multipart_form("ID" => "test") { "test" }
+      output.should equal_element("FORM", { "ENCTYPE" => "multipart/form-data", "METHOD" => "post", "ID" => "test" }, "test")
+
+      output = @html.multipart_form("ID" => "test", "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get") { "test" }
+      output.should equal_element("FORM", { "ENCTYPE" => "application/x-www-form-urlencoded", "METHOD" => "get", "ID" => "test" }, "test")
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/password_field_spec.rb
+++ b/spec/library/cgi/htmlextension/password_field_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#password_field" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an password-'input'-element without a name" do
+      output = @html.password_field
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "password", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field { "test" }
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "password", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns an password-'input'-element with the passed name" do
+      output = @html.password_field("test")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field("test") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value" do
+    it "returns an password-'input'-element with the passed name and value" do
+      output = @html.password_field("test", "some value")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field("test", "some value") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, size" do
+    it "returns an password-'input'-element with the passed name, value and size" do
+      output = @html.password_field("test", "some value", 60)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "60"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field("test", "some value", 60) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "60"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, size, maxlength" do
+    it "returns an password-'input'-element with the passed name, value, size and maxlength" do
+      output = @html.password_field("test", "some value", 60, 12)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "60", "MAXLENGTH" => 12}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field("test", "some value", 60, 12) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "password", "VALUE" => "some value", "SIZE" => "60", "MAXLENGTH" => 12}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a checkbox-'input'-element using the passed Hash for attributes" do
+      output = @html.password_field("NAME" => "test", "VALUE" => "some value")
+      output.should equal_element("INPUT", { "NAME" => "test", "VALUE" => "some value", "TYPE" => "password" }, "", not_closed: true)
+
+      output = @html.password_field("TYPE" => "hidden")
+      output.should equal_element("INPUT", {"TYPE" => "password"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.password_field("NAME" => "test", "VALUE" => "some value") { "test" }
+      output.should equal_element("INPUT", { "NAME" => "test", "VALUE" => "some value", "TYPE" => "password" }, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/popup_menu_spec.rb
+++ b/spec/library/cgi/htmlextension/popup_menu_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+require_relative 'shared/popup_menu'
+
+describe "CGI::HtmlExtension#popup_menu" do
+  it_behaves_like :cgi_htmlextension_popup_menu, :popup_menu
+end

--- a/spec/library/cgi/htmlextension/radio_button_spec.rb
+++ b/spec/library/cgi/htmlextension/radio_button_spec.rb
@@ -1,0 +1,77 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#radio_button" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns a radio-'input'-element without a name" do
+      output = @html.radio_button
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "radio"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.radio_button { "test" }
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "radio"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns a radio-'input'-element with the passed name" do
+      output = @html.radio_button("test")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.radio_button("test") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio"}, "", not_closed: true)
+    end
+  end
+
+  describe "CGI::HtmlExtension#checkbox when passed name, value" do
+    it "returns a radio-'input'-element with the passed name and value" do
+      output = @html.radio_button("test", "test-value")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.radio_button("test", "test-value") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, checked" do
+    it "returns a checked radio-'input'-element with the passed name and value when checked is true" do
+      output = @html.radio_button("test", "test-value", true)
+      output.should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+
+      output = @html.radio_button("test", "test-value", false)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+
+      output = @html.radio_button("test", "test-value", nil)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.radio_button("test", "test-value", nil) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "test-value"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a radio-'input'-element using the passed Hash for attributes" do
+      attributes = {"NAME" => "test", "VALUE" => "test-value", "CHECKED" => true}
+      output = @html.radio_button(attributes)
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      attributes = {"NAME" => "test", "VALUE" => "test-value", "CHECKED" => true}
+      output = @html.radio_button(attributes) { "test" }
+      output.should equal_element("INPUT", attributes, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/radio_group_spec.rb
+++ b/spec/library/cgi/htmlextension/radio_group_spec.rb
@@ -1,0 +1,77 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#radio_group" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed name, values ..." do
+    it "returns a sequence of 'radio'-elements with the passed name and the passed values" do
+      output = CGISpecs.split(@html.radio_group("test", "foo", "bar", "baz"))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+
+    it "allows passing a value inside an Array" do
+      output = CGISpecs.split(@html.radio_group("test", ["foo"], "bar", ["baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+
+    it "allows passing a value as an Array containing the value and the checked state or a label" do
+      output = CGISpecs.split(@html.radio_group("test", ["foo"], ["bar", true], ["baz", "label for baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "baz"}, "label for baz", not_closed: true)
+    end
+
+    # TODO: CGI does not like passing false instead of true.
+    it "allows passing a value as an Array containing the value, a label and the checked state" do
+      output = CGISpecs.split(@html.radio_group("test", ["foo", "label for foo", true], ["bar", "label for bar", false], ["baz", "label for baz", true]))
+      output[0].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "radio", "VALUE" => "foo"}, "label for foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "bar"}, "label for bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "test", "TYPE" => "radio", "VALUE" => "baz"}, "label for baz", not_closed: true)
+    end
+
+    it "returns an empty String when passed no values" do
+      @html.radio_group("test").should == ""
+    end
+
+    it "ignores a passed block" do
+      output = CGISpecs.split(@html.radio_group("test", "foo", "bar", "baz") { "test" })
+      output[0].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "test", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "uses the passed Hash to generate the radio sequence" do
+      output = CGISpecs.split(@html.radio_group("NAME" => "name", "VALUES" => ["foo", "bar", "baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+
+      output = CGISpecs.split(@html.radio_group("NAME" => "name", "VALUES" => [["foo"], ["bar", true], "baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "name", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+
+      output = CGISpecs.split(@html.radio_group("NAME" => "name", "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"]))
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "1"}, "Foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"CHECKED" => true, "NAME" => "name", "TYPE" => "radio", "VALUE" => "2"}, "Bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "Baz"}, "Baz", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = CGISpecs.split(@html.radio_group("NAME" => "name", "VALUES" => ["foo", "bar", "baz"]) { "test" })
+      output[0].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "foo"}, "foo", not_closed: true)
+      output[1].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "bar"}, "bar", not_closed: true)
+      output[2].should equal_element("INPUT", {"NAME" => "name", "TYPE" => "radio", "VALUE" => "baz"}, "baz", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/reset_spec.rb
+++ b/spec/library/cgi/htmlextension/reset_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#reset" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns a reset-'input'-element" do
+      output = @html.reset
+      output.should equal_element("INPUT", {"TYPE" => "reset"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.reset { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "reset"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed value" do
+    it "returns a reset-'input'-element with the passed value" do
+      output = @html.reset("Example")
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.reset("Example") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed value, name" do
+    it "returns a reset-'input'-element with the passed value and the passed name" do
+      output = @html.reset("Example", "test-name")
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example", "NAME" => "test-name"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.reset("Example", "test-name") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example", "NAME" => "test-name"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a reset-'input'-element with the passed value" do
+      output = @html.reset("Example")
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.reset("Example") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "reset", "VALUE" => "Example"}, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/scrolling_list_spec.rb
+++ b/spec/library/cgi/htmlextension/scrolling_list_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../spec_helper'
+require_relative 'fixtures/common'
+require 'cgi'
+require_relative 'shared/popup_menu'
+
+describe "CGI::HtmlExtension#scrolling_list" do
+  it_behaves_like :cgi_htmlextension_popup_menu, :scrolling_list
+end

--- a/spec/library/cgi/htmlextension/shared/popup_menu.rb
+++ b/spec/library/cgi/htmlextension/shared/popup_menu.rb
@@ -1,0 +1,94 @@
+describe :cgi_htmlextension_popup_menu, shared: true do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an empty 'select'-element without a name" do
+      output = @html.send(@method)
+      output.should equal_element("SELECT", {"NAME" => ""}, "")
+    end
+
+    it "ignores a passed block" do
+      output = @html.send(@method) { "test" }
+      output.should equal_element("SELECT", {"NAME" => ""}, "")
+    end
+  end
+
+  describe "when passed name, values ..." do
+    it "returns a 'select'-element with the passed name containing 'option'-elements based on the passed values" do
+      content = @html.option("VALUE" => "foo") { "foo" }
+      content << @html.option("VALUE" => "bar") { "bar" }
+      content << @html.option("VALUE" => "baz") { "baz" }
+
+      output = @html.send(@method, "test", "foo", "bar", "baz")
+      output.should equal_element("SELECT", {"NAME" => "test"}, content)
+    end
+
+    it "allows passing values inside of arrays" do
+      content = @html.option("VALUE" => "foo") { "foo" }
+      content << @html.option("VALUE" => "bar") { "bar" }
+      content << @html.option("VALUE" => "baz") { "baz" }
+
+      output = @html.send(@method, "test", ["foo"], ["bar"], ["baz"])
+      output.should equal_element("SELECT", {"NAME" => "test"}, content)
+    end
+
+    it "allows passing a value as an Array containing the value and the select state or a label" do
+      content = @html.option("VALUE" => "foo") { "foo" }
+      content << @html.option("VALUE" => "bar", "SELECTED" => true) { "bar" }
+      content << @html.option("VALUE" => "baz") { "baz" }
+
+      output = @html.send(@method, "test", ["foo"], ["bar", true], "baz")
+      output.should equal_element("SELECT", {"NAME" => "test"}, content)
+    end
+
+    it "allows passing a value as an Array containing the value, a label and the select state" do
+      content = @html.option("VALUE" => "1") { "Foo" }
+      content << @html.option("VALUE" => "2", "SELECTED" => true) { "Bar" }
+      content << @html.option("VALUE" => "Baz") { "Baz" }
+
+      output = @html.send(@method, "test", ["1", "Foo"], ["2", "Bar", true], "Baz")
+      output.should equal_element("SELECT", {"NAME" => "test"}, content)
+    end
+
+    it "ignores a passed block" do
+      content = @html.option("VALUE" => "foo") { "foo" }
+      content << @html.option("VALUE" => "bar") { "bar" }
+      content << @html.option("VALUE" => "baz") { "baz" }
+
+      output = @html.send(@method, "test", "foo", "bar", "baz") { "woot" }
+      output.should equal_element("SELECT", {"NAME" => "test"}, content)
+    end
+  end
+
+  describe "when passed a Hash" do
+    it "uses the passed Hash to generate the 'select'-element and the 'option'-elements" do
+      attributes = {
+        "NAME"   => "test", "SIZE" => 2, "MULTIPLE" => true,
+        "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"]
+      }
+
+      content = @html.option("VALUE" => "1") { "Foo" }
+      content << @html.option("VALUE" => "2", "SELECTED" => true) { "Bar" }
+      content << @html.option("VALUE" => "Baz") { "Baz" }
+
+      output = @html.send(@method, attributes)
+      output.should equal_element("SELECT", {"NAME" => "test", "SIZE" => 2, "MULTIPLE" => true}, content)
+    end
+
+    it "ignores a passed block" do
+      attributes = {
+        "NAME"   => "test", "SIZE" => 2, "MULTIPLE" => true,
+        "VALUES" => [["1", "Foo"], ["2", "Bar", true], "Baz"]
+      }
+
+      content = @html.option("VALUE" => "1") { "Foo" }
+      content << @html.option("VALUE" => "2", "SELECTED" => true) { "Bar" }
+      content << @html.option("VALUE" => "Baz") { "Baz" }
+
+      output = @html.send(@method, attributes) { "testing" }
+      output.should equal_element("SELECT", {"NAME" => "test", "SIZE" => 2, "MULTIPLE" => true}, content)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/submit_spec.rb
+++ b/spec/library/cgi/htmlextension/submit_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#submit" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns a submit-'input'-element" do
+      output = @html.submit
+      output.should equal_element("INPUT", {"TYPE" => "submit"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.submit { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "submit"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed value" do
+    it "returns a submit-'input'-element with the passed value" do
+      output = @html.submit("Example")
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.submit("Example") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed value, name" do
+    it "returns a submit-'input'-element with the passed value and the passed name" do
+      output = @html.submit("Example", "test-name")
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example", "NAME" => "test-name"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.submit("Example", "test-name") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example", "NAME" => "test-name"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a submit-'input'-element with the passed value" do
+      output = @html.submit("Example")
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.submit("Example") { "test" }
+      output.should equal_element("INPUT", {"TYPE" => "submit", "VALUE" => "Example"}, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/text_field_spec.rb
+++ b/spec/library/cgi/htmlextension/text_field_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#text_field" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an text-'input'-element without a name" do
+      output = @html.text_field
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "text", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field { "test" }
+      output.should equal_element("INPUT", {"NAME" => "", "TYPE" => "text", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name" do
+    it "returns an text-'input'-element with the passed name" do
+      output = @html.text_field("test")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field("test") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value" do
+    it "returns an text-'input'-element with the passed name and value" do
+      output = @html.text_field("test", "some value")
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "40"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field("test", "some value") { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "40"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, size" do
+    it "returns an text-'input'-element with the passed name, value and size" do
+      output = @html.text_field("test", "some value", 60)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "60"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field("test", "some value", 60) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "60"}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed name, value, size, maxlength" do
+    it "returns an text-'input'-element with the passed name, value, size and maxlength" do
+      output = @html.text_field("test", "some value", 60, 12)
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "60", "MAXLENGTH" => 12}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field("test", "some value", 60, 12) { "test" }
+      output.should equal_element("INPUT", {"NAME" => "test", "TYPE" => "text", "VALUE" => "some value", "SIZE" => "60", "MAXLENGTH" => 12}, "", not_closed: true)
+    end
+  end
+
+  describe "when passed Hash" do
+    it "returns a checkbox-'input'-element using the passed Hash for attributes" do
+      output = @html.text_field("NAME" => "test", "VALUE" => "some value")
+      output.should equal_element("INPUT", { "NAME" => "test", "VALUE" => "some value", "TYPE" => "text" }, "", not_closed: true)
+
+      output = @html.text_field("TYPE" => "hidden")
+      output.should equal_element("INPUT", {"TYPE" => "text"}, "", not_closed: true)
+    end
+
+    it "ignores a passed block" do
+      output = @html.text_field("NAME" => "test", "VALUE" => "some value") { "test" }
+      output.should equal_element("INPUT", { "NAME" => "test", "VALUE" => "some value", "TYPE" => "text" }, "", not_closed: true)
+    end
+  end
+end

--- a/spec/library/cgi/htmlextension/textarea_spec.rb
+++ b/spec/library/cgi/htmlextension/textarea_spec.rb
@@ -1,0 +1,73 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'fixtures/common'
+
+describe "CGI::HtmlExtension#textarea" do
+  before :each do
+    @html = CGISpecs.cgi_new
+  end
+
+  describe "when passed no arguments" do
+    it "returns an 'textarea'-element without a name" do
+      output = @html.textarea
+      output.should equal_element("TEXTAREA", {"NAME" => "", "COLS" => "70", "ROWS" => "10"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.textarea { "Example" }
+      output.should equal_element("TEXTAREA", {"NAME" => "", "COLS" => "70", "ROWS" => "10"}, "Example")
+    end
+  end
+
+  describe "when passed name" do
+    it "returns an 'textarea'-element with the passed name" do
+      output = @html.textarea("test")
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "70", "ROWS" => "10"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.textarea("test") { "Example" }
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "70", "ROWS" => "10"}, "Example")
+    end
+  end
+
+  describe "when passed name, cols" do
+    it "returns an 'textarea'-element with the passed name and the passed amount of columns" do
+      output = @html.textarea("test", 40)
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "40", "ROWS" => "10"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.textarea("test", 40) { "Example" }
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "40", "ROWS" => "10"}, "Example")
+    end
+  end
+
+  describe "when passed name, cols, rows" do
+    it "returns an 'textarea'-element with the passed name, the passed amount of columns and the passed number of rows" do
+      output = @html.textarea("test", 40, 5)
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "40", "ROWS" => "5"}, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      output = @html.textarea("test", 40, 5) { "Example" }
+      output.should equal_element("TEXTAREA", {"NAME" => "test", "COLS" => "40", "ROWS" => "5"}, "Example")
+    end
+  end
+
+  describe "when passed Hash" do
+    it "uses the passed Hash as attributes" do
+      @html.textarea("ID" => "test").should == '<TEXTAREA ID="test"></TEXTAREA>'
+
+      attributes = {"ID" => "test-id", "NAME" => "test-name"}
+      output = @html.textarea(attributes)
+      output.should equal_element("TEXTAREA", attributes, "")
+    end
+
+    it "includes the return value of the passed block when passed a block" do
+      attributes = {"ID" => "test-id", "NAME" => "test-name"}
+      output = @html.textarea(attributes) { "test" }
+      output.should equal_element("TEXTAREA", attributes, "test")
+    end
+  end
+end

--- a/spec/library/cgi/http_header_spec.rb
+++ b/spec/library/cgi/http_header_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+require_relative 'shared/http_header'
+
+describe "CGI#http_header" do
+  it_behaves_like :cgi_http_header, :http_header
+end

--- a/spec/library/cgi/initialize_spec.rb
+++ b/spec/library/cgi/initialize_spec.rb
@@ -1,0 +1,133 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI#initialize" do
+  it "is private" do
+    CGI.should have_private_instance_method(:initialize)
+  end
+end
+
+describe "CGI#initialize when passed no arguments" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.allocate
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "extends self with CGI::QueryExtension" do
+    @cgi.send(:initialize)
+    @cgi.should be_kind_of(CGI::QueryExtension)
+  end
+
+  it "does not extend self with CGI::HtmlExtension" do
+    @cgi.send(:initialize)
+    @cgi.should_not be_kind_of(CGI::HtmlExtension)
+  end
+
+  it "does not extend self with any of the other HTML modules" do
+    @cgi.send(:initialize)
+    @cgi.should_not be_kind_of(CGI::HtmlExtension)
+    @cgi.should_not be_kind_of(CGI::Html3)
+    @cgi.should_not be_kind_of(CGI::Html4)
+    @cgi.should_not be_kind_of(CGI::Html4Tr)
+    @cgi.should_not be_kind_of(CGI::Html4Fr)
+  end
+
+  it "sets #cookies based on ENV['HTTP_COOKIE']" do
+    begin
+      old_env, ENV["HTTP_COOKIE"] = ENV["HTTP_COOKIE"], "test=test yay"
+      @cgi.send(:initialize)
+      @cgi.cookies.should == { "test"=>[ "test yay" ] }
+    ensure
+      ENV["HTTP_COOKIE"] = old_env
+    end
+  end
+
+  it "sets #params based on ENV['QUERY_STRING'] when ENV['REQUEST_METHOD'] is GET" do
+    begin
+      old_env_query, ENV["QUERY_STRING"] = ENV["QUERY_STRING"], "?test=a&test2=b"
+      old_env_method, ENV["REQUEST_METHOD"] = ENV["REQUEST_METHOD"], "GET"
+      @cgi.send(:initialize)
+      @cgi.params.should == { "test2" => ["b"], "?test" => ["a"] }
+    ensure
+      ENV["QUERY_STRING"] = old_env_query
+      ENV["REQUEST_METHOD"] = old_env_method
+    end
+  end
+
+  it "sets #params based on ENV['QUERY_STRING'] when ENV['REQUEST_METHOD'] is HEAD" do
+    begin
+      old_env_query, ENV["QUERY_STRING"] = ENV["QUERY_STRING"], "?test=a&test2=b"
+      old_env_method, ENV["REQUEST_METHOD"] = ENV["REQUEST_METHOD"], "HEAD"
+      @cgi.send(:initialize)
+      @cgi.params.should == { "test2" => ["b"], "?test" => ["a"] }
+    ensure
+      ENV["QUERY_STRING"] = old_env_query
+      ENV["REQUEST_METHOD"] = old_env_method
+    end
+  end
+end
+
+describe "CGI#initialize when passed type" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.allocate
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+
+  it "extends self with CGI::QueryExtension" do
+    @cgi.send(:initialize, "test")
+    @cgi.should be_kind_of(CGI::QueryExtension)
+  end
+
+  it "extends self with CGI::QueryExtension, CGI::Html3 and CGI::HtmlExtension when the passed type is 'html3'" do
+    @cgi.send(:initialize, "html3")
+    @cgi.should be_kind_of(CGI::Html3)
+    @cgi.should be_kind_of(CGI::HtmlExtension)
+    @cgi.should be_kind_of(CGI::QueryExtension)
+
+    @cgi.should_not be_kind_of(CGI::Html4)
+    @cgi.should_not be_kind_of(CGI::Html4Tr)
+    @cgi.should_not be_kind_of(CGI::Html4Fr)
+  end
+
+  it "extends self with CGI::QueryExtension, CGI::Html4 and CGI::HtmlExtension when the passed type is 'html4'" do
+    @cgi.send(:initialize, "html4")
+    @cgi.should be_kind_of(CGI::Html4)
+    @cgi.should be_kind_of(CGI::HtmlExtension)
+    @cgi.should be_kind_of(CGI::QueryExtension)
+
+    @cgi.should_not be_kind_of(CGI::Html3)
+    @cgi.should_not be_kind_of(CGI::Html4Tr)
+    @cgi.should_not be_kind_of(CGI::Html4Fr)
+  end
+
+  it "extends self with CGI::QueryExtension, CGI::Html4Tr and CGI::HtmlExtension when the passed type is 'html4Tr'" do
+    @cgi.send(:initialize, "html4Tr")
+    @cgi.should be_kind_of(CGI::Html4Tr)
+    @cgi.should be_kind_of(CGI::HtmlExtension)
+    @cgi.should be_kind_of(CGI::QueryExtension)
+
+    @cgi.should_not be_kind_of(CGI::Html3)
+    @cgi.should_not be_kind_of(CGI::Html4)
+    @cgi.should_not be_kind_of(CGI::Html4Fr)
+  end
+
+  it "extends self with CGI::QueryExtension, CGI::Html4Tr, CGI::Html4Fr and CGI::HtmlExtension when the passed type is 'html4Fr'" do
+    @cgi.send(:initialize, "html4Fr")
+    @cgi.should be_kind_of(CGI::Html4Tr)
+    @cgi.should be_kind_of(CGI::Html4Fr)
+    @cgi.should be_kind_of(CGI::HtmlExtension)
+    @cgi.should be_kind_of(CGI::QueryExtension)
+
+    @cgi.should_not be_kind_of(CGI::Html3)
+    @cgi.should_not be_kind_of(CGI::Html4)
+  end
+end

--- a/spec/library/cgi/out_spec.rb
+++ b/spec/library/cgi/out_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI#out" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+    $stdout, @old_stdout = IOStub.new, $stdout
+  end
+
+  after :each do
+    $stdout = @old_stdout
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "it writes a HTMl header based on the passed argument to $stdout" do
+    @cgi.out { "" }
+    $stdout.should == "Content-Type: text/html\r\nContent-Length: 0\r\n\r\n"
+  end
+
+  it "appends the block's return value to the HTML header" do
+    @cgi.out { "test!" }
+    $stdout.should == "Content-Type: text/html\r\nContent-Length: 5\r\n\r\ntest!"
+  end
+
+  it "automatically sets the Content-Length Header based on the block's return value" do
+    @cgi.out { "0123456789" }
+    $stdout.should == "Content-Type: text/html\r\nContent-Length: 10\r\n\r\n0123456789"
+  end
+
+  it "includes Cookies in the @output_cookies field" do
+    @cgi.instance_variable_set(:@output_cookies, ["multiple", "cookies"])
+    @cgi.out { "" }
+    $stdout.should == "Content-Type: text/html\r\nContent-Length: 0\r\nSet-Cookie: multiple\r\nSet-Cookie: cookies\r\n\r\n"
+  end
+end
+
+describe "CGI#out when passed no block" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "raises a LocalJumpError" do
+    -> { @cgi.out }.should raise_error(LocalJumpError)
+  end
+end

--- a/spec/library/cgi/parse_spec.rb
+++ b/spec/library/cgi/parse_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.parse when passed String" do
+  it "parses a HTTP Query String into a Hash" do
+    CGI.parse("test=test&a=b").should == { "a" => ["b"], "test" => ["test"] }
+    CGI.parse("test=1,2,3").should == { "test" => ["1,2,3"] }
+    CGI.parse("test=a&a=&b=").should == { "test" => ["a"], "a" => [""], "b" => [""] }
+  end
+
+  it "parses query strings with semicolons in place of ampersands" do
+    CGI.parse("test=test;a=b").should == { "a" => ["b"], "test" => ["test"] }
+    CGI.parse("test=a;a=;b=").should == { "test" => ["a"], "a" => [""], "b" => [""] }
+  end
+
+  it "allows passing multiple values for one key" do
+    CGI.parse("test=1&test=2&test=3").should == { "test" => ["1", "2", "3"] }
+    CGI.parse("test[]=1&test[]=2&test[]=3").should == { "test[]" => [ "1", "2", "3" ] }
+  end
+
+  it "unescapes keys and values" do
+    CGI.parse("hello%3F=hello%21").should == { "hello?" => ["hello!"] }
+  end
+end

--- a/spec/library/cgi/pretty_spec.rb
+++ b/spec/library/cgi/pretty_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.pretty when passed html" do
+  it "indents the passed html String with two spaces" do
+    CGI.pretty("<HTML><BODY></BODY></HTML>").should == <<-EOS
+<HTML>
+  <BODY>
+  </BODY>
+</HTML>
+EOS
+  end
+end
+
+describe "CGI.pretty when passed html, indentation_unit" do
+  it "indents the passed html String with the passed indentation_unit" do
+    CGI.pretty("<HTML><BODY></BODY></HTML>", "\t").should == <<-EOS
+<HTML>
+\t<BODY>
+\t</BODY>
+</HTML>
+EOS
+  end
+end

--- a/spec/library/cgi/print_spec.rb
+++ b/spec/library/cgi/print_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI#print" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "passes all arguments to $stdout.print" do
+    $stdout.should_receive(:print).with("test")
+    @cgi.print("test")
+
+    $stdout.should_receive(:print).with("one", "two", "three", ["four", "five"])
+    @cgi.print("one", "two", "three", ["four", "five"])
+  end
+
+  it "returns the result of calling $stdout.print" do
+    $stdout.should_receive(:print).with("test").and_return(:expected)
+    @cgi.print("test").should == :expected
+  end
+end

--- a/spec/library/cgi/queryextension/accept_charset_spec.rb
+++ b/spec/library/cgi/queryextension/accept_charset_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#accept_charset" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_ACCEPT_CHARSET']" do
+    old_value, ENV['HTTP_ACCEPT_CHARSET'] = ENV['HTTP_ACCEPT_CHARSET'], "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+    begin
+      @cgi.accept_charset.should == "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+    ensure
+      ENV['HTTP_ACCEPT_CHARSET'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/accept_encoding_spec.rb
+++ b/spec/library/cgi/queryextension/accept_encoding_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#accept_encoding" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_ACCEPT_ENCODING']" do
+    old_value, ENV['HTTP_ACCEPT_ENCODING'] = ENV['HTTP_ACCEPT_ENCODING'], "gzip,deflate"
+    begin
+      @cgi.accept_encoding.should == "gzip,deflate"
+    ensure
+      ENV['HTTP_ACCEPT_ENCODING'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/accept_language_spec.rb
+++ b/spec/library/cgi/queryextension/accept_language_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#accept_language" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_ACCEPT_LANGUAGE']" do
+    old_value, ENV['HTTP_ACCEPT_LANGUAGE'] = ENV['HTTP_ACCEPT_LANGUAGE'], "en-us,en;q=0.5"
+    begin
+      @cgi.accept_language.should == "en-us,en;q=0.5"
+    ensure
+      ENV['HTTP_ACCEPT_LANGUAGE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/accept_spec.rb
+++ b/spec/library/cgi/queryextension/accept_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#accept" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_ACCEPT']" do
+    old_value, ENV['HTTP_ACCEPT'] = ENV['HTTP_ACCEPT'], "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+    begin
+      @cgi.accept.should == "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+    ensure
+      ENV['HTTP_ACCEPT'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/auth_type_spec.rb
+++ b/spec/library/cgi/queryextension/auth_type_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#auth_type" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['AUTH_TYPE']" do
+    old_value, ENV['AUTH_TYPE'] = ENV['AUTH_TYPE'], "Basic"
+    begin
+      @cgi.auth_type.should == "Basic"
+    ensure
+      ENV['AUTH_TYPE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/cache_control_spec.rb
+++ b/spec/library/cgi/queryextension/cache_control_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#cache_control" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_CACHE_CONTROL']" do
+    old_value, ENV['HTTP_CACHE_CONTROL'] = ENV['HTTP_CACHE_CONTROL'], "no-cache"
+    begin
+      @cgi.cache_control.should == "no-cache"
+    ensure
+      ENV['HTTP_CACHE_CONTROL'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/content_length_spec.rb
+++ b/spec/library/cgi/queryextension/content_length_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#content_length" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['CONTENT_LENGTH'] as Integer" do
+    old_value = ENV['CONTENT_LENGTH']
+    begin
+      ENV['CONTENT_LENGTH'] = nil
+      @cgi.content_length.should be_nil
+
+      ENV['CONTENT_LENGTH'] = "100"
+      @cgi.content_length.should eql(100)
+    ensure
+      ENV['CONTENT_LENGTH'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/content_type_spec.rb
+++ b/spec/library/cgi/queryextension/content_type_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#content_type" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['CONTENT_TYPE']" do
+    old_value, ENV['CONTENT_TYPE'] = ENV['CONTENT_TYPE'], "text/html"
+    begin
+      @cgi.content_type.should == "text/html"
+    ensure
+      ENV['CONTENT_TYPE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/cookies_spec.rb
+++ b/spec/library/cgi/queryextension/cookies_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#cookies" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "CGI::QueryExtension#cookies=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/spec/library/cgi/queryextension/element_reference_spec.rb
+++ b/spec/library/cgi/queryextension/element_reference_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#[]" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    ENV['QUERY_STRING'], @old_query_string = "one=a&two=b&two=c", ENV['QUERY_STRING']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+    ENV['QUERY_STRING']   = @old_query_string
+  end
+
+  it "it returns the value for the parameter with the given key" do
+    @cgi["one"].should == "a"
+  end
+
+  it "only returns the first value for parameters with multiple values" do
+    @cgi["two"].should == "b"
+  end
+
+  it "returns a String" do
+    @cgi["one"].should be_kind_of(String)
+  end
+end

--- a/spec/library/cgi/queryextension/from_spec.rb
+++ b/spec/library/cgi/queryextension/from_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#from" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_FROM']" do
+    old_value, ENV['HTTP_FROM'] = ENV['HTTP_FROM'], "googlebot(at)googlebot.com"
+    begin
+      @cgi.from.should == "googlebot(at)googlebot.com"
+    ensure
+      ENV['HTTP_FROM'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/gateway_interface_spec.rb
+++ b/spec/library/cgi/queryextension/gateway_interface_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#gateway_interface" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['GATEWAY_INTERFACE']" do
+    old_value, ENV['GATEWAY_INTERFACE'] = ENV['GATEWAY_INTERFACE'], "CGI/1.1"
+    begin
+      @cgi.gateway_interface.should == "CGI/1.1"
+    ensure
+      ENV['GATEWAY_INTERFACE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/has_key_spec.rb
+++ b/spec/library/cgi/queryextension/has_key_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'shared/has_key'
+
+describe "CGI::QueryExtension#has_key?" do
+  it_behaves_like :cgi_query_extension_has_key_p, :has_key?
+end

--- a/spec/library/cgi/queryextension/host_spec.rb
+++ b/spec/library/cgi/queryextension/host_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#host" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_HOST']" do
+    old_value, ENV['HTTP_HOST'] = ENV['HTTP_HOST'], "localhost"
+    begin
+      @cgi.host.should == "localhost"
+    ensure
+      ENV['HTTP_HOST'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/include_spec.rb
+++ b/spec/library/cgi/queryextension/include_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'shared/has_key'
+
+describe "CGI::QueryExtension#include?" do
+  it_behaves_like :cgi_query_extension_has_key_p, :include?
+end

--- a/spec/library/cgi/queryextension/key_spec.rb
+++ b/spec/library/cgi/queryextension/key_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require_relative 'shared/has_key'
+
+describe "CGI::QueryExtension#key?" do
+  it_behaves_like :cgi_query_extension_has_key_p, :key?
+end

--- a/spec/library/cgi/queryextension/keys_spec.rb
+++ b/spec/library/cgi/queryextension/keys_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#keys" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    ENV['QUERY_STRING'], @old_query_string = "one=a&two=b", ENV['QUERY_STRING']
+
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+    ENV['QUERY_STRING']   = @old_query_string
+  end
+
+  it "returns all parameter keys as an Array" do
+    @cgi.keys.sort.should == ["one", "two"]
+  end
+end

--- a/spec/library/cgi/queryextension/multipart_spec.rb
+++ b/spec/library/cgi/queryextension/multipart_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+require "stringio"
+
+describe "CGI::QueryExtension#multipart?" do
+  before :each do
+    @old_stdin = $stdin
+
+    @old_request_method = ENV['REQUEST_METHOD']
+    @old_content_type = ENV['CONTENT_TYPE']
+    @old_content_length = ENV['CONTENT_LENGTH']
+
+    ENV['REQUEST_METHOD'] = "POST"
+    ENV["CONTENT_TYPE"] = "multipart/form-data; boundary=---------------------------1137522503144128232716531729"
+    ENV["CONTENT_LENGTH"] = "222"
+
+    $stdin = StringIO.new <<-EOS
+-----------------------------1137522503144128232716531729\r
+Content-Disposition: form-data; name="file"; filename=""\r
+Content-Type: application/octet-stream\r
+\r
+\r
+-----------------------------1137522503144128232716531729--\r
+EOS
+
+    @cgi = CGI.new
+  end
+
+  after :each do
+    $stdin = @old_stdin
+
+    ENV['REQUEST_METHOD'] = @old_request_method
+    ENV['CONTENT_TYPE'] = @old_content_type
+    ENV['CONTENT_LENGTH'] = @old_content_length
+  end
+
+  it "returns true if the current Request is a multipart request" do
+    @cgi.multipart?.should be_true
+  end
+end

--- a/spec/library/cgi/queryextension/negotiate_spec.rb
+++ b/spec/library/cgi/queryextension/negotiate_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#negotiate" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_NEGOTIATE']" do
+    old_value, ENV['HTTP_NEGOTIATE'] = ENV['HTTP_NEGOTIATE'], "trans"
+    begin
+      @cgi.negotiate.should == "trans"
+    ensure
+      ENV['HTTP_NEGOTIATE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/params_spec.rb
+++ b/spec/library/cgi/queryextension/params_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#params" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    ENV['QUERY_STRING'], @old_query_string = "one=a&two=b&two=c&three", ENV['QUERY_STRING']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['QUERY_STRING'] = @old_query_string
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns the parsed HTTP Query Params" do
+    @cgi.params.should == {"three"=>[], "two"=>["b", "c"], "one"=>["a"]}
+  end
+end
+
+describe "CGI::QueryExtension#params=" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "sets the HTTP Query Params to the passed argument" do
+    @cgi.params.should == {}
+
+    @cgi.params = {"one"=>["a"], "two"=>["b", "c"]}
+    @cgi.params.should == {"one"=>["a"], "two"=>["b", "c"]}
+  end
+end

--- a/spec/library/cgi/queryextension/path_info_spec.rb
+++ b/spec/library/cgi/queryextension/path_info_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#path_info" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['PATH_INFO']" do
+    old_value, ENV['PATH_INFO'] = ENV['PATH_INFO'], "/test/path"
+    begin
+      @cgi.path_info.should == "/test/path"
+    ensure
+      ENV['PATH_INFO'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/path_translated_spec.rb
+++ b/spec/library/cgi/queryextension/path_translated_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#path_translated" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['PATH_TRANSLATED']" do
+    old_value, ENV['PATH_TRANSLATED'] = ENV['PATH_TRANSLATED'], "/full/path/to/dir"
+    begin
+      @cgi.path_translated.should == "/full/path/to/dir"
+    ensure
+      ENV['PATH_TRANSLATED'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/pragma_spec.rb
+++ b/spec/library/cgi/queryextension/pragma_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#pragma" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_PRAGMA']" do
+    old_value, ENV['HTTP_PRAGMA'] = ENV['HTTP_PRAGMA'], "no-cache"
+    begin
+      @cgi.pragma.should == "no-cache"
+    ensure
+      ENV['HTTP_PRAGMA'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/query_string_spec.rb
+++ b/spec/library/cgi/queryextension/query_string_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#query_string" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['QUERY_STRING']" do
+    old_value, ENV['QUERY_STRING'] = ENV['QUERY_STRING'], "one=a&two=b"
+    begin
+      @cgi.query_string.should == "one=a&two=b"
+    ensure
+      ENV['QUERY_STRING'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/raw_cookie2_spec.rb
+++ b/spec/library/cgi/queryextension/raw_cookie2_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#raw_cookie2" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_COOKIE2']" do
+    old_value, ENV['HTTP_COOKIE2'] = ENV['HTTP_COOKIE2'], "some_cookie=data"
+    begin
+      @cgi.raw_cookie2.should == "some_cookie=data"
+    ensure
+      ENV['HTTP_COOKIE2'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/raw_cookie_spec.rb
+++ b/spec/library/cgi/queryextension/raw_cookie_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#raw_cookie" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_COOKIE']" do
+    old_value, ENV['HTTP_COOKIE'] = ENV['HTTP_COOKIE'], "some_cookie=data"
+    begin
+      @cgi.raw_cookie.should == "some_cookie=data"
+    ensure
+      ENV['HTTP_COOKIE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/referer_spec.rb
+++ b/spec/library/cgi/queryextension/referer_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#referer" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_REFERER']" do
+    old_value, ENV['HTTP_REFERER'] = ENV['HTTP_REFERER'], "example.com"
+    begin
+      @cgi.referer.should == "example.com"
+    ensure
+      ENV['HTTP_REFERER'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/remote_addr_spec.rb
+++ b/spec/library/cgi/queryextension/remote_addr_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#remote_addr" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['REMOTE_ADDR']" do
+    old_value, ENV['REMOTE_ADDR'] = ENV['REMOTE_ADDR'], "127.0.0.1"
+    begin
+      @cgi.remote_addr.should == "127.0.0.1"
+    ensure
+      ENV['REMOTE_ADDR'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/remote_host_spec.rb
+++ b/spec/library/cgi/queryextension/remote_host_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#remote_host" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['REMOTE_HOST']" do
+    old_value, ENV['REMOTE_HOST'] = ENV['REMOTE_HOST'], "test.host"
+    begin
+      @cgi.remote_host.should == "test.host"
+    ensure
+      ENV['REMOTE_HOST'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/remote_ident_spec.rb
+++ b/spec/library/cgi/queryextension/remote_ident_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#remote_ident" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['REMOTE_IDENT']" do
+    old_value, ENV['REMOTE_IDENT'] = ENV['REMOTE_IDENT'], "no-idea-what-this-is-for"
+    begin
+      @cgi.remote_ident.should == "no-idea-what-this-is-for"
+    ensure
+      ENV['REMOTE_IDENT'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/remote_user_spec.rb
+++ b/spec/library/cgi/queryextension/remote_user_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#remote_user" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['REMOTE_USER']" do
+    old_value, ENV['REMOTE_USER'] = ENV['REMOTE_USER'], "username"
+    begin
+      @cgi.remote_user.should == "username"
+    ensure
+      ENV['REMOTE_USER'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/request_method_spec.rb
+++ b/spec/library/cgi/queryextension/request_method_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#request_method" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['REQUEST_METHOD']" do
+    old_value, ENV['REQUEST_METHOD'] = ENV['REQUEST_METHOD'], "GET"
+    begin
+      @cgi.request_method.should == "GET"
+    ensure
+      ENV['REQUEST_METHOD'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/script_name_spec.rb
+++ b/spec/library/cgi/queryextension/script_name_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#script_name" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['SCRIPT_NAME']" do
+    old_value, ENV['SCRIPT_NAME'] = ENV['SCRIPT_NAME'], "/path/to/script.rb"
+    begin
+      @cgi.script_name.should == "/path/to/script.rb"
+    ensure
+      ENV['SCRIPT_NAME'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/server_name_spec.rb
+++ b/spec/library/cgi/queryextension/server_name_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#server_name" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['SERVER_NAME']" do
+    old_value, ENV['SERVER_NAME'] = ENV['SERVER_NAME'], "localhost"
+    begin
+      @cgi.server_name.should == "localhost"
+    ensure
+      ENV['SERVER_NAME'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/server_port_spec.rb
+++ b/spec/library/cgi/queryextension/server_port_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#server_port" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['SERVER_PORT'] as Integer" do
+    old_value = ENV['SERVER_PORT']
+    begin
+      ENV['SERVER_PORT'] = nil
+      @cgi.server_port.should be_nil
+
+      ENV['SERVER_PORT'] = "3000"
+      @cgi.server_port.should eql(3000)
+    ensure
+      ENV['SERVER_PORT'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/server_protocol_spec.rb
+++ b/spec/library/cgi/queryextension/server_protocol_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#server_protocol" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['SERVER_PROTOCOL']" do
+    old_value, ENV['SERVER_PROTOCOL'] = ENV['SERVER_PROTOCOL'], "HTTP/1.1"
+    begin
+      @cgi.server_protocol.should == "HTTP/1.1"
+    ensure
+      ENV['SERVER_PROTOCOL'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/server_software_spec.rb
+++ b/spec/library/cgi/queryextension/server_software_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#server_software" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['SERVER_SOFTWARE']" do
+    old_value, ENV['SERVER_SOFTWARE'] = ENV['SERVER_SOFTWARE'], "Server/1.0.0"
+    begin
+      @cgi.server_software.should == "Server/1.0.0"
+    ensure
+      ENV['SERVER_SOFTWARE'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/queryextension/shared/has_key.rb
+++ b/spec/library/cgi/queryextension/shared/has_key.rb
@@ -1,0 +1,19 @@
+describe :cgi_query_extension_has_key_p, shared: true do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    ENV['QUERY_STRING'], @old_query_string = "one=a&two=b", ENV['QUERY_STRING']
+
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+    ENV['QUERY_STRING']   = @old_query_string
+  end
+
+  it "returns true when the passed key exists in the HTTP Query" do
+    @cgi.send(@method, "one").should be_true
+    @cgi.send(@method, "two").should be_true
+    @cgi.send(@method, "three").should be_false
+  end
+end

--- a/spec/library/cgi/queryextension/user_agent_spec.rb
+++ b/spec/library/cgi/queryextension/user_agent_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe "CGI::QueryExtension#user_agent" do
+  before :each do
+    ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+    @cgi = CGI.new
+  end
+
+  after :each do
+    ENV['REQUEST_METHOD'] = @old_request_method
+  end
+
+  it "returns ENV['HTTP_USER_AGENT']" do
+    old_value, ENV['HTTP_USER_AGENT'] = ENV['HTTP_USER_AGENT'], "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_2; de-de) AppleWebKit/527+ (KHTML, like Gecko) Version/3.1 Safari/525.13"
+    begin
+      @cgi.user_agent.should == "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_2; de-de) AppleWebKit/527+ (KHTML, like Gecko) Version/3.1 Safari/525.13"
+    ensure
+      ENV['HTTP_USER_AGENT'] = old_value
+    end
+  end
+end

--- a/spec/library/cgi/rfc1123_date_spec.rb
+++ b/spec/library/cgi/rfc1123_date_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.rfc1123_date when passed Time" do
+  it "returns the passed Time formatted in RFC1123 ('Sat, 01 Dec 2007 15:56:42 GMT')" do
+    input = Time.at(1196524602)
+    expected = 'Sat, 01 Dec 2007 15:56:42 GMT'
+    CGI.rfc1123_date(input).should == expected
+  end
+end

--- a/spec/library/cgi/shared/http_header.rb
+++ b/spec/library/cgi/shared/http_header.rb
@@ -1,0 +1,112 @@
+require_relative '../../../spec_helper'
+require 'cgi'
+
+describe :cgi_http_header, shared: true do
+  describe "CGI#http_header when passed no arguments" do
+    before :each do
+      ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+      @cgi = CGI.new
+    end
+
+    after :each do
+      ENV['REQUEST_METHOD'] = @old_request_method
+    end
+
+
+    it "returns a HTTP header specifying the Content-Type as text/html" do
+      @cgi.send(@method).should == "Content-Type: text/html\r\n\r\n"
+    end
+
+    it "includes Cookies in the @output_cookies field" do
+      @cgi.instance_variable_set(:@output_cookies, ["multiple", "cookies"])
+      @cgi.send(@method).should == "Content-Type: text/html\r\nSet-Cookie: multiple\r\nSet-Cookie: cookies\r\n\r\n"
+    end
+  end
+
+  describe "CGI#http_header when passed String" do
+    before :each do
+      ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+      @cgi = CGI.new
+    end
+
+    after :each do
+      ENV['REQUEST_METHOD'] = @old_request_method
+    end
+
+
+    it "returns a HTTP header specifying the Content-Type as the passed String's content" do
+      @cgi.send(@method, "text/plain").should == "Content-Type: text/plain\r\n\r\n"
+    end
+
+    it "includes Cookies in the @output_cookies field" do
+      @cgi.instance_variable_set(:@output_cookies, ["multiple", "cookies"])
+      @cgi.send(@method, "text/plain").should == "Content-Type: text/plain\r\nSet-Cookie: multiple\r\nSet-Cookie: cookies\r\n\r\n"
+    end
+  end
+
+  describe "CGI#http_header when passed Hash" do
+    before :each do
+      ENV['REQUEST_METHOD'], @old_request_method = "GET", ENV['REQUEST_METHOD']
+      @cgi = CGI.new
+    end
+
+    after :each do
+      ENV['REQUEST_METHOD'] = @old_request_method
+    end
+
+
+    it "returns a HTTP header based on the Hash's key/value pairs" do
+      header = @cgi.send(@method, "type" => "text/plain")
+      header.should == "Content-Type: text/plain\r\n\r\n"
+
+      header = @cgi.send(@method, "type" => "text/plain", "charset" => "UTF-8")
+      header.should == "Content-Type: text/plain; charset=UTF-8\r\n\r\n"
+
+      header = @cgi.send(@method, "nph" => true)
+      header.should include("HTTP/1.0 200 OK\r\n")
+      header.should include("Date: ")
+      header.should include("Server: ")
+      header.should include("Connection: close\r\n")
+      header.should include("Content-Type: text/html\r\n")
+
+      header = @cgi.send(@method, "status" => "OK")
+      header.should == "Status: 200 OK\r\nContent-Type: text/html\r\n\r\n"
+
+      header = @cgi.send(@method, "status" => "PARTIAL_CONTENT")
+      header.should == "Status: 206 Partial Content\r\nContent-Type: text/html\r\n\r\n"
+
+      header = @cgi.send(@method, "status" => "MULTIPLE_CHOICES")
+      header.should == "Status: 300 Multiple Choices\r\nContent-Type: text/html\r\n\r\n"
+
+      header = @cgi.send(@method, "server" => "Server Software used")
+      header.should == "Server: Server Software used\r\nContent-Type: text/html\r\n\r\n"
+
+      header = @cgi.send(@method, "connection" => "connection type")
+      header.should == "Connection: connection type\r\nContent-Type: text/html\r\n\r\n"
+
+      header = @cgi.send(@method, "length" => 103)
+      header.should == "Content-Type: text/html\r\nContent-Length: 103\r\n\r\n"
+
+      header = @cgi.send(@method, "language" => "ja")
+      header.should == "Content-Type: text/html\r\nContent-Language: ja\r\n\r\n"
+
+      header = @cgi.send(@method, "expires" => Time.at(0))
+      header.should == "Content-Type: text/html\r\nExpires: Thu, 01 Jan 1970 00:00:00 GMT\r\n\r\n"
+
+      header = @cgi.send(@method, "cookie" => "my cookie's content")
+      header.should == "Content-Type: text/html\r\nSet-Cookie: my cookie's content\r\n\r\n"
+
+      header = @cgi.send(@method, "cookie" => ["multiple", "cookies"])
+      header.should == "Content-Type: text/html\r\nSet-Cookie: multiple\r\nSet-Cookie: cookies\r\n\r\n"
+    end
+
+    it "includes Cookies in the @output_cookies field" do
+      @cgi.instance_variable_set(:@output_cookies, ["multiple", "cookies"])
+      @cgi.send(@method, {}).should == "Content-Type: text/html\r\nSet-Cookie: multiple\r\nSet-Cookie: cookies\r\n\r\n"
+    end
+
+    it "returns a HTTP header specifying the Content-Type as text/html when passed an empty Hash" do
+      @cgi.send(@method, {}).should == "Content-Type: text/html\r\n\r\n"
+    end
+  end
+end

--- a/spec/library/cgi/unescapeElement_spec.rb
+++ b/spec/library/cgi/unescapeElement_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.unescapeElement when passed String, elements, ..." do
+  it "unescapes only the tags of the passed elements in the passed String" do
+    res = CGI.unescapeElement("&lt;BR&gt;&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;", "A", "IMG")
+    res.should == '&lt;BR&gt;<A HREF="url"></A>'
+
+    res = CGI.unescapeElement('&lt;BR&gt;&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;', ["A", "IMG"])
+    res.should == '&lt;BR&gt;<A HREF="url"></A>'
+  end
+
+  it "is case-insensitive" do
+    res = CGI.unescapeElement("&lt;BR&gt;&lt;A HREF=&quot;url&quot;&gt;&lt;/A&gt;", "a", "img")
+    res.should == '&lt;BR&gt;<A HREF="url"></A>'
+
+    res = CGI.unescapeElement("&lt;br&gt;&lt;a href=&quot;url&quot;&gt;&lt;/a&gt;", "A", "IMG")
+    res.should == '&lt;br&gt;<a href="url"></a>'
+  end
+end

--- a/spec/library/cgi/unescapeHTML_spec.rb
+++ b/spec/library/cgi/unescapeHTML_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.unescapeHTML" do
+  it "unescapes '&amp; &lt; &gt; &quot;' to '& < > \"'" do
+    input = '&amp; &lt; &gt; &quot;'
+    expected = '& < > "'
+    CGI.unescapeHTML(input).should == expected
+  end
+
+  it "doesn't unescape other html entities such as '&copy;' or '&heart'" do
+    input = '&copy;&heart;'
+    expected = input
+    CGI.unescapeHTML(input).should == expected
+  end
+
+  it "unescapes '&#99' format entities" do
+    input = '&#34;&#38;&#39;&#60;&#62;'
+    expected = '"&\'<>'
+    CGI.unescapeHTML(input).should == expected
+  end
+
+  it "unescapes '&#x9999' format entities" do
+    input = '&#x0022;&#x0026;&#x0027;&#x003c;&#x003E;'
+    expected = '"&\'<>'
+    CGI.unescapeHTML(input).should == expected
+  end
+
+  it "leaves invalid formatted strings" do
+    input = '&&lt;&amp&gt;&quot&abcdefghijklmn'
+    expected = '&<&amp>&quot&abcdefghijklmn'
+    CGI.unescapeHTML(input).should == expected
+  end
+
+  it "leaves partial invalid &# at end of string" do
+    input = "fooooooo&#"
+    CGI.unescapeHTML(input).should == input
+  end
+
+  it "unescapes invalid encoding" do
+    input = "\xFF&"
+    CGI.unescapeHTML(input).should == input
+  end
+end

--- a/spec/library/cgi/unescape_spec.rb
+++ b/spec/library/cgi/unescape_spec.rb
@@ -1,0 +1,15 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require 'cgi'
+
+describe "CGI.unescape" do
+  it "url-decodes the passed argument" do
+    input    = "+%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D%7E"
+    expected = " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    CGI.unescape(input).should == expected
+
+    input    = 'https%3A%2F%2Fja.wikipedia.org%2Fwiki%2F%E3%83%AD%E3%83%A0%E3%82%B9%E3%82%AB%E3%83%BB%E3%83%91%E3%83%AD%E3%83%BB%E3%82%A6%E3%83%AB%E3%83%BB%E3%83%A9%E3%83%94%E3%83%A5%E3%82%BF'
+    expected = "https://ja.wikipedia.org/wiki/\343\203\255\343\203\240\343\202\271\343\202\253\343\203\273\343\203\221\343\203\255\343\203\273\343\202\246\343\203\253\343\203\273\343\203\251\343\203\224\343\203\245\343\202\277"
+    CGI.unescape(input).should == expected
+  end
+end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -28,9 +28,7 @@ Value ArrayObject::initialize(Env *env, Value size, Value value, Block *block) {
         env->verbose_warn("given block not used");
 
     if (!size) {
-        ArrayObject new_array;
-        *this = std::move(new_array);
-        return this;
+        return initialize_copy(env, new ArrayObject);
     }
 
     if (!value) {
@@ -39,9 +37,7 @@ Value ArrayObject::initialize(Env *env, Value size, Value value, Block *block) {
             size = size->send(env, to_ary);
 
         if (size->is_array()) {
-            auto target = *size->as_array();
-            *this = std::move(target);
-            return this;
+            return initialize_copy(env, size);
         }
     }
 

--- a/src/file.rb
+++ b/src/file.rb
@@ -3,6 +3,7 @@ class File
   Separator = SEPARATOR
   ALT_SEPARATOR = nil
   PATH_SEPARATOR = ":".freeze
+  BINARY = 0
 
   # NATFIXME: File.join still has many unhandled special cases
   def self.join(*parts)

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -158,6 +158,15 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exceptio
         return nullptr;
 }
 
+Value KernelModule::cur_callee(Env *env) {
+    auto method = env->caller()->current_method();
+    if (method) {
+        return SymbolObject::intern(method->name());
+    }
+
+    return NilObject::the();
+}
+
 Value KernelModule::cur_dir(Env *env) {
     if (env->file() == nullptr) {
         env->raise("RuntimeError", "could not get current directory");

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -841,7 +841,10 @@ Value KernelModule::test(Env *env, Value cmd, Value file) {
 
 Value KernelModule::this_method(Env *env) {
     auto method = env->caller()->current_method();
-    return SymbolObject::intern(method->name());
+    if (method) {
+        return SymbolObject::intern(method->original_name());
+    }
+    return NilObject::the();
 }
 
 Value KernelModule::throw_method(Env *env, Value name, Value value) {

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -5,7 +5,7 @@ namespace Natalie {
 bool MethodObject::eq(Env *env, Value other_value) {
     if (other_value->is_method()) {
         auto other = other_value->as_method();
-        return m_object == other->m_object && m_method == other->m_method;
+        return m_object == other->m_object && (m_method == other->m_method || (m_method->original_method() && m_method->original_method() == other->m_method));
     } else {
         return false;
     }

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -24,9 +24,15 @@ Value MethodObject::hash() const {
 }
 
 Value MethodObject::source_location() {
-    if (!m_method->get_file())
+    auto method = m_method;
+
+    if (m_method->original_method())
+        method = m_method->original_method();
+
+    if (!method->get_file())
         return NilObject::the();
-    return new ArrayObject { new StringObject { m_method->get_file().value() }, Value::integer(static_cast<nat_int_t>(m_method->get_line().value())) };
+
+    return new ArrayObject { new StringObject { method->get_file().value() }, Value::integer(static_cast<nat_int_t>(method->get_line().value())) };
 }
 
 Value MethodObject::unbind(Env *env) {

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -19,6 +19,10 @@ Value MethodObject::gtgt(Env *env, Value other) {
     return to_proc(env)->gtgt(env, other);
 }
 
+Value MethodObject::hash() const {
+    return Value::integer(m_method->original_name().djb2_hash());
+}
+
 Value MethodObject::source_location() {
     if (!m_method->get_file())
         return NilObject::the();

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -334,7 +334,10 @@ Value ModuleObject::const_missing(Env *env, Value name) {
 void ModuleObject::make_method_alias(Env *env, SymbolObject *new_name, SymbolObject *old_name) {
     auto method_info = find_method(env, old_name);
     assert_method_defined(env, old_name, method_info);
-    define_method(env, new_name, method_info.method(), method_info.visibility());
+
+    auto old_method = method_info.method();
+    auto new_method = Method::from_other(new_name->string(), old_method);
+    define_method(env, new_name, new_method, method_info.visibility());
 };
 
 void ModuleObject::method_alias(Env *env, SymbolObject *new_name, SymbolObject *old_name) {

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -816,12 +816,16 @@ Value super(Env *env, Value self, Args args, Block *block) {
     auto klass = self->singleton_class();
     if (!klass)
         klass = self->klass();
-    auto super_method = klass->find_method(env, SymbolObject::intern(current_method->name()), current_method);
+    auto after_method = current_method;
+    if (current_method->original_method())
+        after_method = current_method->original_method();
+
+    auto super_method = klass->find_method(env, SymbolObject::intern(after_method->name()), after_method);
     if (!super_method.is_defined()) {
         if (self->is_module()) {
-            env->raise("NoMethodError", "super: no superclass method `{}' for {}:{}", current_method->name(), self->as_module()->inspect_str(), self->klass()->inspect_str());
+            env->raise("NoMethodError", "super: no superclass method `{}' for {}:{}", current_method->original_name(), self->as_module()->inspect_str(), self->klass()->inspect_str());
         } else {
-            env->raise("NoMethodError", "super: no superclass method `{}' for {}", current_method->name(), self->inspect_str(env));
+            env->raise("NoMethodError", "super: no superclass method `{}' for {}", current_method->original_name(), self->inspect_str(env));
         }
     }
     assert(super_method.method() != current_method);

--- a/test/natalie/array_test.rb
+++ b/test/natalie/array_test.rb
@@ -363,6 +363,22 @@ describe 'array' do
     end
   end
 
+  describe 'Array#initialize' do
+    it 'keeps instance variables if called from subclass' do
+      foo_class = Class.new(Array) do
+        attr_reader :foo
+
+        def initialize
+          @foo = 1
+          super([1])
+        end
+      end
+
+      foo = foo_class.new
+      foo.foo.should == 1
+    end
+  end
+
   describe '#inspect' do
     it 'returns the syntax representation' do
       [1, 2, 3].inspect.should == '[1, 2, 3]'

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -663,6 +663,86 @@ class EqualExpectation
   end
 end
 
+# Largely taken from
+# https://github.com/ruby/ruby/blob/master/spec/mspec/lib/mspec/matchers/equal_element.rb#L76
+class EqualElementExpectation
+  def initialize(element, attributes = nil, content = nil, options = {})
+    @element = element
+    @attributes = attributes
+    @content = content
+    @options = options
+  end
+
+  def match(subject)
+    @actual = subject
+    unless matches?
+      raise SpecFailedException,  "Expected #{@actual} to be a '#{@element}' element with #{attributes_for_failure_message} and #{content_for_failure_message}"
+    end
+  end
+
+  def inverted_match(subject)
+    @actual = subject
+    if matches?
+      raise SpecFailedException "Expected #{@actual} not to be a '#{@element}' element with #{attributes_for_failure_message} and #{content_for_failure_message}"
+    end
+  end
+
+  private
+
+  def matches?
+    actual = @actual
+    matched = true
+
+    if @options[:not_closed]
+      matched &&= actual =~ /^#{Regexp.quote("<" + @element)}.*#{Regexp.quote(">" + (@content || ''))}$/
+    else
+      matched &&= actual =~ /^#{Regexp.quote("<" + @element)}/
+      matched &&= actual =~ /#{Regexp.quote("</" + @element + ">")}$/
+      matched &&= actual =~ /#{Regexp.quote(">" + @content + "</")}/ if @content
+    end
+
+    if @attributes
+      if @attributes.empty?
+        matched &&= actual.scan(/\w+\=\"(.*)\"/).size == 0
+      else
+        @attributes.each do |key, value|
+          if value == true
+            matched &&= (actual.scan(/#{Regexp.quote(key)}(\s|>)/).size == 1)
+          else
+            matched &&= (actual.scan(%Q{ #{key}="#{value}"}).size == 1)
+          end
+        end
+      end
+    end
+
+    !!matched
+  end
+
+  def attributes_for_failure_message
+    if @attributes
+      if @attributes.empty?
+        "no attributes"
+      else
+        @attributes.inject([]) { |memo, n| memo << %Q{#{n[0]}="#{n[1]}"} }.join(" ")
+      end
+    else
+      "any attributes"
+    end
+  end
+
+  def content_for_failure_message
+    if @content
+      if @content.empty?
+        "no content"
+      else
+        "#{@content.inspect} as content"
+      end
+    else
+      "any content"
+    end
+  end
+end
+
 class TrueFalseExpectation
   def match(subject)
     unless subject == true || subject == false
@@ -1421,6 +1501,10 @@ class Object
 
   def equal(other)
     EqualExpectation.new(other)
+  end
+
+  def equal_element(*args)
+    EqualElementExpectation.new(*args)
   end
 
   def output(expected_stdout=nil, expected_stderr=nil)


### PR DESCRIPTION
Apart from the CGI module (and friends) this changes the following things:

* Make Array#initialize more correct
* Implement Kernel#__callee__
* Make Kernel#__method__ spec compliant
* Implement the equal_element spec matcher

Apart from those changes the CGI module only needed one small modification in cgi/util.rb. It feels a bit hacky to use `__inline__` like that but I could not think of a different easy way of fixing this.