### PR TITLE
Extend checks for fsync in File.open with block

### DIFF
--- a/src/io.rb
+++ b/src/io.rb
@@ -10,7 +10,8 @@ class IO
         yield(obj)
       ensure
         begin
-          obj.fsync unless obj.tty? || obj.respond_to?(:setsockopt)
+          stat = obj.stat
+          obj.fsync unless stat.blockdev? || stat.chardev? || stat.pipe? || stat.socket? && !obj.tty?
           obj.close
         rescue IOError => e
           raise unless e.message == 'closed stream'


### PR DESCRIPTION
fsync(2) fails with EINVAL for special file descriptors like blockdevs or sockets. Skip the fsync step on these objects. Simplify the check for socket, the `respond_to?(:setsockopt)` feels like a hack.

Easiest way to trigger an exception with the old code:

    File.open('/dev/urandom') {}