### PR TITLE
Upgrade minitest gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,12 @@ GEM
   specs:
     ansi (1.5.0)
     ast (2.4.2)
-    builder (3.2.4)
+    builder (3.3.0)
     concurrent-ruby (1.2.2)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
-    minitest (5.23.0)
-    minitest-reporters (1.6.1)
+    minitest (5.25.4)
+    minitest-reporters (1.7.1)
       ansi
       builder
       minitest (>= 5.0)


### PR DESCRIPTION
The old version shows a warning when used in Ruby 3.4.