### PR TITLE
Don't die on empty argument in optparse

### DIFF
--- a/lib/optparse.rb
+++ b/lib/optparse.rb
@@ -21,7 +21,7 @@ class OptionParser
     end
 
     def match?(arg)
-      name = arg.split('=', 2).first
+      name = arg.split('=', 2).first || ''
       name[0...2] == "-#{short_name}" || name == "--#{long_name}"
     end
 


### PR DESCRIPTION
Previously, empty arguments would result in a nil value value, which in turn would cause a NoMethodError. This way the optionparser ignores them.

Easiest way to trigger: `bin/natalie -e '' ''`

The sequel to https://github.com/natalie-lang/natalie/pull/2311#issuecomment-2466156814. Once again: this just turns one error into the next one, so it does not fix any of the issues.