### PR TITLE
Change default build to release mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
       - name: run tests
         env:
           RUBY: ruby3.3
+          NAT_BUILD_MODE: debug
         run: |
           export GLOB=$(ruby spec/support/split_specs.rb 3 ${{ matrix.group }})
           rake docker_test_${{ matrix.compiler }}
@@ -48,6 +49,7 @@ jobs:
           - group1
           - group2
           - group3
+          - group4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,8 +78,9 @@ jobs:
       - name: test with clang on macOS
         env:
           PKG_CONFIG_PATH: /usr/local/opt/openssl@3/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig:/opt/homebrew/opt/libffi/lib/pkgconfig
+          NAT_BUILD_MODE: release
         run: |
-          export GLOB=$(ruby spec/support/split_specs.rb 3 ${{ matrix.group }})
+          export GLOB=$(ruby spec/support/split_specs.rb 4 ${{ matrix.group }})
           export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
           rake test
   self-hosted:

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY lib lib
 COPY src src
 COPY include include
 
-ARG NAT_BUILD_MODE=debug
+ARG NAT_BUILD_MODE=release
 RUN rake build_${NAT_BUILD_MODE}
 
 COPY spec spec

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ rake
 - If you get an error about missing `bundler`, then your operating system probably didn't
   install it alongside Ruby. You can run `gem install bundler` to get it.
 
-**NOTE:** Currently, the default build is the "debug" build, since Nataile is in active development.
-But you can build in release mode with `rake build_release`.
-
 ## Usage
 
 **REPL:**

--- a/Rakefile
+++ b/Rakefile
@@ -284,20 +284,26 @@ end
 DEFAULT_HOST_RUBY_VERSION = 'ruby3.3'.freeze
 SUPPORTED_HOST_RUBY_VERSIONS = %w[ruby3.1 ruby3.2 ruby3.3].freeze
 
+def default_docker_build_args
+  [
+    "--build-arg IMAGE='ruby:#{ruby_version_number}'",
+    '--build-arg NAT_CXX_FLAGS=-DNAT_GC_GUARD',
+    "--build-arg NAT_BUILD_MODE=#{ENV.fetch('NAT_BUILD_MODE', 'release')}",
+    "--build-arg NEED_VALGRIND=#{ENV.fetch('NEED_VALGRIND', 'false')}",
+  ]
+end
+
 task :docker_build_gcc do
   sh "docker build -t natalie_gcc_#{ruby_version_string} " \
-     "--build-arg IMAGE='ruby:#{ruby_version_number}' " \
-     '--build-arg NAT_CXX_FLAGS=-DNAT_GC_GUARD .'
+     "#{default_docker_build_args.join(' ')} " \
+     '.'
 end
 
 task :docker_build_clang do
   sh "docker build -t natalie_clang_#{ruby_version_string} " \
-     "--build-arg IMAGE='ruby:#{ruby_version_number}' " \
-     '--build-arg NAT_CXX_FLAGS=-DNAT_GC_GUARD ' \
+     "#{default_docker_build_args.join(' ')} " \
      '--build-arg CC=clang ' \
      '--build-arg CXX=clang++ ' \
-     '--build-arg NAT_CXX_FLAGS=-DNAT_GC_GUARD ' \
-     "--build-arg NEED_VALGRIND=#{ENV.fetch('NEED_VALGRIND', 'false')} " \
      '.'
 end
 


### PR DESCRIPTION
We've had some folks drop in and start benchmarking Natalie. It's counterintuitive that we would build in debug mode by default, so it's easy to miss. And now that I'm not chasing GC bugs regularly, I think it's time we switch the default build mode.

Of course, when debugging, we can easily `rake clean build_debug` to get back the debug build.

NOTE: This will slow down CI since compilation takes longer. Most of our time in CI is on compilation, since each script runs very quickly. I kept CI on Linux in debug mode because 2 hours just seemed like way too long to wait for a build. The macOS tests build in release mode and take around an hour.