### PR TITLE
Reduce process stack usage during GC mark phase

### DIFF
--- a/include/natalie/abstract_method_object.hpp
+++ b/include/natalie/abstract_method_object.hpp
@@ -19,7 +19,7 @@ public:
     Method *method() { return m_method; }
     int arity() { return m_method->arity(); }
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_method);
     }

--- a/include/natalie/args.hpp
+++ b/include/natalie/args.hpp
@@ -66,6 +66,7 @@ public:
     const Value *data() const { return m_data.data(); }
 
     Vector<Value> &vector() { return m_data; }
+    const Vector<Value> &vector() const { return m_data; }
 
     bool has_keyword_hash() const { return m_has_keyword_hash; }
     HashObject *keyword_hash() const;

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -207,7 +207,7 @@ public:
     Value values_at(Env *, Args);
     Value zip(Env *, Args, Block *);
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);
         for (auto val : m_vector) {
             visitor.visit(val);

--- a/include/natalie/array_packer/float_handler.hpp
+++ b/include/natalie/array_packer/float_handler.hpp
@@ -16,7 +16,7 @@ namespace ArrayPacker {
 
         String pack(Env *env);
 
-        virtual void visit_children(Visitor &visitor) override {
+        virtual void visit_children(Visitor &visitor) const override {
             visitor.visit(m_source);
         }
 

--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -16,7 +16,7 @@ namespace ArrayPacker {
 
         String pack(Env *env);
 
-        virtual void visit_children(Visitor &visitor) override {
+        virtual void visit_children(Visitor &visitor) const override {
             visitor.visit(m_source);
         }
 

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -24,7 +24,7 @@ namespace ArrayPacker {
 
         StringObject *pack(Env *env, StringObject *buffer);
 
-        virtual void visit_children(Visitor &visitor) override {
+        virtual void visit_children(Visitor &visitor) const override {
             visitor.visit(m_source);
             visitor.visit(m_encoding);
         }

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -19,7 +19,7 @@ namespace ArrayPacker {
 
         using PackHandlerFn = void (StringHandler::*)();
 
-        virtual void visit_children(Visitor &visitor) override {
+        virtual void visit_children(Visitor &visitor) const override {
             visitor.visit(m_string_object);
         }
 

--- a/include/natalie/binding_object.hpp
+++ b/include/natalie/binding_object.hpp
@@ -13,7 +13,7 @@ public:
 
     Env *env() { return &m_env; }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);
         visitor.visit(&m_env);
     }

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -55,7 +55,7 @@ public:
 
     void copy_fn_pointer_to_method(Method *);
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         visitor.visit(m_env);
         visitor.visit(m_calling_env);
         visitor.visit(m_self);

--- a/include/natalie/complex_object.hpp
+++ b/include/natalie/complex_object.hpp
@@ -40,7 +40,7 @@ public:
     Value inspect(Env *);
     Value real(Env *);
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_real);
         visitor.visit(m_imaginary);

--- a/include/natalie/constant.hpp
+++ b/include/natalie/constant.hpp
@@ -34,7 +34,7 @@ public:
     StringObject *autoload_path() const { return m_autoload_path; }
     void autoload(Env *, Value);
 
-    void visit_children(Visitor &visitor);
+    virtual void visit_children(Visitor &visitor) const override;
 
 private:
     SymbolObject *m_name;

--- a/include/natalie/dir_object.hpp
+++ b/include/natalie/dir_object.hpp
@@ -28,7 +28,7 @@ public:
 
     virtual ~DirObject();
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_path);
         visitor.visit(m_encoding);

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -43,7 +43,7 @@ public:
         snprintf(buf, len, "<Enumerator::ArithmeticSequence %p>", this);
     }
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_begin);
         visitor.visit(m_end);

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -176,7 +176,7 @@ public:
 
     bool is_main() { return this == GlobalEnv::the()->main_env(); }
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<Env %p>", this);

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -54,7 +54,7 @@ public:
     ExceptionObject *cause() const { return m_cause; }
     void set_cause(ExceptionObject *e) { m_cause = e; }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         if (m_message == nullptr) {

--- a/include/natalie/false_object.hpp
+++ b/include/natalie/false_object.hpp
@@ -28,7 +28,7 @@ public:
     bool or_method(const Env *, Value) const;
     Value to_s(const Env *) const;
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<FalseObject %p>", this);

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -98,7 +98,7 @@ public:
         NAT_UNREACHABLE();
     }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
     void visit_children_from_stack(Visitor &) const;
     void visit_children_from_asan_fake_stack(Visitor &, Cell *) const;
 

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -22,14 +22,11 @@ public:
 
     class Visitor {
     public:
-        virtual void visit(Cell *cell) = 0;
-        void visit(const Cell *cell) {
-            visit(const_cast<Cell *>(cell));
-        }
+        virtual void visit(const Cell *cell) = 0;
         void visit(Value);
     };
 
-    virtual void visit_children(Visitor &) {
+    virtual void visit_children(Visitor &) const {
     }
 
     // only for debugging the GC
@@ -52,16 +49,16 @@ public:
         return m_marked;
     }
 
-    void mark() {
+    void mark() const {
         m_marked = true;
     }
 
-    void unmark() {
+    void unmark() const {
         m_marked = false;
     }
 
 private:
-    bool m_marked { false };
+    mutable bool m_marked { false };
 };
 
 }

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -22,9 +22,11 @@ public:
 
     class Visitor {
     public:
-        virtual void visit(Cell *) = 0;
-        virtual void visit(const Cell *) = 0;
-        virtual void visit(Value) = 0;
+        virtual void visit(Cell *cell) = 0;
+        void visit(const Cell *cell) {
+            visit(const_cast<Cell *>(cell));
+        }
+        void visit(Value);
     };
 
     virtual void visit_children(Visitor &) {

--- a/include/natalie/gc/marking_visitor.hpp
+++ b/include/natalie/gc/marking_visitor.hpp
@@ -2,6 +2,12 @@
 
 #include "natalie/gc/cell.hpp"
 #include "tm/vector.hpp"
+#include <stack>
+
+// time boardslam.rb 3 5 1
+// 1.656 using C stack
+// 1.692 using std::stack
+// 2.847 using std::queue
 
 namespace Natalie {
 
@@ -9,15 +15,20 @@ class MarkingVisitor : public Cell::Visitor {
 public:
     virtual void visit(Cell *cell) override final {
         if (!cell || cell->is_marked()) return;
-        cell->mark();
-        cell->visit_children(*this);
+        m_stack.push(cell);
     }
 
-    virtual void visit(const Cell *cell) override final {
-        visit(const_cast<Cell *>(cell));
+    void visit_all() {
+        while (!m_stack.empty()) {
+            auto cell = m_stack.top();
+            m_stack.pop();
+            cell->mark();
+            cell->visit_children(*this);
+        }
     }
 
-    virtual void visit(Value val) override final;
+private:
+    std::stack<Cell *> m_stack;
 };
 
 }

--- a/include/natalie/gc/marking_visitor.hpp
+++ b/include/natalie/gc/marking_visitor.hpp
@@ -13,7 +13,7 @@ namespace Natalie {
 
 class MarkingVisitor : public Cell::Visitor {
 public:
-    virtual void visit(Cell *cell) override final {
+    virtual void visit(const Cell *cell) override final {
         if (!cell || cell->is_marked()) return;
         m_stack.push(cell);
     }
@@ -28,7 +28,7 @@ public:
     }
 
 private:
-    std::stack<Cell *> m_stack;
+    std::stack<const Cell *> m_stack;
 };
 
 }

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -117,7 +117,7 @@ public:
 
     friend class SymbolObject;
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<GlobalEnv %p>", this);

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -22,7 +22,7 @@ public:
     void set_read_hook(read_hook_t read_hook) { m_read_hook = read_hook; }
     void set_write_hook(write_hook_t write_hook) { m_write_hook = write_hook; }
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
 private:
     class Object *m_object { nullptr };

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -24,7 +24,7 @@ public:
         size_t hash { 0 };
         bool removed { false };
 
-        virtual void visit_children(Visitor &visitor) override final {
+        virtual void visit_children(Visitor &visitor) const override final {
             visitor.visit(prev);
             visitor.visit(next);
             visitor.visit(key);
@@ -205,7 +205,7 @@ public:
     Value to_h(Env *, Block *);
     Value to_hash() { return this; }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
 
     virtual String dbg_inspect() const override;
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -39,7 +39,7 @@ public:
         }
     }
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_external_encoding);
         visitor.visit(m_internal_encoding);

--- a/include/natalie/managed_vector.hpp
+++ b/include/natalie/managed_vector.hpp
@@ -18,7 +18,7 @@ public:
 
     virtual ~ManagedVector() { }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         for (auto it = TM::Vector<T>::begin(); it != TM::Vector<T>::end(); ++it) {
             visitor.visit(*it);
         }

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -69,7 +69,7 @@ public:
         snprintf(buf, len, "<MatchDataObject %p>", this);
     }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);
         visitor.visit(m_string);
         visitor.visit(m_regexp);

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -90,7 +90,7 @@ public:
     const Optional<String> &get_file() const { return m_file; }
     const Optional<size_t> &get_line() const { return m_line; }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         visitor.visit(m_owner);
         visitor.visit(m_env);
         visitor.visit(m_self);

--- a/include/natalie/method_info.hpp
+++ b/include/natalie/method_info.hpp
@@ -30,7 +30,7 @@ public:
 
     bool is_defined() const { return !m_undefined && m_method; }
 
-    void visit_children(Cell::Visitor &);
+    void visit_children(Cell::Visitor &) const;
 
 private:
     MethodVisibility m_visibility { MethodVisibility::Public };

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -42,7 +42,7 @@ public:
         return m_method->call(env, m_object, args, block);
     }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         AbstractMethodObject::visit_children(visitor);
         visitor.visit(m_object);
         visitor.visit(m_method);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -167,7 +167,7 @@ public:
     bool has_env() { return !!m_env; }
     Env *env() { return m_env; }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         if (m_class_name)

--- a/include/natalie/nil_object.hpp
+++ b/include/natalie/nil_object.hpp
@@ -36,7 +36,7 @@ public:
     Value to_r(const Env *) const;
     Value inspect(const Env *) const;
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<NilObject %p>", this);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -368,7 +368,7 @@ public:
 
     Value enum_for(Env *env, const char *method, Args args = {});
 
-    virtual void visit_children(Visitor &visitor) override;
+    virtual void visit_children(Visitor &visitor) const override;
 
     virtual String dbg_inspect() const;
 

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -60,7 +60,7 @@ public:
 
     int arity() { return m_block ? m_block->arity() : 0; }
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_block);
     }

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -43,7 +43,7 @@ public:
         return Value::integer(self->as_range()->to_a(env)->as_array()->size());
     }
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_begin);
         visitor.visit(m_end);

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -48,7 +48,7 @@ public:
     Value to_s(Env *);
     Value truncate(Env *, Value);
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_numerator);
         visitor.visit(m_denominator);

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -184,7 +184,7 @@ public:
         snprintf(buf, len, "<RegexpObject %p>", this);
     }
 
-    void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         if (m_pattern)
             visitor.visit(m_pattern);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -450,7 +450,7 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);
         visitor.visit(m_encoding.ptr());
     }

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -21,7 +21,7 @@ public:
     ArrayObject *unpack(Env *env);
     Value unpack1(Env *env);
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         visitor.visit(m_source);
         visitor.visit(m_unpacked_value);
         visitor.visit(m_unpacked_array);

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -73,7 +73,7 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_string);
         visitor.visit(m_encoding);

--- a/include/natalie/thread/backtrace/location_object.hpp
+++ b/include/natalie/thread/backtrace/location_object.hpp
@@ -27,7 +27,7 @@ public:
     Value path() const { return m_file; }
     StringObject *to_s() const;
 
-    void visit_children(Visitor &);
+    virtual void visit_children(Visitor &) const override;
 
 private:
     StringObject *m_source_location { nullptr };

--- a/include/natalie/thread/mutex_object.hpp
+++ b/include/natalie/thread/mutex_object.hpp
@@ -29,7 +29,7 @@ public:
     bool is_locked();
     bool is_owned();
 
-    void visit_children(Visitor &);
+    virtual void visit_children(Visitor &) const override;
 
 private:
     std::mutex m_mutex;

--- a/include/natalie/thread_group_object.hpp
+++ b/include/natalie/thread_group_object.hpp
@@ -29,7 +29,7 @@ public:
     static void initialize_default();
     static ThreadGroupObject *get_default() { return m_default; }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
 
 private:
     static inline std::mutex m_mutex;

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -198,7 +198,7 @@ public:
     ThreadGroupObject *group() { return m_group; }
     void set_group(ThreadGroupObject *group) { m_group = group; }
 
-    virtual void visit_children(Visitor &) override final;
+    virtual void visit_children(Visitor &) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(

--- a/include/natalie/throw_catch_exception.hpp
+++ b/include/natalie/throw_catch_exception.hpp
@@ -14,7 +14,7 @@ public:
     Value get_name() const { return m_name; }
     Value get_value() const { return m_value; }
 
-    void visit_children(Visitor &visitor);
+    virtual void visit_children(Visitor &visitor) const override;
 
 private:
     Value m_name { nullptr };

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -62,7 +62,7 @@ public:
     Value year(Env *) const;
     Value zone(Env *) const;
 
-    virtual void visit_children(Visitor &visitor) override {
+    virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_integer);
         visitor.visit(m_subsec);

--- a/include/natalie/true_object.hpp
+++ b/include/natalie/true_object.hpp
@@ -29,7 +29,7 @@ public:
     bool xor_method(const Env *, Value) const;
     Value to_s(const Env *) const;
 
-    virtual void visit_children(Visitor &visitor) override final;
+    virtual void visit_children(Visitor &visitor) const override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
         snprintf(buf, len, "<TrueObject %p>", this);

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -50,7 +50,7 @@ public:
         }
     }
 
-    virtual void visit_children(Visitor &visitor) override final {
+    virtual void visit_children(Visitor &visitor) const override final {
         AbstractMethodObject::visit_children(visitor);
         visitor.visit(m_module_or_class);
         visitor.visit(m_method);

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -9,7 +9,7 @@ void Constant::autoload(Env *env, Value self) {
     fn(env, self, {}, nullptr);
 }
 
-void Constant::visit_children(Visitor &visitor) {
+void Constant::visit_children(Visitor &visitor) const {
     visitor.visit(m_name);
     visitor.visit(m_value);
     visitor.visit(m_autoload_path);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -386,7 +386,7 @@ Env *Env::non_block_env() {
     return env;
 }
 
-void Env::visit_children(Visitor &visitor) {
+void Env::visit_children(Visitor &visitor) const {
     visitor.visit(m_vars);
     visitor.visit(m_outer);
     visitor.visit(m_block);

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -207,7 +207,7 @@ bool ExceptionObject::is_local_jump_error_with_break_point(nat_int_t match_break
     return m_break_point == match_break_point;
 }
 
-void ExceptionObject::visit_children(Visitor &visitor) {
+void ExceptionObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_message);
     visitor.visit(m_backtrace);

--- a/src/false_object.cpp
+++ b/src/false_object.cpp
@@ -16,7 +16,7 @@ Value FalseObject::to_s(const Env *env) const {
     return s_string;
 }
 
-void FalseObject::visit_children(Visitor &visitor) {
+void FalseObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     if (s_string)
         visitor.visit(s_string);

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -243,7 +243,7 @@ void FiberObject::swap_to_previous(Env *env, Args args) {
     m_previous_fiber = nullptr;
 }
 
-void FiberObject::visit_children(Visitor &visitor) {
+void FiberObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     for (auto arg : m_args)
         visitor.visit(arg);

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -25,7 +25,7 @@ void Cell::operator delete(void *) {
     // object creation. We can just ignore that and let sweep() clean up the cell later.
 }
 
-void MarkingVisitor::visit(Value val) {
+void Cell::Visitor::visit(Value val) {
     visit(val.object_or_null());
 }
 
@@ -138,6 +138,8 @@ void Heap::collect() {
 
     if (is_profiled)
         mark_profiler_event->end_now();
+
+    visitor.visit_all();
 
     ThreadObject::wake_up_the_world();
 

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -116,7 +116,7 @@ void GlobalEnv::set_interned_strings(StringObject **interned_strings, const size
     m_interned_strings.push({ interned_strings, interned_strings_size });
 }
 
-void GlobalEnv::visit_children(Visitor &visitor) {
+void GlobalEnv::visit_children(Visitor &visitor) const {
     for (auto pair : m_global_variables) {
         visitor.visit(pair.first);
         visitor.visit(pair.second);

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -16,7 +16,7 @@ Value GlobalVariableInfo::object(Env *env) {
     return m_object;
 }
 
-void GlobalVariableInfo::visit_children(Visitor &visitor) {
+void GlobalVariableInfo::visit_children(Visitor &visitor) const {
     visitor.visit(m_object);
 }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -700,7 +700,7 @@ Value HashObject::slice(Env *env, Args args) {
     return new_hash;
 }
 
-void HashObject::visit_children(Visitor &visitor) {
+void HashObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     for (auto pair : m_hashmap) {
         visitor.visit(pair.first);

--- a/src/method_info.cpp
+++ b/src/method_info.cpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 
-void MethodInfo::visit_children(Cell::Visitor &visitor) {
+void MethodInfo::visit_children(Cell::Visitor &visitor) const {
     visitor.visit(m_method);
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -1123,7 +1123,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
     return NilObject::the();
 }
 
-void ModuleObject::visit_children(Visitor &visitor) {
+void ModuleObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_env);
     visitor.visit(m_superclass);

--- a/src/nil_object.cpp
+++ b/src/nil_object.cpp
@@ -52,7 +52,7 @@ Value NilObject::inspect(const Env *env) const {
     return new StringObject { "nil" };
 }
 
-void NilObject::visit_children(Visitor &visitor) {
+void NilObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     if (s_string)
         visitor.visit(s_string);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1340,7 +1340,7 @@ Value Object::enum_for(Env *env, const char *method, Args args) {
     return this->public_send(env, "enum_for"_s, Args(std::move(args2), args.has_keyword_hash()));
 }
 
-void Object::visit_children(Visitor &visitor) {
+void Object::visit_children(Visitor &visitor) const {
     visitor.visit(m_klass);
     visitor.visit(m_singleton_class);
     visitor.visit(m_owner);

--- a/src/thread/backtrace/location_object.cpp
+++ b/src/thread/backtrace/location_object.cpp
@@ -14,7 +14,7 @@ StringObject *LocationObject::to_s() const {
     return StringObject::format("{}:{}:in `{}'", m_file, m_line, m_source_location);
 }
 
-void LocationObject::visit_children(Visitor &visitor) {
+void LocationObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_source_location);
     visitor.visit(m_file);

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -105,7 +105,7 @@ bool MutexObject::is_owned() {
     return true;
 }
 
-void MutexObject::visit_children(Visitor &visitor) {
+void MutexObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_thread);
     visitor.visit(m_fiber);

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -38,7 +38,7 @@ ArrayObject *ThreadGroupObject::list() {
     return result;
 }
 
-void ThreadGroupObject::visit_children(Visitor &visitor) {
+void ThreadGroupObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_default);
     for (auto thread : m_threads)

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -619,7 +619,7 @@ void ThreadObject::unlock_mutexes() const {
         pair.first->unlock_without_checks();
 }
 
-void ThreadObject::visit_children(Visitor &visitor) {
+void ThreadObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     for (auto arg : m_args.vector())
         visitor.visit(arg);

--- a/src/throw_catch_exception.cpp
+++ b/src/throw_catch_exception.cpp
@@ -3,7 +3,7 @@
 
 namespace Natalie {
 
-void ThrowCatchException::visit_children(Visitor &visitor) {
+void ThrowCatchException::visit_children(Visitor &visitor) const {
     visitor.visit(m_name);
     visitor.visit(m_value);
 }

--- a/src/true_object.cpp
+++ b/src/true_object.cpp
@@ -20,7 +20,7 @@ Value TrueObject::to_s(const Env *env) const {
     return s_string;
 }
 
-void TrueObject::visit_children(Visitor &visitor) {
+void TrueObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     if (s_string)
         visitor.visit(s_string);


### PR DESCRIPTION
Fixes #2280

For a large tree/graph of Ruby objects, our GC can really blow out the process stack during its marking phase. Here we change the code to _enqueue_ children to walk by adding them to our own `std::stack` data structure, and then walking them in while loop.

I also learned about the `mutable` keyword, which allows us to make these `visit_children` methods `const` again, since they only thing they need to change is the `m_marked` boolean on `Cell`s. Cool!