### PR TITLE
Allow compiler to run with frozen string literals

### DIFF
--- a/lib/natalie/compiler/instructions/variable_get_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_get_instruction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './base_instruction'
 
 module Natalie
@@ -23,7 +25,7 @@ module Natalie
 
         raise "unknown variable #{@name}" if var.nil?
 
-        env = 'env'
+        env = +'env'
         depth.times { env << '->outer()' }
         index = var[:index]
 

--- a/lib/natalie/compiler/instructions/variable_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/variable_set_instruction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './base_instruction'
 
 module Natalie
@@ -22,7 +24,7 @@ module Natalie
         depth, var = transform.find_var(name, local_only: @local_only)
         index = var.fetch(:index)
 
-        env = 'env'
+        env = +'env'
         depth.times { env << '->outer()' }
 
         value = transform.pop


### PR DESCRIPTION
This passes `rake test RUBYOPT="--enable-frozen-string-literal`, which tests the first half of the process.