### PR TITLE
Add Process.warmup

### DIFF
--- a/spec/core/process/warmup_spec.rb
+++ b/spec/core/process/warmup_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "Process.warmup" do
+  ruby_version_is "3.3" do
+    # The behavior is entirely implementation specific.
+    # Other implementations are free to just make it a noop
+    it "is implemented" do
+      Process.warmup.should == true
+    end
+  end
+end

--- a/src/process.rb
+++ b/src/process.rb
@@ -98,4 +98,7 @@ module Process
   end
 
   module_function :waitpid
+
+  def warmup = true
+  module_function :warmup
 end


### PR DESCRIPTION
It's hardly an implementation: the behaviour is implementation specific, and right now we have nothing to warm up. This is just an easy checkbox for the nightly specs output.