### PR TITLE
Utilize TM::Vector::concat

### DIFF
--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -85,9 +85,7 @@ public:
     }
 
     void concat(ArrayObject &other) {
-        for (Value v : other) {
-            push(v);
-        }
+        m_vector.concat(other.m_vector);
     }
 
     void truncate(size_t new_size) {

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1713,15 +1713,17 @@ Value ArrayObject::reverse_in_place(Env *env) {
 Value ArrayObject::concat(Env *env, Args &&args) {
     assert_not_frozen(env);
 
-    ArrayObject *original = new ArrayObject(*this);
+    const auto original_size = size();
 
     for (size_t i = 0; i < args.size(); i++) {
         auto arg = args[i];
 
-        if (arg == this)
-            arg = original;
-
-        concat(*arg->to_ary(env));
+        if (arg == this) {
+            auto original = m_vector.slice(0, original_size);
+            m_vector.concat(original);
+        } else {
+            concat(*arg->to_ary(env));
+        }
     }
 
     return this;


### PR DESCRIPTION
The sequel to https://github.com/seven1m/tm/pull/18

`array/plus_spec` went down from 510,627,871 to 510,521,178 operations, `array_concat_spec` from 509,942,054 to 509,827,801 (all callgrind).