### PR TITLE
Store args on a per-Fiber stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage-report
 .cache
 bin/nat
 /rubyspec_temp
+/master
 
 # Editor tools
 .ccls

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ end
 
 desc 'Run the most-recently-modified test when any source files change (requires entr binary)'
 task :watch do
-  files = Rake::FileList['**/*.cpp', '**/*.c', '**/*.hpp', '**/*.rb'].exclude('{build,ext}/**/*')
+  files = Rake::FileList['**/*.cpp', '**/*.c', '**/*.hpp', '**/*.rb'].exclude('{build,ext,master}/**/*')
   sh "ls #{files} | entr -c -s 'rake test_last_modified'"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -581,7 +581,7 @@ file 'bin/nat' => OBJECT_FILES + ['bin/natalie'] do
   sh 'bin/natalie -c bin/nat bin/natalie'
 end
 
-file "build/libnat.#{SO_EXT}" => SOURCES + ['lib/libnat_api.rb', 'lib/libnat_api.cpp', 'build/libnatalie.a'] do |t|
+file "build/libnat.#{SO_EXT}" => SOURCES + ['lib/libnat_api.rb', 'lib/libnat_api.cpp'] do |t|
   sh 'bin/natalie --write-obj build/libnat.rb.cpp lib/libnat_api.rb'
   if system('pkg-config --exists libffi')
     flags = `pkg-config --cflags --libs libffi`.chomp
@@ -589,7 +589,7 @@ file "build/libnat.#{SO_EXT}" => SOURCES + ['lib/libnat_api.rb', 'lib/libnat_api
   sh "#{cxx} #{cxx_flags.join(' ')} #{flags} -std=#{STANDARD} " \
      '-DNAT_OBJECT_FILE -shared -fPIC -rdynamic ' \
      '-Wl,-undefined,dynamic_lookup ' \
-     "-o #{t.name} build/libnat.rb.cpp build/libnatalie.a"
+     "-o #{t.name} build/libnat.rb.cpp"
 end
 
 rule '.c.o' => 'src/%n' do |t|

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -148,6 +148,7 @@ public:
     Value private_class_method(Env *, Args &&);
     Value public_class_method(Env *, Args &&);
     void set_method_visibility(Env *, Args &&, MethodVisibility);
+    void set_method_visibility(Env *, SymbolObject *, MethodVisibility);
     Value module_function(Env *, Args &&) override;
 
     Value deprecate_constant(Env *, Args &&);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -65,7 +65,8 @@ public:
         detach();
     }
 
-    static void build_main_thread(Env *env, void *start_of_stack);
+    static void prepare_main_thread();
+    static void finish_main_thread_setup(Env *env, void *start_of_stack);
 
     ThreadObject *initialize(Env *env, Args &&args, Block *block);
 
@@ -96,7 +97,7 @@ public:
     void set_exception(ExceptionObject *exception) { m_exception = exception; }
     ExceptionObject *exception() { return m_exception; }
 
-    ArrayObject *args() { return m_args.to_array(); }
+    ArrayObject *args() { return new ArrayObject(m_args.size(), m_args.data()); }
     Block *block() { return m_block; }
 
     bool is_alive() const {
@@ -277,7 +278,7 @@ private:
 
     friend FiberObject;
 
-    Args m_args {};
+    TM::Vector<Value> m_args;
     Block *m_block { nullptr };
     std::thread m_thread {};
     std::thread::native_handle_type m_native_thread_handle { 0 };

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -33,8 +33,7 @@ module Natalie
         -lonigmo
       ].freeze
 
-      # When using the REPL or compiling a binary with the `-c` option,
-      # we use static linking for compatibility.
+      # When compiling a binary with the `-c` option, we use static linking for compatibility.
       LIBRARIES_FOR_STATIC_LINKING = %w[
         -lnatalie
       ].freeze
@@ -88,7 +87,7 @@ module Natalie
         [
           cc,
           build_flags,
-          (shared? ? '-fPIC -shared' : ''),
+          (@compiler.repl? ? LIBNAT_AND_REPL_FLAGS.join(' ') : ''),
           inc_paths.map { |path| "-I #{path}" }.join(' '),
           "-o #{@compiler.out_path}",
           '-x c++ -std=c++17',
@@ -156,7 +155,9 @@ module Natalie
       end
 
       def libraries
-        if @compiler.dynamic_linking?
+        if @compiler.repl?
+          []
+        elsif @compiler.dynamic_linking?
           LIBRARIES_FOR_DYNAMIC_LINKING
         else
           LIBRARIES_FOR_STATIC_LINKING
@@ -264,10 +265,6 @@ module Natalie
 
       def write_object_file?
         !!@compiler.write_obj_path
-      end
-
-      def shared?
-        @compiler.repl?
       end
 
       def declarations

--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -34,6 +34,13 @@ module Natalie
         -fprofile-arcs
         -ftest-coverage
       ].freeze
+
+      LIBNAT_AND_REPL_FLAGS = %w[
+        -fPIC
+        -shared
+        -rdynamic
+        -Wl,-undefined,dynamic_lookup
+      ]
     end
   end
 end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -301,25 +301,30 @@ Value IoObject::read_file(Env *env, Args &&args) {
 Value IoObject::write_file(Env *env, Args &&args) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 2, 3);
+
     auto filename = args.at(0);
     auto string = args.at(1);
     auto offset = args.at(2, nullptr);
     auto mode = Value::integer(O_WRONLY | O_CREAT | O_CLOEXEC);
+
     if (!offset || offset->is_nil())
         mode = Value::integer(IntegerObject::convert_to_nat_int_t(env, mode) | O_TRUNC);
     if (kwargs && kwargs->has_key(env, "mode"_s))
         mode = kwargs->delete_key(env, "mode"_s, nullptr);
     if (filename->is_string() && filename->as_string()->string()[0] == '|')
         env->raise("NotImplementedError", "no support for pipe in IO.write");
-    Args open_args { { filename, mode, kwargs }, true };
+
+    ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
+    FileObject *file = nullptr;
+
     if (kwargs && kwargs->has_key(env, "open_args"_s)) {
         auto next_args = new ArrayObject { filename };
         next_args->concat(*kwargs->fetch(env, "open_args"_s, nullptr, nullptr)->to_ary(env));
         auto open_args_has_kw = next_args->last()->is_hash();
-        open_args = Args(next_args, open_args_has_kw);
+        file = _new(env, File, Args(next_args, open_args_has_kw), nullptr)->as_file();
+    } else {
+        file = _new(env, File, Args({ filename, mode, kwargs }, true), nullptr)->as_file();
     }
-    ClassObject *File = GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class();
-    FileObject *file = _new(env, File, std::move(open_args), nullptr)->as_file();
     if (offset && !offset->is_nil())
         file->set_pos(env, offset);
     Defer close { [&file, &env]() { file->close(env); } };

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -559,7 +559,7 @@ Value KernelModule::print(Env *env, Args &&args) {
     auto _stdout = env->global_get("$stdout"_s);
     assert(_stdout);
     if (args.size() == 0)
-        args = Args { env->global_get("$_"_s) };
+        return _stdout->send(env, "write"_s, Args { env->global_get("$_"_s) });
     // NATFIXME: Kernel.print should actually call IO.print and not
     // IO.write, but for now using IO.print causes crashes.
     // return _stdout->send(env, "print"_s, args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
     setvbuf(stdout, nullptr, _IOLBF, 1024);
 
     Env *env = ::build_top_env();
-    ThreadObject::build_main_thread(env, __builtin_frame_address(0));
+    ThreadObject::finish_main_thread_setup(env, __builtin_frame_address(0));
 
     trap_signal(SIGINT, sigint_handler);
     trap_signal(SIGPIPE, sigpipe_handler);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -377,6 +377,11 @@ Env *build_top_env() {
     Thread->const_set("Mutex"_s, ThreadMutex);
     Object->const_set("Mutex"_s, ThreadMutex);
 
+    // We need a main ThreadObject and main FiberObject
+    // to hold our args stack. This has to happen before
+    // we make any calls using Args.
+    ThreadObject::prepare_main_thread();
+
     ClassObject *Method = Object->subclass(env, "Method", Object::Type::Method);
     Object->const_set("Method"_s, Method);
 

--- a/test/natalie/libnat_test.rb
+++ b/test/natalie/libnat_test.rb
@@ -25,7 +25,7 @@ module LibNat
   def self.compile(ast, path, encoding)
     compiler = Natalie::Compiler.new(ast: ast, path: path, encoding: encoding)
     temp = Tempfile.create("natalie.#{RbConfig::CONFIG['SOEXT']}")
-    compiler.repl = true # actually this should be called "shared"
+    compiler.repl = true # actually this should be called something else ¯\_(ツ)_/¯
     compiler.out_path = temp.path
     compiler.compile
     temp.path


### PR DESCRIPTION
This eliminates a Vector allocation for each call site and gives the garbage collector visibility into the full stack of arguments.

This should fix #2345.