### PR TITLE
Remove NAT_ASM_PREFIX macros

### DIFF
--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -38,12 +38,6 @@
 
 #define NAT_QUOTE(val) #val
 
-#ifdef __APPLE__
-#define NAT_ASM_PREFIX "_"
-#else
-#define NAT_ASM_PREFIX ""
-#endif
-
 #define NAT_MAKE_NONCOPYABLE(c) \
     c(const c &) = delete;      \
     c &operator=(const c &) = delete


### PR DESCRIPTION
They were used in the previous coroutine code.