### PR TITLE
Add ObjectType::Collected

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -92,7 +92,7 @@ public:
     }
 
     virtual ~Object() override {
-        m_type = ObjectType::Nil;
+        m_type = ObjectType::Collected;
         delete m_ivars;
     }
 

--- a/include/natalie/object_type.hpp
+++ b/include/natalie/object_type.hpp
@@ -3,6 +3,7 @@
 namespace Natalie {
 
 enum class ObjectType {
+    Collected,
     Nil,
     Array,
     Binding,

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -139,6 +139,9 @@ Value Object::create(Env *env, ClassObject *klass) {
     case Object::Type::UnboundMethod:
         obj = nullptr;
         break;
+
+    case Object::Type::Collected:
+        NAT_UNREACHABLE();
     }
 
     return obj;


### PR DESCRIPTION
The old version marked garbage collected objects with Nil, which can be very confusing when trying to track down a bug.

For a bit of context: I've been working on [define_finalizer](https://ruby-doc.org/3.4.1/ObjectSpace.html#method-c-define_finalizer) and ran into a bug where one of the objects got GC'd, but that took way too long to figure out because inspecting the structure with GDB showed `Nil`.