### PR TITLE
Fix compilation error with certain frozen string literals

### DIFF
--- a/lib/natalie/compiler/backends/cpp_backend/transform.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/transform.rb
@@ -160,7 +160,7 @@ module Natalie
 
         def interned_string(str, encoding)
           index = @interned_strings[[str, encoding]] ||= @interned_strings.size
-          "#{interned_strings_var_name}[#{index}]/*#{str.inspect.gsub(%r{\*/|\\}, '?')}*/"
+          "#{interned_strings_var_name}[#{index}]/*#{str.inspect.gsub(%r{/\*|\*/|\\}, '?')}*/"
         end
 
         def set_file(file)

--- a/test/natalie/frozen_string_test.rb
+++ b/test/natalie/frozen_string_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'frozen string' do
+  it 'does not produce a compilation error if it contains C++ comment delimiters' do
+    [
+      'foo // bar',
+      'foo /* bar */',
+    ].each do |s|
+      # ensure each string is "used" by testing *something*
+      s.should =~ /foo/
+    end
+  end
+end

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -839,30 +839,34 @@ describe 'string' do
   end
 
   describe 'line continuation' do
-    s = 'foo' \
-        'bar'
-    s.should == 'foobar'
+    it 'works' do
+      s = 'foo' \
+          'bar'
+      s.should == 'foobar'
 
-    s = 'foo' \
-        "bar#{1 + 1}"
-    s.should == 'foobar2'
+      s = 'foo' \
+          "bar#{1 + 1}"
+      s.should == 'foobar2'
 
-    s = "foo#{1 + 1}" \
-        "bar#{1 + 1}"
-    s.should == 'foo2bar2'
+      s = "foo#{1 + 1}" \
+          "bar#{1 + 1}"
+      s.should == 'foo2bar2'
 
-    s = "foo#{1 + 1}" \
-        'bar'
-    s.should == 'foo2bar'
+      s = "foo#{1 + 1}" \
+          'bar'
+      s.should == 'foo2bar'
 
-    s = 'foo' \
-        'bar' \
-        'baz'
-    s.should == 'foobarbaz'
+      s = 'foo' \
+          'bar' \
+          'baz'
+      s.should == 'foobarbaz'
+    end
   end
 
   describe 'trigraph' do
-    s = '??!'
-    s.size.should == 3
+    it 'does not produce a compiler error' do
+      s = '??!'
+      s.size.should == 3
+    end
   end
 end


### PR DESCRIPTION
The Rake gem has the string `"(usually '~/.rake/*.rake')."`, which produces the following compilation error from gcc:

```
/tmp/natalie.cpp20250111-1712441-ptcjol:11879:184: error: "/*" within comment [-Werror=comment]
11879 |     auto send_3915 = Value(interned_strings[165]/*"Using system wide (global) rakefiles "*/).public_send(env, symbols[91]/*:+*/, Args({ Value(interned_strings[166]/*"(usually '~/.rake/*.rake')."*/) }, false), nullptr, self);
```