### PR TITLE
Rename crypt_r to fix ASan false positive

### DIFF
--- a/include/natalie/crypt.h
+++ b/include/natalie/crypt.h
@@ -240,7 +240,7 @@ char *crypt(const char *key, const char *setting);
 void setkey(const char *key);
 void encrypt(char *block, int flag);
 
-char *crypt_r(const char *key, const char *setting, struct crypt_data *data);
+char *crypt_r2(const char *key, const char *setting, struct crypt_data *data);
 void setkey_r(const char *key, struct crypt_data *data);
 void encrypt_r(char *block, int flag, struct crypt_data *data);
 

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -1183,7 +1183,7 @@ static struct crypt_data default_crypt_data;
  */
 char *
 crypt(const char *key, const char *setting) {
-    return crypt_r(key, setting, &default_crypt_data);
+    return crypt_r2(key, setting, &default_crypt_data);
 }
 #endif
 
@@ -1192,7 +1192,7 @@ crypt(const char *key, const char *setting) {
  * encryption produced by the "key" and "setting".
  */
 char *
-crypt_r(const char *key, const char *setting, struct crypt_data *data) {
+crypt_r2(const char *key, const char *setting, struct crypt_data *data) {
     register char *encp;
     register long i;
     register int t;

--- a/test/asan_test.rb
+++ b/test/asan_test.rb
@@ -13,6 +13,7 @@ TESTS = if ENV['SOME_TESTS'] == 'true'
           Dir[
             'spec/language/*_spec.rb',
             'test/natalie/**/*_test.rb',
+            'spec/core/string/crypt_spec.rb',
           ].to_a
         else
           # runs nightly -- all tests
@@ -53,7 +54,6 @@ TESTS_TO_SKIP = [
   'spec/core/process/uid_spec.rb', # not sure why this breaks
   'spec/core/process/euid_spec.rb', # not sure why this breaks
   'spec/core/process/egid_spec.rb', # not sure why this breaks
-  'spec/core/string/crypt_spec.rb', # heap buffer overflow in Natalie::StringObject::crypt
 ].freeze
 
 describe 'ASAN tests' do


### PR DESCRIPTION
The ASan interceptor for CRYPT(3) `::crypt_r` thinks we're doing something naughty, but we have our own implementation. So to keep ASan from intercepting this function, let's rename it.