### PR TITLE
Fix SystemExit segfault for non-main threads

### DIFF
--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -837,10 +837,12 @@ Value super(Env *env, Value self, Args args, Block *block) {
 }
 
 void clean_up_and_exit(int status) {
-    ThreadObject::detach_all();
-    if (Heap::the().collect_all_at_exit()) {
-        delete &Heap::the();
-        delete NativeProfiler::the();
+    if (ThreadObject::i_am_main()) {
+        ThreadObject::detach_all();
+        if (Heap::the().collect_all_at_exit()) {
+            delete &Heap::the();
+            delete NativeProfiler::the();
+        }
     }
     exit(status);
 }


### PR DESCRIPTION
Fixes #2323

I'm not going to pretend I understand the undefined behavior here, but I *think* running `detach_all` while we ourselves are in one of those threads is causing something to go haywire. Only running this on the main thread seems to fix a segfault when you run code like this:

```ruby
Thread.new { Process.exit! 21 }.join
sleep
```