### PR TITLE
Optimize integer comparisons between fixnum and bignum

### DIFF
--- a/include/natalie/bigint.hpp
+++ b/include/natalie/bigint.hpp
@@ -206,7 +206,7 @@ struct BigInt {
         return strtol(buf, nullptr, 10);
     }
 
-    long to_long_long() const {
+    long long to_long_long() const {
         char buf[32];
         bigint_write(buf, 32, data);
         return strtoll(buf, nullptr, 10);

--- a/test/natalie/integer_test.rb
+++ b/test/natalie/integer_test.rb
@@ -165,6 +165,20 @@ describe 'integer' do
       (1 == Rational(1, 2)).should == false
       (1 == Rational(1, 1)).should == true
     end
+
+    it 'handles bignums correctly' do
+      (1 == bignum_value).should == false
+      (0 == bignum_value).should == false
+      (-1 == bignum_value).should == false
+
+      (bignum_value == 1).should == false
+      (bignum_value == 0).should == false
+      (bignum_value == -1).should == false
+
+      (bignum_value == bignum_value).should == true
+      (-bignum_value == -bignum_value).should == true
+      (-bignum_value == bignum_value - 1).should == false
+    end
   end
 
   describe 'eql?' do
@@ -195,6 +209,29 @@ describe 'integer' do
       (0 < Rational(1, 2)).should == true
       (1 < Rational(1, 2)).should == false
       (1 < Rational(1, 1)).should == false
+    end
+
+    it 'handles bignums correctly' do
+      (1 < bignum_value).should == true
+      (0 < bignum_value).should == true
+      (-1 < bignum_value).should == true
+
+      (1 < -bignum_value).should == false
+      (0 < -bignum_value).should == false
+      (-1 < -bignum_value).should == false
+
+      (bignum_value < 1).should == false
+      (bignum_value < 0).should == false
+      (bignum_value < -1).should == false
+
+      (-bignum_value < 1).should == true
+      (-bignum_value < 0).should == true
+      (-bignum_value < -1).should == true
+
+      (-bignum_value < bignum_value).should == true
+      (bignum_value < -bignum_value).should == false
+      (bignum_value < bignum_value - 1).should == false
+      (bignum_value - 1 < bignum_value).should == true
     end
   end
 


### PR DESCRIPTION
Bignums should never be in the NAT_MIN_FIXNUM..NAT_MAX_FIXNUM range, so we can optimize some comparisons between the different backing types.

Fixes #2344.

I'm open to adding an assertion somewhere, but I couldn't think of a nice way of doing it. We could replace all the `m_bignum =` assignments with a setter like `set_bignum()` and add an assertion there. But when I grep for `m_bignum =` they all are in the constructors, and I figure we can easily eyeball that those are all doing the right thing. Again, open to suggestions!