### PR TITLE
RbConfig fixup

### DIFF
--- a/spec/library/rbconfig/rbconfig_spec.rb
+++ b/spec/library/rbconfig/rbconfig_spec.rb
@@ -9,6 +9,13 @@ describe 'RbConfig::CONFIG' do
     end
   end
 
+  it 'has MAJOR, MINOR, TEENY, and PATCHLEVEL matching RUBY_VERSION and RUBY_PATCHLEVEL' do
+    major, minor, teeny = RUBY_VERSION.split('.')
+    RbConfig::CONFIG.values_at("MAJOR", "MINOR", "TEENY", "PATCHLEVEL").should == [
+      major, minor, teeny, RUBY_PATCHLEVEL.to_s
+    ]
+  end
+
   # These directories have no meanings before the installation.
   guard -> { RbConfig::TOPDIR } do
     it "['rubylibdir'] returns the directory containing Ruby standard libraries" do

--- a/spec/library/rbconfig/rbconfig_spec.rb
+++ b/spec/library/rbconfig/rbconfig_spec.rb
@@ -153,9 +153,7 @@ end
 describe "RUBY_DESCRIPTION" do
   guard_not -> { RUBY_ENGINE == "ruby" && !RbConfig::TOPDIR } do
     it "contains version" do
-      NATFIXME 'Update RUBY_DESCRIPTION', exception: SpecFailedException do
-        RUBY_DESCRIPTION.should.include? RUBY_VERSION
-      end
+      RUBY_DESCRIPTION.should.include? RUBY_VERSION
     end
 
     it "contains RUBY_PLATFORM" do

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -464,7 +464,7 @@ Env *build_top_env() {
     Object->const_set("ENV"_s, ENV);
     ENV->extend_once(env, Enumerable);
 
-    Value RUBY_VERSION = new StringObject { "3.4.0" };
+    auto RUBY_VERSION = new StringObject { "3.4.0" };
     RUBY_VERSION->freeze();
     Object->const_set("RUBY_VERSION"_s, RUBY_VERSION);
 
@@ -473,7 +473,7 @@ Env *build_top_env() {
     Object->const_set("RUBY_COPYRIGHT"_s, RUBY_COPYRIGHT);
 
     auto ruby_revision_short = TM::String(ruby_revision, 10);
-    StringObject *RUBY_DESCRIPTION = StringObject::format("natalie ({} revision {}) [{}]", ruby_release_date, ruby_revision_short, ruby_platform);
+    StringObject *RUBY_DESCRIPTION = StringObject::format("natalie (like ruby {}) ({} revision {}) [{}]", RUBY_VERSION->string(), ruby_release_date, ruby_revision_short, ruby_platform);
     RUBY_DESCRIPTION->freeze();
     Object->const_set("RUBY_DESCRIPTION"_s, RUBY_DESCRIPTION);
 

--- a/src/rbconfig.rb
+++ b/src/rbconfig.rb
@@ -1,4 +1,5 @@
 module RbConfig
+  darwin = RUBY_PLATFORM.include?('darwin')
   ruby_version_parts = RUBY_VERSION.split('.')
 
   CONFIG = {
@@ -6,9 +7,9 @@ module RbConfig
     "ruby_install_name" => 'natalie',
     "RUBY_INSTALL_NAME" => 'natalie',
     "EXEEXT" => (RUBY_PLATFORM.include?('msys') ? '.exe' : ''),
-    "DLEXT" => (RUBY_PLATFORM.include?('darwin') ? 'bundle' : 'so'),
-    "SOEXT" => (RUBY_PLATFORM.include?('darwin') ? 'dylib' : 'so'),
-    "LIBPATHENV" => (RUBY_PLATFORM.include?('darwin') ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH'),
+    "DLEXT" => (darwin ? 'bundle' : 'so'),
+    "SOEXT" => (darwin ? 'dylib' : 'so'),
+    "LIBPATHENV" => (darwin ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH'),
     "host_cpu" => RUBY_PLATFORM.split('-')[0],
     "host_os" => RUBY_PLATFORM.split('-')[1],
     "AR" => "ar",

--- a/src/rbconfig.rb
+++ b/src/rbconfig.rb
@@ -1,4 +1,6 @@
 module RbConfig
+  ruby_version_parts = RUBY_VERSION.split('.')
+
   CONFIG = {
     "bindir" => File.expand_path('../bin', __dir__),
     "ruby_install_name" => 'natalie',
@@ -11,6 +13,10 @@ module RbConfig
     "host_os" => RUBY_PLATFORM.split('-')[1],
     "AR" => "ar",
     "STRIP" => "strip",
+    "MAJOR" => ruby_version_parts[0],
+    "MINOR" => ruby_version_parts[1],
+    "TEENY" => ruby_version_parts[2],
+    "PATCHLEVEL" => RUBY_PATCHLEVEL.to_s,
   }.freeze
   TOPDIR = nil
 end


### PR DESCRIPTION
This fixes the two failing specs in https://www.github.com/ruby/spec/tree/master/library/rbconfig/rbconfig_spec.rb

The `RUBY_DESCRIPTION` value now looks like:
```
natalie (like ruby 3.4.0) (2025-01-12 revision b81af1f11a) [x86_64-linux]
```

I based the format on both JRuby and TruffleRuby:
```
jruby 9.4.9.0 (3.1.4) 2024-11-04 547c6b150e OpenJDK 64-Bit Server VM 21.0.6-ea+6-Debian-1 on 21.0.6-ea+6-Debian-1 +jit [x86_64-linux]
truffleruby 24.1.1, like ruby 3.2.4, Oracle GraalVM Native [x86_64-linux]
```
I liked the `like` from TruffleRuby, but I thought it would look better in parentheses, as shown by JRuby.