### PR TITLE
Happy new year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Tim Morgan and contributors
+Copyright (c) 2025 Tim Morgan and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ to supplement the specs in `spec/`.
 
 ## Copyright & License
 
-Natalie is copyright 2023, Tim Morgan and contributors. Natalie is licensed
+Natalie is copyright 2025, Tim Morgan and contributors. Natalie is licensed
 under the MIT License; see the `LICENSE` file in this directory for the full text.
 
 Some parts of this program are copied from other sources, and the copyright

--- a/examples/about.rb
+++ b/examples/about.rb
@@ -33,7 +33,7 @@ body = Gtk3::Label.new(<<-END)
 Compiled Ruby Implementation
 targeting Ruby 3.4 (WIP)
 
-Copyright © 2019-2022, Tim Morgan and contributors
+Copyright © 2019-2025, Tim Morgan and contributors
 
 
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -468,7 +468,7 @@ Env *build_top_env() {
     RUBY_VERSION->freeze();
     Object->const_set("RUBY_VERSION"_s, RUBY_VERSION);
 
-    Value RUBY_COPYRIGHT = new StringObject { "natalie - Copyright (c) 2023 Tim Morgan and contributors" };
+    Value RUBY_COPYRIGHT = new StringObject { "natalie - Copyright (c) 2025 Tim Morgan and contributors" };
     RUBY_COPYRIGHT->freeze();
     Object->const_set("RUBY_COPYRIGHT"_s, RUBY_COPYRIGHT);
 


### PR DESCRIPTION
Which raises a bunch of new questions. Most of these have just been "copyright 2023" with a single year, but the GTK example had a "copyright 2019-2022". So I guess everything should be "copyright 2019-2025" now.