### PR TITLE
Convert internal encoding list from hashmap to vector

### DIFF
--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -136,14 +136,14 @@ public:
     static Value find(Env *, Value);
     static ArrayObject *list(Env *env);
     static ArrayObject *name_list(Env *env);
-    static const TM::Hashmap<Encoding, EncodingObject *> &encodings() { return EncodingObject::s_encoding_list; }
+    static const TM::Vector<EncodingObject *> &encodings() { return EncodingObject::s_encoding_list; }
     static EncodingObject *default_external() { return s_default_external; }
     static EncodingObject *default_internal() { return s_default_internal; }
     static EncodingObject *locale() { return s_locale; }
     static EncodingObject *filesystem() { return s_filesystem; }
     static EncodingObject *set_default_external(Env *, Value);
     static EncodingObject *set_default_internal(Env *, Value);
-    static EncodingObject *get(Encoding encoding) { return s_encoding_list.get(encoding); }
+    static EncodingObject *get(Encoding encoding) { return s_encoding_list.at(static_cast<size_t>(encoding) - 1); }
     static Value locale_charmap();
     static void initialize_defaults(Env *);
 
@@ -170,7 +170,7 @@ private:
     Vector<String> m_names {};
     Encoding m_num;
 
-    static inline TM::Hashmap<Encoding, EncodingObject *> s_encoding_list {};
+    static inline TM::Vector<EncodingObject *> s_encoding_list { EncodingCount, nullptr };
     static inline EncodingObject *s_default_internal = nullptr;
     // external, locale and filesystem are set by a static initializer function
     static inline EncodingObject *s_default_external = nullptr;

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -320,8 +320,8 @@ EncodingObject *EncodingObject::find_encoding(Env *env, Value encoding) {
 
 ArrayObject *EncodingObject::list(Env *) {
     auto ary = new ArrayObject { EncodingCount };
-    for (auto pair : s_encoding_list)
-        ary->push(pair.second);
+    for (auto encoding : s_encoding_list)
+        ary->push(encoding);
     // dbg("size {} enccnt {}", ary->size(), EncodingCount);
     assert(ary->size() == EncodingCount);
     return ary;
@@ -329,21 +329,22 @@ ArrayObject *EncodingObject::list(Env *) {
 
 ArrayObject *EncodingObject::name_list(Env *env) {
     size_t size = 0;
-    for (const auto &[_, encoding] : s_encoding_list)
+    for (const auto &encoding : s_encoding_list)
         size += encoding->m_names.size();
     auto ary = new ArrayObject { size };
-    for (const auto &[_, encoding] : s_encoding_list)
+    for (const auto encoding : s_encoding_list)
         ary->concat(*encoding->names(env));
     return ary;
 }
 
 EncodingObject::EncodingObject(Encoding num, std::initializer_list<const String> names)
     : EncodingObject {} {
-    assert(s_encoding_list.get(num) == nullptr);
+    const auto index = static_cast<size_t>(num) - 1;
+    assert(s_encoding_list.at(index) == nullptr);
     m_num = num;
     for (const auto &name : names)
         m_names.push(name);
-    s_encoding_list.put(num, this);
+    s_encoding_list[index] = this;
 }
 
 Value EncodingObject::name(Env *env) {


### PR DESCRIPTION
The hash keys were a simple list of sequential integers starting at 1. The current Hashmap does not handle integer keys very well, it defaults to pointer lookup, where the return value for non pointers is a hardcoded 0. Effectively, this hashmap was a linked list.