### PR TITLE
Allow short names as FFI libraries

### DIFF
--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -32,6 +32,10 @@ static void *dlopen_wrapper(Env *env, Value name) {
                 auto new_name = new StringObject { str };
                 new_name->append_sprintf(".%s", so_ext->c_str());
                 return dlopen_wrapper(env, new_name);
+            } else if (str.length() <= 3 || (str[0] != '/' && str.find("lib") != 0)) {
+                auto new_name = new StringObject { str };
+                new_name->prepend(env, { new StringObject { "lib" } });
+                return dlopen_wrapper(env, new_name);
             }
             return error();
         }

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -26,7 +26,7 @@ static void *dlopen_wrapper(Env *env, const String &name) {
         auto trail = strstr(errmsg, ": invalid ELF header");
         if (!trail) {
             auto so_ext = GlobalEnv::the()->Object()->const_fetch("RbConfig"_s)->const_fetch("CONFIG"_s)->as_hash_or_raise(env)->fetch(env, new StringObject { "SOEXT" }, nullptr, nullptr)->as_string_or_raise(env);
-            if (name.length() > so_ext->length() && name[0] != '/' && (!name.ends_with(so_ext->string()) || name[name.length() - so_ext->length() - 1] != '.')) {
+            if (name.length() <= so_ext->length() || (name.find('/') != 0 && (!name.ends_with(so_ext->string()) || name[name.length() - so_ext->length() - 1] != '.'))) {
                 const auto new_name = String::format("{}.{}", name, so_ext->string());
                 return dlopen_wrapper(env, new_name);
             } else if (name.length() <= 3 || (name[0] != '/' && name.find("lib") != 0)) {

--- a/test/natalie/ffi_test.rb
+++ b/test/natalie/ffi_test.rb
@@ -222,6 +222,15 @@ describe 'FFI' do
     libm.pow(2.0, 3.0).should == 8.0
   end
 
+  it 'can omit the file extension and the "lib" part' do
+    libm = Module.new do
+      extend FFI::Library
+      ffi_lib "m"
+      attach_function :pow, [:double, :double], :double
+    end
+    libm.pow(2.0, 3.0).should == 8.0
+  end
+
   describe 'Pointer' do
     describe '#initialize' do
       it 'sets address and type_size' do

--- a/test/natalie/ffi_test.rb
+++ b/test/natalie/ffi_test.rb
@@ -213,6 +213,15 @@ describe 'FFI' do
     libm.pow(2.0, 3.0).should == 8.0
   end
 
+  it 'can omit the file extension' do
+    libm = Module.new do
+      extend FFI::Library
+      ffi_lib "libm"
+      attach_function :pow, [:double, :double], :double
+    end
+    libm.pow(2.0, 3.0).should == 8.0
+  end
+
   describe 'Pointer' do
     describe '#initialize' do
       it 'sets address and type_size' do


### PR DESCRIPTION
Turns out you don't have to write `"libm.#{SO_EXT}"`, but `"libm"` and `"m"` work just as fine.

I tried ffi-mysql again (see #2404 for context). This is enough to load the lib. Next step: `FFI::Struct`, which resembles a C struct and needs padding. 