### PR TITLE
Fix `defined?` to not call `const_missing`

### DIFF
--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -48,8 +48,8 @@ public:
 
     Value is_autoload(Env *, Value) const;
 
-    virtual Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise) override;
-    virtual Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise) override;
+    virtual Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing) override;
+    virtual Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing) override;
     virtual Value const_get(SymbolObject *) const override;
     virtual Value const_fetch(SymbolObject *) override;
     virtual Value const_set(SymbolObject *, Value) override;
@@ -175,6 +175,9 @@ public:
         else
             snprintf(buf, len, "<ModuleObject %p name=(none)>", this);
     }
+
+private:
+    Value handle_missing_constant(Env *, Value, ConstLookupFailureMode);
 
 protected:
     Constant *find_constant(Env *, SymbolObject *, ModuleObject **, ConstLookupSearchMode = ConstLookupSearchMode::Strict);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -56,6 +56,7 @@ public:
     enum class ConstLookupFailureMode {
         Null,
         Raise,
+        ConstMissing,
     };
 
     Object()
@@ -248,8 +249,8 @@ public:
     Value extend(Env *, Args);
     void extend_once(Env *, ModuleObject *);
 
-    virtual Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise);
-    virtual Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::Raise);
+    virtual Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
+    virtual Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
     virtual Value const_get(SymbolObject *) const;
     virtual Value const_fetch(SymbolObject *);
     virtual Value const_set(SymbolObject *, Value);

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -952,7 +952,7 @@ module Natalie
           # defined?(CONST)
           IsDefinedInstruction.new(type: 'constant'),
           PushSelfInstruction.new,
-          ConstFindInstruction.new(node.name, strict: false),
+          ConstFindInstruction.new(node.name, strict: false, failure_mode: 'Raise'),
           EndInstruction.new(:is_defined),
           DupInstruction.new,
 
@@ -1072,35 +1072,35 @@ module Natalie
         name, _is_private, prep_instruction = constant_name(node.target)
         # FIXME: is_private shouldn't be ignored I think
         #
-        #                                                       This describes the stack for the three distinct paths
-        instructions = [                                        # if !defined?(tmp::CONST)           if defined?(tmp::CONST) && !tmp::CONST          if defined(tmp::CONST) && tmp::CONST
-          prep_instruction,                                     # [tmp]                              [tmp]                                           [tmp]
-          DupInstruction.new,                                   # [tmp, tmp]                         [tmp, tmp]                                      [tmp, tmp]
-          IsDefinedInstruction.new(type: 'constant'),           # [tmp, tmp, is_defined]             [tmp, tmp, is_defined]                          [tmp, tmp, is_defined]
-          SwapInstruction.new,                                  # [tmp, is_defined, tmp]             [tmp, is_defined, tmp]                          [tmp, is_defined, tmp]
-          ConstFindInstruction.new(name, strict: true),         # [tmp, is_defined, tmp, CONST]      [tmp, is_defined, tmp, CONST]                   [tmp, is_defined, tmp, CONST]
-          EndInstruction.new(:is_defined),                      # [tmp, false]                       [tmp, true]                                     [tmp, true]
-          IfInstruction.new,                                    # [tmp]                              [tmp]                                           [tmp]
-          DupInstruction.new,                                   #                                    [tmp, tmp]                                      [tmp, tmp]
-          ConstFindInstruction.new(name, strict: true),         #                                    [tmp, false]                                    [tmp, tmp::CONST]
+        #                                                                       This describes the stack for the three distinct paths
+        instructions = [                                                        # if !defined?(tmp::CONST)           if defined?(tmp::CONST) && !tmp::CONST          if defined(tmp::CONST) && tmp::CONST
+          prep_instruction,                                                     # [tmp]                              [tmp]                                           [tmp]
+          DupInstruction.new,                                                   # [tmp, tmp]                         [tmp, tmp]                                      [tmp, tmp]
+          IsDefinedInstruction.new(type: 'constant'),                           # [tmp, tmp, is_defined]             [tmp, tmp, is_defined]                          [tmp, tmp, is_defined]
+          SwapInstruction.new,                                                  # [tmp, is_defined, tmp]             [tmp, is_defined, tmp]                          [tmp, is_defined, tmp]
+          ConstFindInstruction.new(name, strict: true, failure_mode: 'Raise'),  # [tmp, is_defined, tmp, CONST]      [tmp, is_defined, tmp, CONST]                   [tmp, is_defined, tmp, CONST]
+          EndInstruction.new(:is_defined),                                      # [tmp, false]                       [tmp, true]                                     [tmp, true]
+          IfInstruction.new,                                                    # [tmp]                              [tmp]                                           [tmp]
+          DupInstruction.new,                                                   #                                    [tmp, tmp]                                      [tmp, tmp]
+          ConstFindInstruction.new(name, strict: true),                         #                                    [tmp, false]                                    [tmp, tmp::CONST]
           ElseInstruction.new(:if),
-          PushFalseInstruction.new,                             # [tmp, false]
+          PushFalseInstruction.new,                                             # [tmp, false]
           EndInstruction.new(:if),
-          IfInstruction.new,                                    # [tmp]                              [tmp]                                           [tmp]
+          IfInstruction.new,                                                    # [tmp]                              [tmp]                                           [tmp]
         ]
         if used
-          instructions << ConstFindInstruction.new(name, strict: true) #                                                                             [tmp::Const]
+          instructions << ConstFindInstruction.new(name, strict: true)          #                                                                                    [tmp::Const]
         else
-          instructions << PopInstruction.new                    #                                                                                    []
+          instructions << PopInstruction.new                                    #                                                                                    []
         end
         instructions << ElseInstruction.new(:if)
-        instructions << DupInstruction.new if used              # [tmp, tmp]                         [tmp, tmp]
+        instructions << DupInstruction.new if used                              # [tmp, tmp]                         [tmp, tmp]
         instructions.append(
-          transform_expression(node.value, used: true),         # [tmp, tmp, value]                  [tmp, tmp, value]
-          SwapInstruction.new,                                  # [tmp, value, tmp]                  [tmp, value, tmp]
-          ConstSetInstruction.new(name),                        # [tmp]                              [tmp]
+          transform_expression(node.value, used: true),                         # [tmp, tmp, value]                  [tmp, tmp, value]
+          SwapInstruction.new,                                                  # [tmp, value, tmp]                  [tmp, value, tmp]
+          ConstSetInstruction.new(name),                                        # [tmp]                              [tmp]
         )
-        instructions << ConstFindInstruction.new(name, strict: true) if used # [value]               [value]
+        instructions << ConstFindInstruction.new(name, strict: true) if used    # [value]               [value]
         instructions << EndInstruction.new(:if)
         instructions
       end

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1258,6 +1258,8 @@ module Natalie
             body[index] = [GlobalVariableDefinedInstruction.new(instruction.name), instruction]
           when InstanceVariableGetInstruction
             body[index] = [InstanceVariableDefinedInstruction.new(instruction.name), instruction]
+          when ConstFindInstruction
+            body[index].raise_if_missing!
           when SendInstruction
             if index == body.length - 1
               body[index] = instruction.to_method_defined_instruction

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -667,9 +667,7 @@ describe 'Optional constant assignment' do
 
     it 'correctly defines non-existing constants' do
       ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1 ||= :assigned
-      NATFIXME "Don't use const_missing in defined?(const)", exception: SpecFailedException do
-        ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1.should == :assigned
-      end
+      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT1.should == :assigned
     end
 
     it 'correctly overwrites nil constants' do
@@ -684,9 +682,7 @@ describe 'Optional constant assignment' do
       x = 0
       (x += 1; ConstantSpecs::ClassA)::OR_ASSIGNED_CONSTANT2 ||= :assigned
       x.should == 1
-      NATFIXME "Don't use const_missing in defined?(const)", exception: SpecFailedException do
-        ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT2.should == :assigned
-      end
+      ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT2.should == :assigned
     end
 
     it 'causes side-effects of the module part to be applied only once (for nil constant)' do
@@ -708,10 +704,8 @@ describe 'Optional constant assignment' do
       }.should raise_error(Exception)
 
       x.should == 1
-      NATFIXME 'it does not evaluate the right-hand side if the module part raises an exception (for undefined constant)', exception: SpecFailedException do
-        y.should == 0
-        defined?(ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT3).should == nil
-      end
+      y.should == 0
+      defined?(ConstantSpecs::ClassA::OR_ASSIGNED_CONSTANT3).should == nil
     end
 
     it 'does not evaluate the right-hand side if the module part raises an exception (for nil constant)' do

--- a/test/natalie/defined_test.rb
+++ b/test/natalie/defined_test.rb
@@ -9,6 +9,12 @@ class Foo
   end
 end
 
+class ConstMissingConst
+  def self.const_missing(const)
+    const
+  end
+end
+
 def foo; end
 
 describe 'defined?' do
@@ -17,6 +23,10 @@ describe 'defined?' do
     defined?(::NUM).should == 'constant'
     defined?(Foo).should == 'constant'
     defined?(NonExistent).should == nil
+  end
+
+  it 'does not call const_missing' do
+    defined?(ConstMissingConst::Bar).should == nil
   end
 
   it 'recognizes namespaced constants' do


### PR DESCRIPTION
This fixes `defined?` to not call `const_missing` if it was implemented, so that missing constants actually return nil. 

Additionally this fixes conditional constant write operations, because those relied on the behavior of `defined?`. 

I also upstreamed the test from `natalie/defined_test.rb` to https://github.com/ruby/spec/pull/1215