### PR TITLE
Fix object size for return values of attr_reader et al

### DIFF
--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -799,7 +799,7 @@ ArrayObject *ModuleObject::attr(Env *env, Args &&args) {
 }
 
 ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
-    auto ary = new ArrayObject {};
+    auto ary = new ArrayObject { args.size() };
     for (size_t i = 0; i < args.size(); i++) {
         auto name = attr_reader(env, args[i]);
         ary->push(name);
@@ -825,7 +825,7 @@ Value ModuleObject::attr_reader_block_fn(Env *env, Value self, Args &&args, Bloc
 }
 
 ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
-    auto ary = new ArrayObject {};
+    auto ary = new ArrayObject { args.size() };
     for (size_t i = 0; i < args.size(); i++) {
         auto name = attr_writer(env, args[i]);
         ary->push(name);
@@ -854,7 +854,7 @@ Value ModuleObject::attr_writer_block_fn(Env *env, Value self, Args &&args, Bloc
 }
 
 ArrayObject *ModuleObject::attr_accessor(Env *env, Args &&args) {
-    auto ary = new ArrayObject {};
+    auto ary = new ArrayObject { args.size() * 2 };
     for (size_t i = 0; i < args.size(); i++) {
         ary->push(attr_reader(env, args[i]));
         ary->push(attr_writer(env, args[i]));


### PR DESCRIPTION
We know exactly how long the return array is going to be. In the unlikely case that we have more than 10 arguments, this removes  a realloc/grow in our array. In the more likely case of less than 10 arguments, we don't overallocate. (As a reminder: the array class reserves 10 places in case you call it without any arguments). It would have been even better if we could just skip this return value completely if we knew the return value would not be used (which is pretty much always).