### PR TITLE
Make floats always heap-allocated

### DIFF
--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -129,7 +129,7 @@ public:
     Value prev_float(Env *) const;
     Value round(Env *, Value);
     Value sub(Env *, Value);
-    Value to_f() const { return Value::floatingpoint(m_double); }
+    Value to_f() const { return new FloatObject { *this }; }
     Value to_i(Env *) const;
     Value to_r(Env *) const;
     Value to_s() const;
@@ -141,11 +141,11 @@ public:
     bool gte(Env *, Value);
 
     Value uminus() const {
-        return Value::floatingpoint(-m_double);
+        return new FloatObject { -m_double };
     }
 
     Value uplus() const {
-        return Value::floatingpoint(m_double);
+        return new FloatObject { m_double };
     }
 
     static void build_constants(Env *env, ClassObject *klass) {

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -91,7 +91,7 @@ public:
 
     static Value to_s(Env *, Integer &self, Value = nullptr);
     static Value to_i(Integer &self) { return self; }
-    static Value to_f(Integer &self) { return Value::floatingpoint(self.to_double()); }
+    static Value to_f(Integer &self);
     static Value add(Env *, Integer &, Value);
     static Value sub(Env *, Integer &, Value);
     static Value mul(Env *, Integer &, Value);

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -18,7 +18,6 @@ class Value {
 public:
     enum class Type {
         Integer,
-        Double,
         Pointer,
     };
 
@@ -44,8 +43,6 @@ public:
         // This is required, because initialization by a literal is often ambiguous.
         return Value { integer };
     }
-    static Value floatingpoint(double value);
-
     Type type() const { return m_type; }
 
     Object &operator*() {
@@ -105,21 +102,11 @@ public:
         return m_type == Type::Integer;
     }
 
-    bool is_fast_double() const {
-        return m_type == Type::Double;
-    }
-
-    double as_double() const;
     nat_int_t as_fast_integer() const;
 
     nat_int_t get_fast_integer() const {
         assert(m_type == Type::Integer);
         return m_integer.to_nat_int_t();
-    }
-
-    double get_fast_double() const {
-        assert(m_type == Type::Double);
-        return m_double;
     }
 
     const Integer &integer() const;
@@ -135,10 +122,6 @@ public:
     void assert_type(Env *, ObjectType, const char *) const;
 
 private:
-    explicit Value(double value)
-        : m_type { Type::Double }
-        , m_double { value } { }
-
     void auto_hydrate() {
         if (m_type != Type::Pointer)
             hydrate();
@@ -149,17 +132,10 @@ private:
 
     void hydrate();
 
-    // Method can use a synthesized value if we are a fast double
-    friend Method;
-    bool holds_raw_double() const {
-        return m_type == Type::Double;
-    }
-
     Type m_type { Type::Pointer };
 
     union {
         Integer m_integer { 0 };
-        double m_double;
         Object *m_object;
     };
 };

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -260,7 +260,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
     } else if (return_type == char_sym) {
         return Value::integer(result);
     } else if (return_type == double_sym) {
-        return Value::floatingpoint(*reinterpret_cast<double *>(&result));
+        return new FloatObject { *reinterpret_cast<double *>(&result) };
     } else if (return_type == int_sym) {
         return Value::integer(result);
     } else if (return_type == pointer_sym) {

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -69,7 +69,7 @@ module Natalie
           value = transform.pop # Pass1 already did the work to push the value onto the stack
           case type
           when 'double'
-            "#{value}.as_double()"
+            "#{value}->as_float()->to_double()"
           when 'int'
             "#{value}.as_fast_integer()"
           when 'bool'
@@ -84,7 +84,7 @@ module Natalie
         cast_value_from_cpp = lambda do |value, type|
           case type
           when 'double'
-            "Value::floatingpoint(#{value})"
+            "Value(new FloatObject { #{value} })"
           when 'Value'
             value
           else

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -53,7 +53,7 @@ bool FloatObject::eql(Value other) const {
             env->raise("FloatDomainError", this->inspect_str(env));             \
                                                                                 \
         if (is_infinity())                                                      \
-            return Value::floatingpoint(m_double);                              \
+            return new FloatObject { m_double };                                \
                                                                                 \
         FloatObject *result;                                                    \
         if (precision == 0)                                                     \
@@ -62,7 +62,7 @@ bool FloatObject::eql(Value other) const {
         double f = ::pow(10, precision);                                        \
         double rounded = ::libm_name(m_double * f) / f;                         \
         if (isinf(f) || isinf(rounded)) {                                       \
-            return Value::floatingpoint(m_double);                              \
+            return new FloatObject { m_double };                                \
         }                                                                       \
         if (precision < 0)                                                      \
             return f_to_i_or_bigint(rounded);                                   \
@@ -187,7 +187,7 @@ Value FloatObject::coerce(Env *env, Value arg) {
         ary->push(arg);
         break;
     case Object::Type::Integer:
-        ary->push(Value::floatingpoint(arg.integer().to_double()));
+        ary->push(new FloatObject { arg.integer().to_double() });
         break;
     default:
         ary->push(KernelModule::Float(env, arg, true));
@@ -243,7 +243,7 @@ Value FloatObject::add(Env *env, Value rhs) {
 
     double addend1 = to_double();
     double addend2 = rhs->as_float()->to_double();
-    return Value::floatingpoint(addend1 + addend2);
+    return new FloatObject { addend1 + addend2 };
 }
 
 Value FloatObject::sub(Env *env, Value rhs) {
@@ -260,7 +260,7 @@ Value FloatObject::sub(Env *env, Value rhs) {
 
     double minuend = to_double();
     double subtrahend = rhs->as_float()->to_double();
-    return Value::floatingpoint(minuend - subtrahend);
+    return new FloatObject { minuend - subtrahend };
 }
 
 Value FloatObject::mul(Env *env, Value rhs) {
@@ -277,7 +277,7 @@ Value FloatObject::mul(Env *env, Value rhs) {
 
     double multiplicand = to_double();
     double multiplier = rhs->as_float()->to_double();
-    return Value::floatingpoint(multiplicand * multiplier);
+    return new FloatObject { multiplicand * multiplier };
 }
 
 Value FloatObject::div(Env *env, Value rhs) {
@@ -295,7 +295,7 @@ Value FloatObject::div(Env *env, Value rhs) {
     double dividend = to_double();
     double divisor = rhs->as_float()->to_double();
 
-    return Value::floatingpoint(dividend / divisor);
+    return new FloatObject { dividend / divisor };
 }
 
 Value FloatObject::mod(Env *env, Value rhs) {
@@ -303,8 +303,8 @@ Value FloatObject::mod(Env *env, Value rhs) {
 
     bool rhs_is_non_zero = (rhs->is_float() && !rhs->as_float()->is_zero()) || (rhs.is_integer() && !IntegerObject::is_zero(rhs.integer()));
 
-    if (rhs->is_float() && rhs->as_float()->is_negative_infinity()) return Value::floatingpoint(rhs->as_float()->to_double());
-    if (is_negative_zero() && rhs_is_non_zero) return Value::floatingpoint(m_double);
+    if (rhs->is_float() && rhs->as_float()->is_negative_infinity()) return new FloatObject { rhs->as_float()->to_double() };
+    if (is_negative_zero() && rhs_is_non_zero) return new FloatObject { m_double };
 
     if (!rhs->is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
@@ -325,7 +325,7 @@ Value FloatObject::mod(Env *env, Value rhs) {
     if (result != 0.0 && signbit(dividend) != signbit(divisor))
         result += divisor;
 
-    return Value::floatingpoint(result);
+    return new FloatObject { result };
 }
 
 Value FloatObject::divmod(Env *env, Value arg) {
@@ -369,19 +369,19 @@ Value FloatObject::pow(Env *env, Value rhs) {
     if (base < 0 && ::floor(exponent) != exponent)
         env->raise("ArgumentError", "Not yet implemented: negative raised to a fractional power");
 
-    return Value::floatingpoint(::pow(base, exponent));
+    return new FloatObject { ::pow(base, exponent) };
 }
 
 Value FloatObject::abs(Env *env) const {
-    return Value::floatingpoint(fabs(m_double));
+    return new FloatObject { fabs(m_double) };
 }
 
 Value FloatObject::next_float(Env *env) const {
-    return Value::floatingpoint(::nextafter(to_double(), HUGE_VAL));
+    return new FloatObject { ::nextafter(to_double(), HUGE_VAL) };
 }
 
 Value FloatObject::prev_float(Env *env) const {
-    return Value::floatingpoint(::nextafter(to_double(), -HUGE_VAL));
+    return new FloatObject { ::nextafter(to_double(), -HUGE_VAL) };
 }
 
 Value FloatObject::arg(Env *env) {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -67,11 +67,15 @@ Value IntegerObject::to_s(Env *env, Integer &self, Value base_value) {
     return str;
 }
 
+Value IntegerObject::to_f(Integer &self) {
+    return new FloatObject { self.to_double() };
+}
+
 Value IntegerObject::add(Env *env, Integer &self, Value arg) {
     if (arg.is_integer()) {
         return create(self + arg.integer());
     } else if (arg->is_float()) {
-        return Value::floatingpoint(self + arg->as_float()->to_double());
+        return new FloatObject { self + arg->as_float()->to_double() };
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -88,7 +92,7 @@ Value IntegerObject::sub(Env *env, Integer &self, Value arg) {
         return create(self - arg.integer());
     } else if (arg->is_float()) {
         double result = self.to_double() - arg->as_float()->to_double();
-        return Value::floatingpoint(result);
+        return new FloatObject { result };
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -124,7 +128,7 @@ Value IntegerObject::div(Env *env, Integer &self, Value arg) {
         double result = self / arg->as_float()->to_double();
         if (isnan(result))
             return FloatObject::nan();
-        return Value::floatingpoint(result);
+        return new FloatObject { result };
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -143,7 +147,8 @@ Value IntegerObject::div(Env *env, Integer &self, Value arg) {
 Value IntegerObject::mod(Env *env, Integer &self, Value arg) {
     Integer argument;
     if (arg->is_float()) {
-        return Value::floatingpoint(self.to_double())->as_float()->mod(env, arg);
+        auto f = new FloatObject { self.to_double() };
+        return f->mod(env, arg);
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -201,8 +206,10 @@ Value IntegerObject::pow(Env *env, Integer &self, Value arg) {
         return comp->send(env, "**"_s, { arg });
     }
 
-    if (arg->is_float())
-        return Value::floatingpoint(self.to_double())->as_float()->pow(env, arg);
+    if (arg->is_float()) {
+        auto f = new FloatObject { self.to_double() };
+        return f->pow(env, arg);
+    }
 
     if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);

--- a/src/math.rb
+++ b/src/math.rb
@@ -186,7 +186,7 @@ module Math
       }
       int exponent;
       auto significand = std::frexp(value->to_double(), &exponent);
-      return new ArrayObject { { Value::floatingpoint(significand), Value::integer(exponent) } };
+      return new ArrayObject { { new FloatObject { significand }, Value::integer(exponent) } };
     END
 
     __function__('::tgamma', ['double'], 'double')
@@ -260,7 +260,7 @@ module Math
       }
       int sign = 1;
       auto v = ::lgamma_r(value->to_double(), &sign);
-      return new ArrayObject { {  Value::floatingpoint(v), Value::integer(sign) } };
+      return new ArrayObject { {  new FloatObject { v }, Value::integer(sign) } };
     END
 
     __function__('::log10', ['double'], 'double')

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -41,10 +41,6 @@ Value Method::call(Env *env, Value self, Args &&args, Block *block) const {
             auto synthesized_arg = IntegerObject { args[0].get_fast_integer() };
             synthesized_arg.add_synthesized_flag();
             return call_fn({ &synthesized_arg });
-        } else if (args.size() == 1 && args[0].holds_raw_double()) {
-            auto synthesized_arg = FloatObject { args[0].as_double() };
-            synthesized_arg.add_synthesized_flag();
-            return call_fn({ &synthesized_arg });
         }
     } else if (!self.is_fast_integer() && self->is_synthesized()) {
         // Turn this object into a heap-allocated one.

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1033,7 +1033,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::False:
         return FalseObject::the();
     case Object::Type::Float:
-        return Value::floatingpoint(as_float()->to_double());
+        return new FloatObject { *as_float() };
     case Object::Type::Hash:
         return new HashObject { env, *as_hash() };
     case Object::Type::Integer:

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -101,7 +101,7 @@ Value ProcessModule::times(Env *env) {
     if (getrusage(RUSAGE_CHILDREN, &rusage_children) == -1)
         env->raise_errno();
     auto tv_to_float = [](const timeval tv) {
-        return Value::floatingpoint(static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) / 1e6);
+        return new FloatObject { static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) / 1e6 };
     };
     auto utime = tv_to_float(rusage_self.ru_utime);
     auto stime = tv_to_float(rusage_self.ru_stime);

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -215,9 +215,6 @@ String RangeObject::dbg_inspect() const {
     auto append = [&](Value v) {
         if (v.is_fast_integer()) {
             str.append(v.get_fast_integer());
-        } else if (v.is_fast_double()) {
-            auto f = FloatObject(v.get_fast_double());
-            str.append(f.to_s());
         } else {
             auto obj = v.object_or_null();
             assert(obj);

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2722,7 +2722,7 @@ StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDa
 
 Value StringObject::to_f(Env *env) const {
     auto result = strtod(c_str(), nullptr);
-    return Value::floatingpoint(result);
+    return new FloatObject { result };
 }
 
 Value StringObject::to_i(Env *env, Value base_obj) const {


### PR DESCRIPTION
...for now.

I know CRuby has some way of encoding these in the VALUE pointer, but I'd like to focus on integers for now. We can revisit floats later.