### PR TITLE
Import specs for Kernel.exit(!) and Process.exit(!)

### DIFF
--- a/spec/core/kernel/exit_spec.rb
+++ b/spec/core/kernel/exit_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../../shared/process/exit'
+
+describe "Kernel#exit" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:exit)
+  end
+
+  it_behaves_like :process_exit, :exit, KernelSpecs::Method.new
+end
+
+describe "Kernel.exit" do
+  it_behaves_like :process_exit, :exit, Kernel
+end
+
+describe "Kernel#exit!" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:exit!)
+  end
+
+  it_behaves_like :process_exit!, :exit!, "self"
+end
+
+describe "Kernel.exit!" do
+  it_behaves_like :process_exit!, :exit!, "Kernel"
+end

--- a/spec/core/process/exit_spec.rb
+++ b/spec/core/process/exit_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/process/exit'
+
+describe "Process.exit" do
+  it_behaves_like :process_exit, :exit, Process
+end
+
+describe "Process.exit!" do
+  it_behaves_like :process_exit!, :exit!, "Process"
+end


### PR DESCRIPTION
One of these is crashing, this way we have documented which one is causing the issues.