### PR TITLE
Import ERB::Util

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ the respective file, in the same directory with a name like `LICENSE`, or both.
 | `cgi/*`          | Wakou Aoyama                      | BSD               |
 | `delegate.rb`    | Yukihiro Matsumoto                | BSD               |
 | `dtoa.c`         | David M. Gay, Lucent Technologies | custom permissive |
+| `erb/util.rb`    | Masatoshi SEKI                    | BSD               |
 | `ipaddr.rb`      | Hajimu Umemoto and Akinori Musha  | BSD               |
 | `find.rb`        | Kazuki Tsujimoto                  | BSD               |
 | `linenoise`      | S. Sanfilippo and P. Noordhuis    | BSD               |

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -1,0 +1,5 @@
+class ERB
+end
+
+require 'cgi/util'
+require 'erb/util'

--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -1,0 +1,72 @@
+# Author:: Masatoshi SEKI
+# Documentation:: James Edward Gray II, Gavin Sinclair, and Simon Chiang
+#
+# Copyright (c) 1999-2000,2002,2003 Masatoshi SEKI
+#
+# You can redistribute it and/or modify it under the same terms as Ruby.
+
+# frozen_string_literal: true
+#--
+# ERB::Escape
+#
+# A subset of ERB::Util. Unlike ERB::Util#html_escape, we expect/hope
+# Rails will not monkey-patch ERB::Escape#html_escape.
+# NATALIE we do not have $LOAD_PATH yet
+# begin
+#   # We don't build the C extension for JRuby, TruffleRuby, and WASM
+#   if $LOAD_PATH.resolve_feature_path('erb/escape')
+#     require 'erb/escape'
+#   end
+# rescue LoadError # resolve_feature_path raises LoadError on TruffleRuby 22.3.0
+# end
+# NATALIE END
+unless defined?(ERB::Escape)
+  module ERB::Escape
+    def html_escape(s)
+      CGI.escapeHTML(s.to_s)
+    end
+    module_function :html_escape
+  end
+end
+
+#--
+# ERB::Util
+#
+# A utility module for conversion routines, often handy in HTML generation.
+module ERB::Util
+  #
+  # A utility method for escaping HTML tag characters in _s_.
+  #
+  #   require "erb"
+  #   include ERB::Util
+  #
+  #   puts html_escape("is a > 0 & a < 10?")
+  #
+  # _Generates_
+  #
+  #   is a &gt; 0 &amp; a &lt; 10?
+  #
+  include ERB::Escape # html_escape
+  module_function :html_escape
+  alias h html_escape
+  module_function :h
+
+  #
+  # A utility method for encoding the String _s_ as a URL.
+  #
+  #   require "erb"
+  #   include ERB::Util
+  #
+  #   puts url_encode("Programming Ruby:  The Pragmatic Programmer's Guide")
+  #
+  # _Generates_
+  #
+  #   Programming%20Ruby%3A%20%20The%20Pragmatic%20Programmer%27s%20Guide
+  #
+  def url_encode(s)
+    CGI.escapeURIComponent(s.to_s)
+  end
+  alias u url_encode
+  module_function :u
+  module_function :url_encode
+end

--- a/spec/library/erb/util/h_spec.rb
+++ b/spec/library/erb/util/h_spec.rb
@@ -1,0 +1,7 @@
+require 'erb'
+require_relative '../../../spec_helper'
+require_relative 'shared/html_escape'
+
+describe "ERB::Util.h" do
+  it_behaves_like :erb_util_html_escape, :h
+end

--- a/spec/library/erb/util/html_escape_spec.rb
+++ b/spec/library/erb/util/html_escape_spec.rb
@@ -1,0 +1,7 @@
+require 'erb'
+require_relative '../../../spec_helper'
+require_relative 'shared/html_escape'
+
+describe "ERB::Util.html_escape" do
+  it_behaves_like :erb_util_html_escape, :html_escape
+end

--- a/spec/library/erb/util/shared/html_escape.rb
+++ b/spec/library/erb/util/shared/html_escape.rb
@@ -1,0 +1,42 @@
+describe :erb_util_html_escape, shared: true do
+  it "escape (& < > \" ') to (&amp; &lt; &gt; &quot; &#39;)" do
+    input = '& < > " \''
+    expected = '&amp; &lt; &gt; &quot; &#39;'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "not escape characters except (& < > \" ')" do
+    input = (0x20..0x7E).to_a.collect {|ch| ch.chr}.join('')
+    expected = input.
+      gsub(/&/,'&amp;').
+      gsub(/</,'&lt;').
+      gsub(/>/,'&gt;').
+      gsub(/'/,'&#39;').
+      gsub(/"/,'&quot;')
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "return empty string when argument is nil" do
+    input = nil
+    expected = ''
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "returns string when argument is number" do
+    input = 123
+    expected = '123'
+    ERB::Util.__send__(@method, input).should == expected
+    input = 3.14159
+    expected = '3.14159'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "returns string when argument is boolean" do
+    input = true
+    expected = 'true'
+    ERB::Util.__send__(@method, input).should == expected
+    input = false
+    expected = 'false'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+end

--- a/spec/library/erb/util/shared/url_encode.rb
+++ b/spec/library/erb/util/shared/url_encode.rb
@@ -1,0 +1,42 @@
+describe :erb_util_url_encode, shared: true do
+  it "encode characters" do
+    #input  = (0x20..0x7E).to_a.collect{|ch| ch.chr}.join
+    input    = " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}"
+    expected = "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D"
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "does not escape tilde" do
+    ERB::Util.__send__(@method, "~").should == "~"
+  end
+
+  it "encode unicode string" do
+    input = "https://ja.wikipedia.org/wiki/\343\203\255\343\203\240\343\202\271\343\202\253\343\203\273\343\203\221\343\203\255\343\203\273\343\202\246\343\203\253\343\203\273\343\203\251\343\203\224\343\203\245\343\202\277"
+    expected = 'https%3A%2F%2Fja.wikipedia.org%2Fwiki%2F%E3%83%AD%E3%83%A0%E3%82%B9%E3%82%AB%E3%83%BB%E3%83%91%E3%83%AD%E3%83%BB%E3%82%A6%E3%83%AB%E3%83%BB%E3%83%A9%E3%83%94%E3%83%A5%E3%82%BF'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "returns empty string when argument is nil" do
+    input = nil
+    expected = ''
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "returns string when argument is number" do
+    input = 123
+    expected = '123'
+    ERB::Util.__send__(@method, input).should == expected
+    input = 3.14159
+    expected = '3.14159'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+
+  it "returns string when argument is boolean" do
+    input = true
+    expected = 'true'
+    ERB::Util.__send__(@method, input).should == expected
+    input = false
+    expected = 'false'
+    ERB::Util.__send__(@method, input).should == expected
+  end
+end

--- a/spec/library/erb/util/u_spec.rb
+++ b/spec/library/erb/util/u_spec.rb
@@ -1,0 +1,7 @@
+require 'erb'
+require_relative '../../../spec_helper'
+require_relative 'shared/url_encode'
+
+describe "ERB::Util.u" do
+  it_behaves_like :erb_util_url_encode, :u
+end

--- a/spec/library/erb/util/url_encode_spec.rb
+++ b/spec/library/erb/util/url_encode_spec.rb
@@ -1,0 +1,7 @@
+require 'erb'
+require_relative '../../../spec_helper'
+require_relative 'shared/url_encode'
+
+describe "ERB::Util.url_encode" do
+  it_behaves_like :erb_util_url_encode, :url_encode
+end


### PR DESCRIPTION
We will probably not support erb itself (at least not with dynamic strings), but the Erb::Util module is used a lot to escape HTML content and seems to run perfectly fine with Natalie.