### PR TITLE
Skip some more tests that don't play nice with ASan

### DIFF
--- a/test/asan_test.rb
+++ b/test/asan_test.rb
@@ -44,35 +44,38 @@ TESTS = if ENV['SOME_TESTS'] == 'true'
 
 TESTS_TO_SKIP = [
   # calls GC.start/GC.enable, but we're not ready for that
-  'test/natalie/thread_test.rb',
+  'spec/core/gc/disable_spec.rb',
+  'spec/core/gc/enable_spec.rb',
   'test/natalie/gc_test.rb',
+  'test/natalie/thread_test.rb',
 
   # getaddrinfo "leak"
   # https://bugs.kde.org/show_bug.cgi?id=448991
   # https://bugzilla.redhat.com/show_bug.cgi?id=859717
   # My understanding is that it is a single object that is internal to glibc and never freed.
+  'spec/library/socket/basicsocket/do_not_reverse_lookup_spec.rb',
+  'spec/library/socket/ipsocket/addr_spec.rb',
   'spec/library/socket/ipsocket/getaddress_spec.rb',
+  'spec/library/socket/ipsocket/peeraddr_spec.rb',
+  'spec/library/socket/ipsocket/recvfrom_spec.rb',
   'spec/library/socket/socket/getaddrinfo_spec.rb',
-  'spec/library/socket/tcpsocket/initialize_spec.rb',
   'spec/library/socket/tcpserver/new_spec.rb',
   'spec/library/socket/tcpserver/sysaccept_spec.rb',
-  'spec/library/socket/tcpsocket/setsockopt_spec.rb',
-  'spec/library/socket/ipsocket/peeraddr_spec.rb',
-  'spec/library/socket/tcpsocket/recv_nonblock_spec.rb',
-  'spec/library/socket/udpsocket/bind_spec.rb',
+  'spec/library/socket/tcpsocket/initialize_spec.rb',
   'spec/library/socket/tcpsocket/open_spec.rb',
+  'spec/library/socket/tcpsocket/recv_nonblock_spec.rb',
+  'spec/library/socket/tcpsocket/setsockopt_spec.rb',
+  'spec/library/socket/udpsocket/bind_spec.rb',
   'spec/library/socket/udpsocket/write_spec.rb',
-  'spec/library/socket/ipsocket/recvfrom_spec.rb',
-  'spec/library/socket/ipsocket/addr_spec.rb',
 
   # spec timeout, hangs on waitpid
-  'spec/core/process/fork_spec.rb',
   'spec/core/kernel/fork_spec.rb',
+  'spec/core/process/fork_spec.rb',
 
    # some issue to do with ptrace + Docker privileges
-  'spec/core/process/uid_spec.rb',
-  'spec/core/process/euid_spec.rb',
   'spec/core/process/egid_spec.rb',
+  'spec/core/process/euid_spec.rb',
+  'spec/core/process/uid_spec.rb',
 ].freeze
 
 describe 'Sanitizers tests' do


### PR DESCRIPTION
Nothing new here:

- GC tests don't work because the GC is disabled with ASan (for now)
- getaddrinfo "leaks" internally in glibc