### PR TITLE
Force install pkg-config for macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           ruby --version
           which bundle
       - name: install build tools
-        run: brew install autoconf automake libtool pkg-config
+        run: brew install --force --overwrite autoconf automake libtool pkg-config
       - name: install openssl
         run: brew install openssl
       - name: install libffi


### PR DESCRIPTION
This was failing with the error:

    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /opt/homebrew
    Could not symlink bin/pkg-config
    Target /opt/homebrew/bin/pkg-config
    is a symlink belonging to pkg-config@0.29.2. You can unlink it:
      brew unlink pkg-config@0.29.2