### PR TITLE
Refresh specs for Enumerator#(each_)with_index

### DIFF
--- a/spec/core/enumerator/each_with_index_spec.rb
+++ b/spec/core/enumerator/each_with_index_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/enumerator/with_index'
+require_relative '../enumerable/shared/enumeratorized'
+
+describe "Enumerator#each_with_index" do
+  it_behaves_like :enum_with_index, :each_with_index
+  it_behaves_like :enumeratorized_with_origin_size, :each_with_index, [1,2,3].select
+
+  it "returns a new Enumerator when no block is given" do
+    enum1 = [1,2,3].select
+    enum2 = enum1.each_with_index
+    enum2.should be_an_instance_of(Enumerator)
+    enum1.should_not == enum2
+  end
+
+  it "raises an ArgumentError if passed extra arguments" do
+    NATFIXME 'it raises an ArgumentError if passed extra arguments', exception: SpecFailedException do
+      -> do
+        [1].to_enum.each_with_index(:glark)
+      end.should raise_error(ArgumentError)
+    end
+  end
+
+  it "passes on the given block's return value" do
+    NATFIXME "it passes on the given block's return value", exception: SpecFailedException do
+      arr = [1,2,3]
+      arr.delete_if.each_with_index { |a,b| false }
+      arr.should == [1,2,3]
+    end
+  end
+
+  it "returns the iterator's return value" do
+    NATFIXME "it returns the iterator's return value", exception: SpecFailedException do
+      [1,2,3].select.each_with_index { |a,b| false }.should == []
+      [1,2,3].select.each_with_index { |a,b| true }.should == [1,2,3]
+    end
+  end
+
+  it "returns the correct value if chained with itself" do
+    [:a].each_with_index.each_with_index.to_a.should == [[[:a,0],0]]
+  end
+end

--- a/spec/core/enumerator/with_index_spec.rb
+++ b/spec/core/enumerator/with_index_spec.rb
@@ -69,4 +69,27 @@ describe "Enumerator#with_index" do
     @enum.with_index(-1) { |*x| res << x}
     res.should == [[1,-1], [2,0], [3,1], [4,2]]
   end
+
+  it "passes on the given block's return value" do
+    NATFIXME "it passes on the given block's return value", exception: SpecFailedException do
+      arr = [1,2,3]
+      arr.delete_if.with_index { |a,b| false }
+      arr.should == [1,2,3]
+
+      arr.delete_if.with_index { |a,b| true }
+      arr.should == []
+    end
+  end
+
+  it "returns the iterator's return value" do
+    NATFIXME "it returns the iterator's return value", exception: SpecFailedException do
+      @enum.select.with_index { |a,b| false }.should == []
+    end
+  end
+
+  it "returns the correct value if chained with itself" do
+    NATFIXME 'it returns the correct value if chained with itself', exception: SpecFailedException do
+      [:a].each.with_index.with_index.to_a.should == [[[:a,0],0]]
+    end
+  end
 end


### PR DESCRIPTION
In an attempt to clean things up: this is the new and improved version of the current changes of #2153, with some upstream spec fixes. I am going to close the other PR for now.