### PR TITLE
Make Args const in a couple of places

### DIFF
--- a/include/natalie/args.hpp
+++ b/include/natalie/args.hpp
@@ -47,7 +47,7 @@ public:
 
     Args &operator=(const Args &other);
 
-    static Args shift(Args &args);
+    static Args shift(const Args &args);
     Value shift();
 
     Value operator[](size_t index) const;

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -72,7 +72,7 @@ public:
     bool is_optimized() const { return m_optimized; }
     void set_optimized(bool optimized) { m_optimized = optimized; }
 
-    Value call(Env *env, Value self, Args args, Block *block) const;
+    Value call(Env *env, Value self, const Args& args, Block *block) const;
 
     String name() const { return m_name; }
     ModuleObject *owner() const { return m_owner; }

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -18,6 +18,7 @@ extern "C" {
 #include "onigmo.h"
 }
 
+    static const Args empty_args = {};
 class Object : public Cell {
 public:
     using Type = ObjectType;
@@ -300,11 +301,11 @@ public:
         return buf;
     }
 
-    Value public_send(Env *, SymbolObject *, Args = {}, Block * = nullptr, Value sent_from = nullptr);
-    Value public_send(Env *, Args, Block *);
+    Value public_send(Env *, SymbolObject *, const Args& = empty_args, Block * = nullptr, Value sent_from = nullptr);
+    Value public_send(Env *, const Args&, Block *);
 
-    Value send(Env *, SymbolObject *, Args = {}, Block * = nullptr, Value sent_from = nullptr);
-    Value send(Env *, Args, Block *);
+    Value send(Env *, SymbolObject *, const Args& = empty_args, Block * = nullptr, Value sent_from = nullptr);
+    Value send(Env *, const Args&, Block *);
 
     Value send(Env *env, SymbolObject *name, std::initializer_list<Value> args, Block *block = nullptr, Value sent_from = nullptr) {
         // NOTE: sent_from is unused, but accepting it makes the SendInstruction codegen simpler. :-)

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -44,7 +44,7 @@ Args &Args::operator=(const Args &other) {
     return *this;
 }
 
-Args Args::shift(Args &args) {
+Args Args::shift(const Args &args) {
     assert(args.size() > 0);
     if (args.size() == 1)
         return Args();

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 
-Value Method::call(Env *env, Value self, Args args, Block *block) const {
+Value Method::call(Env *env, Value self, const Args& args, Block *block) const {
     assert(m_fn);
 
     Env *closure_env;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -943,20 +943,20 @@ Value Object::module_function(Env *env, Args args) {
     abort();
 }
 
-Value Object::public_send(Env *env, SymbolObject *name, Args args, Block *block, Value sent_from) {
+Value Object::public_send(Env *env, SymbolObject *name, const Args& args, Block *block, Value sent_from) {
     return send(env, name, args, block, MethodVisibility::Public, sent_from);
 }
 
-Value Object::public_send(Env *env, Args args, Block *block) {
+Value Object::public_send(Env *env, const Args& args, Block *block) {
     auto name = args[0]->to_symbol(env, Object::Conversion::Strict);
     return public_send(env->caller(), name, Args::shift(args), block);
 }
 
-Value Object::send(Env *env, SymbolObject *name, Args args, Block *block, Value sent_from) {
+Value Object::send(Env *env, SymbolObject *name, const Args& args, Block *block, Value sent_from) {
     return send(env, name, args, block, MethodVisibility::Private, sent_from);
 }
 
-Value Object::send(Env *env, Args args, Block *block) {
+Value Object::send(Env *env, const Args& args, Block *block) {
     auto name = args[0]->to_symbol(env, Object::Conversion::Strict);
     return send(env->caller(), name, Args::shift(args), block);
 }
@@ -964,6 +964,7 @@ Value Object::send(Env *env, Args args, Block *block) {
 Value Object::send(Env *env, SymbolObject *name, Args args, Block *block, MethodVisibility visibility_at_least, Value sent_from) {
     static const auto initialize = SymbolObject::intern("initialize");
     Method *method = find_method(env, name, visibility_at_least, sent_from);
+    // TODO: make a copy if has empty keyword hash (unless that's not rare)
     args.pop_empty_keyword_hash();
     if (method) {
         auto result = method->call(env, this, args, block);


### PR DESCRIPTION
This otherwise copy-constructs on many calls which calls malloc and so
on and that's not good for function call performance.

Side by side of fib(25) callgrind instructions:

Before:
  summary: 2554791411
After:
  summary: 2167984106

Or about 15% faster.
