### PR TITLE
Remove Break and Redo flags from Object

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -139,7 +139,7 @@ extern "C" {
 #include "onigmo.h"
 }
 
-enum FlipFlopState {
+enum class FlipFlopState {
     On,
     Transitioning,
     Off,

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -3,7 +3,6 @@
 #include "natalie/args.hpp"
 #include "natalie/env.hpp"
 #include "natalie/forward.hpp"
-#include "natalie/gc.hpp"
 #include "tm/owned_ptr.hpp"
 
 namespace Natalie {
@@ -33,15 +32,7 @@ public:
         , m_self { self }
         , m_type { type } { }
 
-    // NOTE: This should only be called from one of the RUN_BLOCK_* macros!
-    Value _run(Env *env, Args &&args = {}, Block *block = nullptr) {
-        Env e { m_env };
-        e.set_caller(env);
-        e.set_this_block(this);
-        args.pop_empty_keyword_hash();
-        auto result = m_fn(&e, m_self, std::move(args), block);
-        return result;
-    }
+    Value run(Env *env, Args &&args = {}, Block *block = nullptr);
 
     int arity() const { return m_arity; }
 

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -133,8 +133,15 @@ public:
 
     FiberObject *previous_fiber() const { return m_previous_fiber; }
 
+    bool redo_block() const { return m_redo_block; }
+    void set_redo_block() { m_redo_block = true; }
+    void clear_redo_block() { m_redo_block = false; }
+
 #ifdef __SANITIZE_ADDRESS__
-    void *asan_stack_base() const { return m_asan_stack_base; }
+    void *
+    asan_stack_base() const {
+        return m_asan_stack_base;
+    }
     void set_asan_stack_base(void *base) { m_asan_stack_base = base; }
 
     size_t asan_stack_size() const { return m_asan_stack_size; }
@@ -168,6 +175,7 @@ private:
     TM::Vector<Value> m_args {};
     FiberObject *m_previous_fiber { nullptr };
     ExceptionObject *m_error { nullptr };
+    bool m_redo_block { false };
 };
 
 }

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -133,9 +133,12 @@ public:
 
     FiberObject *previous_fiber() const { return m_previous_fiber; }
 
-    bool redo_block() const { return m_redo_block; }
     void set_redo_block() { m_redo_block = true; }
-    void clear_redo_block() { m_redo_block = false; }
+    bool check_redo_block_and_clear() {
+        auto value = m_redo_block;
+        m_redo_block = false;
+        return value;
+    }
 
 #ifdef __SANITIZE_ADDRESS__
     void *

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -12,11 +12,11 @@
 
 #define NAT_RUN_BLOCK(env, the_block, args, block) ({ \
     Natalie::Value _result = nullptr;                 \
+    auto fiber = Natalie::FiberObject::current();     \
     do {                                              \
-        if (_result)                                  \
-            _result->remove_redo_flag();              \
+        fiber->clear_redo_block();                    \
         _result = the_block->_run(env, args, block);  \
-    } while (_result->has_redo_flag());               \
+    } while (fiber->redo_block());                    \
     _result;                                          \
 })
 

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -10,26 +10,14 @@
         abort();                                                                                       \
     }
 
-#define NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, on_break) ({ \
-    Natalie::Value _result = nullptr;                                   \
-    do {                                                                \
-        if (_result)                                                    \
-            _result->remove_redo_flag();                                \
-        _result = the_block->_run(env, args, block);                    \
-    } while (_result->has_redo_flag());                                 \
-    _result;                                                            \
-})
-
-#define NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, the_block, args, block) ({ \
-    NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, return _result);  \
-})
-
-#define NAT_RUN_BLOCK_WITHOUT_BREAK(env, the_block, args, block) ({                                                               \
-    NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, env->raise_local_jump_error(_result, Natalie::LocalJumpErrorType::Break)); \
-})
-
-#define NAT_RUN_BLOCK_FROM_ENV(env, args) ({                               \
-    NAT_RUN_BLOCK_WITHOUT_BREAK(env, env->nearest_block(), args, nullptr); \
+#define NAT_RUN_BLOCK(env, the_block, args, block) ({ \
+    Natalie::Value _result = nullptr;                 \
+    do {                                              \
+        if (_result)                                  \
+            _result->remove_redo_flag();              \
+        _result = the_block->_run(env, args, block);  \
+    } while (_result->has_redo_flag());               \
+    _result;                                          \
 })
 
 #define NAT_QUOTE(val) #val

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -10,18 +10,14 @@
         abort();                                                                                       \
     }
 
-#define NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, on_break_flag) ({ \
-    Natalie::Value _result = nullptr;                                        \
-    do {                                                                     \
-        if (_result)                                                         \
-            _result->remove_redo_flag();                                     \
-        _result = the_block->_run(env, args, block);                         \
-        if (_result->has_break_flag()) {                                     \
-            _result->remove_break_flag();                                    \
-            on_break_flag;                                                   \
-        }                                                                    \
-    } while (_result->has_redo_flag());                                      \
-    _result;                                                                 \
+#define NAT_RUN_BLOCK_GENERIC(env, the_block, args, block, on_break) ({ \
+    Natalie::Value _result = nullptr;                                   \
+    do {                                                                \
+        if (_result)                                                    \
+            _result->remove_redo_flag();                                \
+        _result = the_block->_run(env, args, block);                    \
+    } while (_result->has_redo_flag());                                 \
+    _result;                                                            \
 })
 
 #define NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, the_block, args, block) ({ \

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -10,16 +10,6 @@
         abort();                                                                                       \
     }
 
-#define NAT_RUN_BLOCK(env, the_block, args, block) ({ \
-    Natalie::Value _result = nullptr;                 \
-    auto fiber = Natalie::FiberObject::current();     \
-    do {                                              \
-        fiber->clear_redo_block();                    \
-        _result = the_block->_run(env, args, block);  \
-    } while (fiber->redo_block());                    \
-    _result;                                          \
-})
-
 #define NAT_QUOTE(val) #val
 
 #define NAT_MAKE_NONCOPYABLE(c) \

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -29,12 +29,8 @@ public:
         Frozen = 1,
 
         // set on an object returned from a block to signal
-        // that `break` was called
-        Break = 2,
-
-        // set on an object returned from a block to signal
         // that `redo` was called
-        Redo = 4,
+        Redo = 2,
     };
 
     enum class Conversion {
@@ -286,10 +282,6 @@ public:
     bool is_frozen() const { return m_type == Type::Integer || m_type == Type::Float || (m_flags & Flag::Frozen) == Flag::Frozen; }
 
     bool not_truthy() const { return m_type == Type::Nil || m_type == Type::False; }
-
-    void add_break_flag() { m_flags = m_flags | Flag::Break; }
-    void remove_break_flag() { m_flags = m_flags & ~Flag::Break; }
-    bool has_break_flag() const { return (m_flags & Flag::Break) == Flag::Break; }
 
     void add_redo_flag() { m_flags = m_flags | Flag::Redo; }
     void remove_redo_flag() { m_flags = m_flags & ~Flag::Redo; }

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -27,10 +27,6 @@ public:
         // note that Integer and Float are always frozen,
         // even if this flag is not set
         Frozen = 1,
-
-        // set on an object returned from a block to signal
-        // that `redo` was called
-        Redo = 2,
     };
 
     enum class Conversion {
@@ -282,10 +278,6 @@ public:
     bool is_frozen() const { return m_type == Type::Integer || m_type == Type::Float || (m_flags & Flag::Frozen) == Flag::Frozen; }
 
     bool not_truthy() const { return m_type == Type::Nil || m_type == Type::False; }
-
-    void add_redo_flag() { m_flags = m_flags | Flag::Redo; }
-    void remove_redo_flag() { m_flags = m_flags & ~Flag::Redo; }
-    bool has_redo_flag() const { return (m_flags & Flag::Redo) == Flag::Redo; }
 
     bool eq(Env *, Value other) { return other == this; }
     static bool equal(Value, Value);

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -461,7 +461,7 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
     ptr_obj->ivar_set(env, "@autorelease"_s, TrueObject::the());
 
     if (block)
-        NAT_RUN_BLOCK(env, block, Args({ self }), nullptr);
+        block->run(env, Args({ self }), nullptr);
 
     return NilObject::the();
 }

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -461,7 +461,7 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
     ptr_obj->ivar_set(env, "@autorelease"_s, TrueObject::the());
 
     if (block)
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ self }), nullptr);
+        NAT_RUN_BLOCK(env, block, Args({ self }), nullptr);
 
     return NilObject::the();
 }

--- a/lib/natalie/compiler/instructions/redo_instruction.rb
+++ b/lib/natalie/compiler/instructions/redo_instruction.rb
@@ -8,13 +8,12 @@ module Natalie
       end
 
       def generate(transform)
-        value = transform.memoize(:obj_with_redo_flag, 'Object::_new(env, GlobalEnv::the()->Object(), {}, nullptr)');
-        transform.exec("#{value}->add_redo_flag()")
-        transform.exec("return #{value}")
+        transform.exec('FiberObject::current()->set_redo_block()')
+        transform.exec('return NilObject::the()')
         transform.push_nil
       end
 
-      def execute(vm)
+      def execute(_vm)
         raise 'todo'
       end
     end

--- a/lib/natalie/compiler/instructions/yield_instruction.rb
+++ b/lib/natalie/compiler/instructions/yield_instruction.rb
@@ -28,7 +28,7 @@ module Natalie
           arg_count.times { args.unshift transform.pop }
           args_list = "Args({ #{args.join(', ')} }, #{@has_keyword_hash ? 'true' : 'false'})"
         end
-        transform.exec_and_push :yield, "NAT_RUN_BLOCK(env, env->nearest_block(), #{args_list}, nullptr)"
+        transform.exec_and_push :yield, "env->nearest_block()->run(env, #{args_list}, nullptr)"
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/yield_instruction.rb
+++ b/lib/natalie/compiler/instructions/yield_instruction.rb
@@ -28,7 +28,7 @@ module Natalie
           arg_count.times { args.unshift transform.pop }
           args_list = "Args({ #{args.join(', ')} }, #{@has_keyword_hash ? 'true' : 'false'})"
         end
-        transform.exec_and_push :yield, "NAT_RUN_BLOCK_FROM_ENV(env, #{args_list})"
+        transform.exec_and_push :yield, "NAT_RUN_BLOCK(env, env->nearest_block(), #{args_list}, nullptr)"
       end
 
       def execute(vm)

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1618,7 +1618,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
 
     if (block) {
         try {
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { self }, nullptr);
+            NAT_RUN_BLOCK(env, block, { self }, nullptr);
             Socket_close(env, self, {}, nullptr);
         } catch (ExceptionObject *exception) {
             Socket_close(env, self, {}, nullptr);
@@ -1838,7 +1838,7 @@ Value UNIXSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
 
     if (block) {
         try {
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { self }, nullptr);
+            NAT_RUN_BLOCK(env, block, { self }, nullptr);
             Socket_close(env, self, {}, nullptr);
         } catch (ExceptionObject *exception) {
             Socket_close(env, self, {}, nullptr);

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1618,7 +1618,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
 
     if (block) {
         try {
-            NAT_RUN_BLOCK(env, block, { self }, nullptr);
+            block->run(env, { self }, nullptr);
             Socket_close(env, self, {}, nullptr);
         } catch (ExceptionObject *exception) {
             Socket_close(env, self, {}, nullptr);
@@ -1838,7 +1838,7 @@ Value UNIXSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
 
     if (block) {
         try {
-            NAT_RUN_BLOCK(env, block, { self }, nullptr);
+            block->run(env, { self }, nullptr);
             Socket_close(env, self, {}, nullptr);
         } catch (ExceptionObject *exception) {
             Socket_close(env, self, {}, nullptr);

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -60,7 +60,7 @@ Value ArrayObject::initialize(Env *env, Value size, Value value, Block *block) {
 
         for (nat_int_t i = 0; i < s; i++) {
             Value args[] = { Value::integer(i) };
-            push(NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr));
+            push(NAT_RUN_BLOCK(env, block, Args(1, args), nullptr));
         }
 
     } else {
@@ -453,7 +453,7 @@ Value ArrayObject::each(Env *env, Block *block) {
 
     for (size_t i = 0; i < size(); ++i) {
         Value args[] = { (*this)[i] };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -467,7 +467,7 @@ Value ArrayObject::each_index(Env *env, Block *block) {
     nat_int_t size_nat_int_t = static_cast<nat_int_t>(size());
     for (nat_int_t i = 0; i < size_nat_int_t; i++) {
         Value args[] = { Value::integer(i) };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -493,7 +493,7 @@ Value ArrayObject::map_in_place(Env *env, Block *block) {
 
     for (size_t i = 0; i < m_vector.size(); ++i) {
         Value args[] = { (*this)[i] };
-        m_vector.at(i) = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        m_vector.at(i) = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -568,7 +568,7 @@ Value ArrayObject::fill(Env *env, Value obj, Value start_obj, Value length_obj, 
     for (size_t i = start; i < (size_t)max; ++i) {
         if (block) {
             Value args[1] = { Value::integer(i) };
-            m_vector[i] = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+            m_vector[i] = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         } else
             m_vector[i] = obj;
     }
@@ -700,7 +700,7 @@ Value ArrayObject::delete_if(Env *env, Block *block) {
 
     for (size_t i = 0; i < size(); ++i) {
         Value args[] = { (*this)[i] };
-        Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         if (result.is_truthy()) {
             marked_indexes.push(i);
         }
@@ -731,7 +731,7 @@ Value ArrayObject::delete_item(Env *env, Value target, Block *block) {
     }
 
     if (deleted_item.is_nil() && block) {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, {}, nullptr);
+        return NAT_RUN_BLOCK(env, block, {}, nullptr);
     }
 
     return deleted_item;
@@ -783,7 +783,7 @@ Value ArrayObject::drop_while(Env *env, Block *block) {
     size_t i = 0;
     while (i < m_vector.size()) {
         Value args[] = { m_vector.at(i) };
-        Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         if (result.is_nil() || result.is_false()) {
             break;
         }
@@ -1043,7 +1043,7 @@ void ArrayObject::expand_with_nil(Env *env, size_t total) {
 bool array_sort_compare(Env *env, Value a, Value b, Block *block) {
     if (block) {
         Value args[2] = { a, b };
-        Value compare = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(2, args), nullptr);
+        Value compare = NAT_RUN_BLOCK(env, block, Args(2, args), nullptr);
 
         if (compare->respond_to(env, "<"_s)) {
             Value zero = Value::integer(0);
@@ -1074,10 +1074,10 @@ Value ArrayObject::sort_in_place(Env *env, Block *block) {
 bool array_sort_by_compare(Env *env, Value a, Value b, Block *block) {
     Value args[1];
     args[0] = a;
-    Value a_res = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+    Value a_res = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
 
     args[0] = b;
-    Value b_res = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+    Value b_res = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
 
     Value compare = a_res.send(env, "<=>"_s, { b_res });
     if (compare.is_integer()) {
@@ -1122,7 +1122,7 @@ Value ArrayObject::select_in_place(Env *env, Block *block) {
 
     bool changed = select_in_place([env, block](Value &item) -> bool {
         Value args[] = { item };
-        Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         return result.is_truthy();
     });
 
@@ -1176,7 +1176,7 @@ Value ArrayObject::reject_in_place(Env *env, Block *block) {
 
         try {
             Value args[] = { item };
-            Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+            Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
             if (result.is_falsey())
                 new_array.push(item);
             else
@@ -1206,7 +1206,7 @@ Value ArrayObject::max(Env *env, Value count, Block *block) {
 
     auto is_more = [&](Value item, Value min) -> bool {
         Value block_args[] = { item, min };
-        Value compare = (block) ? NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
+        Value compare = (block) ? NAT_RUN_BLOCK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
 
         if (compare.is_nil())
             env->raise(
@@ -1256,7 +1256,7 @@ Value ArrayObject::min(Env *env, Value count, Block *block) {
 
     auto is_less = [&](Value item, Value min) -> bool {
         Value block_args[] = { item, min };
-        Value compare = (block) ? NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
+        Value compare = (block) ? NAT_RUN_BLOCK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
 
         if (compare.is_nil())
             env->raise(
@@ -1306,7 +1306,7 @@ Value ArrayObject::minmax(Env *env, Block *block) {
 
     auto compare = [&](Value item, Value min) -> nat_int_t {
         Value block_args[] = { item, min };
-        Value compare = (block) ? NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
+        Value compare = (block) ? NAT_RUN_BLOCK(env, block, Args(2, block_args), nullptr) : item.send(env, "<=>"_s, { min });
 
         if (compare.is_nil())
             env->raise(
@@ -1401,7 +1401,7 @@ Value ArrayObject::uniq_in_place(Env *env, Block *block) {
         Value key = item;
         if (block) {
             Value args[] = { item };
-            key = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+            key = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         }
         if (!hash->has_key(env, key)) {
             hash->put(env, key, item);
@@ -1464,7 +1464,7 @@ Value ArrayObject::bsearch_index(Env *env, Block *block) {
     nat_int_t right = m_vector.size() - 1;
 
     auto result = binary_search(env, left, right, [this, env, block](nat_int_t middle) -> Value {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { (*this)[middle] }, nullptr);
+        return NAT_RUN_BLOCK(env, block, { (*this)[middle] }, nullptr);
     });
 
     if (!result.present())
@@ -1671,7 +1671,7 @@ Value ArrayObject::reverse_each(Env *env, Block *block) {
 
     for (size_t i = m_vector.size(); i > 0; --i) {
         Value args[] = { (*this)[i - 1] };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
 
     return this;
@@ -1735,7 +1735,7 @@ Value ArrayObject::fetch(Env *env, Value arg_index, Value default_value, Block *
                 env->warn("block supersedes default value argument");
 
             Value args[] = { arg_index };
-            value = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+            value = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         } else if (default_value) {
             value = default_value;
         } else {
@@ -1761,7 +1761,7 @@ Value ArrayObject::find_index(Env *env, Value object, Block *block, bool search_
                 return Value::integer(index);
         } else {
             Value args[] = { item };
-            auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+            auto result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
             length = static_cast<nat_int_t>(size());
             if (result.is_truthy())
                 return Value::integer(index);

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -4,6 +4,19 @@
 
 namespace Natalie {
 
+Value Block::run(Env *env, Args &&args, Block *block) {
+    Env e { m_env };
+    e.set_caller(env);
+    e.set_this_block(this);
+    args.pop_empty_keyword_hash();
+    auto fiber = Natalie::FiberObject::current();
+    Value result;
+    do {
+        result = m_fn(&e, m_self, std::move(args), block);
+    } while (fiber->check_redo_block_and_clear());
+    return result;
+}
+
 void Block::copy_fn_pointer_to_method(Method *method) {
     method->set_fn(m_fn);
 }

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -55,7 +55,7 @@ Optional<nat_int_t> binary_search(Env *env, nat_int_t left, nat_int_t right, std
 
 Value binary_search_integer(Env *env, nat_int_t left, nat_int_t right, Block *block, bool exclude_end) {
     auto result = binary_search(env, left, right, [env, block](nat_int_t middle) -> Value {
-        return NAT_RUN_BLOCK(env, block, { IntegerObject::create(middle) }, nullptr);
+        return block->run(env, { IntegerObject::create(middle) }, nullptr);
     });
 
     if (!result.present())
@@ -89,7 +89,7 @@ Value binary_search_float(Env *env, double left, double right, Block *block, boo
     nat_int_t right_int = double_to_integer(right);
 
     auto result = binary_search(env, left_int, right_int, [env, block](nat_int_t middle) -> Value {
-        return NAT_RUN_BLOCK(env, block, { new FloatObject(integer_to_double(middle)) }, nullptr);
+        return block->run(env, { new FloatObject(integer_to_double(middle)) }, nullptr);
     });
 
     if (!result.present())

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -55,7 +55,7 @@ Optional<nat_int_t> binary_search(Env *env, nat_int_t left, nat_int_t right, std
 
 Value binary_search_integer(Env *env, nat_int_t left, nat_int_t right, Block *block, bool exclude_end) {
     auto result = binary_search(env, left, right, [env, block](nat_int_t middle) -> Value {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { IntegerObject::create(middle) }, nullptr);
+        return NAT_RUN_BLOCK(env, block, { IntegerObject::create(middle) }, nullptr);
     });
 
     if (!result.present())
@@ -89,7 +89,7 @@ Value binary_search_float(Env *env, double left, double right, Block *block, boo
     nat_int_t right_int = double_to_integer(right);
 
     auto result = binary_search(env, left_int, right_int, [env, block](nat_int_t middle) -> Value {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { new FloatObject(integer_to_double(middle)) }, nullptr);
+        return NAT_RUN_BLOCK(env, block, { new FloatObject(integer_to_double(middle)) }, nullptr);
     });
 
     if (!result.present())

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -22,7 +22,7 @@ Value DirObject::open(Env *env, Value path, Value encoding, Block *block) {
         Defer close_dir([&]() {
             dir->as_dir()->close(env);
         });
-        Value result = NAT_RUN_BLOCK(env, block, Args({ dir }), nullptr);
+        Value result = block->run(env, Args({ dir }), nullptr);
         return result;
     }
     return dir;
@@ -131,7 +131,7 @@ Value DirObject::chdir(Env *env, Value path, Block *block) {
     Value args[] = { path };
     Value result;
     try {
-        result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        result = block->run(env, Args(1, args), nullptr);
     } catch (ExceptionObject *exception) {
         change_current_path(env, old_path);
         throw exception;
@@ -176,7 +176,7 @@ Value DirObject::each(Env *env, Block *block) {
     struct dirent *dirp;
     while ((dirp = ::readdir(m_dir))) {
         Value args[] = { new StringObject { dirp->d_name, m_encoding } };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return this;
 }
@@ -192,7 +192,7 @@ Value DirObject::each_child(Env *env, Block *block) {
         auto name = String(dirp->d_name);
         if (name != "." && name != "..") {
             Value args[] = { new StringObject { name, m_encoding } };
-            NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+            block->run(env, Args(1, args), nullptr);
         }
     }
     return this;

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -22,7 +22,7 @@ Value DirObject::open(Env *env, Value path, Value encoding, Block *block) {
         Defer close_dir([&]() {
             dir->as_dir()->close(env);
         });
-        Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ dir }), nullptr);
+        Value result = NAT_RUN_BLOCK(env, block, Args({ dir }), nullptr);
         return result;
     }
     return dir;
@@ -131,7 +131,7 @@ Value DirObject::chdir(Env *env, Value path, Block *block) {
     Value args[] = { path };
     Value result;
     try {
-        result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     } catch (ExceptionObject *exception) {
         change_current_path(env, old_path);
         throw exception;
@@ -176,7 +176,7 @@ Value DirObject::each(Env *env, Block *block) {
     struct dirent *dirp;
     while ((dirp = ::readdir(m_dir))) {
         Value args[] = { new StringObject { dirp->d_name, m_encoding } };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -192,7 +192,7 @@ Value DirObject::each_child(Env *env, Block *block) {
         auto name = String(dirp->d_name);
         if (name != "." && name != "..") {
             Value args[] = { new StringObject { name, m_encoding } };
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+            NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         }
     }
     return this;

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -78,7 +78,7 @@ Value ArithmeticSequenceObject::each(Env *env, Block *block) {
         return this;
 
     iterate(env, [&env, &block](Value value) -> Value {
-        NAT_RUN_BLOCK(env, block, { value }, nullptr);
+        block->run(env, { value }, nullptr);
         return nullptr;
     });
 

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -78,7 +78,7 @@ Value ArithmeticSequenceObject::each(Env *env, Block *block) {
         return this;
 
     iterate(env, [&env, &block](Value value) -> Value {
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { value }, nullptr);
+        NAT_RUN_BLOCK(env, block, { value }, nullptr);
         return nullptr;
     });
 

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -42,7 +42,7 @@ Value EnvObject::to_hash(Env *env, Block *block) {
         Value name = string_with_default_encoding(pair, index);
         Value value = string_with_default_encoding(getenv(name->as_string()->c_str()));
         if (block) {
-            auto transformed = NAT_RUN_BLOCK(env, block, Args({ name, value }), nullptr);
+            auto transformed = block->run(env, Args({ name, value }), nullptr);
             if (!transformed.is_array() && transformed->respond_to(env, "to_ary"_s))
                 transformed = transformed->to_ary(env);
             if (!transformed.is_array())
@@ -87,7 +87,7 @@ Value EnvObject::delete_key(Env *env, Value name, Block *block) {
         ::unsetenv(namestr->c_str());
         return value_obj;
     } else if (block) {
-        return NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
+        return block->run(env, Args({ name }), nullptr);
     } else {
         return NilObject::the();
     }
@@ -105,7 +105,7 @@ Value EnvObject::each(Env *env, Block *block) {
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto name = node.key;
             auto value = node.val;
-            NAT_RUN_BLOCK(env, block, Args({ name, value }), nullptr);
+            block->run(env, Args({ name, value }), nullptr);
         }
         return this;
     } else {
@@ -120,7 +120,7 @@ Value EnvObject::each_key(Env *env, Block *block) {
         auto envhash = to_hash(env, nullptr);
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto name = node.key;
-            NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
+            block->run(env, Args({ name }), nullptr);
         }
         return this;
     } else {
@@ -135,7 +135,7 @@ Value EnvObject::each_value(Env *env, Block *block) {
         auto envhash = to_hash(env, nullptr);
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto value = node.val;
-            NAT_RUN_BLOCK(env, block, Args({ value }), nullptr);
+            block->run(env, Args({ value }), nullptr);
         }
         return this;
     } else {
@@ -193,7 +193,7 @@ Value EnvObject::fetch(Env *env, Value name, Value default_value, Block *block) 
     } else if (block) {
         if (default_value)
             env->warn("block supersedes default value argument");
-        return NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
+        return block->run(env, Args({ name }), nullptr);
     } else if (default_value) {
         return default_value;
     } else {
@@ -416,7 +416,7 @@ Value EnvObject::update(Env *env, Args &&args, Block *block) {
             if (!old_value.is_nil()) {
                 if (block) {
                     Value args[3] = { node.key, old_value, new_value };
-                    new_value = NAT_RUN_BLOCK(env, block, Args(3, args), nullptr);
+                    new_value = block->run(env, Args(3, args), nullptr);
                 }
             }
             refeq(env, node.key, new_value);

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -42,7 +42,7 @@ Value EnvObject::to_hash(Env *env, Block *block) {
         Value name = string_with_default_encoding(pair, index);
         Value value = string_with_default_encoding(getenv(name->as_string()->c_str()));
         if (block) {
-            auto transformed = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ name, value }), nullptr);
+            auto transformed = NAT_RUN_BLOCK(env, block, Args({ name, value }), nullptr);
             if (!transformed.is_array() && transformed->respond_to(env, "to_ary"_s))
                 transformed = transformed->to_ary(env);
             if (!transformed.is_array())
@@ -87,7 +87,7 @@ Value EnvObject::delete_key(Env *env, Value name, Block *block) {
         ::unsetenv(namestr->c_str());
         return value_obj;
     } else if (block) {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ name }), nullptr);
+        return NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
     } else {
         return NilObject::the();
     }
@@ -105,7 +105,7 @@ Value EnvObject::each(Env *env, Block *block) {
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto name = node.key;
             auto value = node.val;
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ name, value }), nullptr);
+            NAT_RUN_BLOCK(env, block, Args({ name, value }), nullptr);
         }
         return this;
     } else {
@@ -120,7 +120,7 @@ Value EnvObject::each_key(Env *env, Block *block) {
         auto envhash = to_hash(env, nullptr);
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto name = node.key;
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ name }), nullptr);
+            NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
         }
         return this;
     } else {
@@ -135,7 +135,7 @@ Value EnvObject::each_value(Env *env, Block *block) {
         auto envhash = to_hash(env, nullptr);
         for (HashObject::Key &node : *envhash->as_hash()) {
             auto value = node.val;
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ value }), nullptr);
+            NAT_RUN_BLOCK(env, block, Args({ value }), nullptr);
         }
         return this;
     } else {
@@ -193,7 +193,7 @@ Value EnvObject::fetch(Env *env, Value name, Value default_value, Block *block) 
     } else if (block) {
         if (default_value)
             env->warn("block supersedes default value argument");
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ name }), nullptr);
+        return NAT_RUN_BLOCK(env, block, Args({ name }), nullptr);
     } else if (default_value) {
         return default_value;
     } else {
@@ -416,7 +416,7 @@ Value EnvObject::update(Env *env, Args &&args, Block *block) {
             if (!old_value.is_nil()) {
                 if (block) {
                     Value args[3] = { node.key, old_value, new_value };
-                    new_value = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(3, args), nullptr);
+                    new_value = NAT_RUN_BLOCK(env, block, Args(3, args), nullptr);
                 }
             }
             refeq(env, node.key, new_value);

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -104,11 +104,11 @@ bool FiberObject::is_blocking() const {
 Value FiberObject::blocking(Env *env, Block *block) {
     auto fiber = current();
     if (fiber->is_blocking()) {
-        return NAT_RUN_BLOCK(env, block, { fiber }, nullptr);
+        return block->run(env, { fiber }, nullptr);
     }
     fiber->m_blocking = true;
     auto unblock = Defer([&fiber] { fiber->m_blocking = false; });
-    return NAT_RUN_BLOCK(env, block, { fiber }, nullptr);
+    return block->run(env, { fiber }, nullptr);
 }
 
 Value FiberObject::is_blocking_current() {
@@ -395,7 +395,7 @@ void fiber_wrapper_func(mco_coro *co) {
         // But that seems to be what Ruby does too.
         Natalie::Env e {};
 
-        return_arg = NAT_RUN_BLOCK((&e), fiber->block(), Natalie::Args(fiber->args()), nullptr);
+        return_arg = fiber->block()->run(&e, Natalie::Args(fiber->args()), nullptr);
     } catch (Natalie::ExceptionObject *exception) {
         fiber->set_error(exception);
         reraise = true;

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -104,11 +104,11 @@ bool FiberObject::is_blocking() const {
 Value FiberObject::blocking(Env *env, Block *block) {
     auto fiber = current();
     if (fiber->is_blocking()) {
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { fiber }, nullptr);
+        return NAT_RUN_BLOCK(env, block, { fiber }, nullptr);
     }
     fiber->m_blocking = true;
     auto unblock = Defer([&fiber] { fiber->m_blocking = false; });
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { fiber }, nullptr);
+    return NAT_RUN_BLOCK(env, block, { fiber }, nullptr);
 }
 
 Value FiberObject::is_blocking_current() {
@@ -395,7 +395,7 @@ void fiber_wrapper_func(mco_coro *co) {
         // But that seems to be what Ruby does too.
         Natalie::Env e {};
 
-        return_arg = NAT_RUN_BLOCK_WITHOUT_BREAK((&e), fiber->block(), Natalie::Args(fiber->args()), nullptr);
+        return_arg = NAT_RUN_BLOCK((&e), fiber->block(), Natalie::Args(fiber->args()), nullptr);
     } catch (Natalie::ExceptionObject *exception) {
         fiber->set_error(exception);
         reraise = true;

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -390,7 +390,7 @@ Value HashObject::delete_if(Env *env, Block *block) {
     assert_not_frozen(env);
     for (auto &node : *this) {
         Value args[2] = { node.key, node.val };
-        if (NAT_RUN_BLOCK(env, block, Args(2, args), nullptr).is_truthy()) {
+        if (block->run(env, Args(2, args), nullptr).is_truthy()) {
             delete_key(env, node.key, nullptr);
         }
     }
@@ -404,7 +404,7 @@ Value HashObject::delete_key(Env *env, Value key, Block *block) {
     if (val)
         return val;
     else if (block)
-        return NAT_RUN_BLOCK(env, block, {}, nullptr);
+        return block->run(env, {}, nullptr);
     else
         return NilObject::the();
 }
@@ -517,7 +517,7 @@ Value HashObject::each(Env *env, Block *block) {
     for (HashObject::Key &node : *this) {
         auto ary = new ArrayObject { { node.key, node.val } };
         Value block_args[1] = { ary };
-        NAT_RUN_BLOCK(env, block, Args(1, block_args), nullptr);
+        block->run(env, Args(1, block_args), nullptr);
     }
     return this;
 }
@@ -542,7 +542,7 @@ Value HashObject::fetch(Env *env, Value key, Value default_value, Block *block) 
                 env->warn("block supersedes default value argument");
 
             Value args[] = { key };
-            value = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+            value = block->run(env, Args(1, args), nullptr);
         } else if (default_value) {
             value = default_value;
         } else {
@@ -579,7 +579,7 @@ Value HashObject::keep_if(Env *env, Block *block) {
     assert_not_frozen(env);
     for (auto &node : *this) {
         Value args[2] = { node.key, node.val };
-        if (!NAT_RUN_BLOCK(env, block, Args(2, args), nullptr).is_truthy()) {
+        if (!block->run(env, Args(2, args), nullptr).is_truthy()) {
             delete_key(env, node.key, nullptr);
         }
     }
@@ -605,7 +605,7 @@ Value HashObject::to_h(Env *env, Block *block) {
     for (auto &node : *this) {
         block_args[0] = node.key;
         block_args[1] = node.val;
-        auto result = NAT_RUN_BLOCK(env, block, Args(2, block_args), nullptr);
+        auto result = block->run(env, Args(2, block_args), nullptr);
         if (!result.is_array() && result->respond_to(env, "to_ary"_s))
             result = result->to_ary(env);
         if (!result.is_array())
@@ -700,7 +700,7 @@ Value HashObject::merge_in_place(Env *env, Args &&args, Block *block) {
                 auto old_value = get(env, node.key);
                 if (old_value) {
                     Value args[3] = { node.key, old_value, new_value };
-                    new_value = NAT_RUN_BLOCK(env, block, Args(3, args), nullptr);
+                    new_value = block->run(env, Args(3, args), nullptr);
                 }
             }
             put(env, node.key, new_value);

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -390,7 +390,7 @@ Value HashObject::delete_if(Env *env, Block *block) {
     assert_not_frozen(env);
     for (auto &node : *this) {
         Value args[2] = { node.key, node.val };
-        if (NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(2, args), nullptr).is_truthy()) {
+        if (NAT_RUN_BLOCK(env, block, Args(2, args), nullptr).is_truthy()) {
             delete_key(env, node.key, nullptr);
         }
     }
@@ -404,7 +404,7 @@ Value HashObject::delete_key(Env *env, Value key, Block *block) {
     if (val)
         return val;
     else if (block)
-        return NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, {}, nullptr);
+        return NAT_RUN_BLOCK(env, block, {}, nullptr);
     else
         return NilObject::the();
 }
@@ -517,7 +517,7 @@ Value HashObject::each(Env *env, Block *block) {
     for (HashObject::Key &node : *this) {
         auto ary = new ArrayObject { { node.key, node.val } };
         Value block_args[1] = { ary };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, block_args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, block_args), nullptr);
     }
     return this;
 }
@@ -542,7 +542,7 @@ Value HashObject::fetch(Env *env, Value key, Value default_value, Block *block) 
                 env->warn("block supersedes default value argument");
 
             Value args[] = { key };
-            value = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+            value = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         } else if (default_value) {
             value = default_value;
         } else {
@@ -579,7 +579,7 @@ Value HashObject::keep_if(Env *env, Block *block) {
     assert_not_frozen(env);
     for (auto &node : *this) {
         Value args[2] = { node.key, node.val };
-        if (!NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(2, args), nullptr).is_truthy()) {
+        if (!NAT_RUN_BLOCK(env, block, Args(2, args), nullptr).is_truthy()) {
             delete_key(env, node.key, nullptr);
         }
     }
@@ -605,7 +605,7 @@ Value HashObject::to_h(Env *env, Block *block) {
     for (auto &node : *this) {
         block_args[0] = node.key;
         block_args[1] = node.val;
-        auto result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(2, block_args), nullptr);
+        auto result = NAT_RUN_BLOCK(env, block, Args(2, block_args), nullptr);
         if (!result.is_array() && result->respond_to(env, "to_ary"_s))
             result = result->to_ary(env);
         if (!result.is_array())
@@ -700,7 +700,7 @@ Value HashObject::merge_in_place(Env *env, Args &&args, Block *block) {
                 auto old_value = get(env, node.key);
                 if (old_value) {
                     Value args[3] = { node.key, old_value, new_value };
-                    new_value = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(3, args), nullptr);
+                    new_value = NAT_RUN_BLOCK(env, block, Args(3, args), nullptr);
                 }
             }
             put(env, node.key, new_value);

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -411,7 +411,7 @@ Value IntegerObject::times(Env *env, Integer &self, Block *block) {
     for (Integer i = 0; i < self; ++i) {
         Value num = create(i);
         Value args[] = { num };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return self;
 }

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -411,7 +411,7 @@ Value IntegerObject::times(Env *env, Integer &self, Block *block) {
     for (Integer i = 0; i < self; ++i) {
         Value num = create(i);
         Value args[] = { num };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return self;
 }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -147,7 +147,7 @@ Value IoObject::each_byte(Env *env, Block *block) {
 
     Value byte;
     while (!(byte = getbyte(env)).is_nil())
-        NAT_RUN_BLOCK(env, block, { byte }, nullptr);
+        block->run(env, { byte }, nullptr);
 
     return this;
 }
@@ -1228,7 +1228,7 @@ Value IoObject::pipe(Env *env, Value external_encoding, Value internal_encoding,
         io_read->public_send(env, "close"_s);
         io_write->public_send(env, "close"_s);
     });
-    return NAT_RUN_BLOCK(env, block, { pipes }, nullptr);
+    return block->run(env, { pipes }, nullptr);
 }
 
 Value IoObject::popen(Env *env, Args &&args, Block *block, ClassObject *klass) {
@@ -1253,7 +1253,7 @@ Value IoObject::popen(Env *env, Args &&args, Block *block, ClassObject *klass) {
         return io;
 
     Defer close_io([&]() { io->public_send(env, "close"_s); });
-    return NAT_RUN_BLOCK(env, block, { io }, nullptr);
+    return block->run(env, { io }, nullptr);
 }
 
 int IoObject::pos(Env *env) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -147,7 +147,7 @@ Value IoObject::each_byte(Env *env, Block *block) {
 
     Value byte;
     while (!(byte = getbyte(env)).is_nil())
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { byte }, nullptr);
+        NAT_RUN_BLOCK(env, block, { byte }, nullptr);
 
     return this;
 }
@@ -1228,7 +1228,7 @@ Value IoObject::pipe(Env *env, Value external_encoding, Value internal_encoding,
         io_read->public_send(env, "close"_s);
         io_write->public_send(env, "close"_s);
     });
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { pipes }, nullptr);
+    return NAT_RUN_BLOCK(env, block, { pipes }, nullptr);
 }
 
 Value IoObject::popen(Env *env, Args &&args, Block *block, ClassObject *klass) {
@@ -1253,7 +1253,7 @@ Value IoObject::popen(Env *env, Args &&args, Block *block, ClassObject *klass) {
         return io;
 
     Defer close_io([&]() { io->public_send(env, "close"_s); });
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { io }, nullptr);
+    return NAT_RUN_BLOCK(env, block, { io }, nullptr);
 }
 
 int IoObject::pos(Env *env) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -120,7 +120,7 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
     try {
         Env block_env { env };
         block_env.set_catch(name);
-        return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(&block_env, block, { name }, nullptr);
+        return NAT_RUN_BLOCK(&block_env, block, { name }, nullptr);
     } catch (ThrowCatchException *e) {
         if (Object::equal(e->get_name(), name))
             return e->get_value();
@@ -294,7 +294,7 @@ Value KernelModule::fork(Env *env, Block *block) {
     if (block) {
         if (pid == 0) {
             // child
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { Value::integer(pid) }, nullptr);
+            NAT_RUN_BLOCK(env, block, { Value::integer(pid) }, nullptr);
             ::exit(0);
         } else {
             // parent
@@ -795,7 +795,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
 
     try {
         for (;;) {
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, {}, nullptr);
+            NAT_RUN_BLOCK(env, block, {}, nullptr);
         }
         return NilObject::the();
     } catch (ExceptionObject *exception) {
@@ -879,7 +879,7 @@ Value KernelModule::tap(Env *env, Value self, Block *block) {
     Value args[] = { self };
     if (!block)
         env->raise("LocalJumpError", "no block given (yield)");
-    NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+    NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     return self;
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -120,7 +120,7 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
     try {
         Env block_env { env };
         block_env.set_catch(name);
-        return NAT_RUN_BLOCK(&block_env, block, { name }, nullptr);
+        return block->run(&block_env, { name }, nullptr);
     } catch (ThrowCatchException *e) {
         if (Object::equal(e->get_name(), name))
             return e->get_value();
@@ -294,7 +294,7 @@ Value KernelModule::fork(Env *env, Block *block) {
     if (block) {
         if (pid == 0) {
             // child
-            NAT_RUN_BLOCK(env, block, { Value::integer(pid) }, nullptr);
+            block->run(env, { Value::integer(pid) }, nullptr);
             ::exit(0);
         } else {
             // parent
@@ -795,7 +795,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
 
     try {
         for (;;) {
-            NAT_RUN_BLOCK(env, block, {}, nullptr);
+            block->run(env, {}, nullptr);
         }
         return NilObject::the();
     } catch (ExceptionObject *exception) {
@@ -879,7 +879,7 @@ Value KernelModule::tap(Env *env, Value self, Block *block) {
     Value args[] = { self };
     if (!block)
         env->raise("LocalJumpError", "no block given (yield)");
-    NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+    block->run(env, Args(1, args), nullptr);
     return self;
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -19,7 +19,7 @@ Value ModuleObject::initialize(Env *env, Block *block) {
         Value self = this;
         block->set_self(self);
         Value args[] = { self };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return this;
 }
@@ -936,7 +936,7 @@ Value ModuleObject::module_eval(Env *env, Block *block) {
     auto old_method_visibility = m_method_visibility;
     auto old_module_function = m_module_function;
     Value args[] = { self };
-    Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+    Value result = block->run(env, Args(1, args), nullptr);
     m_method_visibility = old_method_visibility;
     m_module_function = old_module_function;
     return result;
@@ -947,7 +947,7 @@ Value ModuleObject::module_exec(Env *env, Args &&args, Block *block) {
         env->raise_local_jump_error(NilObject::the(), Natalie::LocalJumpErrorType::None);
     Value self = this;
     block->set_self(self);
-    return NAT_RUN_BLOCK(env, block, std::move(args), nullptr);
+    return block->run(env, std::move(args), nullptr);
 }
 
 Value ModuleObject::private_method(Env *env, Args &&args) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -19,7 +19,7 @@ Value ModuleObject::initialize(Env *env, Block *block) {
         Value self = this;
         block->set_self(self);
         Value args[] = { self };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -936,7 +936,7 @@ Value ModuleObject::module_eval(Env *env, Block *block) {
     auto old_method_visibility = m_method_visibility;
     auto old_module_function = m_module_function;
     Value args[] = { self };
-    Value result = NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+    Value result = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     m_method_visibility = old_method_visibility;
     m_module_function = old_module_function;
     return result;
@@ -947,7 +947,7 @@ Value ModuleObject::module_exec(Env *env, Args &&args, Block *block) {
         env->raise_local_jump_error(NilObject::the(), Natalie::LocalJumpErrorType::None);
     Value self = this;
     block->set_self(self);
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, std::move(args), nullptr);
+    return NAT_RUN_BLOCK(env, block, std::move(args), nullptr);
 }
 
 Value ModuleObject::private_method(Env *env, Args &&args) {

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -569,7 +569,7 @@ void run_at_exit_handlers(Env *env) {
     Value proc;
     while (!(proc = at_exit_handlers->pop()).is_nil()) {
         if (proc.is_proc())
-            NAT_RUN_BLOCK_WITHOUT_BREAK(env, proc->as_proc()->block(), {}, nullptr);
+            NAT_RUN_BLOCK(env, proc->as_proc()->block(), {}, nullptr);
     }
 }
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -569,7 +569,7 @@ void run_at_exit_handlers(Env *env) {
     Value proc;
     while (!(proc = at_exit_handlers->pop()).is_nil()) {
         if (proc.is_proc())
-            NAT_RUN_BLOCK(env, proc->as_proc()->block(), {}, nullptr);
+            proc->as_proc()->block()->run(env, {}, nullptr);
     }
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1237,7 +1237,7 @@ Value Object::instance_eval(Env *env, Args &&args, Block *block) {
         block->set_self(context.block_original_self);
     });
     Value block_args[] = { self };
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, block_args), nullptr);
+    return NAT_RUN_BLOCK(env, block, Args(1, block_args), nullptr);
 }
 
 Value Object::instance_exec(Env *env, Args &&args, Block *block) {
@@ -1251,7 +1251,7 @@ Value Object::instance_exec(Env *env, Args &&args, Block *block) {
         block->set_self(context.block_original_self);
     });
 
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, std::move(args), nullptr);
+    return NAT_RUN_BLOCK(env, block, std::move(args), nullptr);
 }
 
 void Object::assert_not_frozen(Env *env) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1237,7 +1237,7 @@ Value Object::instance_eval(Env *env, Args &&args, Block *block) {
         block->set_self(context.block_original_self);
     });
     Value block_args[] = { self };
-    return NAT_RUN_BLOCK(env, block, Args(1, block_args), nullptr);
+    return block->run(env, Args(1, block_args), nullptr);
 }
 
 Value Object::instance_exec(Env *env, Args &&args, Block *block) {
@@ -1251,7 +1251,7 @@ Value Object::instance_exec(Env *env, Args &&args, Block *block) {
         block->set_self(context.block_original_self);
     });
 
-    return NAT_RUN_BLOCK(env, block, std::move(args), nullptr);
+    return block->run(env, std::move(args), nullptr);
 }
 
 void Object::assert_not_frozen(Env *env) {

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -12,14 +12,14 @@ Value ProcObject::call(Env *env, Args &&args, Block *block) {
     assert(m_block);
     if (is_lambda() && m_break_point != 0) {
         try {
-            return NAT_RUN_BLOCK(env, m_block, std::move(args), block);
+            return m_block->run(env, std::move(args), block);
         } catch (ExceptionObject *exception) {
             if (exception->is_local_jump_error_with_break_point(m_break_point))
                 return exception->send(env, "exit_value"_s);
             throw exception;
         }
     }
-    return NAT_RUN_BLOCK(env, m_block, std::move(args), block);
+    return m_block->run(env, std::move(args), block);
 }
 
 bool ProcObject::equal_value(Value other) const {

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -12,14 +12,14 @@ Value ProcObject::call(Env *env, Args &&args, Block *block) {
     assert(m_block);
     if (is_lambda() && m_break_point != 0) {
         try {
-            return NAT_RUN_BLOCK_WITHOUT_BREAK(env, m_block, std::move(args), block);
+            return NAT_RUN_BLOCK(env, m_block, std::move(args), block);
         } catch (ExceptionObject *exception) {
             if (exception->is_local_jump_error_with_break_point(m_break_point))
                 return exception->send(env, "exit_value"_s);
             throw exception;
         }
     }
-    return NAT_RUN_BLOCK_WITHOUT_BREAK(env, m_block, std::move(args), block);
+    return NAT_RUN_BLOCK(env, m_block, std::move(args), block);
 }
 
 bool ProcObject::equal_value(Value other) const {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -132,7 +132,7 @@ Value RangeObject::each(Env *env, Block *block) {
 
     Value break_value = iterate_over_range(env, [&](Value item) -> Value {
         Value args[] = { item };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
         return nullptr;
     });
     if (break_value) {
@@ -318,7 +318,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto right = left + 1;
 
         // Find a right border in which we can perform the binary search.
-        while (binary_search_check(env, NAT_RUN_BLOCK(env, block, { IntegerObject::create(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
+        while (binary_search_check(env, block->run(env, { IntegerObject::create(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
             right = left + (right - left) * 2;
         }
 
@@ -328,7 +328,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto left = right - 1;
 
         // Find a left border in which we can perform the binary search.
-        while (binary_search_check(env, NAT_RUN_BLOCK(env, block, { IntegerObject::create(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
+        while (binary_search_check(env, block->run(env, { IntegerObject::create(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
             left = right - (right - left) * 2;
         }
 
@@ -390,7 +390,7 @@ Value RangeObject::step(Env *env, Value n, Block *block) {
         Integer index = 0;
         iterate_over_range(env, [env, block, &index, step](Value item) -> Value {
             if (index % step == 0)
-                NAT_RUN_BLOCK(env, block, { item }, nullptr);
+                block->run(env, { item }, nullptr);
 
             index += 1;
             return nullptr;

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -132,7 +132,7 @@ Value RangeObject::each(Env *env, Block *block) {
 
     Value break_value = iterate_over_range(env, [&](Value item) -> Value {
         Value args[] = { item };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         return nullptr;
     });
     if (break_value) {
@@ -318,7 +318,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto right = left + 1;
 
         // Find a right border in which we can perform the binary search.
-        while (binary_search_check(env, NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { IntegerObject::create(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
+        while (binary_search_check(env, NAT_RUN_BLOCK(env, block, { IntegerObject::create(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
             right = left + (right - left) * 2;
         }
 
@@ -328,7 +328,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto left = right - 1;
 
         // Find a left border in which we can perform the binary search.
-        while (binary_search_check(env, NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { IntegerObject::create(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
+        while (binary_search_check(env, NAT_RUN_BLOCK(env, block, { IntegerObject::create(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
             left = right - (right - left) * 2;
         }
 
@@ -390,7 +390,7 @@ Value RangeObject::step(Env *env, Value n, Block *block) {
         Integer index = 0;
         iterate_over_range(env, [env, block, &index, step](Value item) -> Value {
             if (index % step == 0)
-                NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { item }, nullptr);
+                NAT_RUN_BLOCK(env, block, { item }, nullptr);
 
             index += 1;
             return nullptr;

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -474,7 +474,7 @@ Value RegexpObject::match(Env *env, Value other, Value start, Block *block) {
 
     if (block && !result.is_nil()) {
         Value args[] = { result };
-        return NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+        return NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
 
     return result;

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -474,7 +474,7 @@ Value RegexpObject::match(Env *env, Value other, Value start, Block *block) {
 
     if (block && !result.is_nil()) {
         Value args[] = { result };
-        return NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        return block->run(env, Args(1, args), nullptr);
     }
 
     return result;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -150,7 +150,7 @@ Value StringObject::each_char(Env *env, Block *block) {
 
     for (auto c : *this) {
         Value args[] = { new StringObject { c, m_encoding } };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -159,7 +159,7 @@ Value StringObject::chars(Env *env, Block *block) {
     if (block) {
         for (auto c : *this) {
             auto str = new StringObject { c, m_encoding };
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args({ str }), nullptr);
+            NAT_RUN_BLOCK(env, block, Args({ str }), nullptr);
         }
         return this;
     }
@@ -182,7 +182,7 @@ Value StringObject::each_codepoint(Env *env, Block *block) {
             env->raise_invalid_byte_sequence_error(m_encoding.ptr());
 
         Value args[] = { char_obj.ord(env) };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
 
     return this;
@@ -199,7 +199,7 @@ Value StringObject::codepoints(Env *env, Block *block) {
             if (length == 0)
                 break;
             Value args[] = { Value::integer(codepoint) };
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+            NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         }
         return this;
     }
@@ -231,7 +231,7 @@ Value StringObject::each_grapheme_cluster(Env *env, Block *block) {
         if (view.is_empty())
             break;
         Value args[] = { new StringObject { view, m_encoding } };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -1246,7 +1246,7 @@ Value StringObject::each_byte(Env *env, Block *block) {
     for (size_t i = 0; i < length(); i++) {
         unsigned char c = c_str()[i];
         Value args[] = { Value::integer(c) };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
     }
     return this;
 }
@@ -1288,7 +1288,7 @@ Value StringObject::scan(Env *env, Value pattern, Block *block) {
             auto captures = match_obj->captures(env)->as_array_or_raise(env);
             if (block) {
                 Value args[] = { captures };
-                NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+                NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
             } else {
                 ary->push(captures);
             }
@@ -1296,7 +1296,7 @@ Value StringObject::scan(Env *env, Value pattern, Block *block) {
             auto str = match_obj->as_match_data()->to_s(env);
             if (block) {
                 Value args[] = { str };
-                NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+                NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
             } else {
                 ary->push(str);
             }
@@ -2637,7 +2637,7 @@ void StringObject::regexp_sub(Env *env, TM::String &out, StringObject *orig_stri
     if (block) {
         auto string = (*match)->to_s(env);
         Value args[1] = { string };
-        Value replacement_from_block = NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, Args(1, args), nullptr);
+        Value replacement_from_block = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
 
         *expanded_replacement = replacement_from_block->to_s(env);
         out.append((*expanded_replacement)->string());
@@ -3164,7 +3164,7 @@ Value StringObject::each_line(Env *env, Value separator, Value chomp, Block *blo
 
     each_line(env, separator, chomp, [&](StringObject *part) -> Value {
         Value args[] = { part };
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, Args(1, args), nullptr);
+        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
         return this;
     });
     return this;
@@ -3671,7 +3671,7 @@ Value StringObject::upto(Env *env, Value other, Value exclusive, Block *block) {
         if (current.value().length() > string->length())
             return this;
 
-        NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, { new StringObject(current.value(), m_encoding) }, nullptr);
+        NAT_RUN_BLOCK(env, block, { new StringObject(current.value(), m_encoding) }, nullptr);
     }
 
     return this;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -150,7 +150,7 @@ Value StringObject::each_char(Env *env, Block *block) {
 
     for (auto c : *this) {
         Value args[] = { new StringObject { c, m_encoding } };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return this;
 }
@@ -159,7 +159,7 @@ Value StringObject::chars(Env *env, Block *block) {
     if (block) {
         for (auto c : *this) {
             auto str = new StringObject { c, m_encoding };
-            NAT_RUN_BLOCK(env, block, Args({ str }), nullptr);
+            block->run(env, Args({ str }), nullptr);
         }
         return this;
     }
@@ -182,7 +182,7 @@ Value StringObject::each_codepoint(Env *env, Block *block) {
             env->raise_invalid_byte_sequence_error(m_encoding.ptr());
 
         Value args[] = { char_obj.ord(env) };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
 
     return this;
@@ -199,7 +199,7 @@ Value StringObject::codepoints(Env *env, Block *block) {
             if (length == 0)
                 break;
             Value args[] = { Value::integer(codepoint) };
-            NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+            block->run(env, Args(1, args), nullptr);
         }
         return this;
     }
@@ -231,7 +231,7 @@ Value StringObject::each_grapheme_cluster(Env *env, Block *block) {
         if (view.is_empty())
             break;
         Value args[] = { new StringObject { view, m_encoding } };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return this;
 }
@@ -1246,7 +1246,7 @@ Value StringObject::each_byte(Env *env, Block *block) {
     for (size_t i = 0; i < length(); i++) {
         unsigned char c = c_str()[i];
         Value args[] = { Value::integer(c) };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
     }
     return this;
 }
@@ -1288,7 +1288,7 @@ Value StringObject::scan(Env *env, Value pattern, Block *block) {
             auto captures = match_obj->captures(env)->as_array_or_raise(env);
             if (block) {
                 Value args[] = { captures };
-                NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+                block->run(env, Args(1, args), nullptr);
             } else {
                 ary->push(captures);
             }
@@ -1296,7 +1296,7 @@ Value StringObject::scan(Env *env, Value pattern, Block *block) {
             auto str = match_obj->as_match_data()->to_s(env);
             if (block) {
                 Value args[] = { str };
-                NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+                block->run(env, Args(1, args), nullptr);
             } else {
                 ary->push(str);
             }
@@ -2637,7 +2637,7 @@ void StringObject::regexp_sub(Env *env, TM::String &out, StringObject *orig_stri
     if (block) {
         auto string = (*match)->to_s(env);
         Value args[1] = { string };
-        Value replacement_from_block = NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        Value replacement_from_block = block->run(env, Args(1, args), nullptr);
 
         *expanded_replacement = replacement_from_block->to_s(env);
         out.append((*expanded_replacement)->string());
@@ -3164,7 +3164,7 @@ Value StringObject::each_line(Env *env, Value separator, Value chomp, Block *blo
 
     each_line(env, separator, chomp, [&](StringObject *part) -> Value {
         Value args[] = { part };
-        NAT_RUN_BLOCK(env, block, Args(1, args), nullptr);
+        block->run(env, Args(1, args), nullptr);
         return this;
     });
     return this;
@@ -3671,7 +3671,7 @@ Value StringObject::upto(Env *env, Value other, Value exclusive, Block *block) {
         if (current.value().length() > string->length())
             return this;
 
-        NAT_RUN_BLOCK(env, block, { new StringObject(current.value(), m_encoding) }, nullptr);
+        block->run(env, { new StringObject(current.value(), m_encoding) }, nullptr);
     }
 
     return this;

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -52,7 +52,7 @@ Value MutexObject::sleep(Env *env, Value timeout) {
 Value MutexObject::synchronize(Env *env, Block *block) {
     lock(env);
     Defer done_with_synchronization([this, &env] { if (is_owned()) unlock(env); });
-    return NAT_RUN_BLOCK(env, block, {}, nullptr);
+    return block->run(env, {}, nullptr);
 }
 
 bool MutexObject::try_lock() {

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -52,7 +52,7 @@ Value MutexObject::sleep(Env *env, Value timeout) {
 Value MutexObject::synchronize(Env *env, Block *block) {
     lock(env);
     Defer done_with_synchronization([this, &env] { if (is_owned()) unlock(env); });
-    return NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, {}, nullptr);
+    return NAT_RUN_BLOCK(env, block, {}, nullptr);
 }
 
 bool MutexObject::try_lock() {

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -63,7 +63,7 @@ static void *nat_create_thread(void *thread_object) {
     try {
         // This is the guts of the thread --
         // the user code that does what we came here to do.
-        auto return_value = NAT_RUN_BLOCK((&e), block, std::move(args), nullptr);
+        auto return_value = block->run((&e), std::move(args), nullptr);
 
         // If we got here and the thread has an exception,
         // this is our last chance to raise it. The catch directly below

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -63,7 +63,7 @@ static void *nat_create_thread(void *thread_object) {
     try {
         // This is the guts of the thread --
         // the user code that does what we came here to do.
-        auto return_value = NAT_RUN_BLOCK_WITHOUT_BREAK((&e), block, std::move(args), nullptr);
+        auto return_value = NAT_RUN_BLOCK((&e), block, std::move(args), nullptr);
 
         // If we got here and the thread has an exception,
         // this is our last chance to raise it. The catch directly below


### PR DESCRIPTION
1. We weren't using the `Break` flag for anything any more--not since we taught the compiler to add breakpoints.
2. I used a boolean on the current fiber to denote a `redo` so we can get rid of the Redo flag. As a bonus, calling `redo` no longer allocate a new object.

Now that we only have a single flag (`Frozen`), we could remove the `Object::m_flags` integer and add a boolean `m_frozen` instead, but that can be a separate PR.