### PR TITLE
Fixes to Marshal.load with ivars

### DIFF
--- a/spec/core/marshal/dump_spec.rb
+++ b/spec/core/marshal/dump_spec.rb
@@ -438,18 +438,16 @@ describe "Marshal.dump" do
 
     it "dumps an ascii-compatible Regexp" do
       o = Regexp.new("a".encode("us-ascii"), Regexp::FIXEDENCODING)
-      NATFIXME 'dumps an ascii-compatible Regexp', exception: SpecFailedException do
-        Marshal.dump(o).should == "\x04\bI/\x06a\x10\x06:\x06EF"
+      Marshal.dump(o).should == "\x04\bI/\x06a\x10\x06:\x06EF"
 
-        o = Regexp.new("a".encode("us-ascii"))
-        Marshal.dump(o).should == "\x04\bI/\x06a\x00\x06:\x06EF"
+      o = Regexp.new("a".encode("us-ascii"))
+      Marshal.dump(o).should == "\x04\bI/\x06a\x00\x06:\x06EF"
 
-        o = Regexp.new("a".encode("windows-1251"), Regexp::FIXEDENCODING)
-        Marshal.dump(o).should == "\x04\bI/\x06a\x10\x06:\rencoding\"\x11Windows-1251"
+      o = Regexp.new("a".encode("windows-1251"), Regexp::FIXEDENCODING)
+      Marshal.dump(o).should == "\x04\bI/\x06a\x10\x06:\rencoding\"\x11Windows-1251"
 
-        o = Regexp.new("a".encode("windows-1251"))
-        Marshal.dump(o).should == "\x04\bI/\x06a\x00\x06:\x06EF"
-      end
+      o = Regexp.new("a".encode("windows-1251"))
+      Marshal.dump(o).should == "\x04\bI/\x06a\x00\x06:\x06EF"
     end
 
     it "dumps a UTF-8 Regexp" do
@@ -467,10 +465,10 @@ describe "Marshal.dump" do
 
     it "dumps a Regexp in another encoding" do
       o = Regexp.new("".dup.force_encoding("utf-16le"), Regexp::FIXEDENCODING)
-      NATFIXME 'dumps a Regexp in another encoding', exception: SpecFailedException do
-        Marshal.dump(o).should == "\x04\bI/\x00\x10\x06:\rencoding\"\rUTF-16LE"
+      Marshal.dump(o).should == "\x04\bI/\x00\x10\x06:\rencoding\"\rUTF-16LE"
 
-        o = Regexp.new("a".encode("utf-16le"), Regexp::FIXEDENCODING)
+      o = Regexp.new("a".encode("utf-16le"), Regexp::FIXEDENCODING)
+      NATFIXME 'encoding issues', exception: Encoding::CompatibilityError do
         Marshal.dump(o).should == "\x04\bI/\aa\x00\x10\x06:\rencoding\"\rUTF-16LE"
       end
     end

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -570,9 +570,10 @@ module Marshal
           elsif value == true
             object.force_encoding(Encoding::UTF_8)
           end
+        elsif name == :encoding
+          object.force_encoding(value)
         else
-          ivar_name = '@' + name.to_s
-          object.instance_variable_set(ivar_name, value)
+          object.instance_variable_set(name, value)
         end
       end
     end

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -104,15 +104,24 @@ module Marshal
     def write_encoding_bytes(value)
       ivars = value.instance_variables.map { |ivar_name| [ivar_name, value.instance_variable_get(ivar_name)] }
       case value.encoding
+      when Encoding::ASCII_8BIT
+        nil # no encoding saved
       when Encoding::US_ASCII
         ivars.prepend([:E, false])
       when Encoding::UTF_8
         ivars.prepend([:E, true])
+      else
+        ivars.prepend([:encoding, value.encoding.name])
       end
       write_integer_bytes(ivars.size) unless ivars.empty?
       ivars.each do |ivar_name, ivar_value|
         write(ivar_name)
-        write(ivar_value)
+        if ivar_name == :encoding
+          write_char('"')
+          write_string_bytes(ivar_value)
+        else
+          write(ivar_value)
+        end
       end
     end
 


### PR DESCRIPTION
Don't add an additional '@' to the name, and make an exception for the internal encoding value of Strings.