### PR TITLE
GC: Check free cell percentage globally instead of per-allocator

### DIFF
--- a/include/natalie/gc/allocator.hpp
+++ b/include/natalie/gc/allocator.hpp
@@ -50,20 +50,7 @@ public:
         return m_free_cells * 100 / total_cells();
     }
 
-    void *allocate() {
-        Cell *cell = nullptr;
-        if (m_free_blocks.empty()) {
-            auto *block = add_heap_block();
-            cell = block->find_next_free_cell();
-        } else {
-            auto *block = m_free_blocks.back();
-            cell = block->find_next_free_cell();
-            if (!block->has_free())
-                m_free_blocks.pop_back();
-        }
-        --m_free_cells;
-        return cell;
-    }
+    void *allocate();
 
     void add_free_block(HeapBlock *block) {
         m_free_blocks.push_back(block);
@@ -98,14 +85,7 @@ public:
     }
 
 private:
-    HeapBlock *add_heap_block() {
-        auto *block = reinterpret_cast<HeapBlock *>(aligned_alloc(HEAP_BLOCK_SIZE, HEAP_BLOCK_SIZE));
-        new (block) HeapBlock(m_cell_size);
-        m_blocks.set(block);
-        add_free_block(block);
-        m_free_cells += cell_count_per_block();
-        return block;
-    }
+    HeapBlock *add_heap_block();
 
     size_t m_cell_size;
     size_t m_free_cells { 0 };

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -24,7 +24,7 @@ public:
 
     constexpr static int initial_blocks_per_allocator = 10;
     constexpr static int min_percent_free_triggers_collection = 5;
-    constexpr static int min_percent_free_after_collection = 20;
+    constexpr static int check_free_percentage_every = 1000;
 
     static Heap &the() {
         if (s_instance)
@@ -82,6 +82,8 @@ public:
     void set_collect_all_at_exit(bool collect) { m_collect_all_at_exit = collect; }
 
 private:
+    friend Allocator;
+
     inline static Heap *s_instance = nullptr;
 
     Heap() {
@@ -124,6 +126,9 @@ private:
 
     bool m_gc_enabled { false };
     bool m_collect_all_at_exit { false };
+    size_t m_free_cells { 0 };
+    size_t m_total_cells { 0 };
+    size_t m_allocations_without_collection_count { 0 };
 };
 
 }

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -1,3 +1,5 @@
+#include <sys/time.h>
+
 #define NAT_UNREACHABLE()                                                     \
     {                                                                         \
         fprintf(stderr, "panic: unreachable in %s#%d\n", __FILE__, __LINE__); \
@@ -48,3 +50,10 @@
 #else
 #define NAT_THREAD_DEBUG(msg, ...)
 #endif
+
+#define NAT_LOG(msg, ...)                                                               \
+    {                                                                                   \
+        struct timeval tv;                                                              \
+        gettimeofday(&tv, nullptr);                                                     \
+        fprintf(stderr, "[%ld.%06ld] " msg "\n", tv.tv_sec, tv.tv_usec, ##__VA_ARGS__); \
+    }

--- a/test/natalie/gc_test.rb
+++ b/test/natalie/gc_test.rb
@@ -36,11 +36,11 @@ describe 'GC' do
       $gc_ran.should == false
 
       GC.disable
-      1000.times { Object.new }
+      10_000.times { Object.new }
       $gc_ran.should == false
 
       GC.enable
-      1000.times { Object.new }
+      10_000.times { Object.new }
       $gc_ran.should == true
     end
   end


### PR DESCRIPTION
This reduces back-to-back GC collections when we happen to allocate objects of different sizes and each of those allocators are near empty.

This work also adds a counter so we only check free percentage every 1000 allocations.

This should speed up the ConditionVariable specs.

It also speeds up the `boardslam.rb` code by a bit:

<img width="646" alt="Screenshot 2025-02-01 at 2 43 16 PM" src="https://github.com/user-attachments/assets/7035bc5f-079d-4aca-b242-af42e30cbd6e" />
