### PR TITLE
Fix String#<< with US-ASCII source and numeric argument

### DIFF
--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -40,15 +40,13 @@ describe :string_concat, shared: true do
 
     # #5855
     it "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
-      NATFIXME 'out of range', exception: RangeError, message: '128 out of char range' do
-        a = ("".encode(Encoding::US_ASCII).send(@method, 128))
-        a.encoding.should == Encoding::BINARY
-        a.should == 128.chr
+      a = ("".encode(Encoding::US_ASCII).send(@method, 128))
+      a.encoding.should == Encoding::BINARY
+      a.should == 128.chr
 
-        a = ("".encode(Encoding::US_ASCII).send(@method, 255))
-        a.encoding.should == Encoding::BINARY
-        a.should == 255.chr
-      end
+      a = ("".encode(Encoding::US_ASCII).send(@method, 255))
+      a.encoding.should == Encoding::BINARY
+      a.should == 255.chr
     end
 
     it "raises RangeError if the argument is an invalid codepoint for self's encoding" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1036,6 +1036,12 @@ Value StringObject::concat(Env *env, Args args) {
         } else if (arg->is_integer() && arg->as_integer()->is_negative()) {
             env->raise("RangeError", "{} out of char range", arg->as_integer()->to_s(env)->as_string()->string());
         } else if (arg->is_integer()) {
+            // Special case: US-ASCII << (128..255) will change the string to binary
+            if (m_encoding == EncodingObject::get(Encoding::US_ASCII) && arg->as_integer()->is_fixnum()) {
+                const auto nat_int = arg->as_integer()->to_nat_int_t();
+                if (nat_int >= 128 && nat_int <= 255)
+                    m_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
+            }
             str_obj = arg.send(env, "chr"_s, { m_encoding.ptr() })->as_string();
         } else {
             str_obj = arg->to_str(env);


### PR DESCRIPTION
In case of an argument in the range 128..255, the string encoding is converted to binary.