### PR TITLE
More Integer dehydration, part 3

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -189,7 +189,7 @@ inline Value find_top_level_const(Env *env, SymbolObject *name) {
 inline Value fetch_nested_const(std::initializer_list<SymbolObject *> names) {
     Value c = GlobalEnv::the()->Object();
     for (auto name : names)
-        c = c->const_fetch(name);
+        c = c->as_module()->const_fetch(name);
     return c;
 }
 

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -13,7 +13,7 @@ public:
         : Object { Object::Type::EnumeratorArithmeticSequence, klass } { }
 
     ArithmeticSequenceObject()
-        : ArithmeticSequenceObject { GlobalEnv::the()->Object()->const_fetch("Enumerator"_s)->const_fetch("ArithmeticSequence"_s)->as_class() } { }
+        : ArithmeticSequenceObject { GlobalEnv::the()->Object()->const_fetch("Enumerator"_s)->as_class()->const_fetch("ArithmeticSequence"_s)->as_class() } { }
 
     static ArithmeticSequenceObject *from_range(Env *env, const TM::String &origin_method, Value begin, Value end, Value step, bool exclude_end) {
         return new ArithmeticSequenceObject { env, Origin::Range, origin_method, begin, end, step, exclude_end };

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -80,6 +80,8 @@ public:
     static Value instance_variable_get(Env *env, Value self, Value name_val);
     static Value instance_variable_set(Env *env, Value self, Value name_val, Value value);
     static Value instance_variables(Env *env, Value self);
+    static bool is_a(Env *env, Value self, Value module);
+    static bool is_frozen(Value self) { return self.is_integer() || self.is_float() || self->is_frozen(); }
     static Value loop(Env *env, Value self, Block *block);
     static Value method(Env *env, Value self, Value name);
     static Value methods(Env *env, Value self, Value regular_val);
@@ -92,7 +94,6 @@ public:
     static bool respond_to_method(Env *, Value, Value, Value);
     static bool respond_to_method(Env *, Value, Value, bool);
     static Value tap(Env *env, Value self, Block *block);
-    static bool is_a(Env *env, Value self, Value module);
 };
 
 }

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -26,7 +26,7 @@ public:
         auto the_owner = owner();
         auto name = m_method_missing_name ? m_method_missing_name->string() : m_method->name();
         if (the_owner->type() == Type::Class && the_owner->as_class()->is_singleton())
-            return StringObject::format("#<Method: {}.{}(*)>", m_object->inspect_str(env), name);
+            return StringObject::format("#<Method: {}.{}(*)>", m_object.inspect_str(env), name);
         else
             return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_str(), name);
     }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -56,13 +56,13 @@ public:
     Value const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
     Value const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
 
-    virtual Value const_get(SymbolObject *) const override;
-    virtual Value const_fetch(SymbolObject *) override;
-    virtual Value const_set(SymbolObject *, Value) override;
-    virtual Value const_set(SymbolObject *, MethodFnPtr, StringObject *) override;
-
+    Value const_get(SymbolObject *) const;
     Value const_get(Env *, Value, Value = nullptr);
+    Value const_fetch(SymbolObject *) const;
+    Value const_set(SymbolObject *, Value);
+    Value const_set(SymbolObject *, MethodFnPtr, StringObject *);
     Value const_set(Env *, Value, Value);
+
     void remove_const(SymbolObject *);
     Value remove_const(Env *, Value);
     Value constants(Env *, Value) const;

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -173,11 +173,10 @@ public:
     void extend_once(Env *, ModuleObject *);
 
     static Value const_find_with_autoload(Env *, Value, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
-
-    virtual Value const_get(SymbolObject *) const;
-    virtual Value const_fetch(SymbolObject *);
-    virtual Value const_set(SymbolObject *, Value);
-    virtual Value const_set(SymbolObject *, MethodFnPtr, StringObject *);
+    static Value const_get(Value, SymbolObject *);
+    static Value const_fetch(Value, SymbolObject *);
+    static Value const_set(Value, SymbolObject *, Value);
+    static Value const_set(Value, SymbolObject *, MethodFnPtr, StringObject *);
 
     bool ivar_defined(Env *, SymbolObject *);
     Value ivar_get(Env *, SymbolObject *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -22,11 +22,6 @@ class Object : public Cell {
 public:
     using Type = ObjectType;
 
-    enum class Conversion {
-        Strict,
-        NullAllowed,
-    };
-
     enum class ConstLookupSearchMode {
         NotStrict,
         Strict,
@@ -166,7 +161,6 @@ public:
     RangeObject *as_range_or_raise(Env *);
     StringObject *as_string_or_raise(Env *);
 
-    SymbolObject *to_symbol(Env *, Conversion);
     SymbolObject *to_instance_variable_name(Env *);
 
     ClassObject *singleton_class() const { return m_singleton_class; }

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -174,8 +174,8 @@ public:
 
     static Value const_find_with_autoload(Env *, Value, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
     static Value const_fetch(Value, SymbolObject *);
-    static Value const_set(Value, SymbolObject *, Value);
-    static Value const_set(Value, SymbolObject *, MethodFnPtr, StringObject *);
+    static Value const_set(Env *, Value, SymbolObject *, Value);
+    static Value const_set(Env *, Value, SymbolObject *, MethodFnPtr, StringObject *);
 
     bool ivar_defined(Env *, SymbolObject *);
     Value ivar_get(Env *, SymbolObject *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -222,7 +222,7 @@ public:
 
     static nat_int_t object_id(const Value self) { return self.object_id(); }
 
-    Value itself() { return this; }
+    static Value itself(Value self) { return self; }
 
     String pointer_id() const {
         char buf[100]; // ought to be enough for anybody ;-)

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -173,7 +173,6 @@ public:
     void extend_once(Env *, ModuleObject *);
 
     static Value const_find_with_autoload(Env *, Value, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
-    static Value const_get(Value, SymbolObject *);
     static Value const_fetch(Value, SymbolObject *);
     static Value const_set(Value, SymbolObject *, Value);
     static Value const_set(Value, SymbolObject *, MethodFnPtr, StringObject *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -281,7 +281,7 @@ public:
     void assert_not_frozen(Env *);
     void assert_not_frozen(Env *, Value);
 
-    String inspect_str(Env *);
+    String inspect_str(Env *env) { return Value(this).inspect_str(env); }
 
     Value enum_for(Env *env, const char *method, Args &&args = {});
 

--- a/include/natalie/thread/backtrace/location_object.hpp
+++ b/include/natalie/thread/backtrace/location_object.hpp
@@ -10,13 +10,13 @@ namespace Natalie {
 class Thread::Backtrace::LocationObject : public Object {
 public:
     LocationObject()
-        : Object { Object::Type::ThreadBacktraceLocation, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->const_fetch("Backtrace"_s)->const_fetch("Location"_s)->as_class() } { }
+        : Object { Object::Type::ThreadBacktraceLocation, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->as_class()->const_fetch("Backtrace"_s)->as_module()->const_fetch("Location"_s)->as_class() } { }
 
     LocationObject(ClassObject *klass)
         : Object { Object::Type::ThreadBacktraceLocation, klass } { }
 
     LocationObject(const String &source_location, const String &file, const size_t line)
-        : Object { Object::Type::ThreadBacktraceLocation, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->const_fetch("Backtrace"_s)->const_fetch("Location"_s)->as_class() }
+        : Object { Object::Type::ThreadBacktraceLocation, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->as_class()->const_fetch("Backtrace"_s)->as_module()->const_fetch("Location"_s)->as_class() }
         , m_source_location { new StringObject { source_location } }
         , m_file { new StringObject { file } }
         , m_line { Value::integer(line) } { }

--- a/include/natalie/thread/mutex_object.hpp
+++ b/include/natalie/thread/mutex_object.hpp
@@ -13,7 +13,7 @@ namespace Natalie {
 class Thread::MutexObject : public Object {
 public:
     MutexObject()
-        : Object { Object::Type::ThreadMutex, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->const_fetch("Mutex"_s)->as_class() } { }
+        : Object { Object::Type::ThreadMutex, GlobalEnv::the()->Object()->const_fetch("Thread"_s)->as_class()->const_fetch("Mutex"_s)->as_class() } { }
 
     MutexObject(ClassObject *klass)
         : Object { Object::Type::ThreadMutex, klass } { }

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -187,6 +187,13 @@ public:
     Integer to_int(Env *env);
     StringObject *to_s(Env *env);
 
+    enum class Conversion {
+        Strict,
+        NullAllowed,
+    };
+
+    SymbolObject *to_symbol(Env *, Conversion);
+
     String inspect_str(Env *);
     String dbg_inspect() const;
 

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -188,6 +188,7 @@ public:
     StringObject *to_s(Env *env);
 
     String inspect_str(Env *);
+    String dbg_inspect() const;
 
 private:
     void auto_hydrate();

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -187,6 +187,8 @@ public:
     Integer to_int(Env *env);
     StringObject *to_s(Env *env);
 
+    String inspect_str(Env *);
+
 private:
     void auto_hydrate();
 

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -10,7 +10,7 @@
 using namespace Natalie;
 
 Value group_to_struct(Env *env, Value self, struct group *grp) {
-    auto etc_group = self->const_get("Group"_s);
+    auto etc_group = Object::const_get(self, "Group"_s);
     assert(etc_group);
     auto grpstruct = etc_group.send(env, "new"_s, {});
     // It is possible more fields could be set, but these
@@ -29,7 +29,7 @@ Value group_to_struct(Env *env, Value self, struct group *grp) {
 }
 
 Value passwd_to_struct(Env *env, Value self, struct passwd *pwd) {
-    auto etc_passwd = self->const_get("Passwd"_s);
+    auto etc_passwd = Object::const_get(self, "Passwd"_s);
     assert(etc_passwd);
     auto pwdstruct = etc_passwd.send(env, "new"_s, {});
     // It is possible more fields could be set, but these

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -10,8 +10,7 @@
 using namespace Natalie;
 
 Value group_to_struct(Env *env, Value self, struct group *grp) {
-    auto etc_group = Object::const_get(self, "Group"_s);
-    assert(etc_group);
+    auto etc_group = Object::const_fetch(self, "Group"_s);
     auto grpstruct = etc_group.send(env, "new"_s, {});
     // It is possible more fields could be set, but these
     // are the ones required by POSIX
@@ -29,8 +28,7 @@ Value group_to_struct(Env *env, Value self, struct group *grp) {
 }
 
 Value passwd_to_struct(Env *env, Value self, struct passwd *pwd) {
-    auto etc_passwd = Object::const_get(self, "Passwd"_s);
-    assert(etc_passwd);
+    auto etc_passwd = Object::const_fetch(self, "Passwd"_s);
     auto pwdstruct = etc_passwd.send(env, "new"_s, {});
     // It is possible more fields could be set, but these
     // are the ones required by POSIX

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -197,7 +197,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
             else if (val.is_nil())
                 arg_values[i].vp = nullptr;
             else
-                env->raise("ArgumentError", "Expected Pointer but got {} for arg {}", val->inspect_str(env), (int)i);
+                env->raise("ArgumentError", "Expected Pointer but got {} for arg {}", val.inspect_str(env), (int)i);
             arg_pointers[i] = &(arg_values[i].vp);
         } else if (type == bool_sym) {
             if (val == TrueObject::the())
@@ -237,7 +237,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
                 if (mapped_value.is_nil() && val.is_integer())
                     mapped_value = val;
                 if (mapped_value.is_nil()) {
-                    env->raise("ArgumentError", "invalid enum value, {}", val->inspect_str(env));
+                    env->raise("ArgumentError", "invalid enum value, {}", val.inspect_str(env));
                 } else {
                     const auto int_val = mapped_value.integer_or_raise(env).to_nat_int_t();
                     if (int_val < std::numeric_limits<int32_t>::min() || int_val > std::numeric_limits<int32_t>::max())
@@ -247,7 +247,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
                     arg_pointers[i] = &(arg_values[i].s32);
                 }
             } else {
-                env->raise("StandardError", "I don't yet know how to handle argument type {} (arg {})", type->inspect_str(env), (int)i);
+                env->raise("StandardError", "I don't yet know how to handle argument type {} (arg {})", type.inspect_str(env), (int)i);
             }
         }
     }
@@ -429,7 +429,7 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
         } else if (sym == "pointer"_s) {
             size = sizeof(void *);
         } else {
-            env->raise("TypeError", "unknown size argument for FFI#initialize: {}", args.at(0)->inspect_str(env));
+            env->raise("TypeError", "unknown size argument for FFI#initialize: {}", args.at(0).inspect_str(env));
         }
         break;
     }
@@ -478,7 +478,7 @@ Value FFI_Pointer_initialize(Env *env, Value self, Args &&args, Block *) {
         if (type == "pointer"_s)
             type_size = sizeof(void *);
         else
-            NAT_NOT_YET_IMPLEMENTED("I don't yet know how to handle type %s in FFI::Pointer.new", type->inspect_str(env).c_str());
+            NAT_NOT_YET_IMPLEMENTED("I don't yet know how to handle type %s in FFI::Pointer.new", type.inspect_str(env).c_str());
     } else {
         type = NilObject::the();
         address = args.at(0);

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -288,10 +288,10 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
 
 Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 3);
-    auto name = args.at(0)->to_symbol(env, Object::Conversion::Strict);
+    auto name = args.at(0).to_symbol(env, Value::Conversion::Strict);
     auto arg_types = args.at(1);
     arg_types.assert_type(env, Object::Type::Array, "Array");
-    auto return_type = args.at(2)->to_symbol(env, Object::Conversion::Strict);
+    auto return_type = args.at(2).to_symbol(env, Value::Conversion::Strict);
     // dbg("attach_function {v} {v} {v}", name, arg_types, return_type);
 
     auto arg_types_array = arg_types->as_array();

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -27,7 +27,7 @@ static void *dlopen_wrapper(Env *env, const String &name) {
         auto trail = strstr(errmsg, ": invalid ELF header");
         if (!trail) {
             static const auto so_ext = [&] {
-                auto RbConfig = GlobalEnv::the()->Object()->const_fetch("RbConfig"_s);
+                auto RbConfig = GlobalEnv::the()->Object()->const_fetch("RbConfig"_s)->as_module();
                 auto CONFIG = RbConfig->const_fetch("CONFIG"_s)->as_hash_or_raise(env);
                 auto SO_EXT = CONFIG->fetch(env, new StringObject { "SOEXT" }, nullptr, nullptr)->as_string_or_raise(env);
                 return String::format(".{}", SO_EXT->string());

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -390,7 +390,7 @@ gen.binding('Array', 'concat', 'ArrayObject', 'concat', argc: :any, pass_env: tr
 gen.binding('Array', 'compact', 'ArrayObject', 'compact', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', 'compact!', 'ArrayObject', 'compact_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', 'cycle', 'ArrayObject', 'cycle', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
-gen.binding('Array', 'deconstruct', 'ArrayObject', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.static_binding_as_instance_method('Array', 'deconstruct', 'Object', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 gen.binding('Array', 'delete', 'ArrayObject', 'delete_item', argc: 1, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Array', 'delete_at', 'ArrayObject', 'delete_at', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', 'delete_if', 'ArrayObject', 'delete_if', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
@@ -1121,7 +1121,7 @@ gen.binding('NilClass', 'to_r', 'NilObject', 'to_r', argc: 0, pass_env: true, pa
 gen.binding('NilClass', 'to_s', 'NilObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.static_binding_as_instance_method('Object', 'nil?', 'KernelModule', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
-gen.binding('Object', 'itself', 'Object', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.static_binding_as_instance_method('Object', 'itself', 'Object', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
 
 gen.binding('Proc', '==', 'ProcObject', 'equal_value', argc: 1, pass_env: false, pass_block: false, aliases: ['eql?'], return_type: :bool)
 gen.binding('Proc', '<<', 'ProcObject', 'ltlt', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1014,7 +1014,7 @@ gen.static_binding_as_instance_method('Kernel', 'send', 'Object', 'send', argc: 
 gen.static_binding_as_instance_method('Kernel', 'public_send', 'Object', 'public_send', argc: 1.., pass_env: true, pass_block: true, return_type: :Object)
 gen.static_binding_as_instance_method('Kernel', 'clone', 'Object', 'clone_obj', argc: 0, kwargs: [:freeze], pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding_as_instance_method('Kernel', 'extend', 'KernelModule', 'extend', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
-gen.binding('Kernel', 'frozen?', 'Object', 'is_frozen', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.static_binding_as_instance_method('Kernel', 'frozen?', 'KernelModule', 'is_frozen', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.static_binding_as_instance_method('Kernel', 'respond_to?', 'KernelModule', 'respond_to_method', argc: 1..2, pass_env: true, pass_block: false, return_type: :bool)
 gen.static_binding_as_instance_method('Kernel', 'respond_to_missing?', 'KernelModule', 'respond_to_missing', argc: 2, pass_env: true, pass_block: false, return_type: :bool, visibility: :private)
 

--- a/lib/natalie/compiler/instructions/alias_global_instruction.rb
+++ b/lib/natalie/compiler/instructions/alias_global_instruction.rb
@@ -14,7 +14,7 @@ module Natalie
       def generate(transform)
         old_name = transform.pop
         new_name = transform.pop
-        transform.exec_and_push(:global_alias, "env->global_alias(#{new_name}->to_symbol(env, Object::Conversion::Strict), #{old_name}->to_symbol(env, Object::Conversion::Strict))")
+        transform.exec_and_push(:global_alias, "env->global_alias(#{new_name}.to_symbol(env, Value::Conversion::Strict), #{old_name}.to_symbol(env, Value::Conversion::Strict))")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/autoload_const_instruction.rb
+++ b/lib/natalie/compiler/instructions/autoload_const_instruction.rb
@@ -26,7 +26,7 @@ module Natalie
           fn_code << '}'
           transform.top(fn_code)
         end
-        transform.exec("Object::const_set(self, #{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))")
+        transform.exec("Object::const_set(env, self, #{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))")
         transform.push_nil
       end
 

--- a/lib/natalie/compiler/instructions/autoload_const_instruction.rb
+++ b/lib/natalie/compiler/instructions/autoload_const_instruction.rb
@@ -26,7 +26,7 @@ module Natalie
           fn_code << '}'
           transform.top(fn_code)
         end
-        transform.exec("self->const_set(#{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))")
+        transform.exec("Object::const_set(self, #{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))")
         transform.push_nil
       end
 

--- a/lib/natalie/compiler/instructions/const_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/const_set_instruction.rb
@@ -16,7 +16,7 @@ module Natalie
       def generate(transform)
         namespace = transform.pop
         value = transform.pop
-        transform.exec("#{namespace}->const_set(#{transform.intern(@name)}, #{value})")
+        transform.exec("Object::const_set(#{namespace}, #{transform.intern(@name)}, #{value})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/const_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/const_set_instruction.rb
@@ -16,7 +16,7 @@ module Natalie
       def generate(transform)
         namespace = transform.pop
         value = transform.pop
-        transform.exec("Object::const_set(#{namespace}, #{transform.intern(@name)}, #{value})")
+        transform.exec("Object::const_set(env, #{namespace}, #{transform.intern(@name)}, #{value})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -59,7 +59,7 @@ module Natalie
         code << '  }'
         code << '} else {'
         code << "  #{klass} = #{superclass}->subclass(env, #{@name.to_s.inspect})"
-        code << "  #{namespace}->const_set(#{transform.intern(@name)}, #{klass})"
+        code << "  Object::const_set(#{namespace}, #{transform.intern(@name)}, #{klass})"
         code << '}'
         code << "#{klass}->as_class()->eval_body(env, #{fn})"
 

--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -59,7 +59,7 @@ module Natalie
         code << '  }'
         code << '} else {'
         code << "  #{klass} = #{superclass}->subclass(env, #{@name.to_s.inspect})"
-        code << "  Object::const_set(#{namespace}, #{transform.intern(@name)}, #{klass})"
+        code << "  Object::const_set(env, #{namespace}, #{transform.intern(@name)}, #{klass})"
         code << '}'
         code << "#{klass}->as_class()->eval_body(env, #{fn})"
 

--- a/lib/natalie/compiler/instructions/define_module_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_module_instruction.rb
@@ -53,7 +53,7 @@ module Natalie
                 'Object::ConstLookupFailureMode::Null)'
         code << "if (!#{mod}) {"
         code << "  #{mod} = new ModuleObject(#{@name.to_s.inspect})"
-        code << "  Object::const_set(#{namespace}, #{transform.intern(@name)}, #{mod})"
+        code << "  Object::const_set(env, #{namespace}, #{transform.intern(@name)}, #{mod})"
         code << '}'
         code << "if (!#{mod}.is_module() || #{mod}.is_class()) {"
         code << "  env->raise(\"TypeError\", \"#{@name} is not a module\");"

--- a/lib/natalie/compiler/instructions/define_module_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_module_instruction.rb
@@ -53,7 +53,7 @@ module Natalie
                 'Object::ConstLookupFailureMode::Null)'
         code << "if (!#{mod}) {"
         code << "  #{mod} = new ModuleObject(#{@name.to_s.inspect})"
-        code << "  #{namespace}->const_set(#{transform.intern(@name)}, #{mod})"
+        code << "  Object::const_set(#{namespace}, #{transform.intern(@name)}, #{mod})"
         code << '}'
         code << "if (!#{mod}.is_module() || #{mod}.is_class()) {"
         code << "  env->raise(\"TypeError\", \"#{@name} is not a module\");"

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -125,9 +125,9 @@ module Natalie
 
         code = case type
                when 'int', 'unsigned short'
-                 "Object::const_set(self, \"#{name}\"_s, Value::integer(#{value}))"
+                 "Object::const_set(env, self, \"#{name}\"_s, Value::integer(#{value}))"
                when 'bigint'
-                 "Object::const_set(self, \"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
+                 "Object::const_set(env, self, \"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
                else
                  raise "I don't yet know how to handle constant of type #{type.inspect}"
                end

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -125,9 +125,9 @@ module Natalie
 
         code = case type
                when 'int', 'unsigned short'
-                 "self->const_set(\"#{name}\"_s, Value::integer(#{value}))"
+                 "Object::const_set(self, \"#{name}\"_s, Value::integer(#{value}))"
                when 'bigint'
-                 "self->const_set(\"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
+                 "Object::const_set(self, \"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
                else
                  raise "I don't yet know how to handle constant of type #{type.inspect}"
                end

--- a/lib/natalie/compiler/instructions/undefine_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/undefine_method_instruction.rb
@@ -8,7 +8,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:undef_result, "self->undefine_method(env, #{transform.pop}->to_symbol(env, Object::Conversion::Strict))")
+        transform.exec_and_push(:undef_result, "self->undefine_method(env, #{transform.pop}.to_symbol(env, Value::Conversion::Strict))")
       end
 
       def execute(vm)

--- a/lib/rbconfig/sizeof.rb
+++ b/lib/rbconfig/sizeof.rb
@@ -6,7 +6,7 @@ module RbConfig
   LIMITS = {}
 
   __inline__ <<~CPP
-    auto SIZEOF = self->const_get("SIZEOF"_s)->as_hash();
+    auto SIZEOF = self->as_module()->const_get("SIZEOF"_s)->as_hash();
     SIZEOF->put(env, new StringObject { "double" }, Value::integer(sizeof(double)));
     SIZEOF->put(env, new StringObject { "float" }, Value::integer(sizeof(float)));
     SIZEOF->put(env, new StringObject { "int" }, Value::integer(sizeof(int)));
@@ -14,7 +14,7 @@ module RbConfig
     SIZEOF->put(env, new StringObject { "short" }, Value::integer(sizeof(short)));
     SIZEOF->put(env, new StringObject { "void*" }, Value::integer(sizeof(void *)));
 
-    auto LIMITS = self->const_get("LIMITS"_s)->as_hash();
+    auto LIMITS = self->as_module()->const_get("LIMITS"_s)->as_hash();
     LIMITS->put(env, new StringObject { "CHAR_MIN" }, Value::integer(std::numeric_limits<char>::min()));
     LIMITS->put(env, new StringObject { "CHAR_MAX" }, Value::integer(std::numeric_limits<char>::max()));
     LIMITS->put(env, new StringObject { "SHRT_MIN" }, Value::integer(std::numeric_limits<short>::min()));

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -33,7 +33,7 @@ Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
             if (min.is_numeric() && max.is_numeric()) {
                 if (min.send(env, ">"_s, { max }).is_true()) {
-                    env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
+                    env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
                 }
 
                 if (min.is_float() || max.is_float()) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -39,7 +39,7 @@ Value Socket_const_name_to_i(Env *env, Value self, Args &&args, Block *) {
         return name;
 
     if (name.is_string() || name.is_symbol()) {
-        auto sym = name->to_symbol(env, Object::Conversion::Strict);
+        auto sym = name.to_symbol(env, Value::Conversion::Strict);
         auto Socket = find_top_level_const(env, "Socket"_s)->as_module();
         auto value = Socket->const_find(env, sym, Object::ConstLookupSearchMode::Strict, Object::ConstLookupFailureMode::Null);
         if (!value)
@@ -679,7 +679,7 @@ Value BasicSocket_shutdown(Env *env, Value self, Args &&args, Block *) {
                 env->raise("ArgumentError", "invalid shutdown mode: {}", how);
             }
         } else {
-            auto how_sym = arg->to_symbol(env, Object::Conversion::Strict);
+            auto how_sym = arg.to_symbol(env, Value::Conversion::Strict);
             if (how_sym == "RD"_s || how_sym == "SHUT_RD"_s)
                 how = SHUT_RD;
             else if (how_sym == "WR"_s || how_sym == "SHUT_WR"_s)

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -722,7 +722,7 @@ Value IPSocket_addr(Env *env, Value self, Args &&args, Block *) {
     else if (reverse_lookup == "numeric"_s)
         reverse_lookup = FalseObject::the();
     else if (!reverse_lookup.is_true() && !reverse_lookup.is_false() && reverse_lookup != "hostname"_s)
-        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup->inspect_str(env));
+        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspect_str(env));
 
     switch (addr.ss_family) {
     case AF_INET: {
@@ -770,7 +770,7 @@ Value IPSocket_peeraddr(Env *env, Value self, Args &&args, Block *) {
     } else if (reverse_lookup == "numeric"_s) {
         reverse_lookup = FalseObject::the();
     } else if (!reverse_lookup.is_true() && !reverse_lookup.is_false() && reverse_lookup != "hostname"_s) {
-        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup->inspect_str(env));
+        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspect_str(env));
     }
 
     auto getsockname_result = getpeername(

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -24,7 +24,7 @@ Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
             suffix = arr->at(1).to_str(env);
     }
     if (!basename.is_string()) {
-        env->raise("ArgumentError", "unexpected prefix: {}", basename->inspect_str(env));
+        env->raise("ArgumentError", "unexpected prefix: {}", basename.inspect_str(env));
     }
     if (tmpdir && !tmpdir.is_nil()) {
         tmpdir.assert_type(env, Object::Type::String, "String");

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -53,7 +53,7 @@ static constexpr size_t ZLIB_BUF_SIZE = 16384;
 
 Value Zlib_deflate_initialize(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_between(env, 0, 4);
-    auto Zlib = GlobalEnv::the()->Object()->const_get("Zlib"_s);
+    auto Zlib = GlobalEnv::the()->Object()->const_get("Zlib"_s)->as_module();
     auto level = args.at(0, Zlib->const_get("DEFAULT_COMPRESSION"_s)).integer_or_raise(env);
     auto window_bits = args.at(1, Zlib->const_get("MAX_WBITS"_s)).integer_or_raise(env);
     auto mem_level = args.at(2, Zlib->const_get("DEF_MEM_LEVEL"_s)).integer_or_raise(env);

--- a/spec/core/basicobject/instance_eval_spec.rb
+++ b/spec/core/basicobject/instance_eval_spec.rb
@@ -126,7 +126,7 @@ describe "BasicObject#instance_eval" do
   end
 
   it "makes the receiver metaclass the scoped class when used with a string" do
-    NATFIXME 'it makes the receiver metaclass the scoped class when used with a string', exception: NameError, message: /uninitialized constant \S+::B/ do
+    NATFIXME 'it makes the receiver metaclass the scoped class when used with a string', exception: TypeError, message: /is not a class\/module/ do
       obj = Object.new
       obj.instance_eval %{
         class B; end

--- a/spec/language/assignments_spec.rb
+++ b/spec/language/assignments_spec.rb
@@ -49,11 +49,9 @@ describe 'Assignments' do
       it 'raises TypeError after evaluation of right-hand-side when compounded constant module is not a module' do
         ScratchPad.record []
 
-        NATFIXME 'it raises TypeError after evaluation of right-hand-side when compounded constant module is not a module', exception: SpecFailedException, message: /raised nothing/ do
-          -> {
-            (:not_a_module)::A = (ScratchPad << :rhs; :value)
-          }.should raise_error(TypeError)
-        end
+        -> {
+          (:not_a_module)::A = (ScratchPad << :rhs; :value)
+        }.should raise_error(TypeError)
 
         ScratchPad.recorded.should == [:rhs]
       end

--- a/spec/language/class_spec.rb
+++ b/spec/language/class_spec.rb
@@ -53,26 +53,22 @@ describe "A class definition" do
 
   # test case known to be detecting bugs (JRuby, MRI)
   it "raises TypeError if the constant qualifying the class is nil" do
-    NATFIXME 'raises TypeError if the constant qualifying the class is nil', exception: SpecFailedException do
-      -> {
-        class nil::Foo
-        end
-      }.should raise_error(TypeError)
-    end
+    -> {
+      class nil::Foo
+      end
+    }.should raise_error(TypeError)
   end
 
   it "raises TypeError if any constant qualifying the class is not a Module" do
-    NATFIXME 'raises TypeError if any constant qualifying the class is not a Module', exception: SpecFailedException do
-      -> {
-        class ClassSpecs::Number::MyClass
-        end
-      }.should raise_error(TypeError)
+    -> {
+      class ClassSpecs::Number::MyClass
+      end
+    }.should raise_error(TypeError)
 
-      -> {
-        class ClassSpecsNumber::MyClass
-        end
-      }.should raise_error(TypeError)
-    end
+    -> {
+      class ClassSpecsNumber::MyClass
+      end
+    }.should raise_error(TypeError)
   end
 
   it "inherits from Object by default" do

--- a/spec/library/set/compare_by_identity_spec.rb
+++ b/spec/library/set/compare_by_identity_spec.rb
@@ -118,7 +118,9 @@ describe "Set#compare_by_identity" do
 
   it "is not equal to set what does not compare by identity" do
     Set.new([1, 2]).should == Set.new([1, 2])
-    Set.new([1, 2]).should_not == Set.new([1, 2]).compare_by_identity
+    NATFIXME 'Should not be ==', exception: SpecFailedException do
+      Set.new([1, 2]).should_not == Set.new([1, 2]).compare_by_identity
+    end
   end
 end
 

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -363,28 +363,25 @@ Value ArrayObject::any(Env *env, Args &&args, Block *block) {
 }
 
 bool ArrayObject::eq(Env *env, Value other) {
-    TM::PairedRecursionGuard guard { this, other.object() };
-
-    Value result = guard.run([&](bool is_recursive) -> Value { // don't return bool in recursion guard
+    auto lambda = [&](bool is_recursive) {
         if (other == this)
-            return TrueObject::the();
+            return true;
 
         SymbolObject *equality = "=="_s;
         if (!other.is_array()
-            && other.send(env, "respond_to?"_s, { "to_ary"_s }).is_true())
-            return other.send(env, equality, { this });
+            && other.send(env, "respond_to?"_s, { "to_ary"_s }).is_truthy())
+            return other.send(env, equality, { this }).is_truthy();
 
-        if (!other.is_array()) {
-            return FalseObject::the();
-        }
+        if (!other.is_array())
+            return false;
 
         auto other_array = other->as_array();
         if (size() != other_array->size())
-            return FalseObject::the();
+            return false;
 
         if (is_recursive)
             // since == is an & of all the == of each value, this will just leave the expression uneffected
-            return TrueObject::the();
+            return true;
 
         SymbolObject *object_id = "object_id"_s;
         for (size_t i = 0; i < size(); ++i) {
@@ -402,47 +399,53 @@ bool ArrayObject::eq(Env *env, Value other) {
             }
 
             Value result = this_item.send(env, equality, { item }, nullptr);
-            if (result.is_false())
-                return result;
+            if (result.is_falsey())
+                return false;
         }
 
-        return TrueObject::the();
-    });
+        return true;
+    };
 
-    return result.is_true();
+    if (other.is_integer())
+        return lambda(false);
+
+    TM::PairedRecursionGuard guard { this, other.object() };
+    return guard.run(lambda);
 }
 
 bool ArrayObject::eql(Env *env, Value other) {
-    TM::PairedRecursionGuard guard { this, other.object() };
-
-    Value result = guard.run([&](bool is_recursive) -> Value { // don't return bool in recursion guard
+    auto lambda = [&](bool is_recursive) {
         if (other == this)
-            return TrueObject::the();
+            return true;
         if (!other.is_array())
-            return FalseObject::the();
+            return false;
 
         if (!other.is_array()) {
-            return FalseObject::the();
+            return false;
         }
 
         auto other_array = other->as_array();
         if (size() != other_array->size())
-            return FalseObject::the();
+            return false;
 
         if (is_recursive)
             // since eql is an & of all the eql of each value, this will just leave the expression uneffected
-            return TrueObject::the();
+            return true;
 
         for (size_t i = 0; i < size(); ++i) {
             Value result = (*this)[i].send(env, "eql?"_s, { (*other_array)[i] }, nullptr);
             if (result.is_false())
-                return result;
+                return false;
         }
 
-        return TrueObject::the();
-    });
+        return true;
+    };
 
-    return result.is_true();
+    if (other.is_integer())
+        return lambda(false);
+
+    TM::PairedRecursionGuard guard { this, other.object() };
+    return guard.run(lambda);
 }
 
 Value ArrayObject::each(Env *env, Block *block) {

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -191,7 +191,7 @@ String ArrayObject::dbg_inspect() const {
     size_t index = 0;
     for (size_t index = 0; index < size(); index++) {
         auto item = (*this)[index];
-        str.append(item->dbg_inspect());
+        str.append(item.dbg_inspect());
         if (index < size() - 1)
             str.append(", ");
     }

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -529,7 +529,7 @@ Value ArrayObject::fill(Env *env, Value obj, Value start_obj, Value length_obj, 
                 if (start < 0)
                     start += size();
                 if (start < 0)
-                    env->raise("RangeError", "{} out of range", start_obj->inspect_str(env));
+                    env->raise("RangeError", "{} out of range", start_obj.inspect_str(env));
             }
 
             auto end = start_obj->as_range()->end();

--- a/src/complex_object.cpp
+++ b/src/complex_object.cpp
@@ -7,7 +7,7 @@ Value ComplexObject::imaginary(Env *env) {
 }
 
 Value ComplexObject::inspect(Env *env) {
-    return StringObject::format("({}+{}i)", m_real->inspect_str(env), m_imaginary->inspect_str(env));
+    return StringObject::format("({}+{}i)", m_real.inspect_str(env), m_imaginary.inspect_str(env));
 }
 
 Value ComplexObject::real(Env *env) {

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -283,7 +283,7 @@ Value EncodingObject::find(Env *env, Value name) {
                 return encoding;
         }
     }
-    env->raise("ArgumentError", "unknown encoding name - {}", name->inspect_str(env));
+    env->raise("ArgumentError", "unknown encoding name - {}", name.inspect_str(env));
 }
 
 // Lookup an EncodingObject by its string-name, or return null.

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -55,7 +55,7 @@ Value HashObject::get(Env *env, Value key) {
 }
 
 nat_int_t HashObject::generate_key_hash(Env *env, Value key) const {
-    if (m_is_comparing_by_identity && !key.is_float()) {
+    if (m_is_comparing_by_identity && !key.is_float() && !key.is_integer()) {
         auto obj = key.object();
         return TM::HashmapUtils::hashmap_hash_ptr((uintptr_t)obj);
     } else {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -329,9 +329,9 @@ String HashObject::dbg_inspect() const {
     String str("{");
     size_t index = 0;
     for (auto pair : *this) {
-        str.append(pair.key->dbg_inspect());
+        str.append(pair.key.dbg_inspect());
         str.append(" => ");
-        str.append(pair.val->dbg_inspect());
+        str.append(pair.val.dbg_inspect());
         if (index < size() - 1)
             str.append(", ");
         index++;

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -320,7 +320,7 @@ bool IntegerObject::lt(Env *env, Integer &self, Value other) {
         return result.first.send(env, "<"_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
 }
 
 bool IntegerObject::lte(Env *env, Integer &self, Value other) {
@@ -345,7 +345,7 @@ bool IntegerObject::lte(Env *env, Integer &self, Value other) {
         return result.first.send(env, "<="_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
 }
 
 bool IntegerObject::gt(Env *env, Integer &self, Value other) {
@@ -370,7 +370,7 @@ bool IntegerObject::gt(Env *env, Integer &self, Value other) {
         return result.first.send(env, ">"_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
 }
 
 bool IntegerObject::gte(Env *env, Integer &self, Value other) {
@@ -395,7 +395,7 @@ bool IntegerObject::gte(Env *env, Integer &self, Value other) {
         return result.first.send(env, ">="_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
 }
 
 Value IntegerObject::times(Env *env, Integer &self, Block *block) {
@@ -512,7 +512,7 @@ Value IntegerObject::coerce(Env *env, Value self, Value arg) {
             arg = arg.send(env, "to_f"_s);
         }
         if (!arg.is_float())
-            env->raise("TypeError", "can't convert {} into Float", arg->inspect_str(env));
+            env->raise("TypeError", "can't convert {} into Float", arg.inspect_str(env));
 
         ary->push(arg);
         ary->push(self.send(env, "to_f"_s));

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -501,27 +501,21 @@ Value IntegerObject::size(Env *env, Integer &self) {
 
 Value IntegerObject::coerce(Env *env, Value self, Value arg) {
     ArrayObject *ary = new ArrayObject {};
-    switch (arg->type()) {
-    case Object::Type::Integer:
+    if (arg.is_integer()) {
         ary->push(arg);
         ary->push(self);
-        break;
-    case Object::Type::String:
+    } else if (arg.is_string()) {
         ary->push(self.send(env, "Float"_s, { arg }));
         ary->push(self.send(env, "to_f"_s));
-        break;
-    default:
+    } else {
         if (!arg.is_nil() && !arg.is_float() && arg.respond_to(env, "to_f"_s)) {
             arg = arg.send(env, "to_f"_s);
         }
+        if (!arg.is_float())
+            env->raise("TypeError", "can't convert {} into Float", arg->inspect_str(env));
 
-        if (arg.is_float()) {
-            ary->push(arg);
-            ary->push(self.send(env, "to_f"_s));
-            break;
-        }
-
-        env->raise("TypeError", "can't convert {} into Float", arg->inspect_str(env));
+        ary->push(arg);
+        ary->push(self.send(env, "to_f"_s));
     }
     return ary;
 }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -291,7 +291,7 @@ Value IoObject::read_file(Env *env, Args &&args) {
     file->set_encoding(env, flags.external_encoding(), flags.internal_encoding());
     if (offset && !offset.is_nil()) {
         if (offset.is_integer() && IntegerObject::is_negative(offset.integer()))
-            env->raise("ArgumentError", "negative offset {} given", offset->inspect_str(env));
+            env->raise("ArgumentError", "negative offset {} given", offset.inspect_str(env));
         file->set_pos(env, offset);
     }
     auto data = file->read(env, length, nullptr);
@@ -667,7 +667,7 @@ void IoObject::puts(Env *env, Value val) {
         if (str.is_string()) {
             this->putstr(env, str->as_string());
         } else { // to_s did not return a string, so inspect val instead.
-            this->putstr(env, new StringObject { val->inspect_str(env) });
+            this->putstr(env, new StringObject { val.inspect_str(env) });
         }
     }
 }

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -44,10 +44,12 @@ namespace ioutil {
             }
         }
 
-        switch (flags_obj->type()) {
-        case Object::Type::Integer:
+        if (flags_obj.is_integer()) {
             m_flags = flags_obj.integer().to_nat_int_t();
-            break;
+            return;
+        }
+
+        switch (flags_obj->type()) {
         case Object::Type::String: {
             auto colon = new StringObject { ":" };
             auto flagsplit = flags_obj->as_string()->split(env, colon, nullptr)->as_array();

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -684,7 +684,7 @@ Value KernelModule::klass_obj(Env *env, Value self) {
 
 Value KernelModule::define_singleton_method(Env *env, Value self, Value name, Block *block) {
     env->ensure_block_given(block);
-    SymbolObject *name_obj = name->to_symbol(env, Object::Conversion::Strict);
+    SymbolObject *name_obj = name.to_symbol(env, Value::Conversion::Strict);
     self->define_singleton_method(env, name_obj, block);
     return name_obj;
 }
@@ -837,7 +837,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
 }
 
 Value KernelModule::method(Env *env, Value self, Value name) {
-    auto name_symbol = name->to_symbol(env, Object::Conversion::Strict);
+    auto name_symbol = name.to_symbol(env, Value::Conversion::Strict);
     auto singleton = self.singleton_class();
     auto module = singleton ? singleton : self.klass();
     auto method_info = module->find_method(env, name_symbol);
@@ -908,7 +908,7 @@ bool KernelModule::respond_to_method(Env *env, Value self, Value name_val, Value
 }
 
 bool KernelModule::respond_to_method(Env *env, Value self, Value name_val, bool include_all) {
-    auto name_symbol = name_val->to_symbol(env, Object::Conversion::Strict);
+    auto name_symbol = name_val.to_symbol(env, Value::Conversion::Strict);
 
     ClassObject *klass = self.singleton_class();
     if (!klass)

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -760,6 +760,8 @@ Value KernelModule::inspect(Env *env, Value value) {
 }
 
 bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_val) {
+    if (self.is_integer())
+        return false;
     switch (self->type()) {
     case Object::Type::Nil:
     case Object::Type::True:

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -838,7 +838,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
 
 Value KernelModule::method(Env *env, Value self, Value name) {
     auto name_symbol = name->to_symbol(env, Object::Conversion::Strict);
-    auto singleton = self->singleton_class();
+    auto singleton = self.singleton_class();
     auto module = singleton ? singleton : self.klass();
     auto method_info = module->find_method(env, name_symbol);
     if (!method_info.is_defined()) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -219,7 +219,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
     if (value.is_string()) {
         auto result = value->as_string()->convert_integer(env, base);
         if (!result && exception) {
-            env->raise("ArgumentError", "invalid value for Integer(): {}", value->inspect_str(env));
+            env->raise("ArgumentError", "invalid value for Integer(): {}", value.inspect_str(env));
         }
         return result;
     }
@@ -270,7 +270,7 @@ Value KernelModule::Float(Env *env, Value value, bool exception) {
     } else if (value.is_string()) {
         auto result = value->as_string()->convert_float();
         if (!result && exception) {
-            env->raise("ArgumentError", "invalid value for Float(): {}", value->inspect_str(env));
+            env->raise("ArgumentError", "invalid value for Float(): {}", value.inspect_str(env));
         }
         return result;
     } else if (!value.is_nil() && value.respond_to(env, "to_f"_s)) {
@@ -665,7 +665,7 @@ Value KernelModule::this_method(Env *env) {
 Value KernelModule::throw_method(Env *env, Value name, Value value) {
     if (!env->has_catch(name)) {
         auto klass = GlobalEnv::the()->Object()->const_fetch("UncaughtThrowError"_s)->as_class();
-        auto message = StringObject::format("uncaught throw {}", name->inspect_str(env));
+        auto message = StringObject::format("uncaught throw {}", name.inspect_str(env));
         auto exception = Object::_new(env, klass, { name, value, message }, nullptr)->as_exception();
         env->raise_exception(exception);
     }

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -226,7 +226,7 @@ Value MatchDataObject::inspect(Env *env) {
             }
             out->append_char(':');
         }
-        out->append(this->group(i)->inspect_str(env));
+        out->append(this->group(i).inspect_str(env));
     }
     out->append_char('>');
     return out;

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -359,7 +359,7 @@ ArrayObject *MatchDataObject::values_at(Env *env, Args &&args) {
 }
 
 Value MatchDataObject::ref(Env *env, Value index_value, Value size_value) {
-    if (index_value->type() == Object::Type::String || index_value->type() == Object::Type::Symbol) {
+    if (index_value.is_string() || index_value.is_symbol()) {
         const auto &str = index_value->type() == Object::Type::String ? index_value->as_string()->string() : index_value->as_symbol()->string();
         const nat_int_t index = onig_name_to_backref_number(m_regexp->m_regex, reinterpret_cast<const UChar *>(str.c_str()), reinterpret_cast<const UChar *>(str.c_str() + str.size()), m_region);
 
@@ -368,7 +368,7 @@ Value MatchDataObject::ref(Env *env, Value index_value, Value size_value) {
 
         return group(index);
     }
-    if (index_value->type() == Object::Type::Range) {
+    if (index_value.is_range()) {
         auto range = index_value->as_range();
         const nat_int_t first = range->begin().is_nil() ? 0 : IntegerObject::convert_to_nat_int_t(env, range->begin());
         nat_int_t last = range->end().is_nil() ? size() - 1 : IntegerObject::convert_to_nat_int_t(env, range->end());
@@ -389,15 +389,15 @@ Value MatchDataObject::ref(Env *env, Value index_value, Value size_value) {
         return result;
     }
     nat_int_t index;
-    if (index_value.is_fast_integer()) {
-        index = index_value.get_fast_integer();
+    if (index_value.is_integer()) {
+        index = index_value.integer().to_nat_int_t();
     } else {
         index = IntegerObject::convert_to_nat_int_t(env, index_value);
     }
     if (size_value && !size_value.is_nil()) {
         nat_int_t size;
-        if (size_value.is_fast_integer()) {
-            size = size_value.get_fast_integer();
+        if (size_value.is_integer()) {
+            size = size_value.integer().to_nat_int_t();
         } else {
             size = IntegerObject::convert_to_nat_int_t(env, size_value);
         }

--- a/src/math.rb
+++ b/src/math.rb
@@ -251,7 +251,7 @@ module Math
       if (value->is_positive_infinity()) {
         return new ArrayObject { {  Value(FloatObject::positive_infinity(env)), Value::integer(1) } };
       } else if (value->is_negative_infinity()) {
-        auto DomainError = self->const_fetch("DomainError"_s)->as_class();
+        auto DomainError = Object::const_fetch(self, "DomainError"_s)->as_class();
         env->raise(DomainError, "Numerical argument is out of domain");
       } else if (value->is_positive_zero()) {
         return new ArrayObject { {  Value(FloatObject::positive_infinity(env)), Value::integer(1) } };

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -1066,7 +1066,7 @@ Value ModuleObject::public_constant(Env *env, Args &&args) {
 bool ModuleObject::const_defined(Env *env, Value name_value, Value inherited) {
     auto name = name_value->to_symbol(env, Object::Conversion::NullAllowed);
     if (!name) {
-        env->raise("TypeError", "no implicit conversion of {} to String", name_value->inspect_str(env));
+        env->raise("TypeError", "no implicit conversion of {} to String", name_value.inspect_str(env));
     }
     if (inherited && inherited.is_falsey()) {
         return !!m_constants.get(name);
@@ -1077,11 +1077,11 @@ bool ModuleObject::const_defined(Env *env, Value name_value, Value inherited) {
 Value ModuleObject::alias_method(Env *env, Value new_name_value, Value old_name_value) {
     auto new_name = new_name_value->to_symbol(env, Object::Conversion::NullAllowed);
     if (!new_name) {
-        env->raise("TypeError", "{} is not a symbol", new_name_value->inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", new_name_value.inspect_str(env));
     }
     auto old_name = old_name_value->to_symbol(env, Object::Conversion::NullAllowed);
     if (!old_name) {
-        env->raise("TypeError", "{} is not a symbol", old_name_value->inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", old_name_value.inspect_str(env));
     }
     make_method_alias(env, new_name, old_name);
     return new_name;
@@ -1112,7 +1112,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
     if (name.is_string()) {
         name = name->as_string()->to_sym(env);
     } else if (!name.is_symbol()) {
-        env->raise("TypeError", "{} is not a symbol nor a string", name->inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol nor a string", name.inspect_str(env));
     }
 
     auto method_wrapper = [](Env *env, Value self, Args &&args, Block *block) -> Value {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -99,7 +99,7 @@ Value ModuleObject::const_get(Env *env, Value name, Value inherited) {
     return constant;
 }
 
-Value ModuleObject::const_fetch(SymbolObject *name) {
+Value ModuleObject::const_fetch(SymbolObject *name) const {
     auto constant = const_get(name);
     if (!constant) {
         TM::String::format("Constant {} is missing!\n", name->string()).print();

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -89,7 +89,7 @@ Value ModuleObject::const_get(SymbolObject *name) const {
 }
 
 Value ModuleObject::const_get(Env *env, Value name, Value inherited) {
-    auto symbol = name->to_symbol(env, Object::Conversion::Strict);
+    auto symbol = name.to_symbol(env, Value::Conversion::Strict);
     auto constant = const_get(symbol);
     if (!constant) {
         if (inherited && inherited.is_falsey())
@@ -217,7 +217,7 @@ Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject
 }
 
 Value ModuleObject::is_autoload(Env *env, Value name) const {
-    auto name_sym = name->to_symbol(env, Conversion::Strict);
+    auto name_sym = name.to_symbol(env, Value::Conversion::Strict);
     auto constant = m_constants.get(name_sym);
     if (constant && constant->needs_load()) {
         auto path = constant->autoload_path();
@@ -301,7 +301,7 @@ Value ModuleObject::const_set(SymbolObject *name, MethodFnPtr autoload_fn, Strin
 }
 
 Value ModuleObject::const_set(Env *env, Value name, Value val) {
-    auto name_as_sym = name->to_symbol(env, Object::Conversion::Strict);
+    auto name_as_sym = name.to_symbol(env, Value::Conversion::Strict);
     if (!name_as_sym->is_constant_name())
         env->raise_name_error(name_as_sym, "wrong constant name {}", name_as_sym->string());
     return const_set(name_as_sym, val);
@@ -314,7 +314,7 @@ void ModuleObject::remove_const(SymbolObject *name) {
 }
 
 Value ModuleObject::remove_const(Env *env, Value name) {
-    auto name_as_sym = name->to_symbol(env, Object::Conversion::Strict);
+    auto name_as_sym = name.to_symbol(env, Value::Conversion::Strict);
     if (!name_as_sym->is_constant_name())
         env->raise_name_error(name_as_sym, "wrong constant name {}", name_as_sym->string());
     auto constant = m_constants.get(name_as_sym);
@@ -437,13 +437,13 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 }
 
 bool ModuleObject::class_variable_defined(Env *env, Value name) {
-    auto *name_sym = name->to_symbol(env, Conversion::Strict);
+    auto *name_sym = name.to_symbol(env, Value::Conversion::Strict);
 
     return cvar_get_or_null(env, name_sym);
 }
 
 Value ModuleObject::class_variable_get(Env *env, Value name) {
-    auto *name_sym = name->to_symbol(env, Conversion::Strict);
+    auto *name_sym = name.to_symbol(env, Value::Conversion::Strict);
 
     auto val = cvar_get_or_null(env, name_sym);
     if (!val) {
@@ -455,7 +455,7 @@ Value ModuleObject::class_variable_get(Env *env, Value name) {
 Value ModuleObject::class_variable_set(Env *env, Value name, Value value) {
     assert_not_frozen(env);
 
-    return cvar_set(env, name->to_symbol(env, Conversion::Strict), value);
+    return cvar_set(env, name.to_symbol(env, Value::Conversion::Strict), value);
 }
 
 ArrayObject *ModuleObject::class_variables(Value inherit) const {
@@ -475,7 +475,7 @@ ArrayObject *ModuleObject::class_variables(Value inherit) const {
 
 Value ModuleObject::remove_class_variable(Env *env, Value name) {
     assert_not_frozen(env);
-    auto *name_sym = name->to_symbol(env, Conversion::Strict);
+    auto *name_sym = name.to_symbol(env, Value::Conversion::Strict);
 
     if (!name_sym->is_cvar_name())
         env->raise_name_error(name_sym, "`{}' is not allowed as a class variable name", name_sym->string());
@@ -605,14 +605,14 @@ void ModuleObject::assert_method_defined(Env *env, SymbolObject *name, MethodInf
 }
 
 Value ModuleObject::instance_method(Env *env, Value name_value) {
-    auto name = name_value->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_value.to_symbol(env, Value::Conversion::Strict);
     auto method_info = find_method(env, name);
     assert_method_defined(env, name, method_info);
     return new UnboundMethodObject { this, method_info.method() };
 }
 
 Value ModuleObject::public_instance_method(Env *env, Value name_value) {
-    auto name = name_value->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_value.to_symbol(env, Value::Conversion::Strict);
     auto method_info = find_method(env, name);
     assert_method_defined(env, name, method_info);
 
@@ -731,7 +731,7 @@ bool ModuleObject::is_subclass_of(ModuleObject *other) {
 }
 
 bool ModuleObject::is_method_defined(Env *env, Value name_value) const {
-    auto name = name_value->to_symbol(env, Conversion::Strict);
+    auto name = name_value.to_symbol(env, Value::Conversion::Strict);
     return !!find_method(env, name);
 }
 
@@ -809,7 +809,7 @@ ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
 }
 
 SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
-    auto name = obj->to_symbol(env, Conversion::Strict);
+    auto name = obj.to_symbol(env, Value::Conversion::Strict);
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, name);
     Block *attr_block = new Block { std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0 };
@@ -835,7 +835,7 @@ ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
 }
 
 SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
-    auto name = obj->to_symbol(env, Conversion::Strict);
+    auto name = obj.to_symbol(env, Value::Conversion::Strict);
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, name);
@@ -901,7 +901,7 @@ bool ModuleObject::does_include_module(Env *env, Value module) {
 }
 
 Value ModuleObject::define_method(Env *env, Value name_value, Value method_value, Block *block) {
-    auto name = name_value->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_value.to_symbol(env, Value::Conversion::Strict);
     if (method_value) {
         if (method_value.is_proc()) {
             define_method(env, name, method_value->as_proc()->block());
@@ -990,7 +990,7 @@ void ModuleObject::set_method_visibility(Env *env, Args &&args, MethodVisibility
     if (args.size() == 1 && args[0].is_array()) {
         auto array = args[0]->as_array();
         for (auto &value : *array) {
-            auto name = value->to_symbol(env, Conversion::Strict);
+            auto name = value.to_symbol(env, Value::Conversion::Strict);
             set_method_visibility(env, name, visibility);
         }
         return;
@@ -998,7 +998,7 @@ void ModuleObject::set_method_visibility(Env *env, Args &&args, MethodVisibility
 
     // private :foo, :bar
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         set_method_visibility(env, name, visibility);
     }
 }
@@ -1016,7 +1016,7 @@ Value ModuleObject::module_function(Env *env, Args &&args) {
 
     if (args.size() > 0) {
         for (size_t i = 0; i < args.size(); ++i) {
-            auto name = args[i]->to_symbol(env, Conversion::Strict);
+            auto name = args[i].to_symbol(env, Value::Conversion::Strict);
             auto method_info = find_method(env, name);
             assert_method_defined(env, name, method_info);
             auto method = method_info.method();
@@ -1032,7 +1032,7 @@ Value ModuleObject::module_function(Env *env, Args &&args) {
 
 Value ModuleObject::deprecate_constant(Env *env, Args &&args) {
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
             env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
@@ -1043,7 +1043,7 @@ Value ModuleObject::deprecate_constant(Env *env, Args &&args) {
 
 Value ModuleObject::private_constant(Env *env, Args &&args) {
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
             env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
@@ -1054,7 +1054,7 @@ Value ModuleObject::private_constant(Env *env, Args &&args) {
 
 Value ModuleObject::public_constant(Env *env, Args &&args) {
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
             env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
@@ -1064,7 +1064,7 @@ Value ModuleObject::public_constant(Env *env, Args &&args) {
 }
 
 bool ModuleObject::const_defined(Env *env, Value name_value, Value inherited) {
-    auto name = name_value->to_symbol(env, Object::Conversion::NullAllowed);
+    auto name = name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!name) {
         env->raise("TypeError", "no implicit conversion of {} to String", name_value.inspect_str(env));
     }
@@ -1075,11 +1075,11 @@ bool ModuleObject::const_defined(Env *env, Value name_value, Value inherited) {
 }
 
 Value ModuleObject::alias_method(Env *env, Value new_name_value, Value old_name_value) {
-    auto new_name = new_name_value->to_symbol(env, Object::Conversion::NullAllowed);
+    auto new_name = new_name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!new_name) {
         env->raise("TypeError", "{} is not a symbol", new_name_value.inspect_str(env));
     }
-    auto old_name = old_name_value->to_symbol(env, Object::Conversion::NullAllowed);
+    auto old_name = old_name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!old_name) {
         env->raise("TypeError", "{} is not a symbol", old_name_value.inspect_str(env));
     }
@@ -1089,7 +1089,7 @@ Value ModuleObject::alias_method(Env *env, Value new_name_value, Value old_name_
 
 Value ModuleObject::remove_method(Env *env, Args &&args) {
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto method = m_methods.get(name, env);
         if (!method)
             env->raise_name_error(name, "method `{}' not defined in {}", name->string(), this->inspect_str());
@@ -1100,7 +1100,7 @@ Value ModuleObject::remove_method(Env *env, Args &&args) {
 
 Value ModuleObject::undef_method(Env *env, Args &&args) {
     for (size_t i = 0; i < args.size(); ++i) {
-        auto name = args[i]->to_symbol(env, Conversion::Strict);
+        auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto method_info = find_method(env, name);
         assert_method_defined(env, name, method_info);
         undefine_method(env, name);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -868,7 +868,7 @@ Value super(Env *env, Value self, Args &&args, Block *block) {
         if (self.is_module()) {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self->as_module()->inspect_str(), self.klass()->inspect_str());
         } else {
-            env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self->inspect_str(env));
+            env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self.inspect_str(env));
         }
     }
     assert(super_method.method() != current_method);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -97,7 +97,7 @@ Env *build_top_env() {
     global_env->set_Rational(Rational);
     Object->const_set("Rational"_s, Rational);
 
-    Value Math = new ModuleObject { "Math" };
+    ModuleObject *Math = new ModuleObject { "Math" };
     Object->const_set("Math"_s, Math);
     Math->const_set("E"_s, new FloatObject { M_E });
     Math->const_set("PI"_s, new FloatObject { M_PI });
@@ -847,7 +847,7 @@ int pclose2(FILE *fp, pid_t pid) {
 }
 
 void set_status_object(Env *env, pid_t pid, int status) {
-    auto status_obj = GlobalEnv::the()->Object()->const_fetch("Process"_s)->const_fetch("Status"_s).send(env, "new"_s);
+    auto status_obj = GlobalEnv::the()->Object()->const_fetch("Process"_s)->as_module()->const_fetch("Status"_s).send(env, "new"_s);
     status_obj->ivar_set(env, "@to_i"_s, Value::integer(status));
     status_obj->ivar_set(env, "@exitstatus"_s, Value::integer(WEXITSTATUS(status)));
     status_obj->ivar_set(env, "@pid"_s, Value::integer(pid));

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -673,18 +673,22 @@ Value Object::const_fetch(Value ns, SymbolObject *name) {
     return ns.klass()->const_fetch(name);
 }
 
-Value Object::const_set(Value ns, SymbolObject *name, Value val) {
+Value Object::const_set(Env *env, Value ns, SymbolObject *name, Value val) {
     if (ns.is_module())
         return ns->as_module()->const_set(name, val);
-
-    return ns.klass()->const_set(name, val);
+    else if (ns == GlobalEnv::the()->main_obj())
+        return GlobalEnv::the()->Object()->const_set(name, val);
+    else
+        env->raise("TypeError", "{} is not a class/module", ns.inspect_str(env));
 }
 
-Value Object::const_set(Value ns, SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
+Value Object::const_set(Env *env, Value ns, SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
     if (ns.is_module())
         return ns->as_module()->const_set(name, autoload_fn, autoload_path);
-
-    return ns.klass()->const_set(name, autoload_fn, autoload_path);
+    else if (ns == GlobalEnv::the()->main_obj())
+        return GlobalEnv::the()->Object()->const_set(name, autoload_fn, autoload_path);
+    else
+        env->raise("TypeError", "{} is not a class/module", ns.inspect_str(env));
 }
 
 bool Object::ivar_defined(Env *env, SymbolObject *name) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -666,20 +666,32 @@ Value Object::const_find_with_autoload(Env *env, Value ns, Value self, SymbolObj
     return ns->m_klass->const_find_with_autoload(env, self, name, search_mode, failure_mode);
 }
 
-Value Object::const_get(SymbolObject *name) const {
-    return m_klass->const_get(name);
+Value Object::const_get(Value ns, SymbolObject *name) {
+    if (ns.is_module())
+        return ns->as_module()->const_get(name);
+
+    return ns.klass()->const_get(name);
 }
 
-Value Object::const_fetch(SymbolObject *name) {
-    return m_klass->const_fetch(name);
+Value Object::const_fetch(Value ns, SymbolObject *name) {
+    if (ns.is_module())
+        return ns->as_module()->const_fetch(name);
+
+    return ns.klass()->const_fetch(name);
 }
 
-Value Object::const_set(SymbolObject *name, Value val) {
-    return m_klass->const_set(name, val);
+Value Object::const_set(Value ns, SymbolObject *name, Value val) {
+    if (ns.is_module())
+        return ns->as_module()->const_set(name, val);
+
+    return ns.klass()->const_set(name, val);
 }
 
-Value Object::const_set(SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
-    return m_klass->const_set(name, autoload_fn, autoload_path);
+Value Object::const_set(Value ns, SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
+    if (ns.is_module())
+        return ns->as_module()->const_set(name, autoload_fn, autoload_path);
+
+    return ns.klass()->const_set(name, autoload_fn, autoload_path);
 }
 
 bool Object::ivar_defined(Env *env, SymbolObject *name) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -666,13 +666,6 @@ Value Object::const_find_with_autoload(Env *env, Value ns, Value self, SymbolObj
     return ns->m_klass->const_find_with_autoload(env, self, name, search_mode, failure_mode);
 }
 
-Value Object::const_get(Value ns, SymbolObject *name) {
-    if (ns.is_module())
-        return ns->as_module()->const_get(name);
-
-    return ns.klass()->const_get(name);
-}
-
 Value Object::const_fetch(Value ns, SymbolObject *name) {
     if (ns.is_module())
         return ns->as_module()->const_fetch(name);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -589,20 +589,8 @@ StringObject *Object::as_string_or_raise(Env *env) {
     return static_cast<StringObject *>(this);
 }
 
-SymbolObject *Object::to_symbol(Env *env, Conversion conversion) {
-    if (m_type == Type::Symbol) {
-        return as_symbol();
-    } else if (m_type == Type::String || respond_to(env, "to_str"_s)) {
-        return Value(this).to_str(env)->to_symbol(env);
-    } else if (conversion == Conversion::NullAllowed) {
-        return nullptr;
-    } else {
-        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
-    }
-}
-
 SymbolObject *Object::to_instance_variable_name(Env *env) {
-    SymbolObject *symbol = to_symbol(env, Conversion::Strict); // TypeError if not Symbol/String
+    SymbolObject *symbol = Value(this).to_symbol(env, Value::Conversion::Strict); // TypeError if not Symbol/String
 
     if (!symbol->is_ivar_name()) {
         if (m_type == Type::String) {
@@ -925,7 +913,7 @@ Value Object::public_send(Env *env, SymbolObject *name, Args &&args, Block *bloc
 }
 
 Value Object::public_send(Env *env, Value self, Args &&args, Block *block) {
-    auto name = args.shift()->to_symbol(env, Object::Conversion::Strict);
+    auto name = args.shift().to_symbol(env, Value::Conversion::Strict);
     if (self.is_integer())
         return self.integer_send(env, name, std::move(args), block, nullptr, MethodVisibility::Public);
 
@@ -937,7 +925,7 @@ Value Object::send(Env *env, SymbolObject *name, Args &&args, Block *block, Valu
 }
 
 Value Object::send(Env *env, Value self, Args &&args, Block *block) {
-    auto name = args.shift()->to_symbol(env, Object::Conversion::Strict);
+    auto name = args.shift().to_symbol(env, Value::Conversion::Strict);
     if (self.is_integer())
         return self.integer_send(env, name, std::move(args), block, nullptr, MethodVisibility::Private);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -631,7 +631,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
     if (self.is_module()) {
         name = String::format("#<Class:{}>", self->as_module()->inspect_str());
     } else if (self.respond_to(env, "inspect"_s)) {
-        name = String::format("#<Class:{}>", self->inspect_str(env));
+        name = String::format("#<Class:{}>", self.inspect_str(env));
     }
 
     ClassObject *singleton_superclass;
@@ -1247,15 +1247,6 @@ String Object::dbg_inspect() const {
         "#<{}:{}>",
         klass ? *klass : "Object",
         String::hex(reinterpret_cast<nat_int_t>(this), String::HexFormat::LowercaseAndPrefixed));
-}
-
-String Object::inspect_str(Env *env) {
-    if (!respond_to(env, "inspect"_s))
-        return String::format("#<{}:{}>", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed));
-    auto inspected = send(env, "inspect"_s);
-    if (!inspected.is_string())
-        return ""; // TODO: what to do here?
-    return inspected->as_string()->string();
 }
 
 Value Object::enum_for(Env *env, const char *method, Args &&args) {

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -88,7 +88,7 @@ long ProcessModule::maxgroups() {
 Value ProcessModule::setmaxgroups(Env *env, Value val) {
     Value int_val = val.to_int(env);
     if (int_val.send(env, "positive?"_s).is_falsey())
-        env->raise("ArgumentError", "maxgroups {} should be positive", int_val->inspect_str(env));
+        env->raise("ArgumentError", "maxgroups {} should be positive", int_val.inspect_str(env));
     const long actual_maxgroups = sysconf(_SC_NGROUPS_MAX);
     globals::maxgroups = std::min(IntegerObject::convert_to_native_type<long>(env, int_val), actual_maxgroups);
     return val;

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -40,7 +40,7 @@ Value RandomObject::rand(Env *env, Value arg) {
         if (arg.is_float()) {
             double max = arg->as_float()->to_double();
             if (max <= 0) {
-                env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
+                env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
             }
             return generate_random(0.0, max);
         } else if (arg.is_range()) {
@@ -50,7 +50,7 @@ Value RandomObject::rand(Env *env, Value arg) {
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
             if (min.is_numeric() && max.is_numeric()) {
                 if (min.send(env, ">"_s, { max }).is_true()) {
-                    env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
+                    env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
                 }
 
                 if (min.is_float() || max.is_float()) {
@@ -87,7 +87,7 @@ Value RandomObject::rand(Env *env, Value arg) {
 
         nat_int_t max = IntegerObject::convert_to_nat_int_t(env, arg);
         if (max <= 0) {
-            env->raise("ArgumentError", "invalid argument - {}", arg->inspect_str(env));
+            env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
         }
         return generate_random(0, max - 1);
     } else {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -213,13 +213,13 @@ Value RangeObject::inspect(Env *env) {
             if (m_begin.is_nil()) {
                 return new StringObject { "nil...nil" };
             } else {
-                return StringObject::format("{}...", m_begin->inspect_str(env));
+                return StringObject::format("{}...", m_begin.inspect_str(env));
             }
         } else {
             if (m_begin.is_nil()) {
-                return StringObject::format("...{}", m_end->inspect_str(env));
+                return StringObject::format("...{}", m_end.inspect_str(env));
             } else {
-                return StringObject::format("{}...{}", m_begin->inspect_str(env), m_end->inspect_str(env));
+                return StringObject::format("{}...{}", m_begin.inspect_str(env), m_end.inspect_str(env));
             }
         }
     } else {
@@ -227,13 +227,13 @@ Value RangeObject::inspect(Env *env) {
             if (m_begin.is_nil()) {
                 return new StringObject { "nil..nil" };
             } else {
-                return StringObject::format("{}..", m_begin->inspect_str(env));
+                return StringObject::format("{}..", m_begin.inspect_str(env));
             }
         } else {
             if (m_begin.is_nil()) {
-                return StringObject::format("..{}", m_end->inspect_str(env));
+                return StringObject::format("..{}", m_end.inspect_str(env));
             } else {
-                return StringObject::format("{}..{}", m_begin->inspect_str(env), m_end->inspect_str(env));
+                return StringObject::format("{}..{}", m_begin.inspect_str(env), m_end.inspect_str(env));
             }
         }
     }

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -237,7 +237,7 @@ Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
                 }
             }
         } else {
-            env->verbose_warn("expected true or false as ignorecase: {}", opts->inspect_str(env));
+            env->verbose_warn("expected true or false as ignorecase: {}", opts.inspect_str(env));
             if (opts.is_truthy())
                 options = RegexOpts::IgnoreCase;
         }

--- a/src/rounding_mode.cpp
+++ b/src/rounding_mode.cpp
@@ -6,7 +6,7 @@ RoundingMode rounding_mode_from_value(Env *env, Value value, RoundingMode defaul
     if (!value) return default_rounding_mode;
     if (value.is_nil()) return default_rounding_mode;
     if (!value.is_symbol()) {
-        env->raise("ArgumentError", "invalid rounding mode: {}", value->inspect_str(env));
+        env->raise("ArgumentError", "invalid rounding mode: {}", value.inspect_str(env));
     }
 
     auto symbol = value->as_symbol();

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3850,6 +3850,11 @@ void StringObject::append(const SymbolObject *sym) {
 }
 
 void StringObject::append(Value val) {
+    if (val.is_integer()) {
+        append(val.integer().to_string());
+        return;
+    }
+
     auto obj = val.object();
     switch (obj->type()) {
     case Type::Array:

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1415,7 +1415,7 @@ Value StringObject::encode_in_place(Env *env, Value dst_encoding, Value src_enco
             else if (xml == "text"_s)
                 options.xml_option = EncodeXmlOption::Text;
             else
-                env->raise("ArgumentError", "unexpected value for xml option: {}", xml->inspect_str(env));
+                env->raise("ArgumentError", "unexpected value for xml option: {}", xml.inspect_str(env));
         }
     }
 
@@ -2433,7 +2433,7 @@ Value StringObject::refeq(Env *env, Value arg1, Value arg2, Value value) {
 
         // raises a RangeError if Range begin is greater than String size
         if (::abs(begin) >= (nat_int_t)chars->size())
-            env->raise("RangeError", "{} out of range", arg1->inspect_str(env));
+            env->raise("RangeError", "{} out of range", arg1.inspect_str(env));
 
         // process the begin later to eventually raise the error above
         begin = process_begin(begin);

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -144,7 +144,7 @@ static Value validate_key(Env *env, Value key) {
     if (key.is_string() || key.respond_to(env, "to_str"_s))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "{} is not a symbol", key->inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", key.inspect_str(env));
     return key;
 }
 

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -444,7 +444,7 @@ Value TimeObject::convert_unit(Env *env, Value value) {
     } else if (value == "nanosecond"_s || value == "nsec"_s) {
         return Value::integer(1000000000);
     } else {
-        env->raise("ArgumentError", "unexpected unit: {}", value->inspect_str(env));
+        env->raise("ArgumentError", "unexpected unit: {}", value.inspect_str(env));
     }
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -503,6 +503,15 @@ void Value::auto_hydrate() {
     }
 }
 
+String Value::inspect_str(Env *env) {
+    if (!respond_to(env, "inspect"_s))
+        return String::format("#<{}:{}>", klass()->inspect_str(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
+    auto inspected = send(env, "inspect"_s);
+    if (!inspected.is_string())
+        return ""; // TODO: what to do here?
+    return inspected->as_string()->string();
+}
+
 #undef PROFILED_SEND
 
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -492,6 +492,23 @@ StringObject *Value::to_s(Env *env) {
     return str->as_string();
 }
 
+SymbolObject *Value::to_symbol(Env *env, Conversion conversion) {
+    if (is_integer()) {
+        if (conversion == Conversion::NullAllowed)
+            return nullptr;
+        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
+    }
+
+    if (is_symbol())
+        return m_object->as_symbol();
+    else if (is_string() || respond_to(env, "to_str"_s))
+        return to_str(env)->to_symbol(env);
+    else if (conversion == Conversion::NullAllowed)
+        return nullptr;
+    else
+        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
+}
+
 void Value::auto_hydrate() {
     switch (m_type) {
     case Type::Integer: {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -512,6 +512,16 @@ String Value::inspect_str(Env *env) {
     return inspected->as_string()->string();
 }
 
+String Value::dbg_inspect() const {
+    switch (m_type) {
+    case Type::Integer:
+        return m_integer.to_string();
+    case Type::Pointer:
+        return m_object->dbg_inspect();
+    }
+    NAT_UNREACHABLE();
+}
+
 #undef PROFILED_SEND
 
 }


### PR DESCRIPTION
This gets the number of failing spec files down from 202 to 47. 🎉 

An interesting fix came out of this work, that we no longer mistakenly set a constant on the class of a non-module...

before:

```ruby
1::FOO = 2 # no error
```

after:

```ruby
1::FOO = 2 # 1 is not a class/module (TypeError)
```