### PR TITLE
Refresh specs for Kernel.sleep

### DIFF
--- a/spec/core/kernel/sleep_spec.rb
+++ b/spec/core/kernel/sleep_spec.rb
@@ -51,18 +51,15 @@ describe "Kernel#sleep" do
     t.value.should == 5
   end
 
-  platform_is_not :darwin do
-    it "sleeps with nanosecond precision" do
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      100.times do
-        sleep(0.0001)
-      end
-      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-      actual_duration = end_time - start_time
-      (actual_duration > 0.01).should == true # 100 * 0.0001 => 0.01
-      (actual_duration < 0.03).should == true
+  it "sleeps with nanosecond precision" do
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    100.times do
+      sleep(0.0001)
     end
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    actual_duration = end_time - start_time
+    actual_duration.should > 0.01 # 100 * 0.0001 => 0.01
   end
 
   ruby_version_is ""..."3.3" do


### PR DESCRIPTION
This one has been removed from upstream for frequent failures, and it just failed on my test too.