### PR TITLE
Refresh specs in Time

### DIFF
--- a/spec/core/time/comparison_spec.rb
+++ b/spec/core/time/comparison_spec.rb
@@ -55,6 +55,38 @@ describe "Time#<=>" do
     }.should_not complain
   end
 
+  context "given different timezones" do
+    it "returns 0 if time is the same as other" do
+      # three timezones, all at the same timestamp
+      time_utc = Time.new(2000, 1, 1, 0, 0, 0, 0)
+      time_cet = Time.new(2000, 1, 1, 1, 0, 0, '+01:00')
+      time_brt = Time.new(1999, 12, 31, 21, 0, 0, '-03:00')
+      NATFIXME 'Time#<=> should account for different timezones', exception: SpecFailedException do
+        (time_utc <=> time_cet).should == 0
+        (time_utc <=> time_brt).should == 0
+        (time_cet <=> time_brt).should == 0
+      end
+    end
+
+    it "returns -1 if the first argument is before the second argument" do
+      # time_brt is later, even though the date is earlier
+      time_utc = Time.new(2000, 1, 1, 0, 0, 0, 0)
+      time_brt = Time.new(1999, 12, 31, 23, 0, 0, '-03:00')
+      NATFIXME 'Time#<=> should account for different timezones', exception: SpecFailedException do
+        (time_utc <=> time_brt).should == -1
+      end
+    end
+
+    it "returns 1 if the first argument is before the second argument" do
+      # time_brt is later, even though the date is earlier
+      time_utc = Time.new(2000, 1, 1, 0, 0, 0, 0)
+      time_brt = Time.new(1999, 12, 31, 23, 0, 0, '-03:00')
+      NATFIXME 'Time#<=> should account for different timezones', exception: SpecFailedException do
+        (time_brt <=> time_utc).should == 1
+      end
+    end
+  end
+
   describe "given a non-Time argument" do
     it "returns nil if argument <=> self returns nil" do
       t = Time.now

--- a/spec/core/time/shared/gmtime.rb
+++ b/spec/core/time/shared/gmtime.rb
@@ -4,7 +4,14 @@ describe :time_gmtime, shared: true do
     with_timezone("CST", -6) do
       t = Time.local(2007, 1, 9, 6, 0, 0)
       t.send(@method)
-      t.should == Time.gm(2007, 1, 9, 12, 0, 0)
+      # Time#== compensates for time zones, so check all parts separately
+      t.year.should == 2007
+      t.month.should == 1
+      t.mday.should == 9
+      t.hour.should == 12
+      t.min.should == 0
+      t.sec.should == 0
+      t.zone.should == "UTC"
     end
   end
 


### PR DESCRIPTION
The specs for `Time#<=>` have some additional checks related to time zones. The shared spec for `Time#gmtime` has related updates, but since we don't yet use this shared spec these could be updated without failing tests.