### PR TITLE
Remove include statements for shared_ptr

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -9,7 +9,6 @@
 #include "natalie/local_jump_error_type.hpp"
 #include "natalie/managed_vector.hpp"
 #include "natalie/value.hpp"
-#include "tm/shared_ptr.hpp"
 
 namespace Natalie {
 


### PR DESCRIPTION
These are not used anywhere in the Natalie source.