### PR TITLE
Add actual File object type

### DIFF
--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -17,7 +17,10 @@ namespace Natalie {
 class FileObject : public IoObject {
 public:
     FileObject()
-        : IoObject { GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class() } { }
+        : FileObject { GlobalEnv::the()->Object()->const_fetch("File"_s)->as_class() } { }
+
+    FileObject(ClassObject *klass)
+        : IoObject { Object::Type::File, klass } { }
 
     Value initialize(Env *, Args &&, Block *);
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -23,6 +23,9 @@ public:
     IoObject(ClassObject *klass)
         : Object { Object::Type::Io, klass } { }
 
+    IoObject(Type type, ClassObject *klass)
+        : Object { type, klass } { }
+
     IoObject(int fileno)
         : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s)->as_class() }
         , m_sync { fileno == STDERR_FILENO } {

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -130,7 +130,8 @@ public:
     bool is_float() const { return m_type == Type::Float; }
     bool is_hash() const { return m_type == Type::Hash; }
     bool is_integer() const { return m_type == Type::Integer; }
-    bool is_io() const { return m_type == Type::Io; }
+    bool is_io() const { return m_type == Type::Io || m_type == Type::File; }
+    bool is_file() const { return m_type == Type::File; }
     bool is_file_stat() const { return m_type == Type::FileStat; }
     bool is_match_data() const { return m_type == Type::MatchData; }
     bool is_proc() const { return m_type == Type::Proc; }

--- a/include/natalie/object_type.hpp
+++ b/include/natalie/object_type.hpp
@@ -16,6 +16,7 @@ enum class ObjectType {
     Exception,
     False,
     Fiber,
+    File,
     FileStat,
     Float,
     Hash,

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -163,7 +163,7 @@ Env *build_top_env() {
     IO->include_once(env, Enumerable);
     IoObject::build_constants(env, IO);
 
-    ClassObject *File = IO->subclass(env, "File");
+    ClassObject *File = IO->subclass(env, "File", Object::Type::File);
     Object->const_set("File"_s, File);
     File->include_once(env, Enumerable);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -62,6 +62,10 @@ Value Object::create(Env *env, ClassObject *klass) {
         obj = new IoObject { klass };
         break;
 
+    case Object::Type::File:
+        obj = new FileObject { klass };
+        break;
+
     case Object::Type::MatchData:
         obj = new MatchDataObject { klass };
         break;
@@ -355,7 +359,7 @@ const IoObject *Object::as_io() const {
 }
 
 FileObject *Object::as_file() {
-    assert(is_io());
+    assert(is_file());
     return static_cast<FileObject *>(this);
 }
 


### PR DESCRIPTION
This keeps us from having to cast an IoObject to a FileObject, which is a subclass, which is undefined behavior.