### PR TITLE
Refresh specs for Struct#inspect (or: does a yak shave in the woods?)

### DIFF
--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -21,6 +21,7 @@ module Natalie
       EVALISH_STRING_TO_BLOCK = %i[
         class_eval
         instance_eval
+        module_eval
       ].freeze
 
       MACROS = %i[

--- a/spec/core/module/module_function_spec.rb
+++ b/spec/core/module/module_function_spec.rb
@@ -226,9 +226,7 @@ describe "Module#module_function as a toggle (no arguments) in a Module body" do
     m = Module.new {
       module_function
       module_eval { def test1() end }
-      NATFIXME 'String eval', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-        module_eval " def test2() end "
-      end
+      module_eval " def test2() end "
     }
 
     NATFIXME 'Make Module#module_eval spec-compliant', exception: SpecFailedException do

--- a/spec/core/struct/fixtures/classes.rb
+++ b/spec/core/struct/fixtures/classes.rb
@@ -13,6 +13,12 @@ module StructClasses
     end
   end
 
+  class StructWithOverriddenName < Struct.new(:a)
+    def self.name
+      "A"
+    end
+  end
+
   class SubclassX < Struct
   end
 

--- a/spec/core/struct/inspect_spec.rb
+++ b/spec/core/struct/inspect_spec.rb
@@ -3,12 +3,5 @@ require_relative 'fixtures/classes'
 require_relative 'shared/inspect'
 
 describe "Struct#inspect" do
-  it "returns a string representation showing members and values" do
-    car = StructClasses::Car.new('Ford', 'Ranger')
-    NATFIXME 'Include the name of the created class', exception: SpecFailedException do
-      car.inspect.should == '#<struct StructClasses::Car make="Ford", model="Ranger", year=nil>'
-    end
-  end
-
   it_behaves_like :struct_inspect, :inspect
 end

--- a/spec/core/struct/shared/inspect.rb
+++ b/spec/core/struct/shared/inspect.rb
@@ -1,5 +1,48 @@
 describe :struct_inspect, shared: true do
+  it "returns a string representation showing members and values" do
+    car = StructClasses::Car.new('Ford', 'Ranger')
+    NATFIXME 'Include the name of the created class', exception: SpecFailedException do
+      car.send(@method).should == '#<struct StructClasses::Car make="Ford", model="Ranger", year=nil>'
+    end
+  end
+
   it "returns a string representation without the class name for anonymous structs" do
     Struct.new(:a).new("").send(@method).should == '#<struct a="">'
+  end
+
+  it "returns a string representation without the class name for structs nested in anonymous classes" do
+    c = Class.new
+    NATFIXME 'Support class_eval with string', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      c.class_eval <<~DOC
+        class Foo < Struct.new(:a); end
+      DOC
+
+      c::Foo.new("").send(@method).should == '#<struct a="">'
+    end
+  end
+
+  it "returns a string representation without the class name for structs nested in anonymous modules" do
+    m = Module.new
+    NATFIXME 'Support module_eval with string', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+      m.module_eval <<~DOC
+        class Foo < Struct.new(:a); end
+      DOC
+
+      m::Foo.new("").send(@method).should == '#<struct a="">'
+    end
+  end
+
+  it "does not call #name method" do
+    struct = StructClasses::StructWithOverriddenName.new("")
+    NATFIXME 'it does not call #name method', exception: SpecFailedException do
+      struct.send(@method).should == '#<struct StructClasses::StructWithOverriddenName a="">'
+    end
+  end
+
+  it "does not call #name method when struct is anonymous" do
+    struct = Struct.new(:a)
+    def struct.name; "A"; end
+
+    struct.new("").send(@method).should == '#<struct a="">'
   end
 end

--- a/spec/core/struct/shared/inspect.rb
+++ b/spec/core/struct/shared/inspect.rb
@@ -21,13 +21,11 @@ describe :struct_inspect, shared: true do
 
   it "returns a string representation without the class name for structs nested in anonymous modules" do
     m = Module.new
-    NATFIXME 'Support module_eval with string', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-      m.module_eval <<~DOC
-        class Foo < Struct.new(:a); end
-      DOC
+    m.module_eval <<~DOC
+      class Foo < Struct.new(:a); end
+    DOC
 
-      m::Foo.new("").send(@method).should == '#<struct a="">'
-    end
+    m::Foo.new("").send(@method).should == '#<struct a="">'
   end
 
   it "does not call #name method" do

--- a/spec/core/struct/shared/inspect.rb
+++ b/spec/core/struct/shared/inspect.rb
@@ -12,13 +12,11 @@ describe :struct_inspect, shared: true do
 
   it "returns a string representation without the class name for structs nested in anonymous classes" do
     c = Class.new
-    NATFIXME 'Support class_eval with string', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-      c.class_eval <<~DOC
-        class Foo < Struct.new(:a); end
-      DOC
+    c.class_eval <<~DOC
+      class Foo < Struct.new(:a); end
+    DOC
 
-      c::Foo.new("").send(@method).should == '#<struct a="">'
-    end
+    c::Foo.new("").send(@method).should == '#<struct a="">'
   end
 
   it "returns a string representation without the class name for structs nested in anonymous modules" do

--- a/spec/language/alias_spec.rb
+++ b/spec/language/alias_spec.rb
@@ -53,7 +53,7 @@ describe "The alias keyword" do
   end
 
   it "works with an interpolated symbol with non-literal embedded expression on the left-hand side" do
-    NATFIXME 'implement class_eval with string (maybe)', exception: TypeError, message: 'eval() only works on static strings' do
+    NATFIXME 'eval with dynamic strings', exception: TypeError, message: 'eval() only works on static strings' do
       @meta.class_eval do
         eval %Q{
           alias :"#{'a' + ''.to_s}" value
@@ -92,7 +92,7 @@ describe "The alias keyword" do
   end
 
   it "works with an interpolated symbol with non-literal embedded expression on the right-hand side" do
-    NATFIXME 'implement class_eval with string (maybe)', exception: TypeError, message: 'eval() only works on static strings' do
+    NATFIXME 'eval with dynamic strings', exception: TypeError, message: 'eval() only works on static strings' do
       @meta.class_eval do
         eval %Q{
           alias a :"#{'value' + ''.to_s}"
@@ -227,19 +227,17 @@ describe "The alias keyword" do
 
   it "operates on methods with splat arguments defined in a superclass using text block for class eval" do
     subclass = Class.new(AliasObject)
-    NATFIXME 'implement class_eval with string (maybe)', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-      AliasObject.class_eval <<-code
-        def test(*args)
-          4
-        end
-        def test_with_check(*args)
-          test_without_check(*args)
-        end
-        alias test_without_check test
-        alias test test_with_check
-      code
-      subclass.new.test("testing").should == 4
-    end
+    AliasObject.class_eval <<-code
+      def test(*args)
+        4
+      end
+      def test_with_check(*args)
+        test_without_check(*args)
+      end
+      alias test_without_check test
+      alias test test_with_check
+    code
+    subclass.new.test("testing").should == 4
   end
 
   it "is not allowed against Integer or String instances" do

--- a/spec/language/constants_spec.rb
+++ b/spec/language/constants_spec.rb
@@ -151,7 +151,7 @@ describe "Literal (A::X) constant resolution" do
       it "evaluates left-to-right" do
         mod = Module.new
 
-        NATFIXME 'Implement argument for Module#module_eval', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
+        NATFIXME 'it evaluates left-to-right', exception: SpecFailedException do
           mod.module_eval <<-EOC
             order = []
             ConstantSpecsRHS = Module.new

--- a/spec/language/hash_spec.rb
+++ b/spec/language/hash_spec.rb
@@ -289,19 +289,17 @@ describe "The ** operator" do
 
       it "works with methods and local vars" do
         a = Class.new
-        NATFIXME 'class_eval with string', exception: ArgumentError, message: 'wrong number of arguments (given 1, expected 0)' do
-          a.class_eval(<<-RUBY)
-            def bar
-              "baz"
-            end
+        a.class_eval(<<-RUBY)
+          def bar
+            "baz"
+          end
 
-            def foo(val)
-              {bar:, val:}
-            end
-          RUBY
+          def foo(val)
+            {bar:, val:}
+          end
+        RUBY
 
-          a.new.foo(1).should == {bar: "baz", val: 1}
-        end
+        a.new.foo(1).should == {bar: "baz", val: 1}
       end
 
       it "raises a SyntaxError when the hash key ends with `!`" do


### PR DESCRIPTION
A few new specs have been added upstream, including calls to `class_eval` and `module_eval` with static strings. Support has been added for those, similar to `instance_eval`.