### PR TITLE
Upgrade to Prism 1.3

### DIFF
--- a/lib/natalie/parser.rb
+++ b/lib/natalie/parser.rb
@@ -77,7 +77,9 @@ module Natalie
     end
 
     def encoding
-      result.source.source.encoding
+      encoding = result.magic_comments.find { |e| e.key == 'encoding' }
+      return result.encoding if encoding.nil?
+      Encoding.find(encoding.value)
     end
   end
 end

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -745,6 +745,15 @@ describe 'string' do
     end
   end
 
+  describe 'magic comments' do
+    it 'returns ASCII-8BIT for binary magic comment with UTF-8 in source' do
+      ruby_exe(<<~'RUBY').should == "ASCII-8BIT\n"
+        # -*- encoding: binary -*-
+
+        puts "😊".encoding
+      RUBY
+    end
+  end
 
   describe "Shift_JIS" do
     # NATFIXME : Possible issue in escaped_char or String#inspect


### PR DESCRIPTION
The retry of #2266, but an upgrade to 1.3 instead. The deduction of the string encoding feels kind of hacky, but I have no idea how else to fix this.