### PR TITLE
Update expectations in bytecode tests

### DIFF
--- a/test/bytecode/call_with_to_proc_test.rb
+++ b/test/bytecode/call_with_to_proc_test.rb
@@ -13,6 +13,6 @@ describe 'call a method with a to_proc argument' do
     code = 'p [1, 2].map(&:to_s)'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "[\"1\", \"2\"]\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/define_method_test.rb
+++ b/test/bytecode/define_method_test.rb
@@ -18,7 +18,7 @@ describe 'define a method' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with required positional arguments' do
@@ -28,7 +28,7 @@ describe 'define a method' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with optional arguments' do
@@ -39,7 +39,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with required keyword arguments' do
@@ -50,7 +50,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with optional keyword arguments' do
@@ -61,7 +61,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with splat positional arguments' do
@@ -72,7 +72,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with splat keyword arguments' do
@@ -83,7 +83,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with splat positional and keyword arguments' do
@@ -94,7 +94,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can handle a block argument' do
@@ -106,7 +106,7 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "false\ntrue\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can define a method with forwarding for everything (...)' do
@@ -118,6 +118,6 @@ describe 'define a method' do
 
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "barbaz\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/global_variables_test.rb
+++ b/test/bytecode/global_variables_test.rb
@@ -13,7 +13,7 @@ describe 'it can read and write global variables' do
     code = 'p $FOO'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "nil\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can read and write global variables' do
@@ -23,6 +23,6 @@ describe 'it can read and write global variables' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "123\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/if_test.rb
+++ b/test/bytecode/if_test.rb
@@ -18,7 +18,7 @@ describe 'it can run some code with if instructions' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "Foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run some code with an if and an else' do
@@ -31,7 +31,7 @@ describe 'it can run some code with if instructions' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "Foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run some code with an elsif' do
@@ -46,13 +46,13 @@ describe 'it can run some code with if instructions' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "Bar\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can use a ternary operator' do
     code = 'puts :foo ? "Foo" : "Bar"'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "Foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/monkeypatch_test.rb
+++ b/test/bytecode/monkeypatch_test.rb
@@ -28,6 +28,6 @@ describe 'support monkey patching' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "16\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/multiple_assignment_test.rb
+++ b/test/bytecode/multiple_assignment_test.rb
@@ -18,6 +18,6 @@ describe 'support multiple assignment' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "[1, [2, 3], 4]\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/point_test.rb
+++ b/test/bytecode/point_test.rb
@@ -36,6 +36,6 @@ describe 'define a class and use it' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "(14, 2)\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_array_test.rb
+++ b/test/bytecode/puts_array_test.rb
@@ -13,13 +13,13 @@ describe 'puts an array' do
     code = 'puts ["foo", "bar"]'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\nbar\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with a string representation of an array with static strings' do
     code = 'puts ["foo", "bar"].to_s'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "[\"foo\", \"bar\"]\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_bool_test.rb
+++ b/test/bytecode/puts_bool_test.rb
@@ -13,6 +13,6 @@ describe 'puts a boolean' do
     code = 'puts true; puts false'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "true\nfalse\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_complex_test.rb
+++ b/test/bytecode/puts_complex_test.rb
@@ -13,20 +13,20 @@ describe 'puts a complex number' do
     code = 'puts 2i'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "0+2i\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with a complex float' do
     code = 'puts 2.5i'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "0+2.5i\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can construct a complex integer with a real part' do
     code = 'puts 2i + 1'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "1+2i\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_const_test.rb
+++ b/test/bytecode/puts_const_test.rb
@@ -13,13 +13,13 @@ describe 'puts a const' do
     code = 'puts Float'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "Float\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with a const with path' do
     code = 'puts Float::NAN'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "NaN\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_float_test.rb
+++ b/test/bytecode/puts_float_test.rb
@@ -13,6 +13,6 @@ describe 'puts a float' do
     code = 'puts 1.5'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "1.5\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_hash_test.rb
+++ b/test/bytecode/puts_hash_test.rb
@@ -13,6 +13,6 @@ describe 'puts a hash' do
     code = 'puts({foo: "foo", bar: "baz"})'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should =~ /\A(?:{foo: "foo", bar: "baz"}|{:foo=>"foo", :bar=>"baz"})\n\z/
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_integer_test.rb
+++ b/test/bytecode/puts_integer_test.rb
@@ -13,21 +13,21 @@ describe 'puts an integer' do
     code = 'puts 0'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "0\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with 1' do
     code = 'puts 1'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "1\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with -1' do
     code = 'puts -1'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "-1\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with the extreme positive value for regular int encoding' do
@@ -35,7 +35,7 @@ describe 'puts an integer' do
     code = "puts #{num}"
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with the extreme negative value for regular int encoding' do
@@ -43,7 +43,7 @@ describe 'puts an integer' do
     code = "puts #{num}"
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with a bignum' do
@@ -51,7 +51,7 @@ describe 'puts an integer' do
     code = "puts #{num}"
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{num}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can run a puts with a negative bignum' do
@@ -59,6 +59,6 @@ describe 'puts an integer' do
     code = "puts -#{num}"
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "-#{num}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_nil_test.rb
+++ b/test/bytecode/puts_nil_test.rb
@@ -13,6 +13,6 @@ describe 'puts a nil' do
     code = 'puts nil.inspect'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "nil\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_rational_test.rb
+++ b/test/bytecode/puts_rational_test.rb
@@ -13,6 +13,6 @@ describe 'puts a rational number' do
     code = 'puts 2.5r'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "5/2\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_regexp_test.rb
+++ b/test/bytecode/puts_regexp_test.rb
@@ -15,7 +15,7 @@ describe 'puts a regexp match result' do
     code = 'puts /(foo)/.match("foobar")'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'preserves the regexp options' do
@@ -25,7 +25,7 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{Regexp::IGNORECASE}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can use an interpolated regexp' do
@@ -34,7 +34,7 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'preserves the regexp options of an interpolated regexp' do
@@ -44,7 +44,7 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "#{Regexp::IGNORECASE}\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'updates the $~ variable' do
@@ -54,7 +54,7 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can use $1 to access the first match' do
@@ -64,7 +64,7 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'can store matches in local variables' do
@@ -74,6 +74,6 @@ describe 'puts a regexp match result' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "bar\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/puts_string_test.rb
+++ b/test/bytecode/puts_string_test.rb
@@ -15,7 +15,7 @@ describe 'puts a string' do
     code = 'puts "foo"'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'saves the original encoding' do
@@ -26,7 +26,7 @@ describe 'puts a string' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "UTF-8\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'saves the original encoding (2)' do
@@ -37,13 +37,13 @@ describe 'puts a string' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "ASCII-8BIT\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 
   it 'supports string interpolation' do
     code = 'puts "foo #{120 + 3}"'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo 123\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/variable_declare_test.rb
+++ b/test/bytecode/variable_declare_test.rb
@@ -13,6 +13,6 @@ describe 'it can run some code with a variable_declare instruction' do
     code = 'a = 1; puts a'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "1\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/variable_get_test.rb
+++ b/test/bytecode/variable_get_test.rb
@@ -13,6 +13,6 @@ describe 'it can run some code with a variable_get instruction' do
     code = 'puts ["a", "0"].map { |x| x.ord }'
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "97\n48\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/while_test.rb
+++ b/test/bytecode/while_test.rb
@@ -21,6 +21,6 @@ describe 'run a while loop' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "1\n2\n3\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end

--- a/test/bytecode/with_singleton_test.rb
+++ b/test/bytecode/with_singleton_test.rb
@@ -20,6 +20,6 @@ describe 'it can define a class with a singleton part' do
     RUBY
     ruby_exe(code, options: "--compile-bytecode #{@bytecode_file}")
 
-    ruby_exe(@bytecode_file, options: "--bytecode").should == "foo\n"
+    ruby_exe(@bytecode_file, options: "--bytecode").should == ruby_exe(code)
   end
 end


### PR DESCRIPTION
Compare them with the output of Natalie running the same code, this should be equal. This resolves some issues with versions.

The boardslam test is an exception, since we would use a require statement in Ruby, and our bytecode version ignores the `$0` check.