### PR TITLE
Fix Mutex#sleep race condition

### DIFF
--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -252,10 +252,10 @@ public:
 
     static void check_current_exception(Env *env);
 
-    static void setup_interrupt_pipe(Env *env);
-    static int interrupt_read_fileno() { return s_interrupt_read_fileno; }
-    static void interrupt();
-    static void clear_interrupt();
+    static void setup_wake_pipe(Env *env);
+    static int wake_pipe_read_fileno() { return s_wake_pipe_read_fileno; }
+    static void wake_all();
+    static void clear_wake_pipe();
 
     static ClassObject *thread_kill_class() { return s_thread_kill_class; }
     static ClassObject *thread_kill_class(Env *env) {
@@ -329,13 +329,13 @@ private:
     // In addition to m_sleep_cond which can wake a sleeping thread,
     // we also need a way to wake a thread that is blocked on reading
     // from a file descriptor. Any time select(2) is called, we can
-    // add this s_interrupt_read_fileno to the fd_set so we have
+    // add this s_wake_pipe_read_fileno to the fd_set so we have
     // a way to unblock the call. This is also signaled when any
     // IO object is closed, since we'll need to wake up any blocking
     // select() calls and check if the IO object was closed.
     // TODO: we'll need to rebuild these after a fork :-/
-    inline static int s_interrupt_read_fileno { -1 };
-    inline static int s_interrupt_write_fileno { -1 };
+    inline static int s_wake_pipe_read_fileno { -1 };
+    inline static int s_wake_pipe_write_fileno { -1 };
 
     // We use this special class as an off-the-books exception class
     // for killing threads. It cannot be rescued in user code, but it

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -124,7 +124,7 @@ public:
     Value run(Env *);
     Value wakeup(Env *);
 
-    Value sleep(Env *, float);
+    Value sleep(Env *, float, Thread::MutexObject * = nullptr);
 
     void set_value(Value value) { m_value = value; }
     Value value(Env *);
@@ -318,6 +318,7 @@ private:
 
     // This condition variable is used to wake a sleeping thread,
     // i.e. a thread where Kernel#sleep has been called.
+    bool m_wakeup { false };
     std::condition_variable m_sleep_cond;
     std::mutex m_sleep_lock;
 

--- a/src/thread/conditionvariable.rb
+++ b/src/thread/conditionvariable.rb
@@ -7,9 +7,11 @@ class Thread
 
     def broadcast
       @mutex.synchronize do
-        while !@waiting.empty?
+        until @waiting.empty?
           thread = @waiting.shift
-          thread.wakeup if thread&.status == 'sleep'
+          if thread.status != 'dead'
+            thread.wakeup
+          end
         end
       end
     end
@@ -21,10 +23,13 @@ class Thread
     def signal
       @mutex.synchronize do
         thread = nil
-        while !@waiting.empty? && thread&.status != 'sleep'
+        until @waiting.empty?
           thread = @waiting.shift
+          if thread.status != 'dead'
+            thread.wakeup
+            break
+          end
         end
-        thread&.wakeup
       end
     end
 

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -29,8 +29,7 @@ Value MutexObject::lock(Env *env) {
 
 Value MutexObject::sleep(Env *env, Value timeout) {
     if (!timeout || timeout->is_nil()) {
-        unlock(env);
-        ThreadObject::current()->sleep(env, -1.0);
+        ThreadObject::current()->sleep(env, -1.0, this);
         lock(env);
         return this;
     }
@@ -43,9 +42,8 @@ Value MutexObject::sleep(Env *env, Value timeout) {
     if (timeout_int < 0)
         env->raise("ArgumentError", "timeout must be positive");
 
-    unlock(env);
     const auto timeout_float = timeout->is_float() ? static_cast<float>(timeout->as_float()->to_double()) : static_cast<float>(timeout_int);
-    ThreadObject::current()->sleep(env, timeout_float);
+    ThreadObject::current()->sleep(env, timeout_float, this);
     lock(env);
 
     return Value::integer(timeout_int);


### PR DESCRIPTION
`Mutex#sleep` acts like an atomic `Mutex#unlock` + `Thread#sleep`.

If some other thread sneaks in the middle of that and calls `Thread#wakeup`, the wakeup can be lost because we're not quite sleeping yet. `m_wakeup` is the "condition" for our `std::condition_variable` that allows us to check if we should immediately wake up.

Fixes #2340 and #1966.