### PR TITLE
Implement BasicObject#instance_exec and improve #instance_eval

### DIFF
--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -48,8 +48,12 @@ public:
     void set_calling_env(Env *env) { m_calling_env = env; }
     void clear_calling_env() { m_calling_env = nullptr; }
 
-    void set_self(Value self) { m_self = self; }
+    void set_self(Value self) {
+        m_original_self = m_self;
+        m_self = self;
+    }
     Value self() const { return m_self; }
+    Value original_self() const { return m_original_self; }
 
     void copy_fn_pointer_to_method(Method *);
 
@@ -57,6 +61,7 @@ public:
         visitor.visit(m_env);
         visitor.visit(m_calling_env);
         visitor.visit(m_self);
+        visitor.visit(m_original_self);
     }
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -69,6 +74,7 @@ private:
     Env *m_env { nullptr };
     Env *m_calling_env { nullptr };
     Value m_self { nullptr };
+    Value m_original_self { nullptr };
     BlockType m_type { BlockType::Proc };
 };
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -49,11 +49,9 @@ public:
     void clear_calling_env() { m_calling_env = nullptr; }
 
     void set_self(Value self) {
-        m_original_self = m_self;
         m_self = self;
     }
     Value self() const { return m_self; }
-    Value original_self() const { return m_original_self; }
 
     void copy_fn_pointer_to_method(Method *);
 
@@ -61,7 +59,6 @@ public:
         visitor.visit(m_env);
         visitor.visit(m_calling_env);
         visitor.visit(m_self);
-        visitor.visit(m_original_self);
     }
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -74,7 +71,6 @@ private:
     Env *m_env { nullptr };
     Env *m_calling_env { nullptr };
     Value m_self { nullptr };
-    Value m_original_self { nullptr };
     BlockType m_type { BlockType::Proc };
 };
 

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -160,8 +160,8 @@ public:
     const Method *method() { return m_method; }
     void set_method(const Method *method) { m_method = method; }
 
-    const ModuleObject *module() { return m_module; }
-    void set_module(const ModuleObject *module) { m_module = module; }
+    ModuleObject *module() { return m_module; }
+    void set_module(ModuleObject *module) { m_module = module; }
 
     Value match() { return m_match; }
     void set_match(Value match) { m_match = match; }
@@ -197,7 +197,7 @@ private:
     const char *m_file { nullptr };
     size_t m_line { 0 };
     const Method *m_method { nullptr };
-    const ModuleObject *m_module { nullptr };
+    ModuleObject *m_module { nullptr };
     Value m_match { nullptr };
     ExceptionObject *m_exception { nullptr };
     Value m_catch { nullptr };

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -356,6 +356,7 @@ public:
     bool neq(Env *env, Value other);
 
     Value instance_eval(Env *, Args, Block *);
+    Value instance_exec(Env *, Args, Block *);
 
     void assert_type(Env *, Object::Type, const char *) const;
     void assert_not_frozen(Env *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -263,6 +263,7 @@ public:
     Value instance_variables(Env *);
 
     Value cvar_get(Env *, SymbolObject *);
+    virtual Value cvar_get_or_raise(Env *, SymbolObject *);
     virtual Value cvar_get_or_null(Env *, SymbolObject *);
     virtual Value cvar_set(Env *, SymbolObject *, Value);
 
@@ -354,7 +355,7 @@ public:
 
     bool neq(Env *env, Value other);
 
-    Value instance_eval(Env *, Value, Block *);
+    Value instance_eval(Env *, Args, Block *);
 
     void assert_type(Env *, Object::Type, const char *) const;
     void assert_not_frozen(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -459,6 +459,7 @@ gen.binding('BasicObject', 'equal?', 'Object', 'equal', argc: 1, pass_env: false
 gen.binding('BasicObject', '!=', 'Object', 'neq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', 'initialize', 'Object', 'initialize', argc: 0, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)
 gen.binding('BasicObject', 'instance_eval', 'Object', 'instance_eval', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('BasicObject', 'instance_exec', 'Object', 'instance_exec', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('BasicObject', 'method_missing', 'Object', 'method_missing', argc: :any, pass_env: true, pass_block: true, return_type: :Object, visibility: :private)
 
 gen.binding('Binding', 'source_location', 'BindingObject', 'source_location', argc: 0, pass_env: false, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -458,7 +458,7 @@ gen.binding('BasicObject', '==', 'Object', 'eq', argc: 1, pass_env: true, pass_b
 gen.binding('BasicObject', 'equal?', 'Object', 'equal', argc: 1, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', '!=', 'Object', 'neq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', 'initialize', 'Object', 'initialize', argc: 0, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)
-gen.binding('BasicObject', 'instance_eval', 'Object', 'instance_eval', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('BasicObject', 'instance_eval', 'Object', 'instance_eval', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('BasicObject', 'method_missing', 'Object', 'method_missing', argc: :any, pass_env: true, pass_block: true, return_type: :Object, visibility: :private)
 
 gen.binding('Binding', 'source_location', 'BindingObject', 'source_location', argc: 0, pass_env: false, pass_block: false, return_type: :Object)

--- a/spec/core/basicobject/fixtures/classes.rb
+++ b/spec/core/basicobject/fixtures/classes.rb
@@ -7,8 +7,7 @@ module BasicObjectSpecs
 
   module InstExec
     def self.included(base)
-      # NATFIXME: BasicObject#instance_exec is not implemented yet
-      # base.instance_exec { @@count = 2 }
+      base.instance_exec { @@count = 2 }
     end
   end
 

--- a/spec/core/basicobject/fixtures/classes.rb
+++ b/spec/core/basicobject/fixtures/classes.rb
@@ -1,0 +1,256 @@
+module BasicObjectSpecs
+  class IVars
+    def initialize
+      @secret = 99
+    end
+  end
+
+  module InstExec
+    def self.included(base)
+      # NATFIXME: BasicObject#instance_exec is not implemented yet
+      # base.instance_exec { @@count = 2 }
+    end
+  end
+
+  module InstExecIncluded
+    include InstExec
+  end
+
+  module InstEval
+    module CVar
+      module Get
+        class ReceiverScope
+          @@cvar = :value_defined_in_receiver_scope
+        end
+
+        class BlockDefinitionScope
+          @@cvar = :value_defined_in_block_definition_scope
+
+          def block
+            -> * { @@cvar }
+          end
+        end
+
+        class CallerScope
+          @@cvar = :value_defined_in_caller_scope
+
+          def get_class_variable_with_string(obj)
+            obj.instance_eval("@@cvar")
+          end
+
+          def get_class_variable_with_block(obj, block)
+            obj.instance_eval(&block)
+          end
+        end
+
+        class CallerWithoutCVarScope
+          def get_class_variable_with_string(obj)
+            obj.instance_eval("@@cvar")
+          end
+        end
+
+        ReceiverWithCVarDefinedInSingletonClass = Class.new.new.tap do |obj|
+          obj.singleton_class.class_variable_set(:@@cvar, :value_defined_in_receiver_singleton_class)
+        end
+      end
+
+      module Set
+        class ReceiverScope
+        end
+
+        class BlockDefinitionScope
+          def self.get_class_variable
+            @@cvar
+          end
+
+          def block_to_assign(value)
+            -> * { @@cvar = value }
+          end
+        end
+
+        class CallerScope
+          def self.get_class_variable
+            @@cvar
+          end
+
+          def set_class_variable_with_string(obj, value)
+            obj.instance_eval("@@cvar=#{value.inspect}")
+          end
+
+          def set_class_variable_with_block(obj, block)
+            obj.instance_eval(&block)
+          end
+        end
+      end
+    end
+  end
+
+  module InstEval
+    module Constants
+      module ConstantInReceiverSingletonClass
+        module ReceiverScope
+          FOO = :ReceiverScope
+
+          class ReceiverParent
+            FOO = :ReceiverParent
+          end
+
+          class Receiver < ReceiverParent
+            FOO = :Receiver
+
+            def initialize
+              self.singleton_class.const_set(:FOO, :singleton_class)
+            end
+          end
+        end
+
+        module CallerScope
+          FOO = :CallerScope
+
+          class CallerParent
+            FOO = :CallerParent
+          end
+
+          class Caller < CallerParent
+            FOO = :Caller
+
+            def get_constant_with_string(receiver)
+              receiver.instance_eval("FOO")
+            end
+          end
+        end
+      end
+
+      module ConstantInReceiverClass
+        module ReceiverScope
+          FOO = :ReceiverScope
+
+          class ReceiverParent
+            FOO = :ReceiverParent
+          end
+
+          class Receiver < ReceiverParent
+            FOO = :Receiver
+          end
+        end
+
+        module CallerScope
+          FOO = :CallerScope
+
+          class CallerParent
+            FOO = :CallerParent
+          end
+
+          class Caller < CallerParent
+            FOO = :Caller
+
+            def get_constant_with_string(receiver)
+              receiver.instance_eval("FOO")
+            end
+          end
+        end
+      end
+
+      module ConstantInCallerClass
+        module ReceiverScope
+          FOO = :ReceiverScope
+
+          class ReceiverParent
+            FOO = :ReceiverParent
+          end
+
+          class Receiver < ReceiverParent
+            # FOO is not declared in a receiver class
+          end
+        end
+
+        module CallerScope
+          FOO = :CallerScope
+
+          class CallerParent
+            FOO = :CallerParent
+          end
+
+          class Caller < CallerParent
+            FOO = :Caller
+
+            def get_constant_with_string(receiver)
+              receiver.instance_eval("FOO")
+            end
+          end
+        end
+      end
+
+      module ConstantInCallerOuterScopes
+        module ReceiverScope
+          FOO = :ReceiverScope
+
+          class ReceiverParent
+            FOO = :ReceiverParent
+          end
+
+          class Receiver < ReceiverParent
+            # FOO is not declared in a receiver class
+          end
+        end
+
+        module CallerScope
+          FOO = :CallerScope
+
+          class CallerParent
+            FOO = :CallerParent
+          end
+
+          class Caller < CallerParent
+            # FOO is not declared in a caller class
+
+            def get_constant_with_string(receiver)
+              receiver.instance_eval("FOO")
+            end
+          end
+        end
+      end
+
+      module ConstantInReceiverParentClass
+        module ReceiverScope
+          FOO = :ReceiverScope
+
+          class ReceiverParent
+            FOO = :ReceiverParent
+          end
+
+          class Receiver < ReceiverParent
+            # FOO is not declared in a receiver class
+          end
+        end
+
+        module CallerScope
+          # FOO is not declared in a caller outer scopes
+
+          class CallerParent
+            FOO = :CallerParent
+          end
+
+          class Caller < CallerParent
+            # FOO is not declared in a caller class
+
+            def get_constant_with_string(receiver)
+              receiver.instance_eval("FOO")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  class InstEvalConst
+    INST_EVAL_CONST_X = 2
+  end
+
+  module InstEvalOuter
+    module Inner
+      obj = InstEvalConst.new
+      X_BY_BLOCK = obj.instance_eval { INST_EVAL_CONST_X } rescue nil
+    end
+  end
+end

--- a/spec/core/basicobject/instance_eval_spec.rb
+++ b/spec/core/basicobject/instance_eval_spec.rb
@@ -1,0 +1,388 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "BasicObject#instance_eval" do
+  before :each do
+    ScratchPad.clear
+  end
+
+  it "is a public instance method" do
+    BasicObject.should have_public_instance_method(:instance_eval)
+  end
+
+  it "sets self to the receiver in the context of the passed block" do
+    a = BasicObject.new
+    a.instance_eval { self }.equal?(a).should be_true
+  end
+
+  it "evaluates strings" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      a = BasicObject.new
+      a.instance_eval('self').equal?(a).should be_true
+    end
+  end
+
+  it "raises an ArgumentError when no arguments and no block are given" do
+    -> { "hola".instance_eval }.should raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1..3)")
+  end
+
+  it "raises an ArgumentError when a block and normal arguments are given" do
+    -> { "hola".instance_eval(4, 5) {|a,b| a + b } }.should raise_error(ArgumentError, "wrong number of arguments (given 2, expected 0)")
+  end
+
+  it "raises an ArgumentError when more than 3 arguments are given" do
+    -> {
+      "hola".instance_eval("1 + 1", "some file", 0, "bogus")
+    }.should raise_error(ArgumentError, "wrong number of arguments (given 4, expected 1..3)")
+  end
+
+  it "yields the object to the block" do
+    "hola".instance_eval {|o| ScratchPad.record o }
+    ScratchPad.recorded.should == "hola"
+  end
+
+  it "returns the result of the block" do
+    "hola".instance_eval { :result }.should == :result
+  end
+
+  it "only binds the eval to the receiver" do
+    f = Object.new
+    f.instance_eval do
+      def foo
+        1
+      end
+    end
+    f.foo.should == 1
+    -> { Object.new.foo }.should raise_error(NoMethodError)
+  end
+
+  it "preserves self in the original block when passed a block argument" do
+    prc = proc { self }
+
+    old_self = prc.call
+
+    new_self = Object.new
+    new_self.instance_eval(&prc).should == new_self
+
+    prc.call.should == old_self
+  end
+
+  # TODO: This should probably be replaced with a "should behave like" that uses
+  # the many scoping/binding specs from kernel/eval_spec, since most of those
+  # behaviors are the same for instance_eval. See also module_eval/class_eval.
+
+  it "binds self to the receiver" do
+    s = "hola"
+    (s == s.instance_eval { self }).should be_true
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      o = mock('o')
+      (o == o.instance_eval("self")).should be_true
+    end
+  end
+
+  it "executes in the context of the receiver" do
+    "Ruby-fu".instance_eval { size }.should == 7
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      "hola".instance_eval("size").should == 4
+      Object.class_eval { "hola".instance_eval("to_s") }.should == "hola"
+    end
+    Object.class_eval { "Ruby-fu".instance_eval{ to_s } }.should == "Ruby-fu"
+  end
+
+  ruby_version_is "3.3" do
+    it "uses the caller location as default location" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        f = Object.new
+        f.instance_eval("[__FILE__, __LINE__]").should == ["(eval at #{__FILE__}:#{__LINE__})", 1]
+      end
+    end
+  end
+
+  it "has access to receiver's instance variables" do
+    BasicObjectSpecs::IVars.new.instance_eval { @secret }.should == 99
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      BasicObjectSpecs::IVars.new.instance_eval("@secret").should == 99
+    end
+  end
+
+  it "raises TypeError for frozen objects when tries to set receiver's instance variables" do
+    -> { nil.instance_eval { @foo = 42 } }.should raise_error(FrozenError, "can't modify frozen NilClass: nil")
+    -> { true.instance_eval { @foo = 42 } }.should raise_error(FrozenError, "can't modify frozen TrueClass: true")
+    -> { false.instance_eval { @foo = 42 } }.should raise_error(FrozenError, "can't modify frozen FalseClass: false")
+    -> { 1.instance_eval { @foo = 42 } }.should raise_error(FrozenError, "can't modify frozen Integer: 1")
+    -> { :symbol.instance_eval { @foo = 42 } }.should raise_error(FrozenError, "can't modify frozen Symbol: :symbol")
+
+    obj = Object.new
+    obj.freeze
+    -> { obj.instance_eval { @foo = 42 } }.should raise_error(FrozenError)
+  end
+
+  it "treats block-local variables as local to the block" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      prc = instance_eval <<-CODE
+        proc do |x, prc|
+          if x
+            n = 2
+          else
+            n = 1
+            prc.call(true, prc)
+            n
+          end
+        end
+      CODE
+
+      prc.call(false, prc).should == 1
+    end
+  end
+
+  it "makes the receiver metaclass the scoped class when used with a string" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      obj = Object.new
+      obj.instance_eval %{
+        class B; end
+        B
+      }
+      obj.singleton_class.const_get(:B).should be_an_instance_of(Class)
+    end
+  end
+
+  describe "constants lookup when a String given" do
+    it "looks in the receiver singleton class first" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverSingletonClass::ReceiverScope::Receiver.new
+        caller = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverSingletonClass::CallerScope::Caller.new
+
+        caller.get_constant_with_string(receiver).should == :singleton_class
+      end
+    end
+
+    ruby_version_is ""..."3.1" do
+      it "looks in the caller scope next" do
+        receiver = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverClass::ReceiverScope::Receiver.new
+        caller = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverClass::CallerScope::Caller.new
+
+        caller.get_constant_with_string(receiver).should == :Caller
+      end
+    end
+
+    ruby_version_is "3.1" do
+      it "looks in the receiver class next" do
+        NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+          receiver = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverClass::ReceiverScope::Receiver.new
+          caller = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverClass::CallerScope::Caller.new
+
+          caller.get_constant_with_string(receiver).should == :Receiver
+        end
+      end
+    end
+
+    it "looks in the caller class next" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::Constants::ConstantInCallerClass::ReceiverScope::Receiver.new
+        caller = BasicObjectSpecs::InstEval::Constants::ConstantInCallerClass::CallerScope::Caller.new
+
+        caller.get_constant_with_string(receiver).should == :Caller
+      end
+    end
+
+    it "looks in the caller outer scopes next" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::Constants::ConstantInCallerOuterScopes::ReceiverScope::Receiver.new
+        caller = BasicObjectSpecs::InstEval::Constants::ConstantInCallerOuterScopes::CallerScope::Caller.new
+
+        caller.get_constant_with_string(receiver).should == :CallerScope
+      end
+    end
+
+    it "looks in the receiver class hierarchy next" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverParentClass::ReceiverScope::Receiver.new
+        caller = BasicObjectSpecs::InstEval::Constants::ConstantInReceiverParentClass::CallerScope::Caller.new
+
+        caller.get_constant_with_string(receiver).should == :ReceiverParent
+      end
+    end
+  end
+
+  it "doesn't get constants in the receiver if a block given" do
+    BasicObjectSpecs::InstEvalOuter::Inner::X_BY_BLOCK.should be_nil
+  end
+
+  it "raises a TypeError when defining methods on an immediate" do
+    -> do
+      1.instance_eval { def foo; end }
+    end.should raise_error(TypeError)
+    -> do
+      :foo.instance_eval { def foo; end }
+    end.should raise_error(TypeError)
+  end
+
+  describe "class variables lookup" do
+    it "gets class variables in the caller class when called with a String" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::CVar::Get::ReceiverScope.new
+        caller = BasicObjectSpecs::InstEval::CVar::Get::CallerScope.new
+
+        caller.get_class_variable_with_string(receiver).should == :value_defined_in_caller_scope
+      end
+    end
+
+    it "gets class variables in the block definition scope when called with a block" do
+      receiver = BasicObjectSpecs::InstEval::CVar::Get::ReceiverScope.new
+      caller = BasicObjectSpecs::InstEval::CVar::Get::CallerScope.new
+      block = BasicObjectSpecs::InstEval::CVar::Get::BlockDefinitionScope.new.block
+
+      caller.get_class_variable_with_block(receiver, block).should == :value_defined_in_block_definition_scope
+    end
+
+    it "sets class variables in the caller class when called with a String" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+        receiver = BasicObjectSpecs::InstEval::CVar::Set::ReceiverScope.new
+        caller = BasicObjectSpecs::InstEval::CVar::Set::CallerScope.new
+
+        caller.set_class_variable_with_string(receiver, 1)
+        BasicObjectSpecs::InstEval::CVar::Set::CallerScope.get_class_variable.should == 1
+      end
+    end
+
+    it "sets class variables in the block definition scope when called with a block" do
+      receiver = BasicObjectSpecs::InstEval::CVar::Set::ReceiverScope.new
+      caller = BasicObjectSpecs::InstEval::CVar::Set::CallerScope.new
+      block = BasicObjectSpecs::InstEval::CVar::Set::BlockDefinitionScope.new.block_to_assign(1)
+
+      caller.set_class_variable_with_block(receiver, block)
+      BasicObjectSpecs::InstEval::CVar::Set::BlockDefinitionScope.get_class_variable.should == 1
+    end
+
+    it "does not have access to class variables in the receiver class when called with a String" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+        receiver = BasicObjectSpecs::InstEval::CVar::Get::ReceiverScope.new
+        caller = BasicObjectSpecs::InstEval::CVar::Get::CallerWithoutCVarScope.new
+        -> { caller.get_class_variable_with_string(receiver) }.should raise_error(NameError, /uninitialized class variable @@cvar/)
+      end
+    end
+
+    it "does not have access to class variables in the receiver's singleton class when called with a String" do
+      NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+        receiver = BasicObjectSpecs::InstEval::CVar::Get::ReceiverWithCVarDefinedInSingletonClass
+        caller = BasicObjectSpecs::InstEval::CVar::Get::CallerWithoutCVarScope.new
+        -> { caller.get_class_variable_with_string(receiver) }.should raise_error(NameError, /uninitialized class variable @@cvar/)
+      end
+    end
+  end
+
+  it "raises a TypeError when defining methods on numerics" do
+    -> do
+      (1.0).instance_eval { def foo; end }
+    end.should raise_error(TypeError)
+    -> do
+      (1 << 64).instance_eval { def foo; end }
+    end.should raise_error(TypeError)
+  end
+
+  it "evaluates procs originating from methods" do
+    def meth(arg); arg; end
+
+    m = method(:meth)
+    obj = Object.new
+
+    obj.instance_eval(&m).should == obj
+  end
+
+  it "evaluates string with given filename and linenumber" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      err = begin
+        Object.new.instance_eval("raise", "a_file", 10)
+      rescue => e
+        e
+      end
+      err.backtrace.first.split(":")[0..1].should == ["a_file", "10"]
+    end
+  end
+
+  it "evaluates string with given filename and negative linenumber" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      err = begin
+        Object.new.instance_eval("\n\nraise\n", "b_file", -100)
+      rescue => e
+        e
+      end
+      err.backtrace.first.split(":")[0..1].should == ["b_file", "-98"]
+    end
+  end
+
+  it "has access to the caller's local variables" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      x = nil
+
+      instance_eval "x = :value"
+      x.should == :value
+    end
+  end
+
+  it "converts string argument with #to_str method" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: ArgumentError, message: 'Natalie only supports instance_eval with a block' do
+      source_code = Object.new
+      def source_code.to_str() "1" end
+
+      a = BasicObject.new
+      a.instance_eval(source_code).should == 1
+    end
+  end
+
+  it "raises ArgumentError if returned value is not String" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      source_code = Object.new
+      def source_code.to_str() :symbol end
+
+      a = BasicObject.new
+      -> { a.instance_eval(source_code) }.should raise_error(TypeError, /can't convert Object to String/)
+    end
+  end
+
+  it "converts filename argument with #to_str method" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      filename = Object.new
+      def filename.to_str() "file.rb" end
+
+      err = begin
+              Object.new.instance_eval("raise", filename)
+            rescue => e
+              e
+            end
+      err.backtrace.first.split(":")[0].should == "file.rb"
+    end
+  end
+
+  it "raises ArgumentError if returned value is not String" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      filename = Object.new
+      def filename.to_str() :symbol end
+
+      -> { Object.new.instance_eval("raise", filename) }.should raise_error(TypeError, /can't convert Object to String/)
+    end
+  end
+
+  it "converts lineno argument with #to_int method" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      lineno = Object.new
+      def lineno.to_int() 15 end
+
+      err = begin
+              Object.new.instance_eval("raise", "file.rb", lineno)
+            rescue => e
+              e
+            end
+      err.backtrace.first.split(":")[1].should == "15"
+    end
+  end
+
+  it "raises ArgumentError if returned value is not Integer" do
+    NATFIXME 'Natalie does not support instance_eval with string', exception: SpecFailedException do
+      lineno = Object.new
+      def lineno.to_int() :symbol end
+
+      -> { Object.new.instance_eval("raise", "file.rb", lineno) }.should raise_error(TypeError, /can't convert Object to Integer/)
+    end
+  end
+end

--- a/spec/core/basicobject/instance_exec_spec.rb
+++ b/spec/core/basicobject/instance_exec_spec.rb
@@ -1,0 +1,110 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "BasicObject#instance_exec" do
+  it "is a public instance method" do
+    BasicObject.should have_public_instance_method(:instance_exec)
+  end
+
+  it "sets self to the receiver in the context of the passed block" do
+    a = BasicObject.new
+    a.instance_exec { self }.equal?(a).should be_true
+  end
+
+  it "passes arguments to the block" do
+    a = BasicObject.new
+    a.instance_exec(1) { |b| b }.should equal(1)
+  end
+
+  it "raises a LocalJumpError unless given a block" do
+    -> { "hola".instance_exec }.should raise_error(LocalJumpError)
+  end
+
+  it "has an arity of -1" do
+    Object.new.method(:instance_exec).arity.should == -1
+  end
+
+  it "accepts arguments with a block" do
+    -> { "hola".instance_exec(4, 5) { |a,b| a + b } }.should_not raise_error
+  end
+
+  it "doesn't pass self to the block as an argument" do
+    "hola".instance_exec { |o| o }.should be_nil
+  end
+
+  it "passes any arguments to the block" do
+    Object.new.instance_exec(1,2) {|one, two| one + two}.should == 3
+  end
+
+  it "only binds the exec to the receiver" do
+    f = Object.new
+    # To implement this we may need something similar to GlobalEnv::is_instance_evaling
+    # to make define_method on the singleton class instead?
+    # maybe its the same behavior for instance_eval actually?
+    f.instance_exec do
+      def foo
+        1
+      end
+    end
+    f.foo.should == 1
+    -> { Object.new.foo }.should raise_error(NoMethodError)
+  end
+
+  # TODO: This should probably be replaced with a "should behave like" that uses
+  # the many scoping/binding specs from kernel/eval_spec, since most of those
+  # behaviors are the same for instance_exec. See also module_eval/class_eval.
+
+  it "binds self to the receiver" do
+    s = "hola"
+    (s == s.instance_exec { self }).should == true
+  end
+
+  it "binds the block's binding self to the receiver" do
+    s = "hola"
+    (s == s.instance_exec { eval "self", binding }).should == true
+  end
+
+  it "executes in the context of the receiver" do
+    "Ruby-fu".instance_exec { size }.should == 7
+    Object.class_eval { "Ruby-fu".instance_exec{ to_s } }.should == "Ruby-fu"
+  end
+
+  it "has access to receiver's instance variables" do
+    BasicObjectSpecs::IVars.new.instance_exec { @secret }.should == 99
+  end
+
+  it "sets class variables in the receiver" do
+    BasicObjectSpecs::InstExec.class_variables.should include(:@@count)
+    BasicObjectSpecs::InstExec.send(:class_variable_get, :@@count).should == 2
+  end
+
+  it "raises a TypeError when defining methods on an immediate" do
+    -> do
+      1.instance_exec { def foo; end }
+    end.should raise_error(TypeError)
+    -> do
+      :foo.instance_exec { def foo; end }
+    end.should raise_error(TypeError)
+  end
+
+quarantine! do # Not clean, leaves cvars lying around to break other specs
+  it "scopes class var accesses in the caller when called on an Integer" do
+    # Integer can take instance vars
+    Integer.class_eval "@@__tmp_instance_exec_spec = 1"
+    (defined? @@__tmp_instance_exec_spec).should == nil
+
+    @@__tmp_instance_exec_spec = 2
+    1.instance_exec { @@__tmp_instance_exec_spec }.should == 2
+    Integer.__send__(:remove_class_variable, :@@__tmp_instance_exec_spec)
+  end
+end
+
+  it "raises a TypeError when defining methods on numerics" do
+    -> do
+      (1.0).instance_exec { def foo; end }
+    end.should raise_error(TypeError)
+    -> do
+      (1 << 64).instance_exec { def foo; end }
+    end.should raise_error(TypeError)
+  end
+end

--- a/spec/core/hash/to_proc_spec.rb
+++ b/spec/core/hash/to_proc_spec.rb
@@ -49,17 +49,14 @@ describe "Hash#to_proc" do
       end
 
       context "to instance_exec" do
-        # NATFIXME: I think this spec might even fail because we are using `self` in the returned proc
         it "always retrieves the original hash's values" do
           hash = {foo: 1, bar: 2}
           proc = hash.to_proc
 
-          NATFIXME 'implement instance_exec', exception: NoMethodError, message: "undefined method `instance_exec'" do
-            hash.instance_exec(:foo, &proc).should == 1
+          hash.instance_exec(:foo, &proc).should == 1
 
-            hash2 = {quux: 1}
-            hash2.instance_exec(:foo, &proc).should == 1
-          end
+          hash2 = {quux: 1}
+          hash2.instance_exec(:foo, &proc).should == 1
         end
       end
     end

--- a/spec/language/alias_spec.rb
+++ b/spec/language/alias_spec.rb
@@ -157,14 +157,12 @@ describe "The alias keyword" do
   end
 
   it "operates on the class/module metaclass when used in instance_exec" do
-    NATFIXME 'implement instance_exec', exception: NoMethodError, message: "undefined method `instance_exec'" do
-      AliasObject.instance_exec do
-        alias __klass_method2 klass_method
-      end
-
-      AliasObject.__klass_method2.should == 7
-      -> { Object.__klass_method2 }.should raise_error(NoMethodError)
+    AliasObject.instance_exec do
+      alias __klass_method2 klass_method
     end
+
+    AliasObject.__klass_method2.should == 7
+    -> { Object.__klass_method2 }.should raise_error(NoMethodError)
   end
 
   it "operates on methods defined via attr, attr_reader, and attr_accessor" do

--- a/spec/language/execution_spec.rb
+++ b/spec/language/execution_spec.rb
@@ -17,7 +17,7 @@ describe "``" do
       str.frozen?.should == true
     end
 
-    NATFIXME 'Implement instance_exec', exception: NoMethodError, message: /undefined method `instance_exec'/ do
+    NATFIXME 'this is broken', exception: SpecFailedException do
       runner.instance_exec do
         `test command`
       end
@@ -38,15 +38,13 @@ describe "``" do
       str << "mutated"
     end
 
-    NATFIXME 'Implement instance_exec', exception: NoMethodError, message: /undefined method `instance_exec'/ do
-      2.times do
-        runner.instance_exec do
-          `test #{:command}` # rubocop:disable Lint/LiteralInInterpolation
-        end
+    2.times do
+      runner.instance_exec do
+        `test #{:command}` # rubocop:disable Lint/LiteralInInterpolation
       end
-
-      called.should == true
     end
+
+    called.should == true
   end
 end
 
@@ -67,7 +65,7 @@ describe "%x" do
       str.frozen?.should == true
     end
 
-    NATFIXME 'Implement instance_exec', exception: NoMethodError, message: /undefined method `instance_exec'/ do
+    NATFIXME 'this is broken', exception: SpecFailedException do
       runner.instance_exec do
         %x{test command}
       end
@@ -88,14 +86,12 @@ describe "%x" do
       str << "mutated"
     end
 
-    NATFIXME 'Implement instance_exec', exception: NoMethodError, message: /undefined method `instance_exec'/ do
-      2.times do
-        runner.instance_exec do
-          %x{test #{:command}} # rubocop:disable Lint/LiteralInInterpolation
-        end
+    2.times do
+      runner.instance_exec do
+        %x{test #{:command}} # rubocop:disable Lint/LiteralInInterpolation
       end
-
-      called.should == true
     end
+
+    called.should == true
   end
 end

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -127,6 +127,10 @@ void GlobalEnv::visit_children(Visitor &visitor) {
     for (const auto &span : m_interned_strings)
         for (auto str : span)
             visitor.visit(str);
+    for (const auto &instance_eval_context : m_instance_eval_contexts) {
+        visitor.visit(instance_eval_context.caller_env);
+        visitor.visit(instance_eval_context.block_original_self);
+    }
     visitor.visit(m_Array);
     visitor.visit(m_BasicObject);
     visitor.visit(m_Binding);

--- a/src/hash.rb
+++ b/src/hash.rb
@@ -173,7 +173,8 @@ class Hash
   end
 
   def to_proc
-    lambda { |arg| self[*arg] }
+    this = self
+    ->(arg) { this[*arg] }
   end
 
   def values_at(*keys)

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -389,24 +389,39 @@ Value ModuleObject::cvar_get_or_null(Env *env, SymbolObject *name) {
 }
 
 Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
-    if (!name->is_cvar_name())
-        env->raise_name_error(name, "`{}' is not allowed as a class variable name", name->string());
+    auto set_cvar_in = [env, name, &val](ModuleObject *module) -> Value {
+        if (!name->is_cvar_name())
+            env->raise_name_error(name, "`{}' is not allowed as a class variable name", name->string());
 
-    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    ModuleObject *current = this;
+        ModuleObject *current = module;
 
-    Value exists = nullptr;
-    while (current) {
-        exists = current->m_class_vars.get(name, env);
-        if (exists) {
-            current->m_class_vars.put(name, val.object(), env);
-            return val;
+        Value exists = nullptr;
+        while (current) {
+            exists = current->m_class_vars.get(name, env);
+            if (exists) {
+                current->m_class_vars.put(name, val.object(), env);
+                return val;
+            }
+            current = current->m_superclass;
         }
-        current = current->m_superclass;
+        module->m_class_vars.put(name, val.object(), env);
+        return val;
+    };
+
+    if (GlobalEnv::the()->instance_evaling()) {
+        // Set class variable in block definition scope
+        if (env->this_block() && env->this_block()->original_self()) {
+            if (env->this_block()->original_self()->is_module()) {
+                return set_cvar_in(env->this_block()->original_self()->as_module());
+            } else {
+                return set_cvar_in(env->this_block()->original_self()->klass());
+            }
+        }
     }
-    m_class_vars.put(name, val.object(), env);
-    return val;
+
+    return set_cvar_in(this);
 }
 
 bool ModuleObject::class_variable_defined(Env *env, Value name) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -412,11 +412,12 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 
     if (GlobalEnv::the()->instance_evaling()) {
         // Set class variable in block definition scope
-        if (env->this_block() && env->this_block()->original_self()) {
-            if (env->this_block()->original_self()->is_module()) {
-                return set_cvar_in(env->this_block()->original_self()->as_module());
+        auto context = GlobalEnv::the()->current_instance_eval_context();
+        if (context.block_original_self) {
+            if (context.block_original_self->is_module()) {
+                return set_cvar_in(context.block_original_self->as_module());
             } else {
-                return set_cvar_in(env->this_block()->original_self()->klass());
+                return set_cvar_in(context.block_original_self->klass());
             }
         }
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -677,6 +677,13 @@ Value Object::const_find(Env *env, SymbolObject *name, ConstLookupSearchMode sea
 }
 
 Value Object::const_find_with_autoload(Env *env, Value self, SymbolObject *name, ConstLookupSearchMode search_mode, ConstLookupFailureMode failure_mode) {
+    if (GlobalEnv::the()->instance_evaling()) {
+        if (env->caller() && env->caller()->caller() && env->caller()->caller()->module()) {
+            // We want to search the constant in the context in which instance_eval was called
+            // This seems pretty hacky, it might be a better idea to store the "context" in which instance_eval was called instead
+            return env->caller()->caller()->module()->const_find_with_autoload(env, self, name, search_mode, failure_mode);
+        }
+    }
     return m_klass->const_find_with_autoload(env, self, name, search_mode, failure_mode);
 }
 
@@ -771,6 +778,16 @@ Value Object::instance_variables(Env *env) {
 }
 
 Value Object::cvar_get(Env *env, SymbolObject *name) {
+    if (GlobalEnv::the()->instance_evaling()) {
+        // Get class variable in block definition scope
+        if (env->this_block() && env->this_block()->original_self()) {
+            return env->this_block()->original_self()->cvar_get_or_raise(env, name);
+        }
+    }
+    return cvar_get_or_raise(env, name);
+}
+
+Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
     Value val = cvar_get_or_null(env, name);
     if (val) {
         return val;
@@ -870,11 +887,17 @@ SymbolObject *Object::undefine_singleton_method(Env *env, SymbolObject *name) {
 }
 
 SymbolObject *Object::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
+    if (GlobalEnv::the()->instance_evaling()) {
+        return define_singleton_method(env, name, fn, arity, optimized);
+    }
     m_klass->define_method(env, name, fn, arity, optimized);
     return name;
 }
 
 SymbolObject *Object::define_method(Env *env, SymbolObject *name, Block *block) {
+    if (GlobalEnv::the()->instance_evaling()) {
+        return define_singleton_method(env, name, block);
+    }
     m_klass->define_method(env, name, block);
     return name;
 }
@@ -1220,16 +1243,25 @@ void Object::freeze() {
     if (m_singleton_class) m_singleton_class->freeze();
 }
 
-Value Object::instance_eval(Env *env, Value string, Block *block) {
-    if (string || !block) {
+Value Object::instance_eval(Env *env, Args args, Block *block) {
+    if (block) {
+        args.ensure_argc_is(env, 0);
+    }
+
+    if (args.size() > 0 || !block) {
+        args.ensure_argc_between(env, 1, 3);
         env->raise("ArgumentError", "Natalie only supports instance_eval with a block");
     }
+
     Value self = this;
     block->set_self(self);
     GlobalEnv::the()->set_instance_evaling(true);
-    Defer done_instance_evaling([]() { GlobalEnv::the()->set_instance_evaling(false); });
-    Value args[] = { self };
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+    Defer done_instance_evaling([block]() {
+        GlobalEnv::the()->set_instance_evaling(false);
+        block->set_self(block->original_self());
+    });
+    Value block_args[] = { self };
+    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, block_args), nullptr);
 }
 
 void Object::assert_type(Env *env, Object::Type expected_type, const char *expected_class_name) const {


### PR DESCRIPTION
I feel like the implementation to implement the scoping requirements of instance evaling code is quite brittle now, but I didn't have a better idea on how to implement this properly.

If you have any ideas about this let me know.