### PR TITLE
Clarify NATFIXME markers in specs of Process.fork

### DIFF
--- a/spec/shared/process/fork.rb
+++ b/spec/shared/process/fork.rb
@@ -60,7 +60,7 @@ describe :process_fork, shared: true do
       else
         Process.waitpid(child_id)
       end
-      NATFIXME 'share @file ivar (I guess', exception: SpecFailedException do
+      NATFIXME "Don't run after(:each) in forked process", exception: SpecFailedException do
         File.should.exist?(@file)
       end
     end
@@ -71,7 +71,7 @@ describe :process_fork, shared: true do
         Process.exit!
       }
       Process.waitpid(pid)
-      NATFIXME 'share @file ivar (I guess', exception: SpecFailedException do
+      NATFIXME "Don't run after(:each) in forked process", exception: SpecFailedException do
         File.should.exist?(@file)
       end
     end
@@ -88,7 +88,7 @@ describe :process_fork, shared: true do
       Process.waitpid(pid)
       t.kill
       t.join
-      NATFIXME 'share @file ivar (I guess', exception: Errno::ENOENT do
+      NATFIXME "Don't run after(:each) in forked process", exception: Errno::ENOENT do
         File.read(@file).should == "truefalse"
       end
     end


### PR DESCRIPTION
The code itself works fine, the issue we're facing is that the file gets created, then the forked process runs the after-hook and removes the file, then the main process tries to read the file and cannot find it. Somehow this issue does not occur if we run this with MRI using our spec runner.