### PR TITLE
Refresh some specs after upstream changes

### DIFF
--- a/spec/core/file/chown_spec.rb
+++ b/spec/core/file/chown_spec.rb
@@ -78,15 +78,15 @@ describe "File.chown" do
 end
 
 describe "File#chown" do
-    before :each do
-      @fname = tmp('file_chown_test')
-      @file = File.open(@fname, 'w')
-    end
+  before :each do
+    @fname = tmp('file_chown_test')
+    @file = File.open(@fname, 'w')
+  end
 
-    after :each do
-      @file.close unless @file.closed?
-      rm_r @fname
-    end
+  after :each do
+    @file.close unless @file.closed?
+    rm_r @fname
+  end
 
   as_superuser do
     platform_is :windows do

--- a/spec/core/hash/hash_spec.rb
+++ b/spec/core/hash/hash_spec.rb
@@ -49,7 +49,7 @@ describe "Hash#hash" do
       a = 1
       b = 2
 
-     eval('{a:, b:}.should == { a: 1, b: 2 }')
+      eval('{a:, b:}.should == { a: 1, b: 2 }')
     end
   end
 end

--- a/spec/core/integer/pow_spec.rb
+++ b/spec/core/integer/pow_spec.rb
@@ -19,13 +19,13 @@ describe "Integer#pow" do
       2.pow(61, 5843009213693951).should eql 3697379018277258
       2.pow(62, 5843009213693952).should eql 1551748822859776
       2.pow(63, 5843009213693953).should eql 3103497645717974
-      2.pow(64, 5843009213693954).should eql  363986077738838
+      2.pow(64, 5843009213693954).should eql 363986077738838
     end
 
     it "handles sign like #divmod does" do
-       2.pow(5,  12).should ==  8
-       2.pow(5, -12).should == -4
-      -2.pow(5,  12).should ==  4
+      2.pow(5, 12).should == 8
+      2.pow(5, -12).should == -4
+      -2.pow(5, 12).should == 4
       -2.pow(5, -12).should == -8
     end
 

--- a/spec/core/integer/remainder_spec.rb
+++ b/spec/core/integer/remainder_spec.rb
@@ -15,8 +15,8 @@ describe "Integer#remainder" do
     end
 
     it "keeps sign of self" do
-       5.remainder( 3).should ==  2
-       5.remainder(-3).should ==  2
+      5.remainder( 3).should == 2
+      5.remainder(-3).should == 2
       -5.remainder( 3).should == -2
       -5.remainder(-3).should == -2
     end

--- a/spec/core/io/dup_spec.rb
+++ b/spec/core/io/dup_spec.rb
@@ -25,27 +25,27 @@ describe "IO#dup" do
     @i.fileno.should_not == @f.fileno
   end
 
-quarantine! do # This does not appear to be consistent across platforms
-  it "shares the original stream between the two IOs" do
-    start = @f.pos
-    @i.pos.should == start
+  quarantine! do # This does not appear to be consistent across platforms
+    it "shares the original stream between the two IOs" do
+      start = @f.pos
+      @i.pos.should == start
 
-    s =  "Hello, wo.. wait, where am I?\n"
-    s2 = "<evil voice>       Muhahahaa!"
+      s =  "Hello, wo.. wait, where am I?\n"
+      s2 = "<evil voice>       Muhahahaa!"
 
-    @f.write s
-    @i.pos.should == @f.pos
+      @f.write s
+      @i.pos.should == @f.pos
 
-    @i.rewind
-    @i.gets.should == s
+      @i.rewind
+      @i.gets.should == s
 
-    @i.rewind
-    @i.write s2
+      @i.rewind
+      @i.write s2
 
-    @f.rewind
-    @f.gets.should == "#{s2}\n"
+      @f.rewind
+      @f.gets.should == "#{s2}\n"
+    end
   end
-end
 
   it "allows closing the new IO without affecting the original" do
     @i.close

--- a/spec/language/fixtures/private.rb
+++ b/spec/language/fixtures/private.rb
@@ -43,17 +43,17 @@ module Private
     end
   end
 
-   class E
-     include D
-   end
+  class E
+    include D
+  end
 
-   class G
-     def foo
-       "foo"
-     end
-   end
+  class G
+    def foo
+      "foo"
+    end
+  end
 
-   class H < A
-     private :foo
-   end
+  class H < A
+    private :foo
+  end
 end

--- a/spec/language/fixtures/send.rb
+++ b/spec/language/fixtures/send.rb
@@ -43,9 +43,9 @@ module LangSendSpecs
     attr_writer :foo
     private :foo=
 
-      def call_self_foo_equals(value)
-        self.foo = value
-      end
+    def call_self_foo_equals(value)
+      self.foo = value
+    end
 
     def call_self_foo_equals_masgn(value)
       a, self.foo = 1, value

--- a/spec/library/socket/basicsocket/send_spec.rb
+++ b/spec/library/socket/basicsocket/send_spec.rb
@@ -16,27 +16,27 @@ describe "BasicSocket#send" do
     @socket.close
   end
 
-   it "sends a message to another socket and returns the number of bytes sent" do
-     data = +""
-     t = Thread.new do
-       client = @server.accept
-       loop do
-         got = client.recv(5)
-         break if got.nil? || got.empty?
-         data << got
-       end
-       client.close
-     end
-     Thread.pass while t.status and t.status != "sleep"
-     t.status.should_not be_nil
+  it "sends a message to another socket and returns the number of bytes sent" do
+    data = +""
+    t = Thread.new do
+      client = @server.accept
+      loop do
+        got = client.recv(5)
+        break if got.nil? || got.empty?
+        data << got
+      end
+      client.close
+    end
+    Thread.pass while t.status and t.status != "sleep"
+    t.status.should_not be_nil
 
-     @socket.send('hello', 0).should == 5
-     @socket.shutdown(1) # indicate, that we are done sending
-     @socket.recv(10)
+    @socket.send('hello', 0).should == 5
+    @socket.shutdown(1) # indicate, that we are done sending
+    @socket.recv(10)
 
-     t.join
-     data.should == 'hello'
-   end
+    t.join
+    data.should == 'hello'
+  end
 
   platform_is_not :solaris, :windows do
     it "accepts flags to specify unusual sending behaviour" do

--- a/spec/library/stringio/fixtures/classes.rb
+++ b/spec/library/stringio/fixtures/classes.rb
@@ -4,12 +4,12 @@ class StringSubclass < String; end
 
 module StringIOSpecs
   def self.build
-  str = <<-EOS
+    str = <<-EOS
     each
     peach
     pear
     plum
-  EOS
+    EOS
     StringIO.new(str)
   end
 end


### PR DESCRIPTION
Mostly whitespace, IO#read includes some frozen string literal fixes and a few new specs.