### PR TITLE
Move convenient predicate methods to Value, and other changes

### DIFF
--- a/examples/gtk3.rb
+++ b/examples/gtk3.rb
@@ -188,7 +188,7 @@ module Gtk3
     __define_method__ :label_new, <<-END
       args.ensure_argc_is(env, 1);
       GtkWidget *gtk_label;
-      if (args[0]->is_nil()) {
+      if (args[0].is_nil()) {
           gtk_label = gtk_label_new(nullptr);
       } else {
           const char *text = args[0]->as_string()->c_str();

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -29,7 +29,7 @@ public:
     bool eq(Env *, Value);
     bool exclude_end() const { return m_exclude_end; }
     Value hash(Env *);
-    bool has_step() { return m_step && !m_step->is_nil(); }
+    bool has_step() { return m_step && !m_step.is_nil(); }
     Value inspect(Env *);
     Value last(Env *, Value);
     Value size(Env *);

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -113,7 +113,7 @@ public:
     bool has_file(SymbolObject *name) const { return m_files.get(name); }
     void add_file(Env *env, SymbolObject *name);
 
-    void set_interned_strings(StringObject **, const size_t);
+    void set_interned_strings(StringObject **, size_t);
 
     friend class SymbolObject;
 

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -12,8 +12,8 @@ public:
     using read_hook_t = std::function<Value(Env *, GlobalVariableInfo &)>;
     using write_hook_t = Value (*)(Env *, Value, GlobalVariableInfo &);
 
-    GlobalVariableInfo(Object *object, bool readonly)
-        : m_object { object }
+    GlobalVariableInfo(Value value, bool readonly)
+        : m_value { value }
         , m_readonly { readonly } { }
 
     void set_object(Env *, Value);
@@ -26,7 +26,7 @@ public:
     virtual void visit_children(Visitor &visitor) const override final;
 
 private:
-    Value m_object { nullptr };
+    Value m_value { nullptr };
     bool m_readonly;
     read_hook_t m_read_hook { nullptr };
     write_hook_t m_write_hook { nullptr };

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -127,7 +127,7 @@ public:
     static Value truncate(Env *, Integer &, Value);
     static Value ref(Env *, Integer &, Value, Value);
 
-    static bool neq(Env *env, Value self, Value other) { return self.send(env, "=="_s, { other })->is_falsey(); }
+    static bool neq(Env *env, Value self, Value other) { return self.send(env, "=="_s, { other }).is_falsey(); }
     static bool eq(Env *, Integer &, Value);
     static bool lt(Env *, Integer &, Value);
     static bool lte(Env *, Integer &, Value);

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -31,6 +31,7 @@ public:
     static Value exit_bang(Env *env, Value status);
     static Value Integer(Env *env, Value value, Value base, Value exception);
     static Value Integer(Env *env, Value value, nat_int_t base = 0, bool exception = true);
+    static bool is_nil(Value value) { return value.is_nil(); }
     static Value Float(Env *env, Value value, Value exception);
     static Value Float(Env *env, Value value, bool exception = true);
     static Value fork(Env *env, Block *);

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -60,9 +60,6 @@ public:
     bool has_env() const { return !!m_env; }
     Env *env() const { return m_env; }
 
-    bool is_optimized() const { return m_optimized; }
-    void set_optimized(bool optimized) { m_optimized = optimized; }
-
     Value call(Env *env, Value self, Args &&args, Block *block) const;
 
     String name() const { return m_name; }
@@ -102,6 +99,5 @@ private:
     Optional<String> m_file {};
     Optional<size_t> m_line {};
     Env *m_env { nullptr };
-    bool m_optimized { false };
 };
 }

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -25,7 +25,7 @@ public:
     Value inspect(Env *env) {
         auto the_owner = owner();
         auto name = m_method_missing_name ? m_method_missing_name->string() : m_method->name();
-        if (the_owner->is_class() && the_owner->as_class()->is_singleton())
+        if (the_owner->type() == Type::Class && the_owner->as_class()->is_singleton())
             return StringObject::format("#<Method: {}.{}(*)>", m_object->inspect_str(env), name);
         else
             return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_str(), name);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -102,7 +102,7 @@ public:
     Value remove_class_variable(Env *, Value);
 
     Value define_method(Env *, Value, Value, Block *);
-    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int, bool optimized = false) override;
+    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int) override;
     virtual SymbolObject *define_method(Env *, SymbolObject *, Block *) override;
     virtual SymbolObject *undefine_method(Env *, SymbolObject *) override;
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -35,11 +35,6 @@ public:
         // set on an object returned from a block to signal
         // that `redo` was called
         Redo = 4,
-
-        // set on an object to signal it only lives for a short time
-        // on the stack, and not to capture it anywhere
-        // (don't store in variables, arrays, hashes)
-        Synthesized = 8,
     };
 
     enum class Conversion {
@@ -330,9 +325,6 @@ public:
 
     void freeze();
     bool is_frozen() const { return m_type == Type::Integer || is_float() || (m_flags & Flag::Frozen) == Flag::Frozen; }
-
-    void add_synthesized_flag() { m_flags = m_flags | Flag::Synthesized; }
-    bool is_synthesized() const { return (m_flags & Flag::Synthesized) == Flag::Synthesized; }
 
     void add_break_flag() { m_flags = m_flags | Flag::Break; }
     void remove_break_flag() { m_flags = m_flags & ~Flag::Break; }

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -255,11 +255,11 @@ public:
     virtual Value cvar_get_or_null(Env *, SymbolObject *);
     virtual Value cvar_set(Env *, SymbolObject *, Value);
 
-    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int, bool = false);
+    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int);
     virtual SymbolObject *define_method(Env *, SymbolObject *, Block *);
     virtual SymbolObject *undefine_method(Env *, SymbolObject *);
 
-    SymbolObject *define_singleton_method(Env *, SymbolObject *, MethodFnPtr, int, bool = false);
+    SymbolObject *define_singleton_method(Env *, SymbolObject *, MethodFnPtr, int);
     SymbolObject *define_singleton_method(Env *, SymbolObject *, Block *);
     SymbolObject *undefine_singleton_method(Env *, SymbolObject *);
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -102,47 +102,6 @@ public:
 
     Value initialize(Env *);
 
-    bool is_nil() const { return m_type == Type::Nil; }
-    bool is_true() const { return m_type == Type::True; }
-    bool is_false() const { return m_type == Type::False; }
-    bool is_fiber() const { return m_type == Type::Fiber; }
-    bool is_enumerator_arithmetic_sequence() const { return m_type == Type::EnumeratorArithmeticSequence; }
-    bool is_array() const { return m_type == Type::Array; }
-    bool is_binding() const { return m_type == Type::Binding; }
-    bool is_method() const { return m_type == Type::Method; }
-    bool is_module() const { return m_type == Type::Module || m_type == Type::Class; }
-    bool is_class() const { return m_type == Type::Class; }
-    bool is_complex() const { return m_type == Type::Complex; }
-    bool is_dir() const { return m_type == Type::Dir; }
-    bool is_encoding() const { return m_type == Type::Encoding; }
-    bool is_env() const { return m_type == Type::Env; }
-    bool is_exception() const { return m_type == Type::Exception; }
-    bool is_float() const { return m_type == Type::Float; }
-    bool is_hash() const { return m_type == Type::Hash; }
-    bool is_io() const { return m_type == Type::Io || m_type == Type::File; }
-    bool is_file() const { return m_type == Type::File; }
-    bool is_file_stat() const { return m_type == Type::FileStat; }
-    bool is_match_data() const { return m_type == Type::MatchData; }
-    bool is_proc() const { return m_type == Type::Proc; }
-    bool is_random() const { return m_type == Type::Random; }
-    bool is_range() const { return m_type == Type::Range; }
-    bool is_rational() const { return m_type == Type::Rational; }
-    bool is_regexp() const { return m_type == Type::Regexp; }
-    bool is_symbol() const { return m_type == Type::Symbol; }
-    bool is_string() const { return m_type == Type::String; }
-    bool is_thread() const { return m_type == Type::Thread; }
-    bool is_thread_backtrace_location() const { return m_type == Type::ThreadBacktraceLocation; }
-    bool is_thread_group() const { return m_type == Type::ThreadGroup; }
-    bool is_thread_mutex() const { return m_type == Type::ThreadMutex; }
-    bool is_time() const { return m_type == Type::Time; }
-    bool is_unbound_method() const { return m_type == Type::UnboundMethod; }
-    bool is_void_p() const { return m_type == Type::VoidP; }
-
-    bool is_truthy() const { return !is_false() && !is_nil(); }
-    bool is_falsey() const { return !is_truthy(); }
-    bool is_numeric() const { return m_type == Type::Integer || is_float(); }
-    bool is_boolean() const { return is_true() || is_false(); }
-
     Enumerator::ArithmeticSequenceObject *as_enumerator_arithmetic_sequence();
     ArrayObject *as_array();
     const ArrayObject *as_array() const;
@@ -324,7 +283,9 @@ public:
     bool is_main_object() const { return this == GlobalEnv::the()->main_obj(); }
 
     void freeze();
-    bool is_frozen() const { return m_type == Type::Integer || is_float() || (m_flags & Flag::Frozen) == Flag::Frozen; }
+    bool is_frozen() const { return m_type == Type::Integer || m_type == Type::Float || (m_flags & Flag::Frozen) == Flag::Frozen; }
+
+    bool not_truthy() const { return m_type == Type::Nil || m_type == Type::False; }
 
     void add_break_flag() { m_flags = m_flags | Flag::Break; }
     void remove_break_flag() { m_flags = m_flags & ~Flag::Break; }

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -111,7 +111,7 @@ public:
 
     static int getsid(Env *env, Value pid = nullptr) {
         pid_t pidnum;
-        if (!pid || pid->is_nil()) {
+        if (!pid || pid.is_nil()) {
             pidnum = 0;
         } else {
             pidnum = IntegerObject::convert_to_nat_int_t(env, pid);
@@ -132,7 +132,7 @@ public:
 private:
     static uid_t value_to_uid(Env *env, Value idval) {
         uid_t uid;
-        if (idval->is_string()) {
+        if (idval.is_string()) {
             struct passwd *pass;
             pass = getpwnam(idval->as_string()->c_str());
             if (pass == NULL)
@@ -147,7 +147,7 @@ private:
 
     static gid_t value_to_gid(Env *env, Value idval) {
         gid_t gid;
-        if (idval->is_string()) {
+        if (idval.is_string()) {
             auto grp = getgrnam(idval->as_string()->c_str());
             if (grp == NULL)
                 env->raise("ArgumentError", "can't find group {}", idval->as_string()->c_str());
@@ -163,14 +163,14 @@ private:
         int resource;
         auto to_str = "to_str"_s;
         SymbolObject *rlimit_symbol = nullptr;
-        if (val->is_symbol()) {
+        if (val.is_symbol()) {
             rlimit_symbol = val->as_symbol();
-        } else if (val->is_string()) {
+        } else if (val.is_string()) {
             rlimit_symbol = val->as_string()->to_symbol(env);
         } else if (val->respond_to(env, to_str)) {
             // Need to support nil, don't use Object::to_str
             auto tsval = val->send(env, to_str);
-            if (tsval->is_string()) {
+            if (tsval.is_string()) {
                 rlimit_symbol = tsval->as_string()->to_sym(env)->as_symbol();
             }
         }

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -143,7 +143,7 @@ public:
 
     bool eq(Env *env, Value other) const {
         assert_initialized(env);
-        if (!other->is_regexp()) return false;
+        if (!other.is_regexp()) return false;
         RegexpObject *other_regexp = other->as_regexp();
         other_regexp->assert_initialized(env);
         return *this == *other_regexp;
@@ -151,12 +151,12 @@ public:
 
     bool eqeqeq(Env *env, Value other) {
         assert_initialized(env);
-        if (!other->is_string() && !other->is_symbol()) {
+        if (!other.is_string() && !other.is_symbol()) {
             if (!other->respond_to(env, "to_str"_s))
                 return false;
             other = other->to_str(env);
         }
-        return match(env, other)->is_truthy();
+        return match(env, other).is_truthy();
     }
 
     Value tilde(Env *env) {

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -235,7 +235,7 @@ public:
     }
 
     bool operator==(const Object &value) const {
-        if (!value.is_string())
+        if (value.type() != Type::String)
             return false;
         return *this == *value.as_string();
     }

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -15,7 +15,7 @@ namespace Natalie {
 
 class SymbolObject : public Object {
 public:
-    static SymbolObject *intern(const char *, const size_t length, EncodingObject *encoding = nullptr);
+    static SymbolObject *intern(const char *, size_t length, EncodingObject *encoding = nullptr);
     static SymbolObject *intern(const String &, EncodingObject *encoding = nullptr);
 
     static ArrayObject *all_symbols(Env *);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -169,7 +169,7 @@ public:
         return abrt;
     }
     bool set_abort_on_exception(Value abrt) {
-        m_abort_on_exception = abrt->is_truthy();
+        m_abort_on_exception = abrt.is_truthy();
         return abrt;
     }
 
@@ -179,7 +179,7 @@ public:
         return report;
     }
     bool set_report_on_exception(Value report) {
-        m_report_on_exception = report->is_truthy();
+        m_report_on_exception = report.is_truthy();
         return report;
     }
 
@@ -232,7 +232,7 @@ public:
         return report;
     }
     static bool set_default_report_on_exception(Value report) {
-        s_report_on_exception = report->is_truthy();
+        s_report_on_exception = report.is_truthy();
         return report;
     }
 
@@ -242,7 +242,7 @@ public:
         return abrt;
     }
     static bool set_global_abort_on_exception(Value abrt) {
-        s_abort_on_exception = abrt->is_truthy();
+        s_abort_on_exception = abrt.is_truthy();
         return abrt;
     }
 

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -16,7 +16,7 @@ public:
         , m_module_or_class { other.m_module_or_class } { }
 
     Value bind(Env *env, Value obj) {
-        if (!owner()->is_class() || obj->is_a(env, owner())) {
+        if (owner()->type() != Type::Class || obj->is_a(env, owner())) {
             return new MethodObject { obj, m_method };
         } else {
             env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_str());
@@ -34,7 +34,7 @@ public:
     }
 
     bool eq(Env *env, Value other_value) {
-        if (other_value->is_unbound_method()) {
+        if (other_value.is_unbound_method()) {
             auto other = other_value->as_unbound_method();
             return m_module_or_class == other->m_module_or_class && m_method == other->m_method;
         } else {

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -121,6 +121,47 @@ public:
 
     void assert_type(Env *, ObjectType, const char *) const;
 
+    bool is_nil() const;
+    bool is_true() const;
+    bool is_false() const;
+    bool is_fiber() const;
+    bool is_enumerator_arithmetic_sequence() const;
+    bool is_array() const;
+    bool is_binding() const;
+    bool is_method() const;
+    bool is_module() const;
+    bool is_class() const;
+    bool is_complex() const;
+    bool is_dir() const;
+    bool is_encoding() const;
+    bool is_env() const;
+    bool is_exception() const;
+    bool is_float() const;
+    bool is_hash() const;
+    bool is_io() const;
+    bool is_file() const;
+    bool is_file_stat() const;
+    bool is_match_data() const;
+    bool is_proc() const;
+    bool is_random() const;
+    bool is_range() const;
+    bool is_rational() const;
+    bool is_regexp() const;
+    bool is_symbol() const;
+    bool is_string() const;
+    bool is_thread() const;
+    bool is_thread_backtrace_location() const;
+    bool is_thread_group() const;
+    bool is_thread_mutex() const;
+    bool is_time() const;
+    bool is_unbound_method() const;
+    bool is_void_p() const;
+
+    bool is_truthy() const;
+    bool is_falsey() const;
+    bool is_numeric() const;
+    bool is_boolean() const;
+
 private:
     void auto_hydrate() {
         if (m_type != Type::Pointer)

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -104,7 +104,7 @@ class Fiddle
       auto pointer_class = self->const_find(env, "Pointer"_s, Object::ConstLookupSearchMode::NotStrict)->as_class();
       if (p1->is_a(env, pointer_class))
           p1_ptr = p1->ivar_get(env, "@ptr"_s)->as_void_p()->void_ptr();
-      else if (p1->is_void_p())
+      else if (p1.is_void_p())
           p1_ptr = p1->as_void_p()->void_ptr();
       else
           p1_ptr = (void*)(p1.object());

--- a/lib/io/nonblock.cpp
+++ b/lib/io/nonblock.cpp
@@ -16,6 +16,6 @@ Value IO_is_nonblock(Env *env, Value self, Args &&args, Block *) {
 
 Value IO_set_nonblock(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 1);
-    self->as_io()->set_nonblock(env, args.at(0)->is_truthy());
+    self->as_io()->set_nonblock(env, args.at(0).is_truthy());
     return args.at(0);
 }

--- a/lib/linenoise.cpp
+++ b/lib/linenoise.cpp
@@ -103,7 +103,7 @@ static char *hints_callback(const char *buf, int *color, int *bold) {
     auto env = proc->env();
 
     auto ret = proc->send(env, "call"_s, { buf_string });
-    if (ret->is_nil())
+    if (ret.is_nil())
         return nullptr;
 
     auto ary = ret->as_array_or_raise(env);
@@ -112,7 +112,7 @@ static char *hints_callback(const char *buf, int *color, int *bold) {
 
     auto hint = ary->at(0)->as_string_or_raise(env)->c_str();
     *color = ary->at(1).integer_or_raise(env).to_nat_int_t();
-    *bold = ary->size() == 3 && ary->at(2)->is_truthy() ? 1 : 0;
+    *bold = ary->size() == 3 && ary->at(2).is_truthy() ? 1 : 0;
 
     return strdup(hint);
 }
@@ -173,7 +173,7 @@ Value Linenoise_set_history_max_len(Env *env, Value self, Args &&args, Block *) 
 
 Value Linenoise_set_multi_line(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 1);
-    auto enabled = args[0]->is_truthy();
+    auto enabled = args[0].is_truthy();
     linenoiseSetMultiLine(enabled);
     return bool_object(enabled);
 }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -65,7 +65,7 @@ class BindingGen
         puts '    ' + binding.get_object
         @consts[binding.rb_class] = true
       end
-      puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{binding.rb_method.inspect}_s, #{binding.name}, #{binding.arity}, #{binding.optimized ? 'true' : 'false'});"
+      puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{binding.rb_method.inspect}_s, #{binding.name}, #{binding.arity});"
       if binding.module_function?
         puts "    #{binding.rb_class_as_c_variable}->module_function(env, #{binding.rb_method.inspect}_s);"
       end
@@ -101,7 +101,6 @@ class BindingGen
       pass_klass: false,
       kwargs: nil,
       visibility: :public,
-      optimized: false,
       aliases: []
     )
       @rb_class = rb_class
@@ -120,7 +119,6 @@ class BindingGen
       @pass_klass = pass_klass
       @kwargs = kwargs
       @visibility = visibility
-      @optimized = optimized
       @aliases = aliases
       generate_name
     end
@@ -135,7 +133,6 @@ class BindingGen
                 :ruby_method_type,
                 :name,
                 :visibility,
-                :optimized,
                 :aliases
 
     def pass_env? = !!@pass_env
@@ -763,7 +760,7 @@ gen.binding('Float', '>=', 'FloatObject', 'gte', argc: 1, pass_env: true, pass_b
 gen.binding('Float', 'abs', 'FloatObject', 'abs', argc: 0, pass_env: true, pass_block: false, aliases: ['magnitude'], return_type: :Object)
 gen.binding('Float', 'arg', 'FloatObject', 'arg', argc: 0, pass_env: true, pass_block: false, aliases: %w[phase angle], return_type: :Object)
 gen.binding('Float', 'ceil', 'FloatObject', 'ceil', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Float', 'coerce', 'FloatObject', 'coerce', argc: 1, pass_env: true, pass_block: false, return_type: :Object, optimized: false)
+gen.binding('Float', 'coerce', 'FloatObject', 'coerce', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Float', 'denominator', 'FloatObject', 'denominator', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Float', 'divmod', 'FloatObject', 'divmod', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Float', 'eql?', 'FloatObject', 'eql', argc: 1, pass_env: false, pass_block: false, return_type: :bool)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -459,7 +459,7 @@ gen.binding('Array', '|', 'ArrayObject', 'union_of', argc: 1, pass_env: true, pa
 gen.static_binding_as_instance_method('BasicObject', '__id__', 'Object', 'object_id', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.static_binding_as_instance_method('BasicObject', 'equal?', 'Object', 'equal', argc: 1, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', '__send__', 'Object', 'send', argc: 1.., pass_env: true, pass_block: true, return_type: :Object)
-gen.binding('BasicObject', '!', 'Object', 'is_falsey', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('BasicObject', '!', 'Object', 'not_truthy', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', '==', 'Object', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', '!=', 'Object', 'neq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', 'initialize', 'Object', 'initialize', argc: 0, pass_env: true, pass_block: false, return_type: :Object, visibility: :private)
@@ -1001,6 +1001,7 @@ gen.static_binding_as_instance_method('Kernel', 'kind_of?', 'KernelModule', 'is_
 gen.static_binding_as_instance_method('Kernel', 'loop', 'KernelModule', 'loop', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.static_binding_as_instance_method('Kernel', 'method', 'KernelModule', 'method', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding_as_instance_method('Kernel', 'methods', 'KernelModule', 'methods', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
+gen.static_binding_as_instance_method('Kernel', 'nil?', 'KernelModule', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.static_binding_as_instance_method('Kernel', 'object_id', 'Object', 'object_id', argc: 0, pass_env: false, pass_block: false, return_type: :int)
 gen.static_binding_as_instance_method('Kernel', 'private_methods', 'KernelModule', 'private_methods', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding_as_instance_method('Kernel', 'protected_methods', 'KernelModule', 'protected_methods', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
@@ -1012,7 +1013,6 @@ gen.static_binding_as_instance_method('Kernel', 'to_s', 'KernelModule', 'inspect
 gen.binding('Kernel', 'clone', 'Object', 'clone', argc: 0, kwargs: [:freeze], pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'extend', 'Object', 'extend', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Kernel', 'frozen?', 'Object', 'is_frozen', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
-gen.binding('Kernel', 'nil?', 'Object', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Kernel', 'public_send', 'Object', 'public_send', argc: 1.., pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Kernel', 'respond_to?', 'Object', 'respond_to_method', argc: 1..2, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Kernel', 'respond_to_missing?', 'Object', 'respond_to_missing', argc: 2, pass_env: true, pass_block: false, return_type: :bool, visibility: :private)
@@ -1120,7 +1120,7 @@ gen.binding('NilClass', 'to_i', 'NilObject', 'to_i', argc: 0, pass_env: true, pa
 gen.binding('NilClass', 'to_r', 'NilObject', 'to_r', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('NilClass', 'to_s', 'NilObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
-gen.binding('Object', 'nil?', 'Object', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.static_binding_as_instance_method('Object', 'nil?', 'KernelModule', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Object', 'itself', 'Object', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 
 gen.binding('Proc', '==', 'ProcObject', 'equal_value', argc: 1, pass_env: false, pass_block: false, aliases: ['eql?'], return_type: :bool)

--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -54,7 +54,7 @@ module Natalie
                 "#{transform.intern(@name)}, Object::ConstLookupSearchMode::#{search_mode}, " \
                 'Object::ConstLookupFailureMode::Null)'
         code << "if (#{klass}) {"
-        code << "  if (!#{klass}->is_class()) {"
+        code << "  if (!#{klass}.is_class()) {"
         code << "    env->raise(\"TypeError\", \"#{@name} is not a class\");"
         code << '  }'
         code << "} else {"

--- a/lib/natalie/compiler/instructions/define_module_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_module_instruction.rb
@@ -55,7 +55,7 @@ module Natalie
         code << "  #{mod} = new ModuleObject(#{@name.to_s.inspect})"
         code << "  #{namespace}->const_set(#{transform.intern(@name)}, #{mod})"
         code << "}"
-        code << "if (!#{mod}->is_module() || #{mod}->is_class()) {"
+        code << "if (!#{mod}.is_module() || #{mod}.is_class()) {"
         code << "  env->raise(\"TypeError\", \"#{@name} is not a module\");"
         code << "}"
         code << "#{mod}->as_module()->eval_body(env, #{fn})"

--- a/lib/natalie/compiler/instructions/flip_flop_instruction.rb
+++ b/lib/natalie/compiler/instructions/flip_flop_instruction.rb
@@ -32,7 +32,7 @@ module Natalie
           transform.with_same_scope(switch_off_body) do |t|
             code << t.transform("Value #{switch_off_result} =")
           end
-          code << "  if (#{switch_off_result}->is_truthy()) {"
+          code << "  if (#{switch_off_result}.is_truthy()) {"
           code << "    #{state} = FlipFlopState::Transitioning"
           code << '  }'
           code << '} else {'
@@ -40,15 +40,15 @@ module Natalie
             code << t.transform("Value #{switch_on_result} =")
           end
           code << "  if (#{state} == FlipFlopState::Transitioning) {"
-          code << "    #{state} = #{switch_on_result}->is_truthy() ? FlipFlopState::On : FlipFlopState::Off"
-          code << "  } else if (#{switch_on_result}->is_truthy()) {"
+          code << "    #{state} = #{switch_on_result}.is_truthy() ? FlipFlopState::On : FlipFlopState::Off"
+          code << "  } else if (#{switch_on_result}.is_truthy()) {"
           if @exclude_end
             code << "    #{state} = FlipFlopState::On"
           else
             transform.with_same_scope(switch_off_body) do |t|
               code << t.transform("Value #{switch_off_result} =")
             end
-            code << "    #{state} = #{switch_off_result}->is_truthy() ? FlipFlopState::Transitioning : FlipFlopState::On"
+            code << "    #{state} = #{switch_off_result}.is_truthy() ? FlipFlopState::Transitioning : FlipFlopState::On"
           end
           code << '  }'
           code << '}'

--- a/lib/natalie/compiler/instructions/if_instruction.rb
+++ b/lib/natalie/compiler/instructions/if_instruction.rb
@@ -27,7 +27,7 @@ module Natalie
         code << "Value #{result}"
 
         transform.normalize_stack do
-          code << "if (#{condition}->is_truthy()) {"
+          code << "if (#{condition}.is_truthy()) {"
           if_size = transform.with_same_scope(true_body) do |t|
             code << t.transform("#{result} =")
           end

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -73,7 +73,7 @@ module Natalie
           when 'int'
             "#{value}.as_fast_integer()"
           when 'bool'
-            "#{value}->is_truthy()"
+            "#{value}.is_truthy()"
           when 'Value'
             value
           else

--- a/lib/natalie/compiler/instructions/is_nil_instruction.rb
+++ b/lib/natalie/compiler/instructions/is_nil_instruction.rb
@@ -9,7 +9,7 @@ module Natalie
 
       def generate(transform)
         obj = transform.pop
-        transform.exec_and_push(:is_nil, "bool_object(#{obj}->is_nil())")
+        transform.exec_and_push(:is_nil, "bool_object(#{obj}.is_nil())")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/while_instruction.rb
+++ b/lib/natalie/compiler/instructions/while_instruction.rb
@@ -53,13 +53,13 @@ module Natalie
 
         transform.with_same_scope(body) do |t|
           if @pre
-            code << "while (#{condition_name}()->is_truthy()) {"
+            code << "while (#{condition_name}().is_truthy()) {"
             code << t.transform
             code << '}'
           else
             code << 'do {'
             code << t.transform
-            code << "} while (#{condition_name}()->is_truthy())"
+            code << "} while (#{condition_name}().is_truthy())"
           end
         end
 

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -18,33 +18,33 @@ static Value generate_random(nat_int_t min, nat_int_t max) {
 Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_between(env, 0, 1);
     auto arg = args.at(0, NilObject::the());
-    if (arg->is_nil()) {
+    if (arg.is_nil()) {
         return generate_random(0.0, 1.0);
     } else {
-        if (arg->is_float()) {
+        if (arg.is_float()) {
             double max = arg->as_float()->to_double();
             if (max <= 0)
                 max = 1.0;
             return generate_random(0.0, max);
-        } else if (arg->is_range()) {
+        } else if (arg.is_range()) {
             Value min = arg->as_range()->begin();
             Value max = arg->as_range()->end();
             // TODO: There can be different types of objects that respond to + and - (according to the docs)
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
-            if (min->is_numeric() && max->is_numeric()) {
-                if (min.send(env, ">"_s, { max })->is_true()) {
+            if (min.is_numeric() && max.is_numeric()) {
+                if (min.send(env, ">"_s, { max }).is_true()) {
                     env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
                 }
 
-                if (min->is_float() || max->is_float()) {
+                if (min.is_float() || max.is_float()) {
                     double min_rand, max_rand;
-                    if (min->is_float()) {
+                    if (min.is_float()) {
                         min_rand = min->as_float()->to_double();
                     } else {
                         min_rand = static_cast<double>(IntegerObject::convert_to_native_type<nat_int_t>(env, min));
                     }
 
-                    if (max->is_float()) {
+                    if (max.is_float()) {
                         max_rand = max->as_float()->to_double();
                     } else {
                         max_rand = static_cast<double>(IntegerObject::convert_to_native_type<nat_int_t>(env, max));

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -15,18 +15,18 @@ Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
 
     if (!basename) {
         basename = new StringObject { "" };
-    } else if (!basename->is_string() && basename->respond_to(env, "to_str"_s)) {
+    } else if (!basename.is_string() && basename->respond_to(env, "to_str"_s)) {
         basename = basename->to_str(env);
-    } else if (basename->is_array()) {
+    } else if (basename.is_array()) {
         auto arr = basename->as_array();
         basename = arr->ref(env, Value::integer(0));
         if (arr->size() >= 2)
             suffix = arr->at(1)->to_str(env);
     }
-    if (!basename->is_string()) {
+    if (!basename.is_string()) {
         env->raise("ArgumentError", "unexpected prefix: {}", basename->inspect_str(env));
     }
-    if (tmpdir && !tmpdir->is_nil()) {
+    if (tmpdir && !tmpdir.is_nil()) {
         tmpdir.assert_type(env, Object::Type::String, "String");
     } else {
         tmpdir = GlobalEnv::the()->Object()->const_fetch("Dir"_s).send(env, "tmpdir"_s);

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -215,35 +215,35 @@ static void emit_object_value(Env *env, Value value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    if (value->is_array()) {
+    if (value.is_array()) {
         emit_value(env, value->as_array(), emitter, event);
-    } else if (value->is_class()) {
+    } else if (value.is_class()) {
         emit_value(env, value->as_class(), emitter, event);
-    } else if (value->is_exception()) {
+    } else if (value.is_exception()) {
         emit_value(env, value->as_exception(), emitter, event);
-    } else if (value->is_false()) {
+    } else if (value.is_false()) {
         emit_value(env, value->as_false(), emitter, event);
-    } else if (value->is_float()) {
+    } else if (value.is_float()) {
         emit_value(env, value->as_float(), emitter, event);
-    } else if (value->is_hash()) {
+    } else if (value.is_hash()) {
         emit_value(env, value->as_hash(), emitter, event);
     } else if (value.is_integer()) {
         emit_value(env, value.integer(), emitter, event);
-    } else if (value->is_module()) {
+    } else if (value.is_module()) {
         emit_value(env, value->as_module(), emitter, event);
-    } else if (value->is_nil()) {
+    } else if (value.is_nil()) {
         emit_value(env, value->as_nil(), emitter, event);
-    } else if (value->is_range()) {
+    } else if (value.is_range()) {
         emit_value(env, value->as_range(), emitter, event);
-    } else if (value->is_regexp()) {
+    } else if (value.is_regexp()) {
         emit_value(env, value->as_regexp(), emitter, event);
-    } else if (value->is_string()) {
+    } else if (value.is_string()) {
         emit_value(env, value->as_string(), emitter, event);
-    } else if (value->is_symbol()) {
+    } else if (value.is_symbol()) {
         emit_value(env, value->as_symbol(), emitter, event);
-    } else if (value->is_time()) {
+    } else if (value.is_time()) {
         emit_value(env, value->as_time(), emitter, event);
-    } else if (value->is_true()) {
+    } else if (value.is_true()) {
         emit_value(env, value->as_true(), emitter, event);
     } else if (GlobalEnv::the()->Object()->defined(env, "Date"_s, false) && value->is_a(env, GlobalEnv::the()->Object()->const_get("Date"_s)->as_class())) {
         emit_value(env, value->send(env, "to_s"_s)->as_string(), emitter, event);
@@ -320,12 +320,12 @@ static Value load_scalar(Env *env, yaml_parser_t &parser, yaml_token_t &token) {
 
     // If it looks like an Integer, and quaks like an Integer
     auto int_value = KernelModule::Integer(env, result, 10, false);
-    if (int_value && !int_value->is_nil())
+    if (int_value && !int_value.is_nil())
         return int_value;
 
     // If it looks like a Float, and quaks like a Float
     auto float_value = KernelModule::Float(env, result, false);
-    if (float_value && !float_value->is_nil())
+    if (float_value && !float_value.is_nil())
         return float_value;
 
     return result;
@@ -407,7 +407,7 @@ Value YAML_load(Env *env, Value self, Args &&args, Block *) {
     Defer parser_deleter { [&parser]() { yaml_parser_delete(&parser); } };
 
     auto input = args.at(0);
-    if (input->is_io() || input->respond_to(env, "to_io"_s)) {
+    if (input.is_io() || input->respond_to(env, "to_io"_s)) {
         auto io = input->to_io(env);
         auto file = fdopen(io->fileno(env), "r");
         yaml_parser_set_input_file(&parser, file);

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -255,13 +255,13 @@ void Zlib_do_inflate(Env *env, Value self, const String &string, int flush) {
 
 Value Zlib_inflate_append(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 1);
-    if (args[0]->is_nil()) {
+    if (args[0].is_nil()) {
         auto *strm = (z_stream *)self->ivar_get(env, "@stream"_s)->as_void_p()->void_ptr();
         inflateEnd(strm);
         self->ivar_set(env, "@inflate_end"_s, TrueObject::the());
     } else {
         auto string = args[0]->as_string_or_raise(env);
-        if (self->ivar_get(env, "@inflate_end"_s)->is_truthy()) {
+        if (self->ivar_get(env, "@inflate_end"_s).is_truthy()) {
             auto result = self->ivar_get(env, "@result"_s)->as_string_or_raise(env);
             result->append(string);
         } else {

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -138,7 +138,7 @@ HashObject *Args::keyword_hash() const {
         return nullptr;
 
     auto hash = last().object_or_null();
-    if (!hash || !hash->is_hash())
+    if (!hash || hash->type() != Object::Type::Hash)
         return nullptr;
 
     return hash->as_hash();

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -34,10 +34,10 @@ namespace ArrayPacker {
                 String string;
                 StringObject *string_object = nullptr;
                 auto item = m_source->at(m_index);
-                if (m_source->is_string()) {
+                if (m_source->type() == Object::Type::String) {
                     string_object = item->as_string();
                     string = item->as_string()->string();
-                } else if (item->is_nil()) {
+                } else if (item.is_nil()) {
                     if (d == 'u' || d == 'm')
                         env->raise("TypeError", "no implicit conversion of nil into String");
                     string = "";
@@ -46,7 +46,7 @@ namespace ArrayPacker {
                     string = string_object->string();
                 } else if (d == 'M' && (item->respond_to(env, "to_s"_s))) {
                     auto str = item->send(env, "to_s"_s);
-                    if (str->is_string()) {
+                    if (str.is_string()) {
                         string_object = str->as_string();
                         string = str->as_string()->string();
                     } else {
@@ -111,7 +111,7 @@ namespace ArrayPacker {
                     auto value = m_source->at(m_index);
                     if (value.is_integer()) {
                         value = IntegerObject::to_f(value.integer());
-                    } else if (value->is_rational()) {
+                    } else if (value.is_rational()) {
                         value = value->as_rational()->to_f(env);
                     }
                     auto packer = FloatHandler { value->as_float_or_raise(env), token };

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -3,7 +3,7 @@
 
 namespace Natalie {
 BSearchCheckResult binary_search_check(Env *env, Value block_result) {
-    if (block_result->is_numeric()) {
+    if (block_result.is_numeric()) {
         if (block_result.is_integer()) {
             auto i = block_result.integer();
             if (IntegerObject::is_zero(i))
@@ -19,8 +19,8 @@ BSearchCheckResult binary_search_check(Env *env, Value block_result) {
         }
 
         return BSearchCheckResult::BIGGER;
-    } else if (block_result->is_boolean() || block_result->is_nil()) {
-        if (block_result->is_true())
+    } else if (block_result.is_boolean() || block_result.is_nil()) {
+        if (block_result.is_true())
             return BSearchCheckResult::SMALLER;
 
         return BSearchCheckResult::BIGGER;
@@ -40,7 +40,7 @@ Optional<nat_int_t> binary_search(Env *env, nat_int_t left, nat_int_t right, std
         case BSearchCheckResult::EQUAL:
             return middle;
         case BSearchCheckResult::SMALLER: {
-            if (!block_result->is_numeric())
+            if (!block_result.is_numeric())
                 result = middle;
             right = middle - 1;
             break;

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -7,7 +7,7 @@ Value ClassObject::initialize(Env *env, Value superclass, Block *block) {
         env->raise("TypeError", "already initialized class");
     if (!superclass)
         superclass = GlobalEnv::the()->Object();
-    if (!superclass->is_class())
+    if (!superclass.is_class())
         env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass->klass()->inspect_str());
     superclass->as_class()->initialize_subclass(this, env, "", superclass->as_class()->object_type());
     ModuleObject::initialize(env, block);

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -32,7 +32,7 @@ Value DirObject::initialize(Env *env, Value path, Value encoding) {
     path = ioutil::convert_using_to_path(env, path);
     m_dir = ::opendir(path->as_string()->c_str());
     if (!m_dir) env->raise_errno();
-    if (encoding && !encoding->is_nil()) {
+    if (encoding && !encoding.is_nil()) {
         m_encoding = EncodingObject::find_encoding(env, encoding);
     } else {
         m_encoding = EncodingObject::filesystem();
@@ -273,7 +273,7 @@ Value DirObject::rmdir(Env *env, Value path) {
 }
 
 Value DirObject::home(Env *env, Value username) {
-    if (username && !username->is_nil()) {
+    if (username && !username.is_nil()) {
         username.assert_type(env, Object::Type::String, "String");
         // lookup home-dir for username
         struct passwd *pw;
@@ -285,7 +285,7 @@ Value DirObject::home(Env *env, Value username) {
         // no argument version
         Value home_str = new StringObject { "HOME" };
         Value home_dir = GlobalEnv::the()->Object()->const_fetch("ENV"_s).send(env, "[]"_s, { home_str });
-        if (!home_dir->is_nil())
+        if (!home_dir.is_nil())
             return home_dir->duplicate(env);
         struct passwd *pw;
         pw = getpwuid(getuid());

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -97,7 +97,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
                 result = options.fallback_option->send(env, "call"_s, { ch });
             }
 
-            if (result->is_nil()) {
+            if (result.is_nil()) {
                 auto message = StringObject::format(
                     "U+{} from {} to {}",
                     String::hex(cpt, String::HexFormat::Uppercase),
@@ -236,9 +236,9 @@ HashObject *EncodingObject::aliases(Env *env) {
 }
 
 EncodingObject *EncodingObject::set_default_external(Env *env, Value arg) {
-    if (arg->is_encoding()) {
+    if (arg.is_encoding()) {
         s_default_external = arg->as_encoding();
-    } else if (arg->is_nil()) {
+    } else if (arg.is_nil()) {
         env->raise("ArgumentError", "default external cannot be nil");
     } else {
         auto name = arg->to_str(env);
@@ -248,9 +248,9 @@ EncodingObject *EncodingObject::set_default_external(Env *env, Value arg) {
     return default_external();
 }
 EncodingObject *EncodingObject::set_default_internal(Env *env, Value arg) {
-    if (arg->is_encoding()) {
+    if (arg.is_encoding()) {
         s_default_internal = arg->as_encoding();
-    } else if (arg->is_nil()) {
+    } else if (arg.is_nil()) {
         s_default_internal = nullptr;
     } else {
         auto name = arg->to_str(env);
@@ -262,7 +262,7 @@ EncodingObject *EncodingObject::set_default_internal(Env *env, Value arg) {
 
 // Typically returns an EncodingObject, but can return nil.
 Value EncodingObject::find(Env *env, Value name) {
-    if (name->is_encoding())
+    if (name.is_encoding())
         return name;
     auto string = name->to_str(env)->string().lowercase();
     if (string == "internal") {
@@ -308,7 +308,7 @@ EncodingObject *EncodingObject::find_encoding_by_name(Env *env, String name) {
 // return the encoding matching the string.  Sets a default if the lookup fails.
 EncodingObject *EncodingObject::find_encoding(Env *env, Value encoding) {
     Value enc_or_nil = EncodingObject::find(env, encoding);
-    if (enc_or_nil->is_encoding())
+    if (enc_or_nil.is_encoding())
         return enc_or_nil->as_encoding();
 
     auto enc = EncodingObject::find_encoding_by_name(env, String("BINARY"));

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -20,7 +20,7 @@ ArithmeticSequenceObject::ArithmeticSequenceObject(Env *env, Origin origin, Valu
     : ArithmeticSequenceObject(env, origin, {}, begin, end, step, exclude_end) { }
 
 bool ArithmeticSequenceObject::calculate_ascending(Env *env) {
-    return step().send(env, ">"_s, { Value::integer(0) })->is_truthy();
+    return step().send(env, ">"_s, { Value::integer(0) }).is_truthy();
 }
 
 Integer ArithmeticSequenceObject::calculate_step_count(Env *env) {
@@ -28,17 +28,17 @@ Integer ArithmeticSequenceObject::calculate_step_count(Env *env) {
     auto _begin = m_begin;
     auto _end = m_end;
 
-    if (!_end || _end->is_nil() || _end.send(env, "infinite?"_s)->is_truthy())
+    if (!_end || _end.is_nil() || _end.send(env, "infinite?"_s).is_truthy())
         return 0;
 
-    if (_begin.send(env, "infinite?"_s)->is_truthy())
+    if (_begin.send(env, "infinite?"_s).is_truthy())
         return 0;
 
     auto cmp = ascending(env) ? ">"_s : "<"_s;
-    if (_begin.send(env, cmp, { _end })->is_truthy())
+    if (_begin.send(env, cmp, { _end }).is_truthy())
         return 0;
 
-    if (_step->is_float() || _begin->is_float() || _end->is_float()) {
+    if (_step.is_float() || _begin.is_float() || _end.is_float()) {
         _step = _step->to_f(env);
         _begin = _begin->to_f(env);
         _end = _end->to_f(env);
@@ -52,10 +52,10 @@ Integer ArithmeticSequenceObject::calculate_step_count(Env *env) {
     // Try to fix float incorrections
     // For example: begin: 1, end: 55.6, step: 18.2
     // n = 3.0 but 1 + 3 * 18.2 = 55.599999999999994
-    if (_end.send(env, cmp, { _begin.send(env, "+"_s, { n.send(env, "*"_s, { _step }) }) })->is_truthy())
+    if (_end.send(env, cmp, { _begin.send(env, "+"_s, { n.send(env, "*"_s, { _step }) }) }).is_truthy())
         n = n.send(env, "+"_s, { Value::integer(1) });
 
-    if (n.send(env, "=="_s, { n.send(env, "floor"_s) })->is_truthy())
+    if (n.send(env, "=="_s, { n.send(env, "floor"_s) }).is_truthy())
         n = Object::to_int(env, n);
 
     Integer step_count;
@@ -92,9 +92,9 @@ Value ArithmeticSequenceObject::iterate(Env *env, std::function<Value(Value)> fu
     auto steps = step_count(env);
 
     auto cmp = ascending(env) ? ">"_s : "<"_s;
-    auto infinite = !_end || _end->is_nil() || (_end.send(env, "infinite?"_s)->is_truthy() && _end.send(env, cmp, { Value::integer(0) })->is_truthy());
+    auto infinite = !_end || _end.is_nil() || (_end.send(env, "infinite?"_s).is_truthy() && _end.send(env, cmp, { Value::integer(0) }).is_truthy());
 
-    if (_step->is_float() || _begin->is_float() || _end->is_float()) {
+    if (_step.is_float() || _begin.is_float() || _end.is_float()) {
         _step = _step->to_f(env);
         _begin = _begin->to_f(env);
 
@@ -103,14 +103,14 @@ Value ArithmeticSequenceObject::iterate(Env *env, std::function<Value(Value)> fu
             _end = _end->to_f(env);
     }
 
-    if (_step.send(env, "infinite?"_s)->is_truthy()) {
-        if (_begin.send(env, cmp, { _end })->is_falsey())
+    if (_step.send(env, "infinite?"_s).is_truthy()) {
+        if (_begin.send(env, cmp, { _end }).is_falsey())
             func(_begin);
         return this;
     }
 
-    if (_begin.send(env, "infinite?"_s)->is_truthy()) {
-        if (_begin.send(env, cmp, { Value::integer(0) })->is_truthy() || _begin.send(env, "=="_s, { _end })->is_truthy())
+    if (_begin.send(env, "infinite?"_s).is_truthy()) {
+        if (_begin.send(env, cmp, { Value::integer(0) }).is_truthy() || _begin.send(env, "=="_s, { _end }).is_truthy())
             return this;
         infinite = true;
     }
@@ -119,7 +119,7 @@ Value ArithmeticSequenceObject::iterate(Env *env, std::function<Value(Value)> fu
         auto value = _step.send(env, "*"_s, { IntegerObject::create(i) }).send(env, "+"_s, { _begin });
 
         // Ensure that we do not yield a number that exceeds `_end`
-        if (!infinite && value.send(env, cmp, { _end })->is_truthy())
+        if (!infinite && value.send(env, cmp, { _end }).is_truthy())
             value = _end;
 
         func(value);
@@ -141,7 +141,7 @@ Value ArithmeticSequenceObject::enum_block(Env *env, Value self, Args &&args, Bl
 }
 
 bool ArithmeticSequenceObject::eq(Env *env, Value other) {
-    if (!other->is_enumerator_arithmetic_sequence())
+    if (!other.is_enumerator_arithmetic_sequence())
         return false;
 
     ArithmeticSequenceObject *other_sequence = other->as_enumerator_arithmetic_sequence();
@@ -155,7 +155,7 @@ Value ArithmeticSequenceObject::hash(Env *env) {
     auto add = [&hash_builder, &hash_method, env](Value value) {
         auto hash = value.send(env, hash_method);
 
-        if (hash->is_nil())
+        if (hash.is_nil())
             return;
 
         auto nat_int = IntegerObject::convert_to_nat_int_t(env, hash);
@@ -226,7 +226,7 @@ Value ArithmeticSequenceObject::last(Env *env, Value n) {
 
         auto _begin = maybe_to_f(env, m_begin);
         auto last = _begin.send(env, "+"_s, { step().send(env, "*"_s, { IntegerObject::create(steps) }) });
-        if (last.send(env, ">="_s, { _end })->is_truthy())
+        if (last.send(env, ">="_s, { _end }).is_truthy())
             last = last.send(env, "-"_s, { step() });
 
         auto begin = last.send(env, "-"_s, { step().send(env, "*"_s, { IntegerObject::create(count) }) });
@@ -239,27 +239,27 @@ Value ArithmeticSequenceObject::last(Env *env, Value n) {
         return array;
     } else {
         auto last = m_begin.send(env, "+"_s, { step().send(env, "*"_s, { IntegerObject::create(steps - 1) }) });
-        if (last.send(env, ">"_s, { m_end })->is_truthy())
+        if (last.send(env, ">"_s, { m_end }).is_truthy())
             last = last.send(env, "-"_s, { step() });
         return last;
     }
 }
 
 Value ArithmeticSequenceObject::maybe_to_f(Env *env, Value v) {
-    if (m_begin->is_float() || m_end->is_float())
+    if (m_begin.is_float() || m_end.is_float())
         return v->to_f(env);
     return v;
 }
 
 Value ArithmeticSequenceObject::size(Env *env) {
-    if (!m_end || m_end->is_nil())
+    if (!m_end || m_end.is_nil())
         return FloatObject::positive_infinity(env);
 
-    if (m_end.send(env, "infinite?"_s)->is_truthy()) {
+    if (m_end.send(env, "infinite?"_s).is_truthy()) {
         auto cmp = ascending(env) ? ">"_s : "<"_s;
-        auto same_sign = m_end.send(env, cmp, { Value::integer(0) })->is_truthy();
+        auto same_sign = m_end.send(env, cmp, { Value::integer(0) }).is_truthy();
 
-        if (step().send(env, "infinite?"_s)->is_truthy()) {
+        if (step().send(env, "infinite?"_s).is_truthy()) {
             if (same_sign)
                 return Value::integer(1);
             else

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -107,9 +107,9 @@ void Env::raise_exception(ExceptionObject *exception) {
         // only build a backtrace the first time the exception is raised (not on a re-raise)
         exception->build_backtrace(this);
     }
-    if (!exception->cause() || exception->cause()->is_nil()) {
+    if (!exception->cause() || exception->cause()->type() == Object::Type::Nil) {
         auto cause = exception_object();
-        if (cause && cause->is_exception() && cause != exception)
+        if (cause && cause.is_exception() && cause != exception)
             exception->set_cause(cause->as_exception());
     }
     throw exception;
@@ -156,13 +156,13 @@ void Env::raise_invalid_byte_sequence_error(const EncodingObject *encoding) {
 
 void Env::raise_no_method_error(Object *receiver, SymbolObject *name, MethodMissingReason reason) {
     String inspect_string;
-    if (receiver->is_nil() || receiver->is_true() || receiver->is_false()) {
+    if (receiver->type() == Object::Type::Nil || receiver->type() == Object::Type::True || receiver->type() == Object::Type::False) {
         inspect_string = receiver->inspect_str(this);
     } else if (receiver->is_main_object()) {
         inspect_string = "main";
-    } else if (receiver->is_class()) {
+    } else if (receiver->type() == Object::Type::Class) {
         inspect_string = String::format("class {}", receiver->inspect_str(this));
-    } else if (receiver->is_module()) {
+    } else if (receiver->type() == Object::Type::Module) {
         inspect_string = String::format("module {}", receiver->inspect_str(this));
     } else {
         inspect_string = String::format("an instance of {}", receiver->klass()->inspect_str());
@@ -205,7 +205,7 @@ void Env::raise_name_error(StringObject *name, String message) {
 void Env::raise_not_comparable_error(Value lhs, Value rhs) {
     String lhs_class = lhs->klass()->inspect_str();
     String rhs_inspect;
-    if (rhs.is_integer() || rhs->is_float() || rhs->is_falsey()) {
+    if (rhs.is_integer() || rhs.is_float() || rhs.is_falsey()) {
         rhs_inspect = rhs->inspect_str(this);
     } else {
         rhs_inspect = rhs->klass()->inspect_str();

--- a/src/false_object.cpp
+++ b/src/false_object.cpp
@@ -7,7 +7,7 @@ bool FalseObject::and_method(const Env *env, const Value other) const {
 }
 
 bool FalseObject::or_method(const Env *env, Value other) const {
-    return other->is_truthy();
+    return other.is_truthy();
 }
 
 Value FalseObject::to_s(const Env *env) const {

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -47,19 +47,19 @@ FiberObject *FiberObject::initialize(Env *env, Value blocking, Value storage, Bl
     m_block = block;
 
     if (blocking != nullptr)
-        m_blocking = blocking->is_truthy();
+        m_blocking = blocking.is_truthy();
 
     m_file = env->file();
     m_line = env->line();
 
-    if (storage != nullptr && !storage->is_nil()) {
-        if (!storage->is_hash())
+    if (storage != nullptr && !storage.is_nil()) {
+        if (!storage.is_hash())
             env->raise("TypeError", "storage must be a hash");
         if (storage->is_frozen())
             env->raise("FrozenError", "storage must not be frozen");
         auto *hash = storage->as_hash();
         for (auto it = hash->begin(); it != hash->end(); it++) {
-            if (!it->key->is_symbol())
+            if (!it->key.is_symbol())
                 env->raise("TypeError", "wrong argument type Object (expected Symbol)");
         }
         m_storage = hash;
@@ -117,9 +117,9 @@ Value FiberObject::is_blocking_current() {
 
 Value FiberObject::ref(Env *env, Value key) {
     const static auto to_str = "to_str"_s;
-    if (key->is_string() || key->respond_to(env, to_str))
+    if (key.is_string() || key->respond_to(env, to_str))
         key = key->to_str(env)->to_sym(env);
-    if (!key->is_symbol())
+    if (!key.is_symbol())
         env->raise("TypeError", "wrong argument type {} (expected Symbol)", key->klass()->inspect_str());
     auto fiber = current();
     while ((fiber->m_storage == nullptr || !fiber->m_storage->has_key(env, key)) && fiber->m_previous_fiber != nullptr)
@@ -131,13 +131,13 @@ Value FiberObject::ref(Env *env, Value key) {
 
 Value FiberObject::refeq(Env *env, Value key, Value value) {
     const static auto to_str = "to_str"_s;
-    if (key->is_string() || key->respond_to(env, to_str))
+    if (key.is_string() || key->respond_to(env, to_str))
         key = key->to_str(env)->to_sym(env);
-    if (!key->is_symbol())
+    if (!key.is_symbol())
         env->raise("TypeError", "wrong argument type {} (expected Symbol)", key->klass()->inspect_str());
     if (current()->m_storage == nullptr)
         current()->m_storage = new HashObject {};
-    if (!value || value->is_nil()) {
+    if (!value || value.is_nil()) {
         current()->m_storage->remove(env, key);
     } else {
         current()->m_storage->refeq(env, key, value);
@@ -201,11 +201,11 @@ bool FiberObject::scheduler_is_relevant() {
         return false;
 
     auto scheduler = FiberObject::scheduler();
-    return !scheduler->is_nil();
+    return !scheduler.is_nil();
 }
 
 Value FiberObject::set_scheduler(Env *env, Value scheduler) {
-    if (scheduler->is_nil()) {
+    if (scheduler.is_nil()) {
         ThreadObject::current()->set_fiber_scheduler(nullptr);
     } else {
         TM::Vector<TM::String> required_methods { "block", "unblock", "kernel_sleep", "io_wait" };
@@ -219,16 +219,16 @@ Value FiberObject::set_scheduler(Env *env, Value scheduler) {
 }
 
 Value FiberObject::set_storage(Env *env, Value storage) {
-    if (storage == nullptr || storage->is_nil()) {
+    if (storage == nullptr || storage.is_nil()) {
         m_storage = nullptr;
-    } else if (!storage->is_hash()) {
+    } else if (!storage.is_hash()) {
         env->raise("TypeError", "storage must be a hash");
     } else {
         if (storage->is_frozen())
             env->raise("FrozenError", "storage must not be frozen");
         auto *hash = storage->as_hash();
         for (auto it = hash->begin(); it != hash->end(); it++) {
-            if (!it->key->is_symbol())
+            if (!it->key.is_symbol())
                 env->raise("TypeError", "wrong argument type Object (expected Symbol)");
         }
         m_storage = hash;

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -72,12 +72,12 @@ Value FileObject::absolute_path(Env *env, Value path, Value dir) {
     path = ioutil::convert_using_to_path(env, path);
     if (path->as_string()->start_with(env, { new StringObject { "/" } }))
         return path;
-    if ((!dir || dir->is_nil()) && path->as_string()->eq(env, new StringObject { "~" }))
+    if ((!dir || dir.is_nil()) && path->as_string()->eq(env, new StringObject { "~" }))
         return path;
 
     auto File = GlobalEnv::the()->Object()->const_get("File"_s);
     assert(File);
-    if (!dir || dir->is_nil())
+    if (!dir || dir.is_nil())
         dir = DirObject::pwd(env);
     return File->send(env, "join"_s, { dir, path });
 }
@@ -135,7 +135,7 @@ Value FileObject::expand_path(Env *env, Value path, Value root) {
     path_string = expand_tilde(std::move(path_string));
 
     auto fs_path = std::filesystem::path(path_string.c_str());
-    if (fs_path.is_relative() && root && !root->is_nil()) {
+    if (fs_path.is_relative() && root && !root.is_nil()) {
         root = ioutil::convert_using_to_path(env, root);
         path_string = expand_tilde(String::format("{}/{}", root->as_string()->string(), path_string));
         fs_path = std::filesystem::path(path_string.c_str());
@@ -640,15 +640,15 @@ Value FileObject::lutime(Env *env, Args &&args) {
     if (gettimeofday(&now, nullptr) < 0)
         env->raise_errno();
     auto time_convert = [&](Value v, timeval &t) {
-        if (v->is_nil()) {
+        if (v.is_nil()) {
             t = now;
-        } else if (v->is_time()) {
+        } else if (v.is_time()) {
             t.tv_sec = static_cast<time_t>(v->as_time()->to_i(env).integer().to_nat_int_t());
             t.tv_usec = static_cast<suseconds_t>(v->as_time()->usec(env).integer().to_nat_int_t());
         } else if (v.is_integer()) {
             t.tv_sec = IntegerObject::convert_to_native_type<time_t>(env, v);
             t.tv_usec = 0;
-        } else if (v->is_float()) {
+        } else if (v.is_float()) {
             const auto tmp = v->to_f(env)->to_double();
             t.tv_sec = static_cast<time_t>(tmp);
             t.tv_usec = (tmp - t.tv_sec) * 1000000;
@@ -694,7 +694,7 @@ Value FileObject::stat(Env *env, Value path) {
 // class methods
 Value FileObject::atime(Env *env, Value path) {
     FileStatObject *statobj;
-    if (path->is_io()) { // using file-descriptor
+    if (path.is_io()) { // using file-descriptor
         statobj = path->as_io()->stat(env)->as_file_stat();
     } else {
         path = ioutil::convert_using_to_path(env, path);
@@ -704,7 +704,7 @@ Value FileObject::atime(Env *env, Value path) {
 }
 Value FileObject::ctime(Env *env, Value path) {
     FileStatObject *statobj;
-    if (path->is_io()) { // using file-descriptor
+    if (path.is_io()) { // using file-descriptor
         statobj = path->as_io()->stat(env)->as_file_stat();
     } else {
         path = ioutil::convert_using_to_path(env, path);
@@ -715,7 +715,7 @@ Value FileObject::ctime(Env *env, Value path) {
 
 Value FileObject::mtime(Env *env, Value path) {
     FileStatObject *statobj;
-    if (path->is_io()) { // using file-descriptor
+    if (path.is_io()) { // using file-descriptor
         statobj = path->as_io()->stat(env)->as_file_stat();
     } else {
         path = ioutil::convert_using_to_path(env, path);
@@ -729,16 +729,16 @@ Value FileObject::utime(Env *env, Args &&args) {
 
     TimeObject *atime, *mtime;
 
-    if (args[0]->is_nil()) {
+    if (args[0].is_nil()) {
         atime = TimeObject::create(env);
-    } else if (args[0]->is_time()) {
+    } else if (args[0].is_time()) {
         atime = args[0]->as_time();
     } else {
         atime = TimeObject::at(env, args[0], nullptr, nullptr);
     }
-    if (args[1]->is_nil()) {
+    if (args[1].is_nil()) {
         mtime = TimeObject::create(env);
-    } else if (args[1]->is_time()) {
+    } else if (args[1].is_time()) {
         mtime = args[1]->as_time();
     } else {
         mtime = TimeObject::at(env, args[1], nullptr, nullptr);

--- a/src/file_stat_object.cpp
+++ b/src/file_stat_object.cpp
@@ -3,7 +3,7 @@
 namespace Natalie {
 
 Value FileStatObject::initialize(Env *env, Value path) {
-    if (!path->is_string() && path->respond_to(env, "to_path"_s))
+    if (!path.is_string() && path->respond_to(env, "to_path"_s))
         path = path->send(env, "to_path"_s, { path });
 
     path.assert_type(env, Object::Type::String, "String");

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -26,15 +26,15 @@ bool FloatObject::eq(Env *env, Value other) {
         return false;
     if (other.is_integer())
         return other.integer() == m_double;
-    if (other->is_float()) {
+    if (other.is_float()) {
         auto *f = other->as_float();
         return f->m_double == m_double;
     }
-    return other.send(env, "=="_s, { this })->is_truthy();
+    return other.send(env, "=="_s, { this }).is_truthy();
 }
 
 bool FloatObject::eql(Value other) const {
-    if (!other->is_float()) return false;
+    if (!other.is_float()) return false;
     auto *f = other->as_float();
     return f->m_double == m_double;
 }
@@ -43,7 +43,7 @@ bool FloatObject::eql(Value other) const {
     Value FloatObject::name(Env *env, Value precision_value) {                  \
         nat_int_t precision = 0;                                                \
         if (precision_value) {                                                  \
-            if (precision_value->is_float()) {                                  \
+            if (precision_value.is_float()) {                                   \
                 precision_value = precision_value->as_float()->to_i(env);       \
             }                                                                   \
             precision_value.assert_type(env, Object::Type::Integer, "Integer"); \
@@ -155,14 +155,14 @@ Value FloatObject::cmp(Env *env, Value rhs) {
             return Value::integer(-1);
     }
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "<=>"_s, { rhs });
-    if (!rhs->is_float()) return NilObject::the();
+    if (!lhs.is_float()) return lhs.send(env, "<=>"_s, { rhs });
+    if (!rhs.is_float()) return NilObject::the();
 
     if (lhs->as_float()->is_nan() || rhs->as_float()->is_nan()) {
         return NilObject::the();
@@ -228,18 +228,18 @@ Value FloatObject::to_r(Env *env) const {
 Value FloatObject::add(Env *env, Value rhs) {
     Value lhs = this;
 
-    if (rhs->is_complex()) {
+    if (rhs.is_complex()) {
         return rhs->send(env, "+"_s, { lhs });
     }
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "+"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "+"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double addend1 = to_double();
     double addend2 = rhs->as_float()->to_double();
@@ -249,14 +249,14 @@ Value FloatObject::add(Env *env, Value rhs) {
 Value FloatObject::sub(Env *env, Value rhs) {
     Value lhs = this;
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "-"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "-"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double minuend = to_double();
     double subtrahend = rhs->as_float()->to_double();
@@ -266,14 +266,14 @@ Value FloatObject::sub(Env *env, Value rhs) {
 Value FloatObject::mul(Env *env, Value rhs) {
     Value lhs = this;
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "*"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "*"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double multiplicand = to_double();
     double multiplier = rhs->as_float()->to_double();
@@ -283,14 +283,14 @@ Value FloatObject::mul(Env *env, Value rhs) {
 Value FloatObject::div(Env *env, Value rhs) {
     Value lhs = this;
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "/"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "/"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double dividend = to_double();
     double divisor = rhs->as_float()->to_double();
@@ -301,19 +301,19 @@ Value FloatObject::div(Env *env, Value rhs) {
 Value FloatObject::mod(Env *env, Value rhs) {
     Value lhs = this;
 
-    bool rhs_is_non_zero = (rhs->is_float() && !rhs->as_float()->is_zero()) || (rhs.is_integer() && !IntegerObject::is_zero(rhs.integer()));
+    bool rhs_is_non_zero = (rhs.is_float() && !rhs->as_float()->is_zero()) || (rhs.is_integer() && !IntegerObject::is_zero(rhs.integer()));
 
-    if (rhs->is_float() && rhs->as_float()->is_negative_infinity()) return new FloatObject { rhs->as_float()->to_double() };
+    if (rhs.is_float() && rhs->as_float()->is_negative_infinity()) return new FloatObject { rhs->as_float()->to_double() };
     if (is_negative_zero() && rhs_is_non_zero) return new FloatObject { m_double };
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "%"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "%"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double dividend = to_double();
     double divisor = rhs->as_float()->to_double();
@@ -332,9 +332,9 @@ Value FloatObject::divmod(Env *env, Value arg) {
     if (is_nan()) env->raise("FloatDomainError", "NaN");
     if (is_infinity()) env->raise("FloatDomainError", "Infinity");
 
-    if (!arg->is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg->klass()->inspect_str());
-    if (arg->is_float() && arg->as_float()->is_nan()) env->raise("FloatDomainError", "NaN");
-    if (arg->is_float() && arg->as_float()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
+    if (!arg.is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg->klass()->inspect_str());
+    if (arg.is_float() && arg->as_float()->is_nan()) env->raise("FloatDomainError", "NaN");
+    if (arg.is_float() && arg->as_float()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
     if (arg.is_integer() && IntegerObject::is_zero(arg.integer())) env->raise("ZeroDivisionError", "divided by 0");
 
     Value division = div(env, arg);
@@ -349,19 +349,19 @@ Value FloatObject::divmod(Env *env, Value arg) {
 Value FloatObject::pow(Env *env, Value rhs) {
     Value lhs = this;
 
-    if ((rhs->is_float() || rhs->is_rational()) && to_double() < 0) {
+    if ((rhs.is_float() || rhs.is_rational()) && to_double() < 0) {
         auto comp = new ComplexObject { this };
         return comp->send(env, "**"_s, { rhs });
     }
 
-    if (!rhs->is_float()) {
+    if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
         lhs = coerced.first;
         rhs = coerced.second;
     }
 
-    if (!lhs->is_float()) return lhs.send(env, "**"_s, { rhs });
-    if (!rhs->is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
+    if (!lhs.is_float()) return lhs.send(env, "**"_s, { rhs });
+    if (!rhs.is_float()) rhs.assert_type(env, Object::Type::Float, "Float");
 
     double base = to_double();
     double exponent = rhs->as_float()->to_double();
@@ -397,14 +397,14 @@ Value FloatObject::arg(Env *env) {
     bool FloatObject::name(Env *env, Value rhs) {                                                           \
         Value lhs = this;                                                                                   \
                                                                                                             \
-        if (!rhs->is_float()) {                                                                             \
+        if (!rhs.is_float()) {                                                                              \
             auto coerced = Natalie::coerce(env, rhs, lhs);                                                  \
             lhs = coerced.first;                                                                            \
             rhs = coerced.second;                                                                           \
         }                                                                                                   \
                                                                                                             \
-        if (!lhs->is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs });           \
-        if (!rhs->is_float()) {                                                                             \
+        if (!lhs.is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs });            \
+        if (!rhs.is_float()) {                                                                              \
             env->raise("ArgumentError", "comparison of Float with {} failed", rhs->klass()->inspect_str()); \
         }                                                                                                   \
                                                                                                             \

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -51,9 +51,9 @@ Value GlobalEnv::global_set(Env *env, SymbolObject *name, Value val, bool readon
         if (readonly)
             assert(info->is_readonly()); // changing a global to read-only is not anticipated.
         if (val)
-            info->set_object(env, val.object());
+            info->set_object(env, val);
     } else {
-        auto info = new GlobalVariableInfo { val.object(), readonly };
+        auto info = new GlobalVariableInfo { val, readonly };
         m_global_variables.put(name, info, env);
     }
     return val;

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -2,22 +2,22 @@
 
 namespace Natalie {
 
-void GlobalVariableInfo::set_object(Env *env, Value object) {
+void GlobalVariableInfo::set_object(Env *env, Value value) {
     if (m_write_hook) {
-        m_object = m_write_hook(env, object, *this);
+        m_value = m_write_hook(env, value, *this);
     } else {
-        m_object = object;
+        m_value = value;
     }
 }
 
 Value GlobalVariableInfo::object(Env *env) {
     if (m_read_hook)
         return m_read_hook(env, *this);
-    return m_object;
+    return m_value;
 }
 
 void GlobalVariableInfo::visit_children(Visitor &visitor) const {
-    visitor.visit(m_object);
+    visitor.visit(m_value);
 }
 
 }

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -17,7 +17,7 @@ namespace GlobalVariableAccessHooks::ReadHooks {
     }
 
     Value last_exception_backtrace(Env *env, GlobalVariableInfo &) {
-        if (!env->exception_object()->is_exception())
+        if (!env->exception_object().is_exception())
             return nullptr;
         return env->exception_object()->as_exception()->backtrace(env);
     }
@@ -28,28 +28,28 @@ namespace GlobalVariableAccessHooks::ReadHooks {
 
     Value last_match_pre_match(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
-        if (last_match->is_nil())
+        if (last_match.is_nil())
             return nullptr;
         return last_match->as_match_data()->pre_match(env);
     }
 
     Value last_match_post_match(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
-        if (last_match->is_nil())
+        if (last_match.is_nil())
             return nullptr;
         return last_match->as_match_data()->post_match(env);
     }
 
     Value last_match_last_group(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
-        if (last_match->is_nil())
+        if (last_match.is_nil())
             return nullptr;
         return last_match->as_match_data()->captures(env)->as_array()->compact(env)->as_array()->last();
     }
 
     Value last_match_to_s(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
-        if (last_match->is_nil())
+        if (last_match.is_nil())
             return nullptr;
         return last_match->as_match_data()->to_s(env);
     }
@@ -59,7 +59,7 @@ namespace GlobalVariableAccessHooks::ReadHooks {
 namespace GlobalVariableAccessHooks::WriteHooks {
 
     Value as_string_or_raise(Env *env, Value v, GlobalVariableInfo &) {
-        if (v->is_nil())
+        if (v.is_nil())
             return NilObject::the();
         return v->as_string_or_raise(env);
     }
@@ -69,7 +69,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
     }
 
     Value last_match(Env *env, Value v, GlobalVariableInfo &) {
-        if (!v || v->is_nil())
+        if (!v || v.is_nil())
             return NilObject::the();
         auto match = v->as_match_data_or_raise(env);
         env->set_last_match(match);
@@ -83,10 +83,10 @@ namespace GlobalVariableAccessHooks::WriteHooks {
     }
 
     Value set_verbose(Env *env, Value v, GlobalVariableInfo &) {
-        GlobalEnv::the()->set_verbose(v->is_truthy());
-        if (v->is_nil())
+        GlobalEnv::the()->set_verbose(v.is_truthy());
+        if (v.is_nil())
             return NilObject::the();
-        return bool_object(v->is_truthy()).object();
+        return bool_object(v.is_truthy()).object();
     }
 }
 

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -74,7 +74,7 @@ Value IntegerObject::to_f(Integer &self) {
 Value IntegerObject::add(Env *env, Integer &self, Value arg) {
     if (arg.is_integer()) {
         return create(self + arg.integer());
-    } else if (arg->is_float()) {
+    } else if (arg.is_float()) {
         return new FloatObject { self + arg->as_float()->to_double() };
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
@@ -90,7 +90,7 @@ Value IntegerObject::add(Env *env, Integer &self, Value arg) {
 Value IntegerObject::sub(Env *env, Integer &self, Value arg) {
     if (arg.is_integer()) {
         return create(self - arg.integer());
-    } else if (arg->is_float()) {
+    } else if (arg.is_float()) {
         double result = self.to_double() - arg->as_float()->to_double();
         return new FloatObject { result };
     } else if (!arg.is_integer()) {
@@ -105,7 +105,7 @@ Value IntegerObject::sub(Env *env, Integer &self, Value arg) {
 }
 
 Value IntegerObject::mul(Env *env, Integer &self, Value arg) {
-    if (arg->is_float()) {
+    if (arg.is_float()) {
         double result = self.to_double() * arg->as_float()->to_double();
         return new FloatObject { result };
     } else if (!arg.is_integer()) {
@@ -124,7 +124,7 @@ Value IntegerObject::mul(Env *env, Integer &self, Value arg) {
 }
 
 Value IntegerObject::div(Env *env, Integer &self, Value arg) {
-    if (arg->is_float()) {
+    if (arg.is_float()) {
         double result = self / arg->as_float()->to_double();
         if (isnan(result))
             return FloatObject::nan();
@@ -146,7 +146,7 @@ Value IntegerObject::div(Env *env, Integer &self, Value arg) {
 
 Value IntegerObject::mod(Env *env, Integer &self, Value arg) {
     Integer argument;
-    if (arg->is_float()) {
+    if (arg.is_float()) {
         auto f = new FloatObject { self.to_double() };
         return f->mod(env, arg);
     } else if (!arg.is_integer()) {
@@ -201,12 +201,12 @@ Value IntegerObject::pow(Env *env, Integer &self, Value arg) {
     if (arg.is_fast_integer())
         return pow(env, self, arg.integer());
 
-    if ((arg->is_float() || arg->is_rational()) && self < 0) {
+    if ((arg.is_float() || arg.is_rational()) && self < 0) {
         auto comp = new ComplexObject { self };
         return comp->send(env, "**"_s, { arg });
     }
 
-    if (arg->is_float()) {
+    if (arg.is_float()) {
         auto f = new FloatObject { self.to_double() };
         return f->pow(env, arg);
     }
@@ -252,7 +252,7 @@ Value IntegerObject::powmod(Env *env, Integer &self, Value exponent, Value mod) 
 
 Value IntegerObject::cmp(Env *env, Integer &self, Value arg) {
     auto is_comparable_with = [](Value arg) -> bool {
-        return arg.is_fast_integer() || arg.is_integer() || (arg->is_float() && !arg->as_float()->is_nan());
+        return arg.is_fast_integer() || arg.is_integer() || (arg.is_float() && !arg->as_float()->is_nan());
     };
 
     // Check if we might want to coerce the value
@@ -280,7 +280,7 @@ bool IntegerObject::eq(Env *env, Integer &self, Value other) {
     if (other.is_fast_integer())
         return self == other.integer();
 
-    if (other->is_float()) {
+    if (other.is_float()) {
         auto *f = other->as_float();
         return !f->is_nan() && self == f->to_double();
     }
@@ -288,18 +288,18 @@ bool IntegerObject::eq(Env *env, Integer &self, Value other) {
     if (!other.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, self);
         if (!lhs.is_integer())
-            return lhs->send(env, "=="_s, { rhs })->is_truthy();
+            return lhs->send(env, "=="_s, { rhs }).is_truthy();
         other = rhs;
     }
 
     if (other.is_integer())
         return self == other.integer();
 
-    return other->send(env, "=="_s, { self })->is_truthy();
+    return other->send(env, "=="_s, { self }).is_truthy();
 }
 
 bool IntegerObject::lt(Env *env, Integer &self, Value other) {
-    if (other->is_float()) {
+    if (other.is_float()) {
         if (other->as_float()->is_nan())
             return false;
         return self < other->as_float()->to_double();
@@ -308,7 +308,7 @@ bool IntegerObject::lt(Env *env, Integer &self, Value other) {
     if (!other.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, self);
         if (!lhs.is_integer())
-            return lhs->send(env, "<"_s, { rhs })->is_truthy();
+            return lhs->send(env, "<"_s, { rhs }).is_truthy();
         other = rhs;
     }
 
@@ -317,14 +317,14 @@ bool IntegerObject::lt(Env *env, Integer &self, Value other) {
 
     if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, self);
-        return result.first->send(env, "<"_s, { result.second })->is_truthy();
+        return result.first->send(env, "<"_s, { result.second }).is_truthy();
     }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
 
 bool IntegerObject::lte(Env *env, Integer &self, Value other) {
-    if (other->is_float()) {
+    if (other.is_float()) {
         if (other->as_float()->is_nan())
             return false;
         return self <= other->as_float()->to_double();
@@ -333,7 +333,7 @@ bool IntegerObject::lte(Env *env, Integer &self, Value other) {
     if (!other.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, self);
         if (!lhs.is_integer())
-            return lhs->send(env, "<="_s, { rhs })->is_truthy();
+            return lhs->send(env, "<="_s, { rhs }).is_truthy();
         other = rhs;
     }
 
@@ -342,14 +342,14 @@ bool IntegerObject::lte(Env *env, Integer &self, Value other) {
 
     if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, self);
-        return result.first->send(env, "<="_s, { result.second })->is_truthy();
+        return result.first->send(env, "<="_s, { result.second }).is_truthy();
     }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
 
 bool IntegerObject::gt(Env *env, Integer &self, Value other) {
-    if (other->is_float()) {
+    if (other.is_float()) {
         if (other->as_float()->is_nan())
             return false;
         return self > other->as_float()->to_double();
@@ -358,7 +358,7 @@ bool IntegerObject::gt(Env *env, Integer &self, Value other) {
     if (!other.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, self, Natalie::CoerceInvalidReturnValueMode::Raise);
         if (!lhs.is_integer())
-            return lhs->send(env, ">"_s, { rhs })->is_truthy();
+            return lhs->send(env, ">"_s, { rhs }).is_truthy();
         other = rhs;
     }
 
@@ -367,14 +367,14 @@ bool IntegerObject::gt(Env *env, Integer &self, Value other) {
 
     if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, self);
-        return result.first->send(env, ">"_s, { result.second })->is_truthy();
+        return result.first->send(env, ">"_s, { result.second }).is_truthy();
     }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
 
 bool IntegerObject::gte(Env *env, Integer &self, Value other) {
-    if (other->is_float()) {
+    if (other.is_float()) {
         if (other->as_float()->is_nan())
             return false;
         return self >= other->as_float()->to_double();
@@ -383,7 +383,7 @@ bool IntegerObject::gte(Env *env, Integer &self, Value other) {
     if (!other.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, other, self, Natalie::CoerceInvalidReturnValueMode::Raise);
         if (!lhs.is_integer())
-            return lhs->send(env, ">="_s, { rhs })->is_truthy();
+            return lhs->send(env, ">="_s, { rhs }).is_truthy();
         other = rhs;
     }
 
@@ -392,7 +392,7 @@ bool IntegerObject::gte(Env *env, Integer &self, Value other) {
 
     if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, self);
-        return result.first->send(env, ">="_s, { result.second })->is_truthy();
+        return result.first->send(env, ">="_s, { result.second }).is_truthy();
     }
 
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
@@ -511,11 +511,11 @@ Value IntegerObject::coerce(Env *env, Value self, Value arg) {
         ary->push(self.send(env, "to_f"_s));
         break;
     default:
-        if (!arg->is_nil() && !arg->is_float() && arg->respond_to(env, "to_f"_s)) {
+        if (!arg.is_nil() && !arg.is_float() && arg->respond_to(env, "to_f"_s)) {
             arg = arg.send(env, "to_f"_s);
         }
 
-        if (arg->is_float()) {
+        if (arg.is_float()) {
             ary->push(arg);
             ary->push(self->send(env, "to_f"_s));
             break;
@@ -570,7 +570,7 @@ Value IntegerObject::chr(Env *env, Integer &self, Value encoding) {
         env->raise("RangeError", "bignum out of char range");
 
     if (encoding) {
-        if (!encoding->is_encoding()) {
+        if (!encoding.is_encoding()) {
             encoding.assert_type(env, Type::String, "String");
             encoding = EncodingObject::find(env, encoding);
         }
@@ -696,17 +696,17 @@ Value IntegerObject::ref(Env *env, Integer &self, Value offset_obj, Value size_o
         return create(result);
     };
 
-    if (!size_obj && offset_obj->is_range()) {
+    if (!size_obj && offset_obj.is_range()) {
         auto range = offset_obj->as_range();
 
         Optional<nat_int_t> begin;
-        if (!range->begin()->is_nil()) {
+        if (!range->begin().is_nil()) {
             auto begin_obj = Object::to_int(env, range->begin());
             begin = begin_obj.to_nat_int_t();
         }
 
         Optional<nat_int_t> end;
-        if (!range->end()->is_nil()) {
+        if (!range->end().is_nil()) {
             auto end_obj = Object::to_int(env, range->end());
             end = end_obj.to_nat_int_t();
         }
@@ -756,7 +756,7 @@ int IntegerObject::convert_to_int(Env *env, Value arg) {
 }
 
 gid_t IntegerObject::convert_to_gid(Env *env, Value arg) {
-    if (arg->is_nil()) return (gid_t)(-1); // special case for nil
+    if (arg.is_nil()) return (gid_t)(-1); // special case for nil
     auto result = convert_to_nat_int_t(env, arg);
     // this lower limit may look incorrect but experimentally matches MRI behavior
     if (result < std::numeric_limits<int>::min())
@@ -767,7 +767,7 @@ gid_t IntegerObject::convert_to_gid(Env *env, Value arg) {
 }
 
 uid_t IntegerObject::convert_to_uid(Env *env, Value arg) {
-    if (arg->is_nil()) return (uid_t)(-1); // special case for nil
+    if (arg.is_nil()) return (uid_t)(-1); // special case for nil
     auto result = convert_to_nat_int_t(env, arg);
     // this lower limit may look incorrect but experimentally matches MRI behavior
     if (result < std::numeric_limits<int>::min())

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -10,9 +10,9 @@ namespace ioutil {
     // before continuing.
     // This is common to many functions in FileObject and DirObject
     StringObject *convert_using_to_path(Env *env, Value path) {
-        if (!path->is_string() && path->respond_to(env, "to_path"_s))
+        if (!path.is_string() && path->respond_to(env, "to_path"_s))
             path = path->send(env, "to_path"_s);
-        if (!path->is_string() && path->respond_to(env, "to_str"_s))
+        if (!path.is_string() && path->respond_to(env, "to_str"_s))
             path = path->to_str(env);
         path.assert_type(env, Object::Type::String, "String");
         return path->as_string();
@@ -21,7 +21,7 @@ namespace ioutil {
     // accepts io or io-like object for fstat
     // accepts path or string like object for stat
     int object_stat(Env *env, Value io, struct stat *sb) {
-        if (io->is_io() || io->respond_to(env, "to_io"_s)) {
+        if (io.is_io() || io->respond_to(env, "to_io"_s)) {
             auto file_desc = io->to_io(env)->fileno();
             return ::fstat(file_desc, sb);
         }
@@ -31,12 +31,12 @@ namespace ioutil {
     }
 
     void flags_struct::parse_flags_obj(Env *env, Value flags_obj) {
-        if (!flags_obj || flags_obj->is_nil())
+        if (!flags_obj || flags_obj.is_nil())
             return;
 
         m_has_mode = true;
 
-        if (!flags_obj.is_integer() && !flags_obj->is_string()) {
+        if (!flags_obj.is_integer() && !flags_obj.is_string()) {
             if (flags_obj->respond_to(env, "to_str"_s)) {
                 flags_obj = flags_obj->to_str(env);
             } else if (flags_obj->respond_to(env, "to_int"_s)) {
@@ -54,8 +54,8 @@ namespace ioutil {
             auto flags_str = flagsplit->fetch(env, IntegerObject::create(static_cast<nat_int_t>(0)), new StringObject { "" }, nullptr)->as_string()->string();
             auto extenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(1)), nullptr);
             auto intenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(2)), nullptr);
-            if (!extenc->is_nil()) m_external_encoding = EncodingObject::find_encoding(env, extenc);
-            if (!intenc->is_nil()) m_internal_encoding = EncodingObject::find_encoding(env, intenc);
+            if (!extenc.is_nil()) m_external_encoding = EncodingObject::find_encoding(env, extenc);
+            if (!intenc.is_nil()) m_internal_encoding = EncodingObject::find_encoding(env, intenc);
 
             if (flags_str.length() < 1 || flags_str.length() > 3)
                 env->raise("ArgumentError", "invalid access mode {}", flags_str);
@@ -102,7 +102,7 @@ namespace ioutil {
     void flags_struct::parse_mode(Env *env) {
         if (!m_kwargs) return;
         auto mode = m_kwargs->remove(env, "mode"_s);
-        if (!mode || mode->is_nil()) return;
+        if (!mode || mode.is_nil()) return;
         if (has_mode())
             env->raise("ArgumentError", "mode specified twice");
         parse_flags_obj(env, mode);
@@ -111,21 +111,21 @@ namespace ioutil {
     void flags_struct::parse_flags(Env *env) {
         if (!m_kwargs) return;
         auto flags = m_kwargs->remove(env, "flags"_s);
-        if (!flags || flags->is_nil()) return;
+        if (!flags || flags.is_nil()) return;
         m_flags |= static_cast<int>(Object::to_int(env, flags).to_nat_int_t());
     }
 
     void flags_struct::parse_encoding(Env *env) {
         if (!m_kwargs) return;
         auto encoding = m_kwargs->remove(env, "encoding"_s);
-        if (!encoding || encoding->is_nil()) return;
+        if (!encoding || encoding.is_nil()) return;
         if (m_external_encoding) {
             env->raise("ArgumentError", "encoding specified twice");
         } else if (m_kwargs->has_key(env, "external_encoding"_s)) {
             env->warn("Ignoring encoding parameter '{}', external_encoding is used", encoding);
         } else if (m_kwargs->has_key(env, "internal_encoding"_s)) {
             env->warn("Ignoring encoding parameter '{}', internal_encoding is used", encoding);
-        } else if (encoding->is_encoding()) {
+        } else if (encoding.is_encoding()) {
             m_external_encoding = encoding->as_encoding();
         } else {
             encoding = encoding->to_str(env);
@@ -143,10 +143,10 @@ namespace ioutil {
     void flags_struct::parse_external_encoding(Env *env) {
         if (!m_kwargs) return;
         auto external_encoding = m_kwargs->remove(env, "external_encoding"_s);
-        if (!external_encoding || external_encoding->is_nil()) return;
+        if (!external_encoding || external_encoding.is_nil()) return;
         if (m_external_encoding)
             env->raise("ArgumentError", "encoding specified twice");
-        if (external_encoding->is_encoding()) {
+        if (external_encoding.is_encoding()) {
             m_external_encoding = external_encoding->as_encoding();
         } else {
             m_external_encoding = EncodingObject::find_encoding(env, external_encoding->to_str(env));
@@ -156,10 +156,10 @@ namespace ioutil {
     void flags_struct::parse_internal_encoding(Env *env) {
         if (!m_kwargs) return;
         auto internal_encoding = m_kwargs->remove(env, "internal_encoding"_s);
-        if (!internal_encoding || internal_encoding->is_nil()) return;
+        if (!internal_encoding || internal_encoding.is_nil()) return;
         if (m_internal_encoding)
             env->raise("ArgumentError", "encoding specified twice");
-        if (internal_encoding->is_encoding()) {
+        if (internal_encoding.is_encoding()) {
             m_internal_encoding = internal_encoding->as_encoding();
         } else {
             internal_encoding = internal_encoding->to_str(env);
@@ -174,26 +174,26 @@ namespace ioutil {
     void flags_struct::parse_textmode(Env *env) {
         if (!m_kwargs) return;
         auto textmode = m_kwargs->remove(env, "textmode"_s);
-        if (!textmode || textmode->is_nil()) return;
+        if (!textmode || textmode.is_nil()) return;
         if (binmode()) {
             env->raise("ArgumentError", "both textmode and binmode specified");
         } else if (this->textmode()) {
             env->raise("ArgumentError", "textmode specified twice");
         }
-        if (textmode->is_truthy())
+        if (textmode.is_truthy())
             m_read_mode = flags_struct::read_mode::text;
     }
 
     void flags_struct::parse_binmode(Env *env) {
         if (!m_kwargs) return;
         auto binmode = m_kwargs->remove(env, "binmode"_s);
-        if (!binmode || binmode->is_nil()) return;
+        if (!binmode || binmode.is_nil()) return;
         if (this->binmode()) {
             env->raise("ArgumentError", "binmode specified twice");
         } else if (textmode()) {
             env->raise("ArgumentError", "both textmode and binmode specified");
         }
-        if (binmode->is_truthy())
+        if (binmode.is_truthy())
             m_read_mode = flags_struct::read_mode::binary;
     }
 
@@ -209,7 +209,7 @@ namespace ioutil {
             return;
         }
 
-        m_autoclose = autoclose->is_truthy();
+        m_autoclose = autoclose.is_truthy();
     }
 
     void flags_struct::parse_path(Env *env) {
@@ -243,7 +243,7 @@ namespace ioutil {
     }
 
     mode_t perm_to_mode(Env *env, Value perm) {
-        if (perm && !perm->is_nil())
+        if (perm && !perm.is_nil())
             return IntegerObject::convert_to_int(env, perm);
         else
             return S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH; // 0660 default

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -436,8 +436,8 @@ module Kernel
     end
 
     __define_method__ :sprintf, [:format, :val], <<-END
-      assert(format->is_string());
-      assert(val->is_float());
+      assert(format.is_string());
+      assert(val.is_float());
       char buf[100];
       auto fmt = format->as_string()->c_str();
       auto dbl = val->as_float()->to_double();

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -26,7 +26,7 @@ Value KernelModule::abort_method(Env *env, Value message) {
     ExceptionObject *exception;
 
     if (message) {
-        if (!message->is_string())
+        if (!message.is_string())
             message = message->to_str(env);
 
         message.assert_type(env, Object::Type::String, "String");
@@ -86,7 +86,7 @@ Value KernelModule::caller(Env *env, Value start, Value length) {
     auto backtrace = env->backtrace();
     auto ary = backtrace->to_ruby_array();
     ary->shift(); // remove the frame for Kernel#caller itself
-    if (start && start->is_range()) {
+    if (start && start.is_range()) {
         ary = ary->ref(env, start)->as_array();
     } else {
         ary->shift(env, start);
@@ -102,7 +102,7 @@ Value KernelModule::caller_locations(Env *env, Value start, Value length) {
     auto backtrace = env->backtrace();
     auto ary = backtrace->to_ruby_backtrace_locations_array();
     ary->shift(); // remove the frame for Kernel#caller_locations itself
-    if (start && start->is_range()) {
+    if (start && start.is_range()) {
         ary = ary->ref(env, start)->as_array();
     } else {
         ary->shift(env, start);
@@ -130,23 +130,23 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value exception) {
-    return Complex(env, real, imaginary, exception ? exception->is_true() : true);
+    return Complex(env, real, imaginary, exception ? exception.is_true() : true);
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
-    if (real->is_string()) {
-        if (auto real_int = Integer(env, real, 10, false); real_int && !real_int->is_nil()) {
+    if (real.is_string()) {
+        if (auto real_int = Integer(env, real, 10, false); real_int && !real_int.is_nil()) {
             real = real_int;
-        } else if (auto real_float = Float(env, real, false); real_float && !real_float->is_nil()) {
+        } else if (auto real_float = Float(env, real, false); real_float && !real_float.is_nil()) {
             real = real_float;
         }
     }
 
-    if (real->is_complex() && imaginary == nullptr) {
+    if (real.is_complex() && imaginary == nullptr) {
         return real;
     } else if (imaginary == nullptr) {
         return new ComplexObject { real };
-    } else if (real->is_string()) {
+    } else if (real.is_string()) {
         // NATFIXME: Add support for strings too.
     } else {
         return new ComplexObject { real, imaginary };
@@ -189,9 +189,9 @@ Value KernelModule::cur_dir(Env *env) {
 }
 
 Value KernelModule::exit(Env *env, Value status) {
-    if (!status || status->is_true()) {
+    if (!status || status.is_true()) {
         status = Value::integer(0);
-    } else if (status->is_false()) {
+    } else if (status.is_false()) {
         status = Value::integer(1);
     } else if (status.is_integer()) {
         // use status passed in
@@ -212,11 +212,11 @@ Value KernelModule::Integer(Env *env, Value value, Value base, Value exception) 
     nat_int_t base_int = 0; // default to zero if unset
     if (base)
         base_int = Object::to_int(env, base).to_nat_int_t();
-    return Integer(env, value, base_int, exception ? exception->is_true() : true);
+    return Integer(env, value, base_int, exception ? exception.is_true() : true);
 }
 
 Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exception) {
-    if (value->is_string()) {
+    if (value.is_string()) {
         auto result = value->as_string()->convert_integer(env, base);
         if (!result && exception) {
             env->raise("ArgumentError", "invalid value for Integer(): {}", value->inspect_str(env));
@@ -232,7 +232,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
         return Value(value);
 
     // Infinity/NaN cannot be converted to Integer
-    if (value->is_float()) {
+    if (value.is_float()) {
         auto float_obj = value->as_float();
         if (float_obj->is_nan() || float_obj->is_infinity()) {
             if (exception)
@@ -242,7 +242,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
         }
     }
 
-    if (!value->is_nil()) {
+    if (!value.is_nil()) {
         // Try using to_int to coerce to an Integer
         if (value->respond_to(env, "to_int"_s)) {
             auto result = value.send(env, "to_int"_s);
@@ -261,21 +261,21 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
 }
 
 Value KernelModule::Float(Env *env, Value value, Value exception) {
-    return Float(env, value, exception ? exception->is_true() : true);
+    return Float(env, value, exception ? exception.is_true() : true);
 }
 
 Value KernelModule::Float(Env *env, Value value, bool exception) {
-    if (value->is_float()) {
+    if (value.is_float()) {
         return value;
-    } else if (value->is_string()) {
+    } else if (value.is_string()) {
         auto result = value->as_string()->convert_float();
         if (!result && exception) {
             env->raise("ArgumentError", "invalid value for Float(): {}", value->inspect_str(env));
         }
         return result;
-    } else if (!value->is_nil() && value->respond_to(env, "to_f"_s)) {
+    } else if (!value.is_nil() && value->respond_to(env, "to_f"_s)) {
         auto result = value.send(env, "to_f"_s);
-        if (result->is_float()) {
+        if (result.is_float()) {
             return result;
         }
     }
@@ -346,10 +346,10 @@ Value KernelModule::global_variables(Env *env) {
 }
 
 Value KernelModule::Hash(Env *env, Value value) {
-    if (value->is_hash())
+    if (value.is_hash())
         return value;
 
-    if (value->is_nil() || (value->is_array() && value->as_array()->is_empty()))
+    if (value.is_nil() || (value.is_array() && value->as_array()->is_empty()))
         return new HashObject;
 
     return value->to_hash(env);
@@ -412,7 +412,7 @@ Value KernelModule::raise(Env *env, Args &&args) {
 }
 
 Value KernelModule::Rational(Env *env, Value x, Value y, Value exception) {
-    return Rational(env, x, y, exception ? exception->is_true() : true);
+    return Rational(env, x, y, exception ? exception.is_true() : true);
 }
 
 Value KernelModule::Rational(Env *env, Value x, Value y, bool exception) {
@@ -440,7 +440,7 @@ Value KernelModule::Rational(Env *env, Value x, Value y, bool exception) {
         if (!exception)
             return nullptr;
 
-        if (x->is_nil())
+        if (x.is_nil())
             env->raise("TypeError", "can't convert {} into Rational", x->klass()->inspect_str());
 
         if (x->respond_to(env, "to_r"_s)) {
@@ -489,15 +489,15 @@ Value KernelModule::sleep(Env *env, Value length) {
         return FiberObject::scheduler()->send(env, "kernel_sleep"_s, { length });
     }
 
-    if (!length || length->is_nil())
+    if (!length || length.is_nil())
         return ThreadObject::current()->sleep(env, -1.0);
 
     float secs;
     if (length.is_integer()) {
         secs = length.integer().to_nat_int_t();
-    } else if (length->is_float()) {
+    } else if (length.is_float()) {
         secs = length->as_float()->to_double();
-    } else if (length->is_rational()) {
+    } else if (length.is_rational()) {
         secs = length->as_rational()->to_f(env)->as_float()->to_double();
     } else if (length->respond_to(env, "divmod"_s)) {
         auto divmod = length->send(env, "divmod"_s, { IntegerObject::create(1) })->as_array();
@@ -525,7 +525,7 @@ Value KernelModule::spawn(Env *env, Args &&args) {
         }
     });
 
-    if (args.size() >= 1 && (args.at(0)->is_hash() || args.at(0)->respond_to(env, "to_hash"_s))) {
+    if (args.size() >= 1 && (args.at(0).is_hash() || args.at(0)->respond_to(env, "to_hash"_s))) {
         auto hash = args.shift()->to_hash(env);
         for (auto ep = environ; *ep; ep++)
             new_env.push(strdup(*ep));
@@ -588,7 +588,7 @@ Value KernelModule::spawn(Env *env, Args &&args) {
 }
 
 Value KernelModule::String(Env *env, Value value) {
-    if (value->is_string()) {
+    if (value.is_string()) {
         return value;
     }
 
@@ -707,7 +707,7 @@ Value KernelModule::initialize_copy(Env *env, Value self, Value object) {
 }
 
 Value KernelModule::inspect(Env *env, Value value) {
-    if (value->is_module() && value->as_module()->name())
+    if (value.is_module() && value->as_module()->name())
         return new StringObject { value->as_module()->name().value() };
     else
         return StringObject::format("#<{}:{}>", value->klass()->inspect_str(), value->pointer_id());
@@ -756,7 +756,7 @@ Value KernelModule::instance_variables(Env *env, Value self) {
 }
 
 bool KernelModule::is_a(Env *env, Value self, Value module) {
-    if (!module->is_module())
+    if (!module.is_module())
         env->raise("TypeError", "class or module required");
     return self->is_a(env, module->as_module());
 }
@@ -794,7 +794,7 @@ Value KernelModule::method(Env *env, Value self, Value name) {
     if (!method_info.is_defined()) {
         auto respond_to_missing = module->find_method(env, "respond_to_missing?"_s);
         if (respond_to_missing.is_defined()) {
-            if (respond_to_missing.method()->call(env, self, { name_symbol, TrueObject::the() }, nullptr)->is_truthy()) {
+            if (respond_to_missing.method()->call(env, self, { name_symbol, TrueObject::the() }, nullptr).is_truthy()) {
                 auto method_missing = module->find_method(env, "method_missing"_s);
                 if (method_missing.is_defined()) {
                     return new MethodObject { self, method_missing.method(), name_symbol };
@@ -807,7 +807,7 @@ Value KernelModule::method(Env *env, Value self, Value name) {
 }
 
 Value KernelModule::methods(Env *env, Value self, Value regular_val) {
-    bool regular = regular_val ? regular_val->is_truthy() : true;
+    bool regular = regular_val ? regular_val.is_truthy() : true;
     if (regular) {
         if (self->singleton_class()) {
             return self->singleton_class()->instance_methods(env, TrueObject::the());
@@ -822,7 +822,7 @@ Value KernelModule::methods(Env *env, Value self, Value regular_val) {
 }
 
 bool KernelModule::neqtilde(Env *env, Value self, Value other) {
-    return self->send(env, "=~"_s, { other })->is_falsey();
+    return self->send(env, "=~"_s, { other }).is_falsey();
 }
 
 Value KernelModule::private_methods(Env *env, Value self, Value recur) {

--- a/src/method.cpp
+++ b/src/method.cpp
@@ -31,22 +31,6 @@ Value Method::call(Env *env, Value self, Args &&args, Block *block) const {
         }
     };
 
-    // This code handles the "fast" integer/float optimization, where certain
-    // IntegerObject and FloatObject methods do not allow their `this` or their
-    // arguments to escape outside their call stack, i.e. they only live for a
-    // short period. Thus the objects can be stack-allocated for speed, and the
-    // GC need not allocate or collect them.
-    if (m_optimized) {
-        if (args.size() == 1 && args[0].is_fast_integer()) {
-            auto synthesized_arg = IntegerObject { args[0].get_fast_integer() };
-            synthesized_arg.add_synthesized_flag();
-            return call_fn({ &synthesized_arg });
-        }
-    } else if (!self.is_fast_integer() && self->is_synthesized()) {
-        // Turn this object into a heap-allocated one.
-        self = self->duplicate(env);
-    }
-
     return call_fn(std::move(args));
 }
 }

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -3,7 +3,7 @@
 namespace Natalie {
 
 bool MethodObject::eq(Env *env, Value other_value) {
-    if (other_value->is_method()) {
+    if (other_value.is_method()) {
         auto other = other_value->as_method();
         return m_object == other->m_object && (m_method == other->m_method || (m_method->original_method() && m_method->original_method() == other->m_method));
     } else {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -487,11 +487,9 @@ Value ModuleObject::remove_class_variable(Env *env, Value name) {
     return val;
 }
 
-SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
+SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity) {
     assert_not_frozen(env, this);
     Method *method = new Method { name->string(), this, fn, arity, env->file(), env->line() };
-    if (optimized)
-        method->set_optimized(true);
     auto visibility = m_method_visibility;
     if (name == "initialize"_s)
         visibility = MethodVisibility::Private;

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -265,7 +265,7 @@ Value ModuleObject::handle_missing_constant(Env *env, Value name, ConstLookupFai
 Value ModuleObject::const_set(SymbolObject *name, Value val) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    m_constants.put(name, new Constant { name, val.object() });
+    m_constants.put(name, new Constant { name, val });
     if (val.is_module()) {
         auto module = val->as_module();
         if (!module->owner()) {
@@ -408,12 +408,12 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
         while (current) {
             exists = current->m_class_vars.get(name, env);
             if (exists) {
-                current->m_class_vars.put(name, val.object(), env);
+                current->m_class_vars.put(name, val, env);
                 return val;
             }
             current = current->m_superclass;
         }
-        module->m_class_vars.put(name, val.object(), env);
+        module->m_class_vars.put(name, val, env);
         return val;
     };
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -761,10 +761,6 @@ void arg_spread(Env *env, const Args &args, const char *arrangement, ...) {
 std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs, CoerceInvalidReturnValueMode invalid_return_value_mode) {
     auto coerce_symbol = "coerce"_s;
     if (lhs->respond_to(env, coerce_symbol)) {
-        if (lhs->is_synthesized())
-            lhs = lhs->duplicate(env);
-        if (rhs->is_synthesized())
-            rhs = rhs->duplicate(env);
         Value coerced = lhs.send(env, coerce_symbol, { rhs });
         if (!coerced->is_array()) {
             if (invalid_return_value_mode == CoerceInvalidReturnValueMode::Raise)

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -512,7 +512,6 @@ Env *build_top_env() {
     Object->const_set("RUBY_ENGINE"_s, RUBY_ENGINE);
 
     Value RUBY_PATCHLEVEL = Value::integer(-1);
-    RUBY_PATCHLEVEL->freeze();
     Object->const_set("RUBY_PATCHLEVEL"_s, RUBY_PATCHLEVEL);
 
     StringObject *RUBY_PLATFORM = new StringObject { ruby_platform };

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -536,7 +536,7 @@ Env *build_top_env() {
 }
 
 Value splat(Env *env, Value obj) {
-    if (obj->is_array()) {
+    if (obj.is_array()) {
         return new ArrayObject { *obj->as_array() };
     } else {
         return to_ary(env, obj, false);
@@ -545,16 +545,16 @@ Value splat(Env *env, Value obj) {
 
 Value is_case_equal(Env *env, Value case_value, Value when_value, bool is_splat) {
     if (is_splat) {
-        if (!when_value->is_array() && when_value->respond_to(env, "to_a"_s)) {
+        if (!when_value.is_array() && when_value->respond_to(env, "to_a"_s)) {
             auto original_class = when_value->klass();
             when_value = when_value->send(env, "to_a"_s);
-            if (!when_value->is_array()) {
+            if (!when_value.is_array()) {
                 env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", original_class->inspect_str(), original_class->inspect_str(), when_value->klass()->inspect_str());
             }
         }
-        if (when_value->is_array()) {
+        if (when_value.is_array()) {
             for (auto item : *when_value->as_array()) {
-                if (item->send(env, "==="_s, { case_value })->is_truthy()) {
+                if (item->send(env, "==="_s, { case_value }).is_truthy()) {
                     return TrueObject::the();
                 }
             }
@@ -568,8 +568,8 @@ void run_at_exit_handlers(Env *env) {
     ArrayObject *at_exit_handlers = env->global_get("$NAT_at_exit_handlers"_s)->as_array_or_raise(env);
 
     Value proc;
-    while (!(proc = at_exit_handlers->pop())->is_nil()) {
-        if (proc->is_proc())
+    while (!(proc = at_exit_handlers->pop()).is_nil()) {
+        if (proc.is_proc())
             NAT_RUN_BLOCK_WITHOUT_BREAK(env, proc->as_proc()->block(), {}, nullptr);
     }
 }
@@ -640,14 +640,14 @@ void handle_top_level_exception(Env *env, ExceptionObject *exception, bool run_e
 }
 
 ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
-    if (obj->is_array()) {
+    if (obj.is_array()) {
         return obj->as_array();
     }
 
     if (obj->respond_to(env, "to_ary"_s)) {
         auto array = obj.send(env, "to_ary"_s);
-        if (!array->is_nil()) {
-            if (array->is_array()) {
+        if (!array.is_nil()) {
+            if (array.is_array()) {
                 return array->as_array();
             } else if (raise_for_non_array) {
                 auto class_name = obj->klass()->inspect_str();
@@ -658,8 +658,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
 
     if (obj->respond_to(env, "to_a"_s)) {
         auto array = obj.send(env, "to_a"_s);
-        if (!array->is_nil()) {
-            if (array->is_array()) {
+        if (!array.is_nil()) {
+            if (array.is_array()) {
                 return array->as_array();
             } else if (raise_for_non_array) {
                 auto class_name = obj->klass()->inspect_str();
@@ -672,7 +672,7 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
 }
 
 Value to_ary_for_masgn(Env *env, Value obj) {
-    if (obj->is_array()) {
+    if (obj.is_array()) {
         if (obj->klass() == GlobalEnv::the()->Array()) {
             return obj->duplicate(env);
         } else {
@@ -682,9 +682,9 @@ Value to_ary_for_masgn(Env *env, Value obj) {
 
     if (obj->respond_to(env, "to_ary"_s)) {
         auto array = obj.send(env, "to_ary"_s);
-        if (array->is_array()) {
+        if (array.is_array()) {
             return array->duplicate(env);
-        } else if (!array->is_nil()) {
+        } else if (!array.is_nil()) {
             auto class_name = obj->klass()->inspect_str();
             env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array->klass()->inspect_str());
         }
@@ -738,7 +738,7 @@ void arg_spread(Env *env, const Args &args, const char *arrangement, ...) {
             bool *bool_ptr = va_arg(va_args, bool *); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
-            *bool_ptr = obj->is_truthy();
+            *bool_ptr = obj.is_truthy();
             break;
         }
         case 'v': {
@@ -762,7 +762,7 @@ std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs, CoerceInvalidRetu
     auto coerce_symbol = "coerce"_s;
     if (lhs->respond_to(env, coerce_symbol)) {
         Value coerced = lhs.send(env, coerce_symbol, { rhs });
-        if (!coerced->is_array()) {
+        if (!coerced.is_array()) {
             if (invalid_return_value_mode == CoerceInvalidReturnValueMode::Raise)
                 env->raise("TypeError", "coerce must return [x, y]");
             else
@@ -777,7 +777,7 @@ std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs, CoerceInvalidRetu
 }
 
 Block *to_block(Env *env, Value proc_or_nil) {
-    if (proc_or_nil->is_nil()) {
+    if (proc_or_nil.is_nil()) {
         return nullptr;
     }
     return proc_or_nil->to_proc(env)->block();
@@ -865,7 +865,7 @@ Value super(Env *env, Value self, Args &&args, Block *block) {
 
     auto super_method = klass->find_method(env, SymbolObject::intern(after_method->name()), after_method);
     if (!super_method.is_defined()) {
-        if (self->is_module()) {
+        if (self.is_module()) {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self->as_module()->inspect_str(), self->klass()->inspect_str());
         } else {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self->inspect_str(env));

--- a/src/nil_object.cpp
+++ b/src/nil_object.cpp
@@ -7,7 +7,7 @@ bool NilObject::and_method(const Env *env, const Value) const {
 }
 
 bool NilObject::or_method(const Env *env, Value other) const {
-    return other->is_truthy();
+    return other.is_truthy();
 }
 
 Value NilObject::eqtilde(const Env *env, const Value) const {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -186,408 +186,408 @@ Value Object::initialize(Env *env) {
 }
 
 NilObject *Object::as_nil() {
-    assert(is_nil());
+    assert(m_type == Type::Nil);
     return static_cast<NilObject *>(this);
 }
 
 const NilObject *Object::as_nil() const {
-    assert(is_nil());
+    assert(m_type == Type::Nil);
     return static_cast<const NilObject *>(this);
 }
 
 Enumerator::ArithmeticSequenceObject *Object::as_enumerator_arithmetic_sequence() {
-    assert(is_enumerator_arithmetic_sequence());
+    assert(m_type == Type::EnumeratorArithmeticSequence);
     return static_cast<Enumerator::ArithmeticSequenceObject *>(this);
 }
 
 ArrayObject *Object::as_array() {
-    assert(is_array());
+    assert(m_type == Type::Array);
     return static_cast<ArrayObject *>(this);
 }
 
 const ArrayObject *Object::as_array() const {
-    assert(is_array());
+    assert(m_type == Type::Array);
     return static_cast<const ArrayObject *>(this);
 }
 
 BindingObject *Object::as_binding() {
-    assert(is_binding());
+    assert(m_type == Type::Binding);
     return static_cast<BindingObject *>(this);
 }
 
 const BindingObject *Object::as_binding() const {
-    assert(is_binding());
+    assert(m_type == Type::Binding);
     return static_cast<const BindingObject *>(this);
 }
 
 MethodObject *Object::as_method() {
-    assert(is_method());
+    assert(m_type == Type::Method);
     return static_cast<MethodObject *>(this);
 }
 
 const MethodObject *Object::as_method() const {
-    assert(is_method());
+    assert(m_type == Type::Method);
     return static_cast<const MethodObject *>(this);
 }
 
 ModuleObject *Object::as_module() {
-    assert(is_module());
+    assert(m_type == Type::Module || m_type == Type::Class);
     return static_cast<ModuleObject *>(this);
 }
 
 const ModuleObject *Object::as_module() const {
-    assert(is_module());
+    assert(m_type == Type::Module);
     return static_cast<const ModuleObject *>(this);
 }
 
 ClassObject *Object::as_class() {
-    assert(is_class());
+    assert(m_type == Type::Class);
     return static_cast<ClassObject *>(this);
 }
 
 const ClassObject *Object::as_class() const {
-    assert(is_class());
+    assert(m_type == Type::Class);
     return static_cast<const ClassObject *>(this);
 }
 
 ComplexObject *Object::as_complex() {
-    assert(is_complex());
+    assert(m_type == Type::Complex);
     return static_cast<ComplexObject *>(this);
 }
 
 const ComplexObject *Object::as_complex() const {
-    assert(is_complex());
+    assert(m_type == Type::Complex);
     return static_cast<const ComplexObject *>(this);
 }
 
 DirObject *Object::as_dir() {
-    assert(is_dir());
+    assert(m_type == Type::Dir);
     return static_cast<DirObject *>(this);
 }
 
 const DirObject *Object::as_dir() const {
-    assert(is_dir());
+    assert(m_type == Type::Dir);
     return static_cast<const DirObject *>(this);
 }
 
 EncodingObject *Object::as_encoding() {
-    assert(is_encoding());
+    assert(m_type == Type::Encoding);
     return static_cast<EncodingObject *>(this);
 }
 
 const EncodingObject *Object::as_encoding() const {
-    assert(is_encoding());
+    assert(m_type == Type::Encoding);
     return static_cast<const EncodingObject *>(this);
 }
 
 EnvObject *Object::as_env() {
-    assert(is_env());
+    assert(m_type == Type::Env);
     return static_cast<EnvObject *>(this);
 }
 
 const EnvObject *Object::as_env() const {
-    assert(is_env());
+    assert(m_type == Type::Env);
     return static_cast<const EnvObject *>(this);
 }
 
 ExceptionObject *Object::as_exception() {
-    assert(is_exception());
+    assert(m_type == Type::Exception);
     return static_cast<ExceptionObject *>(this);
 }
 
 const ExceptionObject *Object::as_exception() const {
-    assert(is_exception());
+    assert(m_type == Type::Exception);
     return static_cast<const ExceptionObject *>(this);
 }
 
 FalseObject *Object::as_false() {
-    assert(is_false());
+    assert(m_type == Type::False);
     return static_cast<FalseObject *>(this);
 }
 
 const FalseObject *Object::as_false() const {
-    assert(is_false());
+    assert(m_type == Type::False);
     return static_cast<const FalseObject *>(this);
 }
 
 FiberObject *Object::as_fiber() {
-    assert(is_fiber());
+    assert(m_type == Type::Fiber);
     return static_cast<FiberObject *>(this);
 }
 
 const FiberObject *Object::as_fiber() const {
-    assert(is_fiber());
+    assert(m_type == Type::Fiber);
     return static_cast<const FiberObject *>(this);
 }
 
 FloatObject *Object::as_float() {
-    assert(is_float());
+    assert(m_type == Type::Float);
     return static_cast<FloatObject *>(this);
 }
 
 const FloatObject *Object::as_float() const {
-    assert(is_float());
+    assert(m_type == Type::Float);
     return static_cast<const FloatObject *>(this);
 }
 
 HashObject *Object::as_hash() {
-    assert(is_hash());
+    assert(m_type == Type::Hash);
     return static_cast<HashObject *>(this);
 }
 
 const HashObject *Object::as_hash() const {
-    assert(is_hash());
+    assert(m_type == Type::Hash);
     return static_cast<const HashObject *>(this);
 }
 
 IoObject *Object::as_io() {
-    assert(is_io());
+    assert(m_type == Type::Io || m_type == Type::File);
     return static_cast<IoObject *>(this);
 }
 
 const IoObject *Object::as_io() const {
-    assert(is_io());
+    assert(m_type == Type::Io);
     return static_cast<const IoObject *>(this);
 }
 
 FileObject *Object::as_file() {
-    assert(is_file());
+    assert(m_type == Type::File);
     return static_cast<FileObject *>(this);
 }
 
 const FileObject *Object::as_file() const {
-    assert(is_io());
+    assert(m_type == Type::File);
     return static_cast<const FileObject *>(this);
 }
 
 FileStatObject *Object::as_file_stat() {
-    assert(is_file_stat());
+    assert(m_type == Type::FileStat);
     return static_cast<FileStatObject *>(this);
 }
 
 const FileStatObject *Object::as_file_stat() const {
-    assert(is_file_stat());
+    assert(m_type == Type::FileStat);
     return static_cast<const FileStatObject *>(this);
 }
 
 MatchDataObject *Object::as_match_data() {
-    assert(is_match_data());
+    assert(m_type == Type::MatchData);
     return static_cast<MatchDataObject *>(this);
 }
 
 const MatchDataObject *Object::as_match_data() const {
-    assert(is_match_data());
+    assert(m_type == Type::MatchData);
     return static_cast<const MatchDataObject *>(this);
 }
 
 ProcObject *Object::as_proc() {
-    assert(is_proc());
+    assert(m_type == Type::Proc);
     return static_cast<ProcObject *>(this);
 }
 
 const ProcObject *Object::as_proc() const {
-    assert(is_proc());
+    assert(m_type == Type::Proc);
     return static_cast<const ProcObject *>(this);
 }
 
 RandomObject *Object::as_random() {
-    assert(is_random());
+    assert(m_type == Type::Random);
     return static_cast<RandomObject *>(this);
 }
 
 const RandomObject *Object::as_random() const {
-    assert(is_random());
+    assert(m_type == Type::Random);
     return static_cast<const RandomObject *>(this);
 }
 
 RangeObject *Object::as_range() {
-    assert(is_range());
+    assert(m_type == Type::Range);
     return static_cast<RangeObject *>(this);
 }
 
 const RangeObject *Object::as_range() const {
-    assert(is_range());
+    assert(m_type == Type::Range);
     return static_cast<const RangeObject *>(this);
 }
 
 RationalObject *Object::as_rational() {
-    assert(is_rational());
+    assert(m_type == Type::Rational);
     return static_cast<RationalObject *>(this);
 }
 
 const RationalObject *Object::as_rational() const {
-    assert(is_rational());
+    assert(m_type == Type::Rational);
     return static_cast<const RationalObject *>(this);
 }
 
 RegexpObject *Object::as_regexp() {
-    assert(is_regexp());
+    assert(m_type == Type::Regexp);
     return static_cast<RegexpObject *>(this);
 }
 
 const RegexpObject *Object::as_regexp() const {
-    assert(is_regexp());
+    assert(m_type == Type::Regexp);
     return static_cast<const RegexpObject *>(this);
 }
 
 StringObject *Object::as_string() {
-    assert(is_string());
+    assert(m_type == Type::String);
     return static_cast<StringObject *>(this);
 }
 
 const StringObject *Object::as_string() const {
-    assert(is_string());
+    assert(m_type == Type::String);
     return static_cast<const StringObject *>(this);
 }
 
 SymbolObject *Object::as_symbol() {
-    assert(is_symbol());
+    assert(m_type == Type::Symbol);
     return static_cast<SymbolObject *>(this);
 }
 
 const SymbolObject *Object::as_symbol() const {
-    assert(is_symbol());
+    assert(m_type == Type::Symbol);
     return static_cast<const SymbolObject *>(this);
 }
 
 ThreadObject *Object::as_thread() {
-    assert(is_thread());
+    assert(m_type == Type::Thread);
     return static_cast<ThreadObject *>(this);
 }
 
 const ThreadObject *Object::as_thread() const {
-    assert(is_thread());
+    assert(m_type == Type::Thread);
     return static_cast<const ThreadObject *>(this);
 }
 
 Thread::Backtrace::LocationObject *Object::as_thread_backtrace_location() {
-    assert(is_thread_backtrace_location());
+    assert(m_type == Type::ThreadBacktraceLocation);
     return static_cast<Thread::Backtrace::LocationObject *>(this);
 }
 
 const Thread::Backtrace::LocationObject *Object::as_thread_backtrace_location() const {
-    assert(is_thread_backtrace_location());
+    assert(m_type == Type::ThreadBacktraceLocation);
     return static_cast<const Thread::Backtrace::LocationObject *>(this);
 }
 
 ThreadGroupObject *Object::as_thread_group() {
-    assert(is_thread_group());
+    assert(m_type == Type::ThreadGroup);
     return static_cast<ThreadGroupObject *>(this);
 }
 
 const ThreadGroupObject *Object::as_thread_group() const {
-    assert(is_thread_group());
+    assert(m_type == Type::ThreadGroup);
     return static_cast<const ThreadGroupObject *>(this);
 }
 
 Thread::MutexObject *Object::as_thread_mutex() {
-    assert(is_thread_mutex());
+    assert(m_type == Type::ThreadMutex);
     return static_cast<Thread::MutexObject *>(this);
 }
 
 const Thread::MutexObject *Object::as_thread_mutex() const {
-    assert(is_thread_mutex());
+    assert(m_type == Type::ThreadMutex);
     return static_cast<const Thread::MutexObject *>(this);
 }
 
 TimeObject *Object::as_time() {
-    assert(is_time());
+    assert(m_type == Type::Time);
     return static_cast<TimeObject *>(this);
 }
 
 const TimeObject *Object::as_time() const {
-    assert(is_time());
+    assert(m_type == Type::Time);
     return static_cast<const TimeObject *>(this);
 }
 
 TrueObject *Object::as_true() {
-    assert(is_true());
+    assert(m_type == Type::True);
     return static_cast<TrueObject *>(this);
 }
 
 const TrueObject *Object::as_true() const {
-    assert(is_true());
+    assert(m_type == Type::True);
     return static_cast<const TrueObject *>(this);
 }
 
 UnboundMethodObject *Object::as_unbound_method() {
-    assert(is_unbound_method());
+    assert(m_type == Type::UnboundMethod);
     return static_cast<UnboundMethodObject *>(this);
 }
 
 const UnboundMethodObject *Object::as_unbound_method() const {
-    assert(is_unbound_method());
+    assert(m_type == Type::UnboundMethod);
     return static_cast<const UnboundMethodObject *>(this);
 }
 
 VoidPObject *Object::as_void_p() {
-    assert(is_void_p());
+    assert(m_type == Type::VoidP);
     return static_cast<VoidPObject *>(this);
 }
 
 const VoidPObject *Object::as_void_p() const {
-    assert(is_void_p());
+    assert(m_type == Type::VoidP);
     return static_cast<const VoidPObject *>(this);
 }
 
 ArrayObject *Object::as_array_or_raise(Env *env) {
-    if (!is_array())
+    if (m_type != Type::Array)
         env->raise("TypeError", "{} can't be coerced into Array", m_klass->inspect_str());
     return static_cast<ArrayObject *>(this);
 }
 
 ClassObject *Object::as_class_or_raise(Env *env) {
-    if (!is_class())
+    if (m_type != Type::Class)
         env->raise("TypeError", "{} can't be coerced into Class", m_klass->inspect_str());
     return static_cast<ClassObject *>(this);
 }
 
 EncodingObject *Object::as_encoding_or_raise(Env *env) {
-    if (!is_encoding())
+    if (m_type != Type::Encoding)
         env->raise("TypeError", "{} can't be coerced into Encoding", m_klass->inspect_str());
     return static_cast<EncodingObject *>(this);
 }
 
 ExceptionObject *Object::as_exception_or_raise(Env *env) {
-    if (!is_exception())
+    if (m_type != Type::Exception)
         env->raise("TypeError", "{} can't be coerced into Exception", m_klass->inspect_str());
     return static_cast<ExceptionObject *>(this);
 }
 
 FloatObject *Object::as_float_or_raise(Env *env) {
-    if (!is_float())
+    if (m_type != Type::Float)
         env->raise("TypeError", "{} can't be coerced into Float", m_klass->inspect_str());
     return static_cast<FloatObject *>(this);
 }
 
 HashObject *Object::as_hash_or_raise(Env *env) {
-    if (!is_hash())
+    if (m_type != Type::Hash)
         env->raise("TypeError", "{} can't be coerced into Hash", m_klass->inspect_str());
     return static_cast<HashObject *>(this);
 }
 
 MatchDataObject *Object::as_match_data_or_raise(Env *env) {
-    if (!is_match_data())
+    if (m_type != Type::MatchData)
         env->raise("TypeError", "{} can't be coerced into MatchData", m_klass->inspect_str());
     return static_cast<MatchDataObject *>(this);
 }
 
 RangeObject *Object::as_range_or_raise(Env *env) {
-    if (!is_range())
+    if (m_type != Type::Range)
         env->raise("TypeError", "{} can't be coerced into Range", m_klass->inspect_str());
     return static_cast<RangeObject *>(this);
 }
 
 StringObject *Object::as_string_or_raise(Env *env) {
-    if (!is_string())
+    if (m_type != Type::String)
         env->raise("TypeError", "{} can't be coerced into String", m_klass->inspect_str());
     return static_cast<StringObject *>(this);
 }
 
 SymbolObject *Object::to_symbol(Env *env, Conversion conversion) {
-    if (is_symbol()) {
+    if (m_type == Type::Symbol) {
         return as_symbol();
-    } else if (is_string() || respond_to(env, "to_str"_s)) {
+    } else if (m_type == Type::String || respond_to(env, "to_str"_s)) {
         return to_str(env)->to_symbol(env);
     } else if (conversion == Conversion::NullAllowed) {
         return nullptr;
@@ -600,7 +600,7 @@ SymbolObject *Object::to_instance_variable_name(Env *env) {
     SymbolObject *symbol = to_symbol(env, Conversion::Strict); // TypeError if not Symbol/String
 
     if (!symbol->is_ivar_name()) {
-        if (is_string()) {
+        if (m_type == Type::String) {
             env->raise_name_error(as_string(), "`{}' is not allowed as an instance variable name", symbol->string());
         } else {
             env->raise_name_error(symbol, "`{}' is not allowed as an instance variable name", symbol->string());
@@ -616,21 +616,21 @@ void Object::set_singleton_class(ClassObject *klass) {
 }
 
 ClassObject *Object::singleton_class(Env *env, Value self) {
-    if (self.is_integer() || self->is_float() || self->is_symbol())
+    if (self.is_integer() || self.is_float() || self.is_symbol())
         env->raise("TypeError", "can't define singleton");
 
     if (self->m_singleton_class)
         return self->m_singleton_class;
 
     String name;
-    if (self->is_module()) {
+    if (self.is_module()) {
         name = String::format("#<Class:{}>", self->as_module()->inspect_str());
     } else if (self->respond_to(env, "inspect"_s)) {
         name = String::format("#<Class:{}>", self->inspect_str(env));
     }
 
     ClassObject *singleton_superclass;
-    if (self->is_class()) {
+    if (self.is_class()) {
         singleton_superclass = singleton_class(env, self->as_class()->superclass(env));
     } else {
         singleton_superclass = self->m_klass;
@@ -644,7 +644,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
 }
 
 ClassObject *Object::subclass(Env *env, const char *name) {
-    if (!is_class())
+    if (m_type != Type::Class)
         env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", klass()->inspect_str());
     return as_class()->subclass(env, name);
 }
@@ -785,11 +785,10 @@ Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
         return val;
     } else {
         ModuleObject *module;
-        if (is_module()) {
+        if (m_type == Type::Module || m_type == Type::Class)
             module = as_module();
-        } else {
+        else
             module = m_klass;
-        }
         env->raise_name_error(name, "uninitialized class variable {} in {}", name->string(), module->inspect_str());
     }
 }
@@ -812,12 +811,12 @@ void Object::method_alias(Env *env, SymbolObject *new_name, SymbolObject *old_na
     if (m_type == Type::Integer)
         env->raise("TypeError", "no klass to make alias");
 
-    if (is_symbol())
+    if (m_type == Type::Symbol)
         env->raise("TypeError", "no klass to make alias");
 
     if (is_main_object()) {
         m_klass->make_method_alias(env, new_name, old_name);
-    } else if (is_module()) {
+    } else if (m_type == Type::Module || m_type == Type::Class) {
         as_module()->method_alias(env, new_name, old_name);
     } else {
         singleton_class(env, this)->make_method_alias(env, new_name, old_name);
@@ -969,7 +968,7 @@ Value Object::method_missing_send(Env *env, SymbolObject *name, Args &&args, Blo
 Value Object::method_missing(Env *env, Args &&args, Block *block) {
     if (args.size() == 0) {
         env->raise("ArgError", "no method name given");
-    } else if (!args[0]->is_symbol()) {
+    } else if (!args[0].is_symbol()) {
         env->raise("ArgError", "method name must be a Symbol but {} is given", args[0]->klass()->inspect_str());
     } else {
         auto name = args[0]->as_symbol();
@@ -1071,9 +1070,9 @@ Value Object::duplicate(Env *env) const {
 Value Object::clone(Env *env, Value freeze) {
     bool freeze_bool = true;
     if (freeze) {
-        if (freeze->is_false()) {
+        if (freeze.is_false()) {
             freeze_bool = false;
-        } else if (!freeze->is_true() && !freeze->is_nil()) {
+        } else if (!freeze.is_true() && !freeze.is_nil()) {
             env->raise("ArgumentError", "unexpected value for freeze: {}", freeze->klass()->inspect_str());
         }
     }
@@ -1111,7 +1110,7 @@ void Object::copy_instance_variables(const Value other) {
 }
 
 bool Object::is_a(Env *env, Value val) const {
-    if (!val->is_module()) return false;
+    if (!val.is_module()) return false;
     ModuleObject *module = val->as_module();
     if (m_klass == module || singleton_class() == module) {
         return true;
@@ -1131,7 +1130,7 @@ bool Object::respond_to(Env *env, Value name_val, bool include_all) {
         } else {
             include_all_val = FalseObject::the();
         }
-        return send(env, "respond_to?"_s, { name_val, include_all_val })->is_truthy();
+        return send(env, "respond_to?"_s, { name_val, include_all_val }).is_truthy();
     }
 
     // Needed for BaseObject as it does not have an actual respond_to? method
@@ -1148,7 +1147,7 @@ bool Object::respond_to_method(Env *env, Value name_val, bool include_all) {
     auto method_info = klass->find_method(env, name_symbol);
     if (!method_info.is_defined()) {
         if (klass->find_method(env, "respond_to_missing?"_s).is_defined()) {
-            return send(env, "respond_to_missing?"_s, { name_val, bool_object(include_all) })->is_truthy();
+            return send(env, "respond_to_missing?"_s, { name_val, bool_object(include_all) }).is_truthy();
         }
         return false;
     }
@@ -1160,14 +1159,14 @@ bool Object::respond_to_method(Env *env, Value name_val, bool include_all) {
     if (visibility == MethodVisibility::Public) {
         return true;
     } else if (klass->find_method(env, "respond_to_missing?"_s).is_defined()) {
-        return send(env, "respond_to_missing?"_s, { name_val, bool_object(include_all) })->is_truthy();
+        return send(env, "respond_to_missing?"_s, { name_val, bool_object(include_all) }).is_truthy();
     } else {
         return false;
     }
 }
 
 bool Object::respond_to_method(Env *env, Value name_val, Value include_all_val) {
-    bool include_all = include_all_val ? include_all_val->is_truthy() : false;
+    bool include_all = include_all_val ? include_all_val.is_truthy() : false;
     return respond_to_method(env, name_val, include_all);
 }
 
@@ -1179,9 +1178,8 @@ const char *Object::defined(Env *env, SymbolObject *name, bool strict) {
     Value obj = nullptr;
     if (name->is_constant_name()) {
         if (strict) {
-            if (is_module()) {
+            if (m_type == Type::Module || m_type == Type::Class)
                 obj = as_module()->const_get(name);
-            }
         } else {
             obj = const_find(env, name, ConstLookupSearchMode::NotStrict, ConstLookupFailureMode::Null);
         }
@@ -1280,14 +1278,14 @@ bool Object::equal(Value self, Value other) {
         return false;
 
     // We still need the pointer compare for the identical NaN equality
-    if (self->is_float() && other->is_float())
+    if (self.is_float() && other.is_float())
         return self == other.object() || self->as_float()->to_double() == other->as_float()->to_double();
 
     return other == self;
 }
 
 bool Object::neq(Env *env, Value other) {
-    return send(env, "=="_s, { other })->is_falsey();
+    return send(env, "=="_s, { other }).is_falsey();
 }
 
 String Object::dbg_inspect() const {
@@ -1302,7 +1300,7 @@ String Object::inspect_str(Env *env) {
     if (!respond_to(env, "inspect"_s))
         return String::format("#<{}:{}>", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed));
     auto inspected = send(env, "inspect"_s);
-    if (!inspected->is_string())
+    if (!inspected.is_string())
         return ""; // TODO: what to do here?
     return inspected->as_string()->string();
 }
@@ -1332,24 +1330,22 @@ void Object::gc_inspect(char *buf, size_t len) const {
 }
 
 ArrayObject *Object::to_ary(Env *env) {
-    if (is_array()) {
+    if (m_type == Type::Array)
         return as_array();
-    }
 
     auto original_class = klass()->inspect_str();
 
     auto to_ary = "to_ary"_s;
 
     if (!respond_to(env, to_ary)) {
-        if (is_nil()) {
+        if (m_type == Type::Nil)
             env->raise("TypeError", "no implicit conversion of nil into Array");
-        }
         env->raise("TypeError", "no implicit conversion of {} into Array", original_class);
     }
 
     Value val = send(env, to_ary);
 
-    if (val->is_array()) {
+    if (val.is_array()) {
         return val->as_array();
     }
 
@@ -1361,7 +1357,7 @@ ArrayObject *Object::to_ary(Env *env) {
 }
 
 IoObject *Object::to_io(Env *env) {
-    if (is_io()) return as_io();
+    if (m_type == Type::Io) return as_io();
 
     auto to_io = "to_io"_s;
     if (!respond_to(env, to_io))
@@ -1369,7 +1365,7 @@ IoObject *Object::to_io(Env *env) {
 
     auto result = send(env, to_io);
 
-    if (result->is_io())
+    if (result.is_io())
         return result->as_io();
 
     env->raise(
@@ -1401,7 +1397,7 @@ Integer Object::to_int(Env *env, Value self) {
 }
 
 FloatObject *Object::to_f(Env *env) {
-    if (is_float()) return as_float();
+    if (m_type == Type::Float) return as_float();
 
     auto to_f = "to_f"_s;
     if (!respond_to(env, to_f))
@@ -1413,7 +1409,7 @@ FloatObject *Object::to_f(Env *env) {
 }
 
 HashObject *Object::to_hash(Env *env) {
-    if (is_hash()) {
+    if (m_type == Type::Hash) {
         return as_hash();
     }
 
@@ -1422,15 +1418,14 @@ HashObject *Object::to_hash(Env *env) {
     auto to_hash = "to_hash"_s;
 
     if (!respond_to(env, to_hash)) {
-        if (is_nil()) {
+        if (m_type == Type::Nil)
             env->raise("TypeError", "no implicit conversion of nil into Hash");
-        }
         env->raise("TypeError", "no implicit conversion of {} into Hash", original_class);
     }
 
     Value val = send(env, to_hash);
 
-    if (val->is_hash()) {
+    if (val.is_hash()) {
         return val->as_hash();
     }
 
@@ -1443,13 +1438,13 @@ HashObject *Object::to_hash(Env *env) {
 
 StringObject *Object::to_s(Env *env) {
     auto str = send(env, "to_s"_s);
-    if (!str->is_string())
+    if (!str.is_string())
         env->raise("TypeError", "no implicit conversion of {} into String", m_klass->name());
     return str->as_string();
 }
 
 StringObject *Object::to_str(Env *env) {
-    if (is_string()) return as_string();
+    if (m_type == Type::String) return as_string();
 
     auto to_str = "to_str"_s;
     if (!respond_to(env, to_str))
@@ -1457,7 +1452,7 @@ StringObject *Object::to_str(Env *env) {
 
     auto result = send(env, to_str);
 
-    if (result->is_string())
+    if (result.is_string())
         return result->as_string();
 
     env->raise(
@@ -1470,7 +1465,7 @@ StringObject *Object::to_str(Env *env) {
 // This is just like Object::to_str, but it raises more consistent error messages.
 // We still need the old error messages because CRuby is inconsistent. :-(
 StringObject *Object::to_str2(Env *env) {
-    if (is_string()) return as_string();
+    if (m_type == Type::String) return as_string();
 
     auto to_str = "to_str"_s;
     if (!respond_to(env, to_str))
@@ -1478,7 +1473,7 @@ StringObject *Object::to_str2(Env *env) {
 
     auto result = send(env, to_str);
 
-    if (result->is_string())
+    if (result.is_string())
         return result->as_string();
 
     env->raise(

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -833,13 +833,13 @@ void Object::singleton_method_alias(Env *env, SymbolObject *new_name, SymbolObje
     klass->method_alias(env, new_name, old_name);
 }
 
-SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
+SymbolObject *Object::define_singleton_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ClassObject *klass = singleton_class(env, this)->as_class();
     if (klass->is_frozen())
         env->raise("FrozenError", "can't modify frozen object: {}", to_s(env)->string());
-    klass->define_method(env, name, fn, arity, optimized);
+    klass->define_method(env, name, fn, arity);
     return name;
 }
 
@@ -861,11 +861,11 @@ SymbolObject *Object::undefine_singleton_method(Env *env, SymbolObject *name) {
     return name;
 }
 
-SymbolObject *Object::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity, bool optimized) {
+SymbolObject *Object::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity) {
     if (GlobalEnv::the()->instance_evaling()) {
-        return define_singleton_method(env, name, fn, arity, optimized);
+        return define_singleton_method(env, name, fn, arity);
     }
-    m_klass->define_method(env, name, fn, arity, optimized);
+    m_klass->define_method(env, name, fn, arity);
     return name;
 }
 

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -23,7 +23,7 @@ Value ProcObject::call(Env *env, Args &&args, Block *block) {
 }
 
 bool ProcObject::equal_value(Value other) const {
-    return other->is_proc() && other->as_proc()->m_block == m_block;
+    return other.is_proc() && other->as_proc()->m_block == m_block;
 }
 
 static Value compose_ltlt(Env *env, Value self, Args &&args, Block *block) {
@@ -46,7 +46,7 @@ Value ProcObject::ltlt(Env *env, Value other) {
 
     env->var_set("other", 0, true, other);
     auto block = new Block { *env, this, compose_ltlt, -1 };
-    if (other->is_proc() && other->as_proc()->is_lambda())
+    if (other.is_proc() && other->as_proc()->is_lambda())
         block->set_type(Block::BlockType::Lambda);
     return new ProcObject { block };
 }
@@ -94,7 +94,7 @@ StringObject *ProcObject::to_s(Env *env) {
         suffix.append(String::format(" {}:{}", m_block->env()->file(), m_block->env()->line()));
     if (is_lambda() || m_block->is_from_method())
         suffix.append(" (lambda)");
-    if (m_block->self()->is_symbol())
+    if (m_block->self().is_symbol())
         suffix.append(String::format(" (&:{})", m_block->self()->as_symbol()->string()));
     auto str = String::format("#<{}:{}{}>", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
     return new StringObject { std::move(str), Encoding::ASCII_8BIT };

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -48,14 +48,14 @@ Value ProcessModule::kill(Env *env, Args &&args) {
     nat_int_t signo;
     bool pid_contains_self = false;
 
-    if (signal->is_symbol())
+    if (signal.is_symbol())
         signal = signal->to_s(env);
     if (signal.is_integer()) {
         signo = IntegerObject::convert_to_nat_int_t(env, signal);
-    } else if (signal->is_string() || signal->respond_to(env, "to_str"_s)) {
+    } else if (signal.is_string() || signal->respond_to(env, "to_str"_s)) {
         auto signame = signal->to_str(env)->delete_prefix(env, new StringObject { "SIG" });
         auto signo_val = SignalModule::list(env)->as_hash()->ref(env, signame);
-        if (signo_val->is_nil())
+        if (signo_val.is_nil())
             env->raise("ArgumentError", "unsupported signal `SIG{}'", signame->to_s(env)->string());
         signo = IntegerObject::convert_to_nat_int_t(env, signo_val);
     } else {
@@ -87,7 +87,7 @@ long ProcessModule::maxgroups() {
 
 Value ProcessModule::setmaxgroups(Env *env, Value val) {
     Value int_val = Object::to_int(env, val);
-    if (int_val.send(env, "positive?"_s)->is_falsey())
+    if (int_val.send(env, "positive?"_s).is_falsey())
         env->raise("ArgumentError", "maxgroups {} should be positive", int_val->inspect_str(env));
     const long actual_maxgroups = sysconf(_SC_NGROUPS_MAX);
     globals::maxgroups = std::min(IntegerObject::convert_to_native_type<long>(env, int_val), actual_maxgroups);
@@ -113,7 +113,7 @@ Value ProcessModule::times(Env *env) {
 
 Value ProcessModule::wait(Env *env, Value pidval, Value flagsval) {
     const pid_t pid = pidval ? IntegerObject::convert_to_native_type<pid_t>(env, pidval) : -1;
-    const int flags = (flagsval && !flagsval->is_nil()) ? IntegerObject::convert_to_native_type<int>(env, flagsval) : 0;
+    const int flags = (flagsval && !flagsval.is_nil()) ? IntegerObject::convert_to_native_type<int>(env, flagsval) : 0;
     int status;
     const auto result = waitpid(pid, &status, flags);
     if (result == -1)

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -7,7 +7,7 @@ Value RandomObject::initialize(Env *env, Value seed) {
     if (!seed) {
         m_seed = (nat_int_t)std::random_device()();
     } else {
-        if (seed->is_float()) {
+        if (seed.is_float()) {
             seed = seed->as_float()->to_i(env);
         }
 
@@ -37,31 +37,31 @@ Value RandomObject::bytes(Env *env, Value size) {
 
 Value RandomObject::rand(Env *env, Value arg) {
     if (arg) {
-        if (arg->is_float()) {
+        if (arg.is_float()) {
             double max = arg->as_float()->to_double();
             if (max <= 0) {
                 env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
             }
             return generate_random(0.0, max);
-        } else if (arg->is_range()) {
+        } else if (arg.is_range()) {
             Value min = arg->as_range()->begin();
             Value max = arg->as_range()->end();
             // TODO: There can be different types of objects that respond to + and - (according to the docs)
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
-            if (min->is_numeric() && max->is_numeric()) {
-                if (min.send(env, ">"_s, { max })->is_true()) {
+            if (min.is_numeric() && max.is_numeric()) {
+                if (min.send(env, ">"_s, { max }).is_true()) {
                     env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
                 }
 
-                if (min->is_float() || max->is_float()) {
+                if (min.is_float() || max.is_float()) {
                     double min_rand, max_rand;
-                    if (min->is_float()) {
+                    if (min.is_float()) {
                         min_rand = min->as_float()->to_double();
                     } else {
                         min_rand = static_cast<double>(IntegerObject::convert_to_native_type<nat_int_t>(env, min));
                     }
 
-                    if (max->is_float()) {
+                    if (max.is_float()) {
                         max_rand = max->as_float()->to_double();
                     } else {
                         max_rand = static_cast<double>(IntegerObject::convert_to_native_type<nat_int_t>(env, max));
@@ -82,7 +82,7 @@ Value RandomObject::rand(Env *env, Value arg) {
             env->raise("ArgumentError", "bad value for range");
         }
 
-        if (arg->is_nil())
+        if (arg.is_nil())
             env->raise("ArgumentError", "invalid argument - {}", arg->to_s(env)->string());
 
         nat_int_t max = IntegerObject::convert_to_nat_int_t(env, arg);

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -23,9 +23,9 @@ Value RationalObject::add(Env *env, Value other) {
     if (other.is_integer()) {
         auto numerator = m_numerator + (m_denominator * other.integer());
         return new RationalObject { numerator, m_denominator };
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return this->to_f(env)->as_float()->add(env, other);
-    } else if (other->is_rational()) {
+    } else if (other.is_rational()) {
         auto num1 = other->as_rational()->numerator(env).integer();
         auto den1 = other->as_rational()->denominator(env).integer();
         auto a = den1 * m_numerator;
@@ -47,14 +47,14 @@ Value RationalObject::cmp(Env *env, Value other) {
             return IntegerObject::cmp(env, m_numerator, other.integer());
         other = new RationalObject { other.integer(), Value::integer(1) };
     }
-    if (other->is_rational()) {
+    if (other.is_rational()) {
         auto rational = other->as_rational();
         auto num1 = m_numerator * rational->denominator(env).integer();
         auto num2 = m_denominator * rational->numerator(env).integer();
         auto a = num1 - num2;
         return IntegerObject::cmp(env, a, Value::integer(0));
     }
-    if (other->is_float()) {
+    if (other.is_float()) {
         return to_f(env)->as_float()->cmp(env, other->as_float());
     }
     if (other->respond_to(env, "coerce"_s)) {
@@ -67,11 +67,11 @@ Value RationalObject::cmp(Env *env, Value other) {
 Value RationalObject::coerce(Env *env, Value other) {
     if (other.is_integer()) {
         return new ArrayObject { new RationalObject(other.integer(), Value::integer(1)), this };
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return new ArrayObject { other, this->to_f(env) };
-    } else if (other->is_rational()) {
+    } else if (other.is_rational()) {
         return new ArrayObject { other, this };
-    } else if (other->is_complex()) {
+    } else if (other.is_complex()) {
         auto complex = other->as_complex();
         if (complex->imaginary(env).integer().is_zero()) {
             auto a = new RationalObject { complex->real(env), Value::integer(1) };
@@ -90,7 +90,7 @@ Value RationalObject::denominator(Env *env) {
 }
 
 Value RationalObject::div(Env *env, Value other) {
-    if (other.is_integer() || other->is_rational()) {
+    if (other.is_integer() || other.is_rational()) {
         RationalObject *arg;
         if (other.is_integer()) {
             arg = create(env, Integer(1), other.integer());
@@ -104,7 +104,7 @@ Value RationalObject::div(Env *env, Value other) {
             env->raise("ZeroDivisionError", "divided by 0");
 
         return mul(env, arg);
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return this->to_f(env)->as_float()->div(env, other);
     } else if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, this);
@@ -118,11 +118,11 @@ bool RationalObject::eq(Env *env, Value other) {
     if (other.is_integer())
         return m_denominator == 1 && m_numerator == other.integer();
 
-    if (other->is_float())
+    if (other.is_float())
         return to_f(env)->as_float()->eq(env, other);
 
-    if (!other->is_rational())
-        return other.send(env, "=="_s, { this })->is_truthy();
+    if (!other.is_rational())
+        return other.send(env, "=="_s, { this }).is_truthy();
 
     if (m_numerator != other->as_rational()->m_numerator)
         return false;
@@ -167,13 +167,13 @@ Value RationalObject::mul(Env *env, Value other) {
     if (other.is_integer())
         other = new RationalObject { other.integer(), Value::integer(1) };
 
-    if (other->is_rational()) {
+    if (other.is_rational()) {
         auto num1 = other->as_rational()->numerator(env).integer();
         auto den1 = other->as_rational()->denominator(env).integer();
         auto num2 = m_numerator * num1;
         auto den2 = m_denominator * den1;
         return create(env, num2, den2);
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return this->to_f(env)->as_float()->mul(env, other);
     } else if (other->respond_to(env, "coerce"_s)) {
         auto result = Natalie::coerce(env, other, this);
@@ -193,10 +193,10 @@ Value RationalObject::pow(Env *env, Value other) {
     if (other.is_integer()) {
         numerator = other.integer();
         denominator = 1;
-    } else if (other->is_rational()) {
+    } else if (other.is_rational()) {
         numerator = other->as_rational()->numerator(env).integer();
         denominator = other->as_rational()->denominator(env).integer();
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return this->to_f(env)->as_float()->pow(env, other);
     } else {
         if (other->respond_to(env, "coerce"_s)) {
@@ -237,9 +237,9 @@ Value RationalObject::sub(Env *env, Value other) {
     if (other.is_integer()) {
         auto numerator = m_numerator - m_denominator * other.integer();
         return new RationalObject { numerator, m_denominator };
-    } else if (other->is_float()) {
+    } else if (other.is_float()) {
         return this->to_f(env)->as_float()->sub(env, other);
-    } else if (other->is_rational()) {
+    } else if (other.is_rational()) {
         auto num1 = other->as_rational()->numerator(env).integer();
         auto den1 = other->as_rational()->denominator(env).integer();
         auto a = den1 * m_numerator;

--- a/src/rounding_mode.cpp
+++ b/src/rounding_mode.cpp
@@ -4,8 +4,8 @@ namespace Natalie {
 
 RoundingMode rounding_mode_from_value(Env *env, Value value, RoundingMode default_rounding_mode) {
     if (!value) return default_rounding_mode;
-    if (value->is_nil()) return default_rounding_mode;
-    if (!value->is_symbol()) {
+    if (value.is_nil()) return default_rounding_mode;
+    if (!value.is_symbol()) {
         env->raise("ArgumentError", "invalid rounding mode: {}", value->inspect_str(env));
     }
 

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -102,7 +102,7 @@ SymbolObject *SymbolObject::capitalize(Env *env) {
     return string->to_symbol(env);
 }
 Value SymbolObject::casecmp(Env *env, Value other) {
-    if (!other->is_symbol()) return NilObject::the();
+    if (!other.is_symbol()) return NilObject::the();
     auto str1 = to_s(env);
     auto str2 = other->to_s(env);
     str1 = str1->send(env, "downcase"_s, { "ascii"_s })->as_string();
@@ -111,7 +111,7 @@ Value SymbolObject::casecmp(Env *env, Value other) {
 }
 
 Value SymbolObject::is_casecmp(Env *env, Value other) {
-    if (!other->is_symbol()) return NilObject::the();
+    if (!other.is_symbol()) return NilObject::the();
     // other.assert_type(env, Object::Type::Symbol, "Symbol");
     auto str1 = to_s(env);
     auto str2 = other->to_s(env);
@@ -138,7 +138,7 @@ Value SymbolObject::to_proc_block_fn(Env *env, Value self_value, Args &&args, Bl
 }
 
 Value SymbolObject::cmp(Env *env, Value other_value) {
-    if (!other_value->is_symbol()) return NilObject::the();
+    if (!other_value.is_symbol()) return NilObject::the();
     SymbolObject *other = other_value->as_symbol();
     return Value::integer(m_name.cmp(other->m_name));
 }

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -28,13 +28,13 @@ Value MutexObject::lock(Env *env) {
 }
 
 Value MutexObject::sleep(Env *env, Value timeout) {
-    if (!timeout || timeout->is_nil()) {
+    if (!timeout || timeout.is_nil()) {
         ThreadObject::current()->sleep(env, -1.0, this);
         lock(env);
         return this;
     }
 
-    if ((timeout->is_float() && timeout->as_float()->is_negative()) || (timeout.is_integer() && IntegerObject::is_negative(timeout.integer())))
+    if ((timeout.is_float() && timeout->as_float()->is_negative()) || (timeout.is_integer() && IntegerObject::is_negative(timeout.integer())))
         env->raise("ArgumentError", "time interval must not be negative");
 
     auto timeout_int = IntegerObject::convert_to_nat_int_t(env, timeout);
@@ -42,7 +42,7 @@ Value MutexObject::sleep(Env *env, Value timeout) {
     if (timeout_int < 0)
         env->raise("ArgumentError", "timeout must be positive");
 
-    const auto timeout_float = timeout->is_float() ? static_cast<float>(timeout->as_float()->to_double()) : static_cast<float>(timeout_int);
+    const auto timeout_float = timeout.is_float() ? static_cast<float>(timeout->as_float()->to_double()) : static_cast<float>(timeout_int);
     ThreadObject::current()->sleep(env, timeout_float, this);
     lock(env);
 
@@ -65,7 +65,7 @@ Value MutexObject::unlock(Env *env) {
     if (!is_locked())
         env->raise("ThreadError", "Attempt to unlock a mutex which is not locked");
 
-    if (m_thread && m_thread->status(env)->is_falsey())
+    if (m_thread && m_thread->status(env).is_falsey())
         env->raise("ThreadError", "Attempt to unlock a mutex which is not locked");
 
     if (m_thread && m_thread != ThreadObject::current())

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -3,7 +3,7 @@
 namespace Natalie {
 
 Value ThreadGroupObject::add(Env *env, Value value) {
-    if (!value->is_thread())
+    if (!value.is_thread())
         env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value->klass()->inspect_str());
     auto thread = value->as_thread();
 

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -141,9 +141,9 @@ namespace Natalie {
 thread_local ThreadObject *tl_current_thread = nullptr;
 
 static Value validate_key(Env *env, Value key) {
-    if (key->is_string() || key->respond_to(env, "to_str"_s))
+    if (key.is_string() || key->respond_to(env, "to_str"_s))
         key = key->to_str(env)->to_sym(env);
-    if (!key->is_symbol())
+    if (!key.is_symbol())
         env->raise("TypeError", "{} is not a symbol", key->inspect_str(env));
     return key;
 }
@@ -161,7 +161,7 @@ ThreadObject *ThreadObject::current() {
 }
 
 Value ThreadObject::thread_kill(Env *env, Value thread) {
-    if (!thread->is_thread())
+    if (!thread.is_thread())
         env->raise("TypeError", "wrong argument type {} (expected VM/thread)", thread->klass()->inspect_str());
 
     return thread->as_thread()->kill(env);
@@ -479,7 +479,7 @@ Value ThreadObject::name(Env *env) {
 }
 
 Value ThreadObject::set_name(Env *env, Value name) {
-    if (!name || name->is_nil()) {
+    if (!name || name.is_nil()) {
         m_name.clear();
         return NilObject::the();
     }
@@ -582,7 +582,7 @@ Value ThreadObject::thread_variable_set(Env *env, Value key, Value value) {
     key = validate_key(env, key);
     if (!m_thread_variables)
         m_thread_variables = new HashObject;
-    if (value->is_nil()) {
+    if (value.is_nil()) {
         m_thread_variables->delete_key(env, key, nullptr);
         return value;
     }

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -43,7 +43,7 @@ TimeObject *TimeObject::create(Env *env) {
 TimeObject *TimeObject::initialize(Env *env, Value year, Value month, Value mday, Value hour, Value min, Value sec, Value tmzone, Value in) {
     if (!year) {
         return now(env, nullptr);
-    } else if (year->is_nil()) {
+    } else if (year.is_nil()) {
         env->raise("TypeError", "Year cannot be nil");
     } else {
         auto result = now(env, nullptr);
@@ -95,7 +95,7 @@ TimeObject *TimeObject::utc(Env *env, Value year, Value month, Value mday, Value
             if (integer < 0 || integer >= 1000000)
                 env->raise("ArgumentError", "subsecx out of range");
             result->m_subsec = RationalObject::create(env, integer, Integer(1000000));
-        } else if (subsec->is_rational()) {
+        } else if (subsec.is_rational()) {
             result->m_subsec = subsec->as_rational()->div(env, Value::integer(1000000));
         } else {
             env->raise("TypeError", "can't convert {} into an exact number", subsec->klass()->inspect_str());
@@ -105,9 +105,9 @@ TimeObject *TimeObject::utc(Env *env, Value year, Value month, Value mday, Value
 }
 
 Value TimeObject::add(Env *env, Value other) {
-    if (other->is_time()) {
+    if (other.is_time()) {
         env->raise("TypeError", "time + time?");
-    } else if (other->is_nil() || other->is_string() || !other->respond_to(env, "to_r"_s)) {
+    } else if (other.is_nil() || other.is_string() || !other->respond_to(env, "to_r"_s)) {
         env->raise("TypeError", "can't convert {} into an exact number", other->klass()->inspect_str());
     }
     RationalObject *rational = to_r(env)->as_rational();
@@ -124,7 +124,7 @@ Value TimeObject::asctime(Env *env) {
 }
 
 Value TimeObject::cmp(Env *env, Value other) {
-    if (other->is_time()) {
+    if (other.is_time()) {
         auto time = other->as_time();
         auto integer = m_integer.integer();
         if (IntegerObject::gt(env, integer, time->m_integer)) {
@@ -136,12 +136,12 @@ Value TimeObject::cmp(Env *env, Value other) {
         }
     } else {
         auto result = other->send(env, "<=>"_s, { this });
-        if (result->is_nil()) {
+        if (result.is_nil()) {
             return result;
         } else {
-            if (result->send(env, ">"_s, { Value::integer(0) })->is_true()) {
+            if (result->send(env, ">"_s, { Value::integer(0) }).is_true()) {
                 return Value::integer(-1);
-            } else if (result->send(env, "<"_s, { Value::integer(0) })->is_true()) {
+            } else if (result->send(env, "<"_s, { Value::integer(0) }).is_true()) {
                 return Value::integer(1);
             } else {
                 return Value::integer(0);
@@ -151,7 +151,7 @@ Value TimeObject::cmp(Env *env, Value other) {
 }
 
 bool TimeObject::eql(Env *env, Value other) {
-    if (other->is_time()) {
+    if (other.is_time()) {
         auto time = other->as_time();
         if (m_integer.integer() == time->m_integer.integer()) {
             if (m_subsec && time->m_subsec && m_subsec->as_rational()->eq(env, time->m_subsec)) {
@@ -204,10 +204,10 @@ Value TimeObject::min(Env *) const {
 }
 
 Value TimeObject::minus(Env *env, Value other) {
-    if (other->is_time()) {
+    if (other.is_time()) {
         return to_r(env)->as_rational()->sub(env, other->as_time()->to_r(env))->as_rational()->to_f(env);
     }
-    if (other->is_nil() || other->is_string() || !other->respond_to(env, "to_r"_s)) {
+    if (other.is_nil() || other.is_string() || !other->respond_to(env, "to_r"_s)) {
         env->raise("TypeError", "can't convert {} into an exact number", other->klass()->inspect_str());
     }
     RationalObject *rational = to_r(env)->as_rational()->sub(env, other->send(env, "to_r"_s))->as_rational();
@@ -308,7 +308,7 @@ nat_int_t TimeObject::normalize_timezone(Env *env, Value val) {
     nat_int_t minsec = 60; // seconds in an minute
     nat_int_t hoursec = 3600; // seconds in an hour
 
-    if (val->is_string()) {
+    if (val.is_string()) {
         auto str = val->as_string()->string();
         auto ssize = str.size();
         if (str == "UTC") {
@@ -365,7 +365,7 @@ nat_int_t TimeObject::normalize_field(Env *env, Value val) {
 }
 
 nat_int_t TimeObject::normalize_field(Env *env, Value val, nat_int_t minval, nat_int_t maxval) {
-    if (val->is_nil()) return minval;
+    if (val.is_nil()) return minval;
     auto ival = normalize_field(env, val);
     if (ival < minval || ival > maxval) {
         env->raise("ArgumentError", "argument out of range");
@@ -374,9 +374,9 @@ nat_int_t TimeObject::normalize_field(Env *env, Value val, nat_int_t minval, nat
 }
 
 nat_int_t TimeObject::normalize_month(Env *env, Value val) {
-    if (val->is_nil()) return 0;
+    if (val.is_nil()) return 0;
     if (!val.is_integer()) {
-        if (val->is_string() || val->respond_to(env, "to_str"_s)) {
+        if (val.is_string() || val->respond_to(env, "to_str"_s)) {
             val = val->to_str(env);
             auto monstr = val->as_string()->downcase(env, nullptr, nullptr)->as_string()->string();
             if (monstr == "jan") {
@@ -425,7 +425,7 @@ nat_int_t TimeObject::normalize_month(Env *env, Value val) {
 RationalObject *TimeObject::convert_rational(Env *env, Value value) {
     if (value.is_integer()) {
         return RationalObject::create(env, value.integer(), Integer(1));
-    } else if (value->is_rational()) {
+    } else if (value.is_rational()) {
         return value->as_rational();
     } else if (value->respond_to(env, "to_r"_s) && value->respond_to(env, "to_int"_s)) {
         return value->send(env, "to_r"_s)->as_rational();
@@ -452,7 +452,7 @@ TimeObject *TimeObject::create(Env *env, RationalObject *rational, Mode mode) {
     Integer integer;
     RationalObject *subseconds;
     TimeObject *result = new TimeObject {};
-    if (rational->send(env, "<"_s, { Value::integer(0) })->is_true()) {
+    if (rational->send(env, "<"_s, { Value::integer(0) }).is_true()) {
         auto floor = rational->floor(env, nullptr);
         integer = floor->send(env, "to_i"_s).integer();
         subseconds = rational->sub(env, floor)->as_rational();
@@ -494,8 +494,8 @@ void TimeObject::build_time(Env *env, Value year, Value month, Value mday, Value
     if (min) {
         m_time.tm_min = TimeObject::normalize_field(env, min, 0, 59);
     }
-    if (sec && !sec->is_nil()) {
-        if (sec->is_string()) {
+    if (sec && !sec.is_nil()) {
+        if (sec.is_string()) {
             // ensure base10 conversion for case of "01" input
             sec = KernelModule::Integer(env, sec, 10, true);
         }
@@ -529,9 +529,8 @@ void TimeObject::set_subsec(Env *env, Integer &usec) {
 }
 
 void TimeObject::set_subsec(Env *, RationalObject *subsec) {
-    if (!subsec->is_zero()) {
+    if (!subsec->is_zero())
         m_subsec = subsec;
-    }
 }
 
 Value TimeObject::build_string(Env *, const char *format) {

--- a/src/true_object.cpp
+++ b/src/true_object.cpp
@@ -3,7 +3,7 @@
 namespace Natalie {
 
 bool TrueObject::and_method(const Env *env, Value other) const {
-    return other->is_truthy();
+    return other.is_truthy();
 }
 
 bool TrueObject::or_method(const Env *env, const Value other) const {
@@ -11,7 +11,7 @@ bool TrueObject::or_method(const Env *env, const Value other) const {
 }
 
 bool TrueObject::xor_method(const Env *env, Value other) const {
-    return other->is_falsey();
+    return other.is_falsey();
 }
 
 Value TrueObject::to_s(const Env *env) const {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -167,17 +167,6 @@ Integer &Value::integer_or_raise(Env *env) {
     NAT_UNREACHABLE();
 }
 
-bool Value::is_integer() const {
-    switch (m_type) {
-    case Type::Integer:
-        return true;
-    case Type::Pointer:
-        return m_object && m_object->type() == Object::Type::Integer;
-    default:
-        return false;
-    }
-}
-
 __attribute__((no_sanitize("undefined"))) static nat_int_t left_shift_with_undefined_behavior(nat_int_t x, nat_int_t y) {
     return x << y;
 }
@@ -218,6 +207,58 @@ void Value::assert_type(Env *env, ObjectType expected_type, const char *expected
             env->raise_type_error(m_object, expected_class_name);
     }
 }
+
+bool Value::is_integer() const {
+    switch (m_type) {
+    case Type::Integer:
+        return true;
+    case Type::Pointer:
+        return m_object && m_object->type() == Object::Type::Integer;
+    default:
+        return false;
+    }
+}
+
+bool Value::is_nil() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Nil; }
+bool Value::is_true() const { return m_type == Type::Pointer && m_object->type() == ObjectType::True; }
+bool Value::is_false() const { return m_type == Type::Pointer && m_object->type() == ObjectType::False; }
+bool Value::is_fiber() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Fiber; }
+bool Value::is_enumerator_arithmetic_sequence() const { return m_type == Type::Pointer && m_object->type() == ObjectType::EnumeratorArithmeticSequence; }
+bool Value::is_array() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Array; }
+bool Value::is_binding() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Binding; }
+bool Value::is_method() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Method; }
+bool Value::is_module() const { return m_type == Type::Pointer && (m_object->type() == ObjectType::Module || m_object->type() == ObjectType::Class); }
+bool Value::is_class() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Class; }
+bool Value::is_complex() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Complex; }
+bool Value::is_dir() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Dir; }
+bool Value::is_encoding() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Encoding; }
+bool Value::is_env() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Env; }
+bool Value::is_exception() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Exception; }
+bool Value::is_float() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Float; }
+bool Value::is_hash() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Hash; }
+bool Value::is_io() const { return m_type == Type::Pointer && (m_object->type() == ObjectType::Io || m_object->type() == ObjectType::File); }
+bool Value::is_file() const { return m_type == Type::Pointer && m_object->type() == ObjectType::File; }
+bool Value::is_file_stat() const { return m_type == Type::Pointer && m_object->type() == ObjectType::FileStat; }
+bool Value::is_match_data() const { return m_type == Type::Pointer && m_object->type() == ObjectType::MatchData; }
+bool Value::is_proc() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Proc; }
+bool Value::is_random() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Random; }
+bool Value::is_range() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Range; }
+bool Value::is_rational() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Rational; }
+bool Value::is_regexp() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Regexp; }
+bool Value::is_symbol() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Symbol; }
+bool Value::is_string() const { return m_type == Type::Pointer && m_object->type() == ObjectType::String; }
+bool Value::is_thread() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Thread; }
+bool Value::is_thread_backtrace_location() const { return m_type == Type::Pointer && m_object->type() == ObjectType::ThreadBacktraceLocation; }
+bool Value::is_thread_group() const { return m_type == Type::Pointer && m_object->type() == ObjectType::ThreadGroup; }
+bool Value::is_thread_mutex() const { return m_type == Type::Pointer && m_object->type() == ObjectType::ThreadMutex; }
+bool Value::is_time() const { return m_type == Type::Pointer && m_object->type() == ObjectType::Time; }
+bool Value::is_unbound_method() const { return m_type == Type::Pointer && m_object->type() == ObjectType::UnboundMethod; }
+bool Value::is_void_p() const { return m_type == Type::Pointer && m_object->type() == ObjectType::VoidP; }
+
+bool Value::is_truthy() const { return !is_false() && !is_nil(); }
+bool Value::is_falsey() const { return !is_truthy(); }
+bool Value::is_numeric() const { return is_integer() || is_float(); }
+bool Value::is_boolean() const { return is_true() || is_false(); }
 
 #undef PROFILED_SEND
 


### PR DESCRIPTION
In my quest to get `hello.rb` to run with `Value::hydrate` removed, here are some more changes that get us closer.

Next step will probably be to remove the `Break` and `Redo` flags and use some sort of wrapping object in the return from a block. Not sure how that will work yet...