### PR TITLE
Replace some calls to Args::shift from the static to the instance method

### DIFF
--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -29,8 +29,8 @@ public:
 
     Value bind_call(Env *env, Args args, Block *block) {
         args.ensure_argc_at_least(env, 1);
-        auto obj = args[0];
-        return bind_call(env, obj, Args::shift(args), block);
+        auto obj = args.shift();
+        return bind_call(env, obj, args, block);
     }
 
     bool eq(Env *env, Value other_value) {

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -751,8 +751,9 @@ Value ArrayObject::difference(Env *env, Args args) {
 Value ArrayObject::dig(Env *env, Args args) {
     args.ensure_argc_at_least(env, 1);
     auto dig = "dig"_s;
-    Value val = ref(env, args[0]);
-    if (args.size() == 1)
+    auto idx = args.shift();
+    Value val = ref(env, idx);
+    if (args.size() == 0)
         return val;
 
     if (val == NilObject::the())
@@ -761,7 +762,7 @@ Value ArrayObject::dig(Env *env, Args args) {
     if (!val->respond_to(env, dig))
         env->raise("TypeError", "{} does not have #dig method", val->klass()->inspect_str());
 
-    return val.send(env, dig, Args::shift(args));
+    return val.send(env, dig, args);
 }
 
 Value ArrayObject::drop(Env *env, Value n) {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -399,8 +399,9 @@ Value HashObject::delete_key(Env *env, Value key, Block *block) {
 Value HashObject::dig(Env *env, Args args) {
     args.ensure_argc_at_least(env, 1);
     auto dig = "dig"_s;
-    Value val = ref(env, args[0]);
-    if (args.size() == 1)
+    auto idx = args.shift();
+    Value val = ref(env, idx);
+    if (args.size() == 0)
         return val;
 
     if (val == NilObject::the())
@@ -409,7 +410,7 @@ Value HashObject::dig(Env *env, Args args) {
     if (!val->respond_to(env, dig))
         env->raise("TypeError", "{} does not have #dig method", val->klass()->inspect_str());
 
-    return val.send(env, dig, Args::shift(args));
+    return val.send(env, dig, args);
 }
 
 Value HashObject::size(Env *env) const {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -132,8 +132,8 @@ Value SymbolObject::to_proc_block_fn(Env *env, Value self_value, Args args, Bloc
     args.ensure_argc_at_least(env, 1);
     SymbolObject *name_obj = env->outer()->var_get("name", 0)->as_symbol();
     assert(name_obj);
-    auto method_args = Args::shift(args);
-    return args[0].send(env, name_obj, method_args);
+    auto receiver = args.shift();
+    return receiver.send(env, name_obj, args);
 }
 
 Value SymbolObject::cmp(Env *env, Value other_value) {


### PR DESCRIPTION
These calls all receive a copy of an Args object, take off the first object, and pass the remaining args to the next method. Using the instance method does skip creating a new object.

The following script:
```ruby
data = {
  foo: [
    {
      bar: [1, 2, 3]
    },
  ],
}
p data.dig(:foo, 0, :bar, 1)
```
under callgrind went from 57,328,985 to 57,320,725 instructions. It's not much, but it's a relative small change.