### PR TITLE
Refresh specs for Rational#**

### DIFF
--- a/spec/shared/rational/exponent.rb
+++ b/spec/shared/rational/exponent.rb
@@ -126,6 +126,28 @@ describe :rational_exponent, shared: true do
           }.should raise_error(ArgumentError)
         end
       end
+
+      it "raises an ArgumentError when self is < -1" do
+        NATFIXME 'it raises an ArgumentError when self is < -1', exception: SpecFailedException do
+          -> {
+            (Rational(-2) ** bignum_value)
+          }.should raise_error(ArgumentError)
+          -> {
+            (Rational(fixnum_min) ** bignum_value)
+          }.should raise_error(ArgumentError)
+        end
+      end
+
+      it "raises an ArgumentError when self is < -1 and the exponent is negative" do
+        NATFIXME 'it raises an ArgumentError when self is < -1 and the exponent is negative', exception: SpecFailedException do
+          -> {
+            (Rational(-2) ** -bignum_value)
+          }.should raise_error(ArgumentError)
+          -> {
+            (Rational(fixnum_min) ** -bignum_value)
+          }.should raise_error(ArgumentError)
+        end
+      end
     end
 
     # Fails on linux due to pow() bugs in glibc: http://sources.redhat.com/bugzilla/show_bug.cgi?id=3866
@@ -150,30 +172,6 @@ describe :rational_exponent, shared: true do
           -> {
             (Rational(fixnum_min) ** -bignum_value).should eql(0.0)
           }.should complain(/warning: in a\*\*b, b may be too big/)
-        end
-      end
-
-      ruby_version_is "3.4" do
-        it "returns positive Infinity when self < -1" do
-          NATFIXME 'it raises an ArgumentError when self < -1', exception: SpecFailedException do
-            -> {
-              (Rational(-2) ** bignum_value)
-            }.should raise_error(ArgumentError)
-            -> {
-              (Rational(fixnum_min) ** bignum_value)
-            }.should raise_error(ArgumentError)
-          end
-        end
-
-        it "returns 0.0 when self is < -1 and the exponent is negative" do
-          NATFIXME 'it raises an ArgumentError when self is < -1 and the exponent is negative' do
-            -> {
-              (Rational(-2) ** -bignum_value)
-            }.should raise_error(ArgumentError)
-            -> {
-              (Rational(fixnum_min) ** -bignum_value)
-            }.should raise_error(ArgumentError)
-          end
         end
       end
     end


### PR DESCRIPTION
This moves some specs out of the non-linux block, which makes it easier to reproduce and fix the issue on Linux systems.