### PR TITLE
Support negative arguments in Kernel.rand

### DIFF
--- a/spec/core/kernel/rand_spec.rb
+++ b/spec/core/kernel/rand_spec.rb
@@ -31,9 +31,7 @@ describe "Kernel#rand" do
   end
 
   it "ignores the sign of the argument" do
-    NATFIXME 'it ignores the sign of the argument', exception: ArgumentError, message: 'invalid argument - -4' do
-      [0, 1, 2, 3].should include(rand(-4))
-    end
+    [0, 1, 2, 3].should include(rand(-4))
   end
 
   it "never returns a value greater or equal to 1.0 with no arguments" do

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -53,6 +53,7 @@ module Kernel
   end
 
   def rand(*args)
+    args.map!(&:abs) if args.size == 1 && args[0].is_a?(Numeric)
     Random::DEFAULT.rand(*args)
   end
   module_function :rand


### PR DESCRIPTION
But not in Random.rand, because these two methods behave differently.