### PR TITLE
Move check for step == 0 in Range#step to numeric path

### DIFF
--- a/spec/core/range/step_spec.rb
+++ b/spec/core/range/step_spec.rb
@@ -67,7 +67,7 @@ describe "Range#step" do
   ruby_version_is "3.4" do
     it "does not raise an ArgumentError if step is 0 for non-numeric ranges" do
       t = Time.utc(2023, 2, 24)
-      NATFIXME 'it does not raise an ArgumentError if step is 0 for non-numeric ranges', exception: SpecFailedException do
+      NATFIXME 'Fix Range#step for non-numeric ranges', exception: TypeError, message: "can't iterate from Time" do
         -> { (t..t+1).step(0) { break } }.should_not raise_error(ArgumentError)
       end
     end

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -357,10 +357,10 @@ Value RangeObject::step(Env *env, Value n, Block *block) {
         n = n->send(env, coerce_sym, { Value::integer(0) })->as_array_or_raise(env)->last();
     }
 
-    if (n.send(env, "=="_s, { Value::integer(0) })->is_true())
-        env->raise("ArgumentError", "step can't be 0");
-
     if (m_begin->is_numeric() || m_end->is_numeric()) {
+        if (n.send(env, "=="_s, { Value::integer(0) })->is_true())
+            env->raise("ArgumentError", "step can't be 0");
+
         auto begin = m_begin;
         auto end = m_end;
         auto enumerator = Enumerator::ArithmeticSequenceObject::from_range(env, env->current_method()->name(), m_begin, m_end, n, m_exclude_end);


### PR DESCRIPTION
This cascades into the next bug, but that one needs a generic fix.