### PR TITLE
String concatenation uses self's encoding if both are ASCII-only

### DIFF
--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -115,9 +115,7 @@ describe :string_concat_encoding, shared: true do
 
   describe "when self and the argument are in different ASCII-compatible encodings" do
     it "uses self's encoding if both are ASCII-only" do
-      NATFIXME "it uses self's encoding if both are ASCII-only", exception: SpecFailedException do
-        "abc".encode("UTF-8").send(@method, "123".encode("SHIFT_JIS")).encoding.should == Encoding::UTF_8
-      end
+      "abc".encode("UTF-8").send(@method, "123".encode("SHIFT_JIS")).encoding.should == Encoding::UTF_8
     end
 
     it "uses self's encoding if the argument is ASCII-only" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3481,7 +3481,7 @@ EncodingObject *StringObject::negotiate_compatible_encoding(const StringObject *
     if (m_encoding->num() == Encoding::ASCII_8BIT)
         return m_encoding.ptr();
 
-    if (this_is_ascii)
+    else if (this_is_ascii && !other_is_ascii)
         return other_string->m_encoding.ptr();
     else
         return m_encoding.ptr();


### PR DESCRIPTION
This fixes the last failure of `plus_spec`, so we can check another box in #217.