### PR TITLE
Fixes to regexp /e flag

### DIFF
--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -69,8 +69,7 @@ public:
     static Value try_convert(Env *, Value);
     static Value regexp_union(Env *, Args &&);
 
-    static Value literal(Env *env, const char *pattern, int options = 0, bool euc_jp = false) {
-        EncodingObject *encoding = euc_jp ? EncodingObject::get(Encoding::EUC_JP) : nullptr;
+    static Value literal(Env *env, const char *pattern, int options = 0, EncodingObject *encoding = nullptr) {
         auto regex = new RegexpObject(env, pattern, options, encoding);
         regex->freeze();
         return regex;

--- a/lib/natalie/compiler/instructions/push_regexp_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_regexp_instruction.rb
@@ -22,7 +22,9 @@ module Natalie
       end
 
       def execute(vm)
-        vm.push(@regexp.dup)
+        regexp = @regexp.dup
+        regexp = Regexp.compile(regexp.source.dup.force_encoding(Encoding::EUC_JP), Regexp::FIXEDENCODING) if @euc_jp
+        vm.push(regexp)
       end
 
       def serialize(rodata)

--- a/lib/natalie/compiler/instructions/push_regexp_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_regexp_instruction.rb
@@ -17,7 +17,8 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:regexp, "Value(RegexpObject::literal(env, #{string_to_cpp(@regexp.source)}, #{@regexp.options}, #{@euc_jp ? 'true' : 'false'}))")
+        encoding = @euc_jp ? 'EncodingObject::get(Encoding::EUC_JP)' : 'nullptr';
+        transform.exec_and_push(:regexp, "Value(RegexpObject::literal(env, #{string_to_cpp(@regexp.source)}, #{@regexp.options}, #{encoding}))")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/string_to_regexp_instruction.rb
+++ b/lib/natalie/compiler/instructions/string_to_regexp_instruction.rb
@@ -27,7 +27,12 @@ module Natalie
 
       def execute(vm)
         string = vm.pop
-        vm.push(Regexp.new(string, @options))
+        options = @options
+        if @euc_jp
+          string = string.dup.force_encoding(Encoding::EUC_JP)
+          options |= Regexp::FIXEDENCODING
+        end
+        vm.push(Regexp.new(string, options))
       end
 
       def serialize(_)


### PR DESCRIPTION
* Refactor the code for regexp literals, to make it easier to extend encodings
* Support interpreter mode