### PR TITLE
Add Block constructor with OwnedPtr<Env>

### DIFF
--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -4,6 +4,7 @@
 #include "natalie/env.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/gc.hpp"
+#include "tm/owned_ptr.hpp"
 
 namespace Natalie {
 
@@ -21,6 +22,13 @@ public:
         : m_fn { fn }
         , m_arity { arity }
         , m_env { new Env(env) }
+        , m_self { self }
+        , m_type { type } { }
+
+    Block(OwnedPtr<Env> &&env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
+        : m_fn { fn }
+        , m_arity { arity }
+        , m_env { env.release() }
         , m_self { self }
         , m_type { type } { }
 

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -5,6 +5,7 @@
 
 #include "natalie.hpp"
 #include "natalie/object_type.hpp"
+#include "tm/owned_ptr.hpp"
 
 using namespace Natalie;
 
@@ -329,13 +330,13 @@ Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     if (status != FFI_OK)
         env->raise("LoadError", "There was an error preparing the FFI call data structure: {}", (int)status);
 
-    Env block_env;
-    block_env.var_set("cif", 0, true, new VoidPObject { cif, [](auto p) { delete (ffi_cif *)p->void_ptr(); } });
-    block_env.var_set("arg_types", 1, true, arg_types_array);
-    block_env.var_set("return_type", 2, true, return_type);
-    block_env.var_set("ffi_args", 3, true, ffi_args_obj);
-    block_env.var_set("fn", 4, true, new VoidPObject { fn });
-    Block *block = new Block { block_env, self, FFI_Library_fn_call_block, 0 };
+    OwnedPtr<Env> block_env { new Env {} };
+    block_env->var_set("cif", 0, true, new VoidPObject { cif, [](auto p) { delete (ffi_cif *)p->void_ptr(); } });
+    block_env->var_set("arg_types", 1, true, arg_types_array);
+    block_env->var_set("return_type", 2, true, return_type);
+    block_env->var_set("ffi_args", 3, true, ffi_args_obj);
+    block_env->var_set("fn", 4, true, new VoidPObject { fn });
+    Block *block = new Block { std::move(block_env), self, FFI_Library_fn_call_block, 0 };
     self->define_singleton_method(env, name, block);
 
     return NilObject::the();

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -1,4 +1,5 @@
 #include "natalie.hpp"
+#include "tm/owned_ptr.hpp"
 
 namespace Natalie {
 
@@ -807,9 +808,9 @@ ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
 
 SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
     auto name = obj->to_symbol(env, Conversion::Strict);
-    Env block_env;
-    block_env.var_set("name", 0, true, name);
-    Block *attr_block = new Block { block_env, this, ModuleObject::attr_reader_block_fn, 0 };
+    OwnedPtr<Env> block_env { new Env {} };
+    block_env->var_set("name", 0, true, name);
+    Block *attr_block = new Block { std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0 };
     define_method(env, name->as_symbol(), attr_block);
     return name;
 }
@@ -834,9 +835,9 @@ ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
 SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
     auto name = obj->to_symbol(env, Conversion::Strict);
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
-    Env block_env;
-    block_env.var_set("name", 0, true, name);
-    Block *attr_block = new Block { block_env, this, ModuleObject::attr_writer_block_fn, 1 };
+    OwnedPtr<Env> block_env { new Env {} };
+    block_env->var_set("name", 0, true, name);
+    Block *attr_block = new Block { std::move(block_env), this, ModuleObject::attr_writer_block_fn, 1 };
     define_method(env, method_name, attr_block);
     return method_name;
 }
@@ -1122,10 +1123,10 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
         return old_method->bind_call(env, self, std::move(new_args), block);
     };
 
-    Env inner_env { *env };
-    inner_env.var_set("old_method", 1, true, instance_method(env, name));
+    OwnedPtr<Env> inner_env { new Env { *env } };
+    inner_env->var_set("old_method", 1, true, instance_method(env, name));
     undef_method(env, { name });
-    define_method(env, name->as_symbol(), new Block { inner_env, this, method_wrapper, -1 });
+    define_method(env, name->as_symbol(), new Block { std::move(inner_env), this, method_wrapper, -1 });
 
     return NilObject::the();
 }

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -1,4 +1,5 @@
 #include "natalie.hpp"
+#include "tm/owned_ptr.hpp"
 
 namespace Natalie {
 
@@ -71,9 +72,9 @@ Value ProcObject::ruby2_keywords(Env *env) {
         return old_block->call(env, std::move(new_args), block);
     };
 
-    Env inner_env { *env };
-    inner_env.var_set("old_block", 1, true, new ProcObject { m_block });
-    m_block = new Block { inner_env, this, block_wrapper, -1 };
+    OwnedPtr<Env> inner_env { new Env { *env } };
+    inner_env->var_set("old_block", 1, true, new ProcObject { m_block });
+    m_block = new Block { std::move(inner_env), this, block_wrapper, -1 };
 
     return this;
 }

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -1,4 +1,5 @@
 #include "natalie.hpp"
+#include "tm/owned_ptr.hpp"
 
 namespace Natalie {
 
@@ -122,9 +123,9 @@ Value SymbolObject::is_casecmp(Env *env, Value other) {
 }
 
 ProcObject *SymbolObject::to_proc(Env *env) {
-    Env block_env;
-    block_env.var_set("name", 0, true, this);
-    Block *proc_block = new Block { block_env, this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda };
+    OwnedPtr<Env> block_env { new Env {} };
+    block_env->var_set("name", 0, true, this);
+    Block *proc_block = new Block { std::move(block_env), this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda };
     return new ProcObject { proc_block };
 }
 


### PR DESCRIPTION
My take on #2476 

It's not exactly the way I expected it to be in that case. I was planning to use make `Block::m_env` a unique pointer, but since our OwnedPtr implementation does not allow access to the underlying raw pointer, this would require `Block::env()` to return a reference instead of a pointer, and there you'd get turtles all the way down.
Instead, the unique pointer is used in the constructor, where we immediately release it (that returns the raw pointer of the actual object) and save that, so it's only used as a temporary wrapper to signal ownership transfer.

My test script was as follows:
```ruby
# frozen_string_literal: true

GC.disable
to_proc = :to_s.to_proc
puts to_proc.call(1)
```
The GC has been disabled to make the results stable.
On release build, this saw the results of callgrind go down from 20,297,022 to 20,295,904, so it's not much, but it's something.

I did experiment with a `Env(Env &&other)` constructor, but that resulted in more code and less speed gain.