### PR TITLE
Reopen module as class

### DIFF
--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -54,7 +54,7 @@ module Natalie
                 "#{transform.intern(@name)}, Object::ConstLookupSearchMode::#{search_mode}, " \
                 'Object::ConstLookupFailureMode::Null)'
         code << "if (#{klass}) {"
-        code << "  if (!#{klass}->is_module()) {"
+        code << "  if (!#{klass}->is_class()) {"
         code << "    env->raise(\"TypeError\", \"#{@name} is not a class\");"
         code << '  }'
         code << "} else {"

--- a/test/natalie/class_test.rb
+++ b/test/natalie/class_test.rb
@@ -34,6 +34,16 @@ describe 'class' do
       Foo.new.foo2.should == 'foo2'
       Foo.new.foo.should == 'foo'
     end
+
+    it 'should check if the reopened constant really is a class' do
+      -> {
+        class RUBY_VERSION; end
+      }.should raise_error(TypeError, /RUBY_VERSION is not a class/)
+
+      -> {
+        class Comparable; end
+      }.should raise_error(TypeError, /Comparable is not a class/)
+    end
   end
 end
 


### PR DESCRIPTION
```ruby
class Kernel; end
```
This code currently crashes with an assertion error, it should raise the same TypeError as MRI.