### PR TITLE
Move VariableDeclareInstructions to beginning of block

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -371,9 +371,9 @@ module Natalie
           instructions << transform_block_args(node.parameters, used: true)
         end
 
-        with_locals(node.locals) do
+        instructions += with_locals(node.locals) do
           body = node.body || Prism.nil_node(location: node.location)
-          instructions << transform_expression(body, used: true)
+          transform_expression(body, used: true)
         end
 
         instructions << EndInstruction.new(:define_block)
@@ -833,8 +833,8 @@ module Natalie
           file: @file.path,
           line: node.location.start_line,
         )
-        with_locals(node.locals) do
-          instructions += transform_body(node.body, used: true, location: node.location)
+        instructions += with_locals(node.locals) do
+          transform_body(node.body, used: true, location: node.location)
         end
         instructions << EndInstruction.new(:define_class)
         instructions << PopInstruction.new unless used
@@ -2213,8 +2213,8 @@ module Natalie
           file: @file.path,
           line: node.location.start_line,
         )
-        with_locals(node.locals) do
-          instructions += transform_body(node.body, used: true, location: node.location)
+        instructions += with_locals(node.locals) do
+          transform_body(node.body, used: true, location: node.location)
         end
         instructions << EndInstruction.new(:define_module)
         instructions << PopInstruction.new unless used


### PR DESCRIPTION
As an example, the following code:
```ruby
a = 1
b = 2
```
Would result in the following instructions on master:
```
0 variable_declare a
1 push_int 1
2 variable_set a
3 variable_declare b
4 push_int 2
5 variable_set b
```
With this change, the `variable_declare` is moved to the start of the scope
```
0 variable_declare a
1 variable_declare b
2 push_int 1
3 variable_set a
4 push_int 2
5 variable_set b
```
This has the following advantages:
* The code is more in line with how Ruby works, this works like a stack based architecture
* This is going to help with implementing `Binding#local_variables`, which is required to get a runtime `eval`
* This simplifies the code, declaring variables is now limited to a single location in the code
* This removes an ugly hack regarding `for` loops which have unusual scoping rules. The output could result in two `variable_declare` instructions for the same variable. A similar thing happens with block-local variables (like the `x` in `{ |a; x| ... }`)