### PR TITLE
Add capacity keyword argument to Hash.new

### DIFF
--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -189,7 +189,7 @@ public:
     Value hash(Env *);
     bool has_key(Env *, Value);
     bool has_value(Env *, Value);
-    Value initialize(Env *, Value, Block *);
+    Value initialize(Env *, Value, Value = nullptr, Block * = nullptr);
     Value inspect(Env *);
     Value keep_if(Env *, Block *);
     Value keys(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -855,7 +855,7 @@ gen.binding('Hash', 'fetch', 'HashObject', 'fetch', argc: 1..2, pass_env: true, 
 gen.binding('Hash', 'fetch_values', 'HashObject', 'fetch_values', argc: :any, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Hash', 'hash', 'HashObject', 'hash', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Hash', 'has_value?', 'HashObject', 'has_value', argc: 1, pass_env: true, pass_block: false, aliases: ['value?'], return_type: :bool)
-gen.binding('Hash', 'initialize', 'HashObject', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object, visibility: :private)
+gen.binding('Hash', 'initialize', 'HashObject', 'initialize', argc: 0..1, kwargs: [:capacity], pass_env: true, pass_block: true, return_type: :Object, visibility: :private)
 gen.binding('Hash', 'initialize_copy', 'HashObject', 'replace', argc: 1, pass_env: true, pass_block: false, aliases: ['replace'], return_type: :Object)
 gen.binding('Hash', 'inspect', 'HashObject', 'inspect', argc: 0, pass_env: true, pass_block: false, aliases: ['to_s'], return_type: :Object)
 gen.binding('Hash', 'include?', 'HashObject', 'has_key', argc: 1, pass_env: true, pass_block: false, aliases: ['member?', 'has_key?', 'key?'], return_type: :bool)

--- a/spec/core/hash/new_spec.rb
+++ b/spec/core/hash/new_spec.rb
@@ -49,11 +49,9 @@ describe "Hash.new" do
 
   ruby_version_is "3.4" do
     it "accepts a capacity: argument" do
-      NATFIXME 'it accepts a capacity: argument', exception: ArgumentError, message: 'wrong number of arguments (given 2, expected 0..1)' do
-        Hash.new(5, capacity: 42).default.should == 5
-        Hash.new(capacity: 42).default.should == nil
-        (Hash.new(capacity: 42) { 1 }).default_proc.should_not == nil
-      end
+      Hash.new(5, capacity: 42).default.should == 5
+      Hash.new(capacity: 42).default.should == nil
+      (Hash.new(capacity: 42) { 1 }).default_proc.should_not == nil
     end
 
     it "ignores negative capacity" do
@@ -61,11 +59,9 @@ describe "Hash.new" do
     end
 
     it "raises an error if unknown keyword arguments are passed" do
-      NATFIXME 'it accepts a capacity: argument', exception: SpecFailedException do
-        -> { Hash.new(unknown: true) }.should raise_error(ArgumentError)
-        -> { Hash.new(1, unknown: true) }.should raise_error(ArgumentError)
-        -> { Hash.new(unknown: true) { 0 } }.should raise_error(ArgumentError)
-      end
+      -> { Hash.new(unknown: true) }.should raise_error(ArgumentError)
+      -> { Hash.new(1, unknown: true) }.should raise_error(ArgumentError)
+      -> { Hash.new(unknown: true) { 0 } }.should raise_error(ArgumentError)
     end
   end
 end

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -208,8 +208,14 @@ void HashObject::key_list_remove_node(Key *node) {
     next->prev = prev;
 }
 
-Value HashObject::initialize(Env *env, Value default_value, Block *block) {
+Value HashObject::initialize(Env *env, Value default_value, Value capacity, Block *block) {
     assert_not_frozen(env);
+
+    if (capacity) {
+        const auto capacity_int = IntegerObject::convert_to_native_type<ssize_t>(env, capacity);
+        if (capacity_int > 0)
+            m_hashmap = TM::Hashmap<Key *, Value> { hash, compare, static_cast<size_t>(capacity_int) };
+    }
 
     if (block) {
         if (default_value) {

--- a/test/natalie/hash_test.rb
+++ b/test/natalie/hash_test.rb
@@ -60,6 +60,18 @@ describe 'hash' do
       h[:foo][3] = 4
       h[:foo].should == { 1 => 2, 3 => 4 }
     end
+
+    it 'has an optional capacity keyword' do
+      Hash.new(capacity: 0).should be_kind_of(Hash)
+      Hash.new(capacity: -1).should be_kind_of(Hash)
+      Hash.new(capacity: 3.14).should be_kind_of(Hash)
+      -> { Hash.new(capacity: nil) }.should raise_error(TypeError, 'no implicit conversion from nil to integer')
+      -> { Hash.new(capacity: 2 ** 64) }.should raise_error(RangeError, /bignum too big to convert/)
+
+      to_int = mock('to_int')
+      to_int.should_receive(:to_int).and_return(10)
+      Hash.new(capacity: to_int).should be_kind_of(Hash)
+    end
   end
 
   describe '.[]' do


### PR DESCRIPTION
The implementation is a bit janky, since we already constructed a TM::Hashmap object on constructing a Natalie::HashObject. Providing an explicit capacity of 10 now means your hashmap gets replaced by a new item of the same size