### PR TITLE
Make fewer throwaway Envs for Blocks

### DIFF
--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -17,10 +17,10 @@ public:
         Method
     };
 
-    Block(Env *env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
+    Block(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
         : m_fn { fn }
         , m_arity { arity }
-        , m_env { new Env(*env) }
+        , m_env { new Env(env) }
         , m_self { self }
         , m_type { type } { }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -26,7 +26,6 @@ public:
 
     // NOTE: This should only be called from one of the RUN_BLOCK_* macros!
     Value _run(Env *env, Args &&args = {}, Block *block = nullptr) {
-        assert(has_env());
         Env e { m_env };
         e.set_caller(env);
         e.set_this_block(this);
@@ -37,7 +36,6 @@ public:
 
     int arity() const { return m_arity; }
 
-    bool has_env() { return !!m_env; }
     Env *env() { return m_env; }
 
     void set_type(BlockType type) { m_type = type; }

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -32,7 +32,7 @@ public:
     }
 
     virtual ProcObject *to_proc(Env *env) override {
-        auto block = new Block { env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method };
+        auto block = new Block { *env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method };
         return new ProcObject { block };
     }
 

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -329,12 +329,12 @@ Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     if (status != FFI_OK)
         env->raise("LoadError", "There was an error preparing the FFI call data structure: {}", (int)status);
 
-    auto block_env = new Env {};
-    block_env->var_set("cif", 0, true, new VoidPObject { cif, [](auto p) { delete (ffi_cif *)p->void_ptr(); } });
-    block_env->var_set("arg_types", 1, true, arg_types_array);
-    block_env->var_set("return_type", 2, true, return_type);
-    block_env->var_set("ffi_args", 3, true, ffi_args_obj);
-    block_env->var_set("fn", 4, true, new VoidPObject { fn });
+    Env block_env;
+    block_env.var_set("cif", 0, true, new VoidPObject { cif, [](auto p) { delete (ffi_cif *)p->void_ptr(); } });
+    block_env.var_set("arg_types", 1, true, arg_types_array);
+    block_env.var_set("return_type", 2, true, return_type);
+    block_env.var_set("ffi_args", 3, true, ffi_args_obj);
+    block_env.var_set("fn", 4, true, new VoidPObject { fn });
     Block *block = new Block { block_env, self, FFI_Library_fn_call_block, 0 };
     self->define_singleton_method(env, name, block);
 

--- a/lib/natalie/compiler/instructions/define_block_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_block_instruction.rb
@@ -27,7 +27,7 @@ module Natalie
           body << '}'
           transform.top(body)
         end
-        transform.push("(new Block(env, self, #{fn}, #{@arity}))")
+        transform.push("(new Block(*env, self, #{fn}, #{@arity}))")
       end
 
       def execute(vm)

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -445,7 +445,7 @@ bool ArrayObject::eql(Env *env, Value other) {
 
 Value ArrayObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 
@@ -458,7 +458,7 @@ Value ArrayObject::each(Env *env, Block *block) {
 
 Value ArrayObject::each_index(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_index"_s }, size_block);
     }
 
@@ -472,7 +472,7 @@ Value ArrayObject::each_index(Env *env, Block *block) {
 
 Value ArrayObject::map(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "map"_s }, size_block);
     }
 
@@ -483,7 +483,7 @@ Value ArrayObject::map(Env *env, Block *block) {
 
 Value ArrayObject::map_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "map!"_s }, size_block);
     }
 
@@ -691,7 +691,7 @@ Value ArrayObject::delete_at(Env *env, Value n) {
 
 Value ArrayObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -893,7 +893,7 @@ Value ArrayObject::sort(Env *env, Block *block) {
 
 Value ArrayObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 
@@ -1108,7 +1108,7 @@ bool array_sort_by_compare(Env *env, Value a, Value b, Block *block) {
 
 Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "sort_by!"_s }, size_block);
     }
 
@@ -1123,7 +1123,7 @@ Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
 
 Value ArrayObject::select(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "select"_s }, size_block);
     }
 
@@ -1134,7 +1134,7 @@ Value ArrayObject::select(Env *env, Block *block) {
 
 Value ArrayObject::select_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "select!"_s }, size_block);
     }
 
@@ -1170,7 +1170,7 @@ bool ArrayObject::select_in_place(std::function<bool(Value &)> predicate) {
 
 Value ArrayObject::reject(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "reject"_s }, size_block);
     }
 
@@ -1181,7 +1181,7 @@ Value ArrayObject::reject(Env *env, Block *block) {
 
 Value ArrayObject::reject_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "reject!"_s }, size_block);
     }
 
@@ -1689,7 +1689,7 @@ Value ArrayObject::reverse(Env *env) {
 
 Value ArrayObject::reverse_each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "reverse_each"_s }, size_block);
     }
 

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -169,7 +169,7 @@ Value DirObject::entries(Env *env) {
 
 Value DirObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, DirObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, DirObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
     if (!m_dir) env->raise("IOError", "closed directory");
@@ -183,7 +183,7 @@ Value DirObject::each(Env *env, Block *block) {
 
 Value DirObject::each_child(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, DirObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, DirObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_child"_s }, size_block);
     }
     if (!m_dir) env->raise("IOError", "closed directory");

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -12,7 +12,7 @@ ArithmeticSequenceObject::ArithmeticSequenceObject(Env *env, Origin origin, cons
     , m_exclude_end { exclude_end } {
     auto Enumerator = GlobalEnv::the()->Object()->const_fetch("Enumerator"_s)->as_module();
     auto method_info = Enumerator->find_method(env, "initialize"_s);
-    method_info.method()->call(env, this, {}, new Block { env, this, enum_block, 1 });
+    method_info.method()->call(env, this, {}, new Block { *env, this, enum_block, 1 });
 }
 
 ArithmeticSequenceObject::ArithmeticSequenceObject(Env *env, Origin origin, Value begin, Value end, Value step, bool exclude_end)

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -71,7 +71,7 @@ size_t EnvObject::size() const {
 
 Value EnvObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -110,7 +110,7 @@ Value EnvObject::each(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { env, envhash->as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, envhash->as_hash(), HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 }
@@ -125,7 +125,7 @@ Value EnvObject::each_key(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { env, envhash->as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, envhash->as_hash(), HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_key"_s }, size_block);
     }
 }
@@ -140,7 +140,7 @@ Value EnvObject::each_value(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { env, envhash->as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, envhash->as_hash(), HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_value"_s }, size_block);
     }
 }
@@ -216,7 +216,7 @@ Value EnvObject::refeq(Env *env, Value name, Value value) {
 
 Value EnvObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 
@@ -286,7 +286,7 @@ Value EnvObject::clone(Env *env) {
 
 Value EnvObject::reject(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "reject"_s }, size_block);
     }
 
@@ -295,7 +295,7 @@ Value EnvObject::reject(Env *env, Block *block) {
 
 Value EnvObject::reject_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "reject!"_s }, size_block);
     }
 
@@ -330,7 +330,7 @@ Value EnvObject::replace(Env *env, Value hash) {
 
 Value EnvObject::select(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "select"_s }, size_block);
     }
 
@@ -339,7 +339,7 @@ Value EnvObject::select(Env *env, Block *block) {
 
 Value EnvObject::select_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, env_size, 0 };
+        Block *size_block = new Block { *env, this, env_size, 0 };
         return send(env, "enum_for"_s, { "select!"_s }, size_block);
     }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -376,7 +376,7 @@ Value HashObject::replace(Env *env, Value other) {
 
 Value HashObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -500,7 +500,7 @@ bool HashObject::lt(Env *env, Value other) {
 
 Value HashObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 
@@ -565,7 +565,7 @@ Value HashObject::keys(Env *env) {
 
 Value HashObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, HashObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -748,7 +748,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
         auto infinity_fn = [](Env *env, Value, Args &&, Block *) -> Value {
             return FloatObject::positive_infinity(env);
         };
-        auto size_block = new Block { env, self, infinity_fn, 0 };
+        auto size_block = new Block { *env, self, infinity_fn, 0 };
         return self->send(env, "enum_for"_s, { "loop"_s }, size_block);
     }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -808,8 +808,8 @@ ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
 
 SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
     auto name = obj->to_symbol(env, Conversion::Strict);
-    auto block_env = new Env {};
-    block_env->var_set("name", 0, true, name);
+    Env block_env;
+    block_env.var_set("name", 0, true, name);
     Block *attr_block = new Block { block_env, this, ModuleObject::attr_reader_block_fn, 0 };
     define_method(env, name->as_symbol(), attr_block);
     return name;
@@ -835,8 +835,8 @@ ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
 SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
     auto name = obj->to_symbol(env, Conversion::Strict);
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
-    auto block_env = new Env {};
-    block_env->var_set("name", 0, true, name);
+    Env block_env;
+    block_env.var_set("name", 0, true, name);
     Block *attr_block = new Block { block_env, this, ModuleObject::attr_writer_block_fn, 1 };
     define_method(env, method_name, attr_block);
     return method_name;
@@ -1123,8 +1123,8 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
         return old_method->bind_call(env, self, std::move(new_args), block);
     };
 
-    auto inner_env = new Env { *env };
-    inner_env->var_set("old_method", 1, true, instance_method(env, name));
+    Env inner_env { *env };
+    inner_env.var_set("old_method", 1, true, instance_method(env, name));
     undef_method(env, { name });
     define_method(env, name->as_symbol(), new Block { inner_env, this, method_wrapper, -1 });
 

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -44,7 +44,7 @@ Value ProcObject::ltlt(Env *env, Value other) {
         env->raise("TypeError", "callable object is expected");
 
     env->var_set("other", 0, true, other);
-    auto block = new Block { env, this, compose_ltlt, -1 };
+    auto block = new Block { *env, this, compose_ltlt, -1 };
     if (other->is_proc() && other->as_proc()->is_lambda())
         block->set_type(Block::BlockType::Lambda);
     return new ProcObject { block };
@@ -55,7 +55,7 @@ Value ProcObject::gtgt(Env *env, Value other) {
         env->raise("TypeError", "callable object is expected");
 
     env->var_set("other", 0, true, other);
-    auto block = new Block { env, this, compose_gtgt, -1 };
+    auto block = new Block { *env, this, compose_gtgt, -1 };
     if (is_lambda())
         block->set_type(Block::BlockType::Lambda);
     return new ProcObject { block };
@@ -71,8 +71,8 @@ Value ProcObject::ruby2_keywords(Env *env) {
         return old_block->call(env, std::move(new_args), block);
     };
 
-    auto inner_env = new Env { *env };
-    inner_env->var_set("old_block", 1, true, new ProcObject { m_block });
+    Env inner_env { *env };
+    inner_env.var_set("old_block", 1, true, new ProcObject { m_block });
     m_block = new Block { inner_env, this, block_wrapper, -1 };
 
     return this;

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -126,7 +126,7 @@ Value RangeObject::to_a(Env *env) {
 
 Value RangeObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, RangeObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, RangeObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -143,7 +143,7 @@ StringView StringObject::next_char(Env *env, size_t *index) const {
 
 Value StringObject::each_char(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, StringObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_char"_s }, size_block);
     }
 
@@ -170,7 +170,7 @@ Value StringObject::chars(Env *env, Block *block) {
 
 Value StringObject::each_codepoint(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, StringObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_codepoint"_s }, size_block);
     }
 
@@ -220,7 +220,7 @@ Value StringObject::codepoints(Env *env, Block *block) {
 
 Value StringObject::each_grapheme_cluster(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, StringObject::size_fn, 0 };
+        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
         return send(env, "enum_for"_s, { "each_grapheme_cluster"_s }, size_block);
     }
 
@@ -1229,7 +1229,7 @@ Value StringObject::bytes(Env *env, Block *block) {
 
 Value StringObject::each_byte(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { env, this, StringObject::bytesize_fn, 0 };
+        Block *size_block = new Block { *env, this, StringObject::bytesize_fn, 0 };
         return send(env, "enum_for"_s, { "each_byte"_s }, size_block);
     }
 

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -122,8 +122,8 @@ Value SymbolObject::is_casecmp(Env *env, Value other) {
 }
 
 ProcObject *SymbolObject::to_proc(Env *env) {
-    auto block_env = new Env {};
-    block_env->var_set("name", 0, true, this);
+    Env block_env;
+    block_env.var_set("name", 0, true, this);
     Block *proc_block = new Block { block_env, this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda };
     return new ProcObject { proc_block };
 }


### PR DESCRIPTION
There were a few places we were doing this:

```cpp
auto block_env = new Env {};
// ...
new Block { block_env, ... }
```

Since Block makes a copy of the passed Env anyway -- it has to because the parent scope can go away -- let's take a reference here to encourage call sites not to allocate a new Env on the heap, since it would be thrown away and collected by the GC on the next collection.