### PR TITLE
Support `it` keyword

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -77,6 +77,10 @@ module Natalie
         when ::Prism::ImplicitRestNode
           clean_up_keyword_args
           transform_implicit_rest_arg(arg)
+        when ::Prism::ItParametersNode
+          clean_up_keyword_args
+          shift_or_pop_next_arg
+          @instructions << variable_set(:it)
         else
           raise "unhandled node: #{arg.inspect} (#{@pass.file.path}##{arg.location.start_line})"
         end

--- a/lib/natalie/compiler/arity.rb
+++ b/lib/natalie/compiler/arity.rb
@@ -22,6 +22,8 @@ module Natalie
           @args = args.maximum.times.map do |i|
             Prism::RequiredParameterNode.new(nil, nil, args.location, 0, :"_#{i + 1}")
           end
+        when ::Prism::ItParametersNode
+          @args = []
         else
           raise "expected args node, but got: #{args.inspect}"
         end

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2025,6 +2025,23 @@ module Natalie
         instructions
       end
 
+      def transform_it_local_variable_read_node(node, used:)
+        # Ruby 3.3 behaviour: call the method `it` instead
+        instructions = [
+          PushSelfInstruction.new,
+          PushArgcInstruction.new(0),
+          SendInstruction.new(
+            :it,
+            receiver_is_self: true,
+            with_block: false,
+            file: @file.path,
+            line: node.location.start_line,
+          )
+        ]
+        instructions << PopInstruction.new unless used
+        instructions
+      end
+
       alias transform_keyword_hash_node transform_hash_node
 
       def transform_lambda_node(node, used:)

--- a/test/natalie/it_test.rb
+++ b/test/natalie/it_test.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+
+describe 'it in block' do
+  it 'should use the local variable if exists' do
+    it = 123
+    [1, 2, 3].map { it }.should == [123, 123, 123]
+  end
+
+  ruby_version_is ''...'3.4' do
+    it 'should use the method if no local variable exists' do
+      # This test is hacky: we now depend on the `it` method of the specs
+      suppress_warning do
+        -> {
+          # eval is required for suppress_warning
+          eval('[1, 2, 3].map { it }')
+        }.should raise_error(ArgumentError, 'wrong number of arguments (given 0, expected 1)')
+      end
+    end
+  end
+
+  ruby_version_is '3.4' do
+    it 'should act as the first argument if no local variable exists' do
+      # eval is required for suppress_warning
+      eval('[1, 2, 3].map { it }').should == [1, 2, 3]
+    end
+  end
+end


### PR DESCRIPTION
This is a new keyword that will be the first block argument in Ruby 3.4. The Ruby 3.3 behaviour is to warn for an upcoming change, but still try to call the local `it` method. This fixes compilation errors, since the AST has been updated for the upcoming behaviour.
This change does not include the warning, with Ruby 3.4 being less than 2 months away, I think we can just wait a little longer and implement the Ruby 3.4 update.