### PR TITLE
Fix object links for Integer values in Marshal.dump

### DIFF
--- a/spec/core/marshal/dump_spec.rb
+++ b/spec/core/marshal/dump_spec.rb
@@ -334,9 +334,7 @@ describe "Marshal.dump" do
 
     it "uses object links for objects repeatedly dumped" do
       n = 2**64
-      NATFIXME 'it uses object links for objects repeatedly dumped', exception: SpecFailedException do
-        Marshal.dump([n, n]).should == "\x04\b[\al+\n\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00@\x06" # @\x06 is a link to the object
-      end
+      Marshal.dump([n, n]).should == "\x04\b[\al+\n\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00@\x06" # @\x06 is a link to the object
     end
 
     it "increases the object links counter" do

--- a/spec/core/marshal/dump_spec.rb
+++ b/spec/core/marshal/dump_spec.rb
@@ -347,12 +347,10 @@ describe "Marshal.dump" do
       # objects: Array, Object, Object
       Marshal.dump([obj, obj]).should == "\x04\b[\ao:\vObject\x00@#{object_1_link}"
 
-      NATFIXME 'increases the object links counter', exception: SpecFailedException do
-        # objects: Array, Bignum, Object, Object
-        Marshal.dump([2**64, obj, obj]).should == "\x04\b[\bl+\n\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
-        Marshal.dump([2**48, obj, obj]).should == "\x04\b[\bl+\t\x00\x00\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
-        Marshal.dump([2**32, obj, obj]).should == "\x04\b[\bl+\b\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
-      end
+      # objects: Array, Bignum, Object, Object
+      Marshal.dump([2**64, obj, obj]).should == "\x04\b[\bl+\n\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
+      Marshal.dump([2**48, obj, obj]).should == "\x04\b[\bl+\t\x00\x00\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
+      Marshal.dump([2**32, obj, obj]).should == "\x04\b[\bl+\b\x00\x00\x00\x00\x01\x00o:\vObject\x00@#{object_2_link}"
     end
   end
 

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -333,7 +333,7 @@ module Marshal
     end
 
     def write(value)
-      if value.respond_to?(:object_id) && @object_lookup.key?(value.object_id)
+      if value.respond_to?(:object_id) && !value.is_a?(Integer) && @object_lookup.key?(value.object_id)
         write_object_link(@object_lookup.fetch(value.object_id))
         return @output
       elsif value.is_a?(Float) && @object_lookup.key?(value)
@@ -343,6 +343,9 @@ module Marshal
 
       if !value.nil? && !value.is_a?(TrueClass) && !value.is_a?(FalseClass) && !value.is_a?(Integer) && !value.is_a?(Float) && !value.is_a?(Symbol)
         @object_lookup[value.object_id] = @object_lookup.size
+      elsif value.is_a?(Integer) && (value >= 2**30 || value < -(2**30))
+        # Integers are special: Object links are only used when 64 bits are used, but the objects are counted when 32 bits are used
+        @object_lookup[[:integer, value]] = @object_lookup.size
       elsif value.is_a?(Float)
         @object_lookup[value] = @object_lookup.size
       end

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -336,6 +336,9 @@ module Marshal
       if value.respond_to?(:object_id) && !value.is_a?(Integer) && @object_lookup.key?(value.object_id)
         write_object_link(@object_lookup.fetch(value.object_id))
         return @output
+      elsif value.is_a?(Integer) && (value >= 2**62 || value < -(2**62)) && @object_lookup.key?([:integer, value])
+        write_object_link(@object_lookup.fetch([:integer, value]))
+        return @output
       elsif value.is_a?(Float) && @object_lookup.key?(value)
         write_object_link(@object_lookup.fetch(value))
         return @output


### PR DESCRIPTION
We are slightly diverting from MRI's behaviour due to #2552: instead of comparing the bigints by identity, compare them by value. This means this code:
```ruby
Marshal.dump([2**64, 2**64])
```
will create an object link in Natalie, but not in MRI. Both versions are able to read each others output, and ints are immutable objects, so there should be no interoperability issue with this change.