### PR TITLE
Do not capture `self` when using ruby2_keywords on a block

### DIFF
--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -68,6 +68,7 @@ Value ProcObject::ruby2_keywords(Env *env) {
         if (!kwargs->is_empty())
             new_args->push(HashObject::ruby2_keywords_hash(env, kwargs));
         auto old_block = env->outer()->var_get("old_block", 1)->as_proc();
+        old_block->block()->set_self(self);
         return old_block->call(env, std::move(new_args), block);
     };
 

--- a/test/natalie/ruby2_keywords_test.rb
+++ b/test/natalie/ruby2_keywords_test.rb
@@ -1,0 +1,15 @@
+require_relative '../spec_helper'
+
+describe '#ruby2_keywords' do
+  it 'does not capture self when used as a method' do
+    x = 9
+    klass = Class.new do
+      define_method(:plain, ->(*) { [self, x] })
+      define_method(:wrapped, ->(*) { [self, x] }.ruby2_keywords)
+    end
+    obj = klass.new
+    obj.wrapped.first.should == obj
+    obj.wrapped.last.should == 9
+    obj.plain.should == obj.wrapped
+  end
+end


### PR DESCRIPTION
Fixes #2209