### PR TITLE
Refresh observer fixtures

### DIFF
--- a/spec/library/observer/fixtures/classes.rb
+++ b/spec/library/observer/fixtures/classes.rb
@@ -1,19 +1,17 @@
-ruby_version_is ""..."3.4" do
-  require 'observer'
+require 'observer'
 
-  class ObserverCallbackSpecs
-    attr_reader :value
+class ObserverCallbackSpecs
+  attr_reader :value
 
-    def initialize
-      @value = nil
-    end
-
-    def update(value)
-      @value = value
-    end
+  def initialize
+    @value = nil
   end
 
-  class ObservableSpecs
-    include Observable
+  def update(value)
+    @value = value
   end
+end
+
+class ObservableSpecs
+  include Observable
 end


### PR DESCRIPTION
Guess it was not removed in 3.4 after all.