### PR TITLE
Precalculate size of return value of Encoding.name_list

### DIFF
--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -328,9 +328,12 @@ ArrayObject *EncodingObject::list(Env *) {
 }
 
 ArrayObject *EncodingObject::name_list(Env *env) {
-    auto ary = new ArrayObject {};
-    for (auto pair : s_encoding_list)
-        ary->concat(*pair.second->names(env));
+    size_t size = 0;
+    for (const auto &[_, encoding] : s_encoding_list)
+        size += encoding->m_names.size();
+    auto ary = new ArrayObject { size };
+    for (const auto &[_, encoding] : s_encoding_list)
+        ary->concat(*encoding->names(env));
     return ary;
 }
 


### PR DESCRIPTION
This array currently contains 105 items, and will only grow larger if we implement additional encodings. With the default array capacity of 10 and doubling it every time we exceed that, this removes 4 reallocs.