### PR TITLE
Remove NATFIXME blocks from Ruby 3.3 and earlier

### DIFF
--- a/spec/core/io/read_spec.rb
+++ b/spec/core/io/read_spec.rb
@@ -67,13 +67,11 @@ describe "IO.read" do
   platform_is_not :windows do
     ruby_version_is ""..."3.3" do
       it "uses an :open_args option" do
-        NATFIXME 'open-args keyword arguments', exception: ArgumentError, message: 'unknown keyword: :open_args' do
-          string = IO.read(@fname, nil, 0, open_args: ["r", nil, {encoding: Encoding::US_ASCII}])
-          string.encoding.should == Encoding::US_ASCII
+        string = IO.read(@fname, nil, 0, open_args: ["r", nil, {encoding: Encoding::US_ASCII}])
+        string.encoding.should == Encoding::US_ASCII
 
-          string = IO.read(@fname, nil, 0, open_args: ["r", nil, {}])
-          string.encoding.should == Encoding::UTF_8
-        end
+        string = IO.read(@fname, nil, 0, open_args: ["r", nil, {}])
+        string.encoding.should == Encoding::UTF_8
       end
     end
   end

--- a/spec/language/block_spec.rb
+++ b/spec/language/block_spec.rb
@@ -1095,24 +1095,20 @@ end
 describe "`it` calls without arguments in a block with no ordinary parameters" do
   ruby_version_is "3.3"..."3.4" do
     it "emits a deprecation warning" do
-      NATFIXME 'it emits a deprecation warning', exception: SpecFailedException do
-        -> {
-          eval "proc { it }"
-        }.should complain(/warning: `it` calls without arguments will refer to the first block param in Ruby 3.4; use it\(\) or self.it/)
-      end
+      -> {
+        eval "proc { it }"
+      }.should complain(/warning: `it` calls without arguments will refer to the first block param in Ruby 3.4; use it\(\) or self.it/)
     end
 
     it "does not emit a deprecation warning when a block has parameters" do
-      NATFIXME 'it does not emit a deprecation warning when a block has parameters', exception: SyntaxError do
-        -> { eval "proc { |a, b| it }" }.should_not complain
-        -> { eval "proc { |*rest| it }" }.should_not complain
-        -> { eval "proc { |*| it }" }.should_not complain
-        -> { eval "proc { |a:, b:| it }" }.should_not complain
-        -> { eval "proc { |**kw| it }" }.should_not complain
-        -> { eval "proc { |**| it }" }.should_not complain
-        -> { eval "proc { |&block| it }" }.should_not complain
-        -> { eval "proc { |&| it }" }.should_not complain
-      end
+      -> { eval "proc { |a, b| it }" }.should_not complain
+      -> { eval "proc { |*rest| it }" }.should_not complain
+      -> { eval "proc { |*| it }" }.should_not complain
+      -> { eval "proc { |a:, b:| it }" }.should_not complain
+      -> { eval "proc { |**kw| it }" }.should_not complain
+      -> { eval "proc { |**| it }" }.should_not complain
+      -> { eval "proc { |&block| it }" }.should_not complain
+      -> { eval "proc { |&| it }" }.should_not complain
     end
 
     it "does not emit a deprecation warning when `it` calls with arguments" do

--- a/spec/language/constants_spec.rb
+++ b/spec/language/constants_spec.rb
@@ -167,17 +167,15 @@ describe "Literal (A::X) constant resolution" do
       it "evaluates the right hand side before evaluating a constant path" do
         mod = Module.new
 
-        NATFIXME 'evaluates the right hand side before evaluating a constant path', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          mod.module_eval <<-EOC
-            ConstantSpecsRHS::B = begin
-              module ConstantSpecsRHS; end
+        mod.module_eval <<-EOC
+          ConstantSpecsRHS::B = begin
+            module ConstantSpecsRHS; end
 
-              "hello"
-            end
-          EOC
+            "hello"
+          end
+        EOC
 
-          mod::ConstantSpecsRHS::B.should == 'hello'
-        end
+        mod::ConstantSpecsRHS::B.should == 'hello'
       end
     end
   end


### PR DESCRIPTION
These are not supposed to be fixed, so removing them from the specs reduces the amount of clutter when searching for NATFIXME issues.

I found them by rewriting the specs runner to only run the specs for old versions, and break if it encounters a NATFIXME block. Anything else, including exceptions and failed specs, is okay.