### PR TITLE
Support GNU ld script in ffi

### DIFF
--- a/test/natalie/ffi_test.rb
+++ b/test/natalie/ffi_test.rb
@@ -204,6 +204,15 @@ describe 'FFI' do
     TestStubs.test_enum_argument(123).should == 'x'.ord
   end
 
+  it 'supports relative paths' do
+    libm = Module.new do
+      extend FFI::Library
+      ffi_lib "libm.#{SO_EXT}"
+      attach_function :pow, [:double, :double], :double
+    end
+    libm.pow(2.0, 3.0).should == 8.0
+  end
+
   describe 'Pointer' do
     describe '#initialize' do
       it 'sets address and type_size' do


### PR DESCRIPTION
Another step to get the ffi-mysql to work.

It turns out so files can contain an ld script to point you towards the actual shared object file. For example, trying to load `libm.so` on my system is done via `/usr/lib/x86_64-linux-gnu/libm.so`, which contains:
```
/* GNU ld script
*/
OUTPUT_FORMAT(elf64-x86-64)
GROUP ( /lib/x86_64-linux-gnu/libm.so.6  AS_NEEDED ( /lib/x86_64-linux-gnu/libmvec.so.1 ) )
```
The actual so file can be found in the `GROUP` section.

This implementation mirrors the behaviour of Ruby's ffi: match the error message, read the filename given in the error message, parse that file, find the GROUP and retry with that file.
The tests are useful on my system, but might not test the indirection in case your system does not use that. My system is a Debian, so this should be tested in every CI run in Gitlab on the Linux images.

As a bonus, this adds support for the `double` type in ffi, I needed a random function from libm to test and every single one of them uses doubles or floats.