### PR TITLE
Fix debug_instructions call

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2847,7 +2847,7 @@ module Natalie
 
       class << self
         def debug_instructions(instructions)
-          instructions.each_with_index do |instruction, index|
+          instructions.flatten.each_with_index do |instruction, index|
             desc = "#{index} #{instruction}"
             puts desc
           end


### PR DESCRIPTION
The instructions oftain contain nested arrays, so flatten them before printing.