### PR TITLE
More Integer dehydration, part 4

### DIFF
--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -19,17 +19,7 @@ namespace Natalie {
 
 class IntegerObject : public Object {
 public:
-    IntegerObject(const nat_int_t integer)
-        : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
-        , m_integer { integer } { }
-
-    IntegerObject(const Integer &integer)
-        : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
-        , m_integer { integer } { }
-
-    IntegerObject(Integer &&integer)
-        : Object { Object::Type::Integer, GlobalEnv::the()->Integer() }
-        , m_integer { std::move(integer) } { }
+    IntegerObject() = delete;
 
     static Value create(nat_int_t);
     static Value create(const Integer &);
@@ -37,14 +27,6 @@ public:
     static Value create(const char *);
     static Value create(const TM::String &);
     static Value create(TM::String &&);
-
-    static Integer integer(const IntegerObject *self) {
-        return self->m_integer;
-    }
-
-    static Integer &integer(IntegerObject *self) {
-        return self->m_integer;
-    }
 
     static bool is_negative(const Integer self) { return self.is_negative(); }
     static bool is_zero(const Integer self) { return self.is_zero(); }
@@ -83,10 +65,8 @@ public:
 
     static Value sqrt(Env *, Value);
 
-    static Value inspect(Env *env, IntegerObject *self) { return to_s(env, self->m_integer); }
     static Value inspect(Env *env, Integer &self) { return to_s(env, self); }
 
-    static String to_s(const IntegerObject *self) { return self->m_integer.to_string(); }
     static String to_s(const Integer &self) { return self.to_string(); }
 
     static Value to_s(Env *, Integer &self, Value = nullptr);
@@ -136,29 +116,12 @@ public:
     static bool is_bignum(const Integer &self) { return self.is_bignum(); }
     static bool is_fixnum(const Integer &self) { return self.is_fixnum(); }
 
-    static nat_int_t to_nat_int_t(const IntegerObject *self) { return self->m_integer.to_nat_int_t(); }
-    static BigInt to_bigint(const IntegerObject *self) { return self->m_integer.to_bigint(); }
     static BigInt to_bigint(const Integer &self) { return self.to_bigint(); }
 
     static void assert_fixnum(Env *env, const Integer &self) {
         if (self.is_bignum())
             env->raise("RangeError", "bignum too big to convert into 'long'");
     }
-
-    virtual String dbg_inspect() const override { return to_s(this); }
-
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<IntegerObject %p value=%s is_fixnum=%s>", this, m_integer.to_string().c_str(), m_integer.is_fixnum() ? "true" : "false");
-    }
-
-    virtual void visit_children(Visitor &visitor) const override {
-        Object::visit_children(visitor);
-        if (m_integer.is_bignum())
-            visitor.visit(m_integer.bigint_pointer());
-    }
-
-private:
-    Integer m_integer;
 };
 
 }

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -65,6 +65,9 @@ public:
     static Value klass_obj(Env *env, Value self);
 
     static Value freeze_obj(Env *env, Value self) {
+        if (self.is_integer() || self.is_float())
+            return self;
+
         self->freeze();
         return self;
     }

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -22,7 +22,7 @@
 #define NAT_GC_GUARD_VALUE(val)                                                               \
     {                                                                                         \
         Object *ptr;                                                                          \
-        if ((ptr = val.object_or_null()) && Heap::the().gc_enabled()) {                       \
+        if (!val.is_integer() && (ptr = val.object()) && Heap::the().gc_enabled()) {          \
             std::lock_guard<std::recursive_mutex> gc_lock(Natalie::g_gc_recursive_mutex);     \
             auto end_of_stack = (uintptr_t)__builtin_frame_address(0);                        \
             auto start_of_stack = (uintptr_t)(ThreadObject::current()->start_of_stack());     \

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -105,9 +105,9 @@ public:
     Value remove_class_variable(Env *, Value);
 
     Value define_method(Env *, Value, Value, Block *);
-    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int) override;
-    virtual SymbolObject *define_method(Env *, SymbolObject *, Block *) override;
-    virtual SymbolObject *undefine_method(Env *, SymbolObject *) override;
+    SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int);
+    SymbolObject *define_method(Env *, SymbolObject *, Block *);
+    SymbolObject *undefine_method(Env *, SymbolObject *);
 
     void methods(Env *, ArrayObject *, bool = true);
     void define_method(Env *, SymbolObject *, Method *, MethodVisibility);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -69,7 +69,7 @@ public:
     Value const_missing(Env *, Value);
 
     void make_method_alias(Env *, SymbolObject *, SymbolObject *);
-    virtual void method_alias(Env *, SymbolObject *, SymbolObject *) override;
+    void method_alias(Env *, SymbolObject *, SymbolObject *);
 
     Value eval_body(Env *, Value (*)(Env *, Value));
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -259,7 +259,7 @@ public:
     bool is_main_object() const { return this == GlobalEnv::the()->main_obj(); }
 
     void freeze();
-    bool is_frozen() const { return m_type == Type::Integer || m_type == Type::Float || m_frozen; }
+    bool is_frozen() const { return m_type == Type::Float || m_frozen; }
 
     static bool not_truthy(Value self) {
         if (self.is_integer())

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -193,13 +193,13 @@ public:
     virtual Value cvar_get_or_null(Env *, SymbolObject *);
     virtual Value cvar_set(Env *, SymbolObject *, Value);
 
-    virtual SymbolObject *define_method(Env *, SymbolObject *, MethodFnPtr, int);
-    virtual SymbolObject *define_method(Env *, SymbolObject *, Block *);
-    virtual SymbolObject *undefine_method(Env *, SymbolObject *);
+    static SymbolObject *define_method(Env *, Value, SymbolObject *, MethodFnPtr, int);
+    static SymbolObject *define_method(Env *, Value, SymbolObject *, Block *);
+    static SymbolObject *undefine_method(Env *, Value, SymbolObject *);
 
-    SymbolObject *define_singleton_method(Env *, SymbolObject *, MethodFnPtr, int);
-    SymbolObject *define_singleton_method(Env *, SymbolObject *, Block *);
-    SymbolObject *undefine_singleton_method(Env *, SymbolObject *);
+    static SymbolObject *define_singleton_method(Env *, Value, SymbolObject *, MethodFnPtr, int);
+    static SymbolObject *define_singleton_method(Env *, Value, SymbolObject *, Block *);
+    static SymbolObject *undefine_singleton_method(Env *, Value, SymbolObject *);
 
     Value main_obj_define_method(Env *, Value, Value, Block *);
     Value main_obj_inspect(Env *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -161,7 +161,7 @@ public:
     RangeObject *as_range_or_raise(Env *);
     StringObject *as_string_or_raise(Env *);
 
-    SymbolObject *to_instance_variable_name(Env *);
+    static SymbolObject *to_instance_variable_name(Env *, Value);
 
     ClassObject *singleton_class() const { return m_singleton_class; }
     static ClassObject *singleton_class(Env *, Value);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -177,6 +177,10 @@ public:
     static Value const_set(Env *, Value, SymbolObject *, Value);
     static Value const_set(Env *, Value, SymbolObject *, MethodFnPtr, StringObject *);
 
+    static bool ivar_defined(Env *, Value, SymbolObject *);
+    static Value ivar_get(Env *, Value, SymbolObject *);
+    static Value ivar_set(Env *, Value, SymbolObject *, Value);
+
     bool ivar_defined(Env *, SymbolObject *);
     Value ivar_get(Env *, SymbolObject *);
     Value ivar_remove(Env *, SymbolObject *);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -166,7 +166,7 @@ public:
     ClassObject *singleton_class() const { return m_singleton_class; }
     static ClassObject *singleton_class(Env *, Value);
 
-    ClassObject *subclass(Env *env, const char *name);
+    static ClassObject *subclass(Env *env, Value superklass, const char *name);
 
     void set_singleton_class(ClassObject *);
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -212,9 +212,9 @@ public:
     void protected_method(Env *, SymbolObject *);
     void module_function(Env *, SymbolObject *);
 
-    void method_alias(Env *env, Value new_name, Value old_name);
-    virtual void method_alias(Env *, SymbolObject *, SymbolObject *);
-    virtual void singleton_method_alias(Env *, SymbolObject *, SymbolObject *);
+    static void method_alias(Env *, Value, Value, Value);
+    static void method_alias(Env *, Value, SymbolObject *, SymbolObject *);
+    static void singleton_method_alias(Env *, Value, SymbolObject *, SymbolObject *);
 
     static nat_int_t object_id(const Value self) { return self.object_id(); }
 

--- a/include/natalie/object_type.hpp
+++ b/include/natalie/object_type.hpp
@@ -21,7 +21,6 @@ enum class ObjectType {
     FileStat,
     Float,
     Hash,
-    Integer,
     Io,
     MatchData,
     Method,

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -139,7 +139,7 @@ private:
                 env->raise("ArgumentError", "can't find user {}", idval->as_string()->c_str());
             uid = pass->pw_uid;
         } else {
-            idval.assert_type(env, Object::Type::Integer, "Integer");
+            idval.assert_integer(env);
             uid = idval.integer().to_nat_int_t();
         }
         return uid;
@@ -153,7 +153,7 @@ private:
                 env->raise("ArgumentError", "can't find group {}", idval->as_string()->c_str());
             gid = grp->gr_gid;
         } else {
-            idval.assert_type(env, Object::Type::Integer, "Integer");
+            idval.assert_integer(env);
             gid = idval.integer().to_nat_int_t();
         }
         return gid;

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -102,7 +102,7 @@ private:
                 // Previously had pushed Value::integer() values, but for large unsigned values
                 // it produced incorrect results.
                 auto bigint = BigInt(*(T *)out.c_str());
-                append(IntegerObject::create(Integer(std::move(bigint))));
+                append(Integer(std::move(bigint)));
             }
             consumed++;
         }

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -46,17 +46,29 @@ public:
     Type type() const { return m_type; }
 
     Object &operator*() {
-        auto_hydrate();
+        if (m_type == Type::Integer) {
+            fprintf(stderr, "Fatal: cannot dereference Value of type Integer\n");
+            abort();
+        }
+
         return *m_object;
     }
 
     Object *operator->() {
-        auto_hydrate();
+        if (m_type == Type::Integer) {
+            fprintf(stderr, "Fatal: cannot dereference Value of type Integer\n");
+            abort();
+        }
+
         return m_object;
     }
 
     Object *object() {
-        auto_hydrate();
+        if (m_type == Type::Integer) {
+            fprintf(stderr, "Fatal: cannot dereference Value of type Integer\n");
+            abort();
+        }
+
         return m_object;
     }
 
@@ -198,12 +210,8 @@ public:
     String dbg_inspect() const;
 
 private:
-    void auto_hydrate();
-
     template <typename Callback>
     Value on_object_value(Callback &&callback);
-
-    void hydrate();
 
     Type m_type { Type::Pointer };
 

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -43,6 +43,7 @@ public:
         // This is required, because initialization by a literal is often ambiguous.
         return Value { integer };
     }
+
     Type type() const { return m_type; }
 
     Object &operator*() {
@@ -131,6 +132,7 @@ public:
 
     nat_int_t object_id() const;
 
+    void assert_integer(Env *) const;
     void assert_type(Env *, ObjectType, const char *) const;
     void assert_not_frozen(Env *) const;
 

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -72,15 +72,12 @@ public:
         return m_object;
     }
 
-    Object *object_or_null() const {
-        if (m_type == Type::Pointer)
-            return m_object;
-        else
-            return nullptr;
-    }
+    const Object *object() const {
+        if (m_type == Type::Integer) {
+            fprintf(stderr, "Fatal: cannot dereference Value of type Integer\n");
+            abort();
+        }
 
-    const Object *object_pointer() const {
-        assert(m_type == Type::Pointer);
         return m_object;
     }
 

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -121,17 +121,6 @@ public:
     // - no implicit conversion of Integer into String
     StringObject *to_str2(Env *env);
 
-    bool is_fast_integer() const {
-        return m_type == Type::Integer;
-    }
-
-    nat_int_t as_fast_integer() const;
-
-    nat_int_t get_fast_integer() const {
-        assert(m_type == Type::Integer);
-        return m_integer.to_nat_int_t();
-    }
-
     const Integer &integer() const;
     Integer &integer();
 

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -147,7 +147,7 @@ Value Etc_nprocessors(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
     const auto result = sysconf(_SC_NPROCESSORS_ONLN);
     if (result < 0) env->raise_errno();
-    return IntegerObject::create(result);
+    return Value::integer(result);
 }
 
 Value Etc_setgrent(Env *env, Value self, Args &&args, Block *_block) {

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -347,7 +347,7 @@ Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     block_env->var_set("ffi_args", 3, true, ffi_args_obj);
     block_env->var_set("fn", 4, true, new VoidPObject { fn });
     Block *block = new Block { std::move(block_env), self, FFI_Library_fn_call_block, 0 };
-    self->define_singleton_method(env, name, block);
+    Object::define_singleton_method(env, self, name, block);
 
     return NilObject::the();
 }

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -388,7 +388,7 @@ Value FFI_Pointer_read_string(Env *env, Value self, Args &&args, Block *) {
 
 Value FFI_Pointer_to_obj(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
-    return (Object *)self.send(env, "address"_s).integer_or_raise(env).to_nat_int_t();
+    return *(Value *)self.send(env, "address"_s).integer_or_raise(env).to_nat_int_t();
 }
 
 Value FFI_Pointer_write_string(Env *env, Value self, Args &&args, Block *) {
@@ -407,8 +407,7 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
     args.ensure_argc_between(env, 1, 3);
 
     size_t size = 0;
-    switch (args.at(0)->type()) {
-    case Object::Type::Symbol: {
+    if (args.at(0).is_symbol()) {
         auto sym = args.at(0)->as_symbol();
         if (sym == "char"_s || sym == "uchar"_s || sym == "int8"_s || sym == "uint8"_s) {
             size = 1;
@@ -431,11 +430,8 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
         } else {
             env->raise("TypeError", "unknown size argument for FFI#initialize: {}", args.at(0).inspect_str(env));
         }
-        break;
-    }
-    default:
+    } else {
         size = IntegerObject::convert_to_native_type<size_t>(env, args.at(0));
-        break;
     }
 
     size_t count = 1;

--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -89,6 +89,13 @@ module FFI
       END
     end
 
+    def self.new_value
+      __inline__ <<~END
+        auto *v = new Value { nullptr };
+        return self.send(env, "new"_s, { Value::integer((uintptr_t)v) });
+      END
+    end
+
     attr_reader :type_size
 
     def null?

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -39,7 +39,7 @@ class Fiddle
     __define_method__ :to_s, <<-END
       auto len = args.size() > 0 ? args[0] : nullptr;
       if (len)
-        len.assert_type(env, Object::Type::Integer, "Integer");
+        len.assert_integer(env);
       auto ptr_obj = self->ivar_get(env, "@ptr"_s);
       ptr_obj.assert_type(env, Object::Type::VoidP, "VoidP");
       auto ptr = (const char *)ptr_obj->as_void_p()->void_ptr();

--- a/lib/linenoise.cpp
+++ b/lib/linenoise.cpp
@@ -182,19 +182,19 @@ Value init_linenoise(Env *env, Value self) {
     auto Linenoise = new ModuleObject { "Linenoise" };
     GlobalEnv::the()->Object()->const_set("Linenoise"_s, Linenoise);
 
-    Linenoise->define_singleton_method(env, "add_history"_s, Linenoise_add_history, 1);
-    Linenoise->define_singleton_method(env, "clear_screen"_s, Linenoise_clear_screen, 0);
-    Linenoise->define_singleton_method(env, "completion_callback="_s, Linenoise_set_completion_callback, 1);
-    Linenoise->define_singleton_method(env, "highlight_callback="_s, Linenoise_set_highlight_callback, 1);
-    Linenoise->define_singleton_method(env, "hints_callback="_s, Linenoise_set_hints_callback, 1);
-    Linenoise->define_singleton_method(env, "history"_s, Linenoise_get_history, 0);
-    Linenoise->define_singleton_method(env, "history="_s, Linenoise_set_history, 1);
-    Linenoise->define_singleton_method(env, "history_max_len="_s, Linenoise_set_history_max_len, 1);
-    Linenoise->define_singleton_method(env, "load_history"_s, Linenoise_load_history, 1);
-    Linenoise->define_singleton_method(env, "multi_line"_s, Linenoise_get_multi_line, 0);
-    Linenoise->define_singleton_method(env, "multi_line="_s, Linenoise_set_multi_line, 1);
-    Linenoise->define_singleton_method(env, "readline"_s, Linenoise_readline, 1);
-    Linenoise->define_singleton_method(env, "save_history"_s, Linenoise_save_history, 1);
+    Object::define_singleton_method(env, Linenoise, "add_history"_s, Linenoise_add_history, 1);
+    Object::define_singleton_method(env, Linenoise, "clear_screen"_s, Linenoise_clear_screen, 0);
+    Object::define_singleton_method(env, Linenoise, "completion_callback="_s, Linenoise_set_completion_callback, 1);
+    Object::define_singleton_method(env, Linenoise, "highlight_callback="_s, Linenoise_set_highlight_callback, 1);
+    Object::define_singleton_method(env, Linenoise, "hints_callback="_s, Linenoise_set_hints_callback, 1);
+    Object::define_singleton_method(env, Linenoise, "history"_s, Linenoise_get_history, 0);
+    Object::define_singleton_method(env, Linenoise, "history="_s, Linenoise_set_history, 1);
+    Object::define_singleton_method(env, Linenoise, "history_max_len="_s, Linenoise_set_history_max_len, 1);
+    Object::define_singleton_method(env, Linenoise, "load_history"_s, Linenoise_load_history, 1);
+    Object::define_singleton_method(env, Linenoise, "multi_line"_s, Linenoise_get_multi_line, 0);
+    Object::define_singleton_method(env, Linenoise, "multi_line="_s, Linenoise_set_multi_line, 1);
+    Object::define_singleton_method(env, Linenoise, "readline"_s, Linenoise_readline, 1);
+    Object::define_singleton_method(env, Linenoise, "save_history"_s, Linenoise_save_history, 1);
 
     return NilObject::the();
 }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -73,7 +73,7 @@ class BindingGen
         puts "    #{binding.rb_class_as_c_variable}->#{binding.set_visibility_method_name}(env, #{binding.rb_method.inspect}_s);"
       end
       binding.aliases.each do |method|
-        puts "    #{binding.rb_class_as_c_variable}->#{binding.alias_name}(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
+        puts "    Object::#{binding.alias_name}(env, #{binding.rb_class_as_c_variable}, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
       end
     end
     @undefine_methods.each { |rb_class, method| puts "    Object::undefine_method(env, #{rb_class}, #{method.inspect}_s);" }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -65,7 +65,7 @@ class BindingGen
         puts '    ' + binding.get_object
         @consts[binding.rb_class] = true
       end
-      puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, #{binding.rb_method.inspect}_s, #{binding.name}, #{binding.arity});"
+      puts "    Object::#{binding.define_method_name}(env, #{binding.rb_class_as_c_variable}, #{binding.rb_method.inspect}_s, #{binding.name}, #{binding.arity});"
       if binding.module_function?
         puts "    #{binding.rb_class_as_c_variable}->module_function(env, #{binding.rb_method.inspect}_s);"
       end
@@ -76,9 +76,9 @@ class BindingGen
         puts "    #{binding.rb_class_as_c_variable}->#{binding.alias_name}(env, #{method.inspect}_s, #{binding.rb_method.inspect}_s);"
       end
     end
-    @undefine_methods.each { |rb_class, method| puts "    #{rb_class}->undefine_method(env, #{method.inspect}_s);" }
+    @undefine_methods.each { |rb_class, method| puts "    Object::undefine_method(env, #{rb_class}, #{method.inspect}_s);" }
     @undefine_singleton_methods.each do |rb_class, method|
-      puts "    #{rb_class}->undefine_singleton_method(env, #{method.inspect}_s);"
+      puts "    Object::undefine_singleton_method(env, #{rb_class}, #{method.inspect}_s);"
     end
     puts '}'
   end

--- a/lib/natalie/compiler/instructions/alias_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/alias_method_instruction.rb
@@ -14,7 +14,7 @@ module Natalie
       def generate(transform)
         old_name = transform.pop
         new_name = transform.pop
-        transform.exec("self->method_alias(env, #{new_name}, #{old_name})")
+        transform.exec("Object::method_alias(env, self, #{new_name}, #{old_name})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_class_instruction.rb
@@ -58,7 +58,7 @@ module Natalie
         code << "    env->raise(\"TypeError\", \"#{@name} is not a class\");"
         code << '  }'
         code << '} else {'
-        code << "  #{klass} = #{superclass}->subclass(env, #{@name.to_s.inspect})"
+        code << "  #{klass} = Object::subclass(env, #{superclass}, #{@name.to_s.inspect})"
         code << "  Object::const_set(env, #{namespace}, #{transform.intern(@name)}, #{klass})"
         code << '}'
         code << "#{klass}->as_class()->eval_body(env, #{fn})"

--- a/lib/natalie/compiler/instructions/define_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_method_instruction.rb
@@ -36,7 +36,7 @@ module Natalie
           body << '}'
           transform.top(body)
         end
-        transform.exec("#{klass}->define_method(env, #{transform.intern(@name)}, #{fn}, #{@arity})")
+        transform.exec("Object::define_method(env, #{klass}, #{transform.intern(@name)}, #{fn}, #{@arity})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -127,7 +127,7 @@ module Natalie
                when 'int', 'unsigned short'
                  "Object::const_set(env, self, \"#{name}\"_s, Value::integer(#{value}))"
                when 'bigint'
-                 "Object::const_set(env, self, \"#{name}\"_s, IntegerObject::create(Integer(BigInt(#{value}))));"
+                 "Object::const_set(env, self, \"#{name}\"_s, Integer(BigInt(#{value})));"
                else
                  raise "I don't yet know how to handle constant of type #{type.inspect}"
                end

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -71,7 +71,7 @@ module Natalie
           when 'double'
             "#{value}->as_float()->to_double()"
           when 'int'
-            "#{value}.as_fast_integer()"
+            "#{value}.integer().to_nat_int_t()"
           when 'bool'
             "#{value}.is_truthy()"
           when 'Value'

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -41,7 +41,7 @@ module Natalie
         arity = arity.value unless arity.is_a?(Integer)
         transform.exec_and_push(
           :method,
-          "self->define_method(env, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
+          "Object::define_method(env, self, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
         )
       end
 
@@ -51,7 +51,7 @@ module Natalie
         arity = arity.value unless arity.is_a?(Integer)
         transform.exec_and_push(
           :method,
-          "self->klass()->define_method(env, #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
+          "Object::define_method(env, self->klass(), #{ruby_name.to_s.inspect}_s, #{cpp_name}, #{arity})",
         )
       end
 

--- a/lib/natalie/compiler/instructions/instance_variable_defined_instruction.rb
+++ b/lib/natalie/compiler/instructions/instance_variable_defined_instruction.rb
@@ -14,7 +14,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec("if (!self->ivar_defined(env, #{transform.intern(@name)})) throw new ExceptionObject")
+        transform.exec("if (!Object::ivar_defined(env, self, #{transform.intern(@name)})) throw new ExceptionObject")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/instance_variable_get_instruction.rb
+++ b/lib/natalie/compiler/instructions/instance_variable_get_instruction.rb
@@ -14,7 +14,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:ivar, "self->ivar_get(env, #{transform.intern(@name)})")
+        transform.exec_and_push(:ivar, "Object::ivar_get(env, self, #{transform.intern(@name)})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/instance_variable_set_instruction.rb
+++ b/lib/natalie/compiler/instructions/instance_variable_set_instruction.rb
@@ -15,7 +15,7 @@ module Natalie
 
       def generate(transform)
         value = transform.pop
-        transform.exec("self->ivar_set(env, #{transform.intern(@name)}, #{value})")
+        transform.exec("Object::ivar_set(env, self, #{transform.intern(@name)}, #{value})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/undefine_method_instruction.rb
+++ b/lib/natalie/compiler/instructions/undefine_method_instruction.rb
@@ -8,7 +8,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec_and_push(:undef_result, "self->undefine_method(env, #{transform.pop}.to_symbol(env, Value::Conversion::Strict))")
+        transform.exec_and_push(:undef_result, "Object::undefine_method(env, self, #{transform.pop}.to_symbol(env, Value::Conversion::Strict))")
       end
 
       def execute(vm)

--- a/lib/natalie/repl.rb
+++ b/lib/natalie/repl.rb
@@ -90,6 +90,7 @@ Linenoise.completion_callback = lambda do |input|
 end
 
 @env = nil
+@result_memory = FFI::Pointer.new_value
 
 GC.disable
 
@@ -128,11 +129,11 @@ loop do
   library = Module.new do
     extend FFI::Library
     ffi_lib temp.path
-    attach_function :EVAL, [:pointer], :pointer
+    attach_function :EVAL, [:pointer, :pointer], :pointer
   end
 
   @env ||= FFI::Pointer.new_env
-  result_ptr = library.EVAL(@env)
+  result_ptr = library.EVAL(@env, @result_memory)
 
   unless result_ptr.null?
     p result_ptr.to_obj

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -1060,52 +1060,52 @@ Value init_openssl(Env *env, Value self) {
 
     OpenSSL->const_set("OPENSSL_VERSION"_s, new StringObject { OPENSSL_VERSION_TEXT });
     OpenSSL->const_set("OPENSSL_VERSION_NUMBER"_s, Value::integer(OPENSSL_VERSION_NUMBER));
-    OpenSSL->define_singleton_method(env, "fixed_length_secure_compare"_s, OpenSSL_fixed_length_secure_compare, 2);
+    Object::define_singleton_method(env, OpenSSL, "fixed_length_secure_compare"_s, OpenSSL_fixed_length_secure_compare, 2);
 
     auto Cipher = OpenSSL->const_get("Cipher"_s);
     if (!Cipher) {
         Cipher = GlobalEnv::the()->Object()->subclass(env, "Cipher");
         OpenSSL->const_set("Cipher"_s, Cipher);
     }
-    Cipher->define_method(env, "initialize"_s, OpenSSL_Cipher_initialize, 1);
-    Cipher->define_method(env, "block_size"_s, OpenSSL_Cipher_block_size, 0);
-    Cipher->define_method(env, "decrypt"_s, OpenSSL_Cipher_decrypt, 0);
-    Cipher->define_method(env, "encrypt"_s, OpenSSL_Cipher_encrypt, 0);
-    Cipher->define_method(env, "final"_s, OpenSSL_Cipher_final, 0);
-    Cipher->define_method(env, "iv="_s, OpenSSL_Cipher_iv_set, 1);
-    Cipher->define_method(env, "iv_len"_s, OpenSSL_Cipher_iv_len, 0);
-    Cipher->define_method(env, "key="_s, OpenSSL_Cipher_key_set, 1);
-    Cipher->define_method(env, "key_len"_s, OpenSSL_Cipher_key_len, 0);
-    Cipher->define_method(env, "update"_s, OpenSSL_Cipher_update, 1);
-    Cipher->define_singleton_method(env, "ciphers"_s, OpenSSL_Cipher_ciphers, 0);
+    Object::define_method(env, Cipher, "initialize"_s, OpenSSL_Cipher_initialize, 1);
+    Object::define_method(env, Cipher, "block_size"_s, OpenSSL_Cipher_block_size, 0);
+    Object::define_method(env, Cipher, "decrypt"_s, OpenSSL_Cipher_decrypt, 0);
+    Object::define_method(env, Cipher, "encrypt"_s, OpenSSL_Cipher_encrypt, 0);
+    Object::define_method(env, Cipher, "final"_s, OpenSSL_Cipher_final, 0);
+    Object::define_method(env, Cipher, "iv="_s, OpenSSL_Cipher_iv_set, 1);
+    Object::define_method(env, Cipher, "iv_len"_s, OpenSSL_Cipher_iv_len, 0);
+    Object::define_method(env, Cipher, "key="_s, OpenSSL_Cipher_key_set, 1);
+    Object::define_method(env, Cipher, "key_len"_s, OpenSSL_Cipher_key_len, 0);
+    Object::define_method(env, Cipher, "update"_s, OpenSSL_Cipher_update, 1);
+    Object::define_singleton_method(env, Cipher, "ciphers"_s, OpenSSL_Cipher_ciphers, 0);
 
     auto Digest = OpenSSL->const_get("Digest"_s);
     if (!Digest) {
         Digest = GlobalEnv::the()->Object()->subclass(env, "Digest");
         OpenSSL->const_set("Digest"_s, Digest);
     }
-    Digest->define_method(env, "initialize"_s, OpenSSL_Digest_initialize, -1);
-    Digest->define_method(env, "block_length"_s, OpenSSL_Digest_block_length, 0);
-    Digest->define_method(env, "digest"_s, OpenSSL_Digest_digest, -1);
-    Digest->define_method(env, "digest_length"_s, OpenSSL_Digest_digest_length, 0);
-    Digest->define_method(env, "reset"_s, OpenSSL_Digest_reset, 0);
-    Digest->define_method(env, "update"_s, OpenSSL_Digest_update, 1);
-    Digest->define_method(env, "<<"_s, OpenSSL_Digest_update, 1);
+    Object::define_method(env, Digest, "initialize"_s, OpenSSL_Digest_initialize, -1);
+    Object::define_method(env, Digest, "block_length"_s, OpenSSL_Digest_block_length, 0);
+    Object::define_method(env, Digest, "digest"_s, OpenSSL_Digest_digest, -1);
+    Object::define_method(env, Digest, "digest_length"_s, OpenSSL_Digest_digest_length, 0);
+    Object::define_method(env, Digest, "reset"_s, OpenSSL_Digest_reset, 0);
+    Object::define_method(env, Digest, "update"_s, OpenSSL_Digest_update, 1);
+    Object::define_method(env, Digest, "<<"_s, OpenSSL_Digest_update, 1);
 
     auto HMAC = OpenSSL->const_get("HMAC"_s);
     if (!HMAC) {
         HMAC = GlobalEnv::the()->Object()->subclass(env, "HMAC");
         OpenSSL->const_set("HMAC"_s, HMAC);
     }
-    HMAC->define_singleton_method(env, "digest"_s, OpenSSL_HMAC_digest, 3);
+    Object::define_singleton_method(env, HMAC, "digest"_s, OpenSSL_HMAC_digest, 3);
 
     auto KDF = OpenSSL->const_get("KDF"_s);
     if (!KDF) {
         KDF = new ModuleObject { "KDF" };
         OpenSSL->const_set("KDF"_s, KDF);
     }
-    KDF->define_singleton_method(env, "pbkdf2_hmac"_s, OpenSSL_KDF_pbkdf2_hmac, -1);
-    KDF->define_singleton_method(env, "scrypt"_s, OpenSSL_KDF_scrypt, -1);
+    Object::define_singleton_method(env, KDF, "pbkdf2_hmac"_s, OpenSSL_KDF_pbkdf2_hmac, -1);
+    Object::define_singleton_method(env, KDF, "scrypt"_s, OpenSSL_KDF_scrypt, -1);
 
     return NilObject::the();
 }

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -302,7 +302,7 @@ Value OpenSSL_Digest_block_length(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
     auto mdctx = static_cast<EVP_MD_CTX *>(self->ivar_get(env, "@mdctx"_s)->as_void_p()->void_ptr());
     const int block_size = EVP_MD_CTX_block_size(mdctx);
-    return IntegerObject::create(block_size);
+    return Value::integer(block_size);
 }
 
 Value OpenSSL_Digest_reset(Env *env, Value self, Args &&args, Block *) {
@@ -349,7 +349,7 @@ Value OpenSSL_Digest_digest_length(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
     auto mdctx = static_cast<EVP_MD_CTX *>(self->ivar_get(env, "@mdctx"_s)->as_void_p()->void_ptr());
     const int digest_length = EVP_MD_CTX_size(mdctx);
-    return IntegerObject::create(digest_length);
+    return Value::integer(digest_length);
 }
 
 Value OpenSSL_HMAC_digest(Env *env, Value self, Args &&args, Block *) {
@@ -1251,7 +1251,7 @@ Value OpenSSL_X509_Name_to_a(Env *env, Value self, Args &&args, Block *) {
             OpenSSL_X509_Name_raise_error(env, "X509_NAME_ENTRY_get_data");
         entry_result->push(new StringObject { reinterpret_cast<const char *>(ASN1_STRING_get0_data(data)), static_cast<size_t>(ASN1_STRING_length(data)) });
 
-        entry_result->push(IntegerObject::create(ASN1_STRING_type(data)));
+        entry_result->push(Value::integer(ASN1_STRING_type(data)));
 
         result->push(entry_result);
     }

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -137,8 +137,8 @@ HashObject *Args::keyword_hash() const {
     if (!m_has_keyword_hash || m_args_size == 0)
         return nullptr;
 
-    auto hash = last().object_or_null();
-    if (!hash || hash->type() != Object::Type::Hash)
+    auto hash = last();
+    if (!hash || !hash.is_hash())
         return nullptr;
 
     return hash->as_hash();

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1475,7 +1475,7 @@ Value ArrayObject::bsearch_index(Env *env, Block *block) {
     if (!result.present())
         return NilObject::the();
 
-    return IntegerObject::create(result.value());
+    return Value::integer(result.value());
 }
 
 Value ArrayObject::rassoc(Env *env, Value needle) {
@@ -1914,7 +1914,7 @@ Value ArrayObject::slice_in_place(Env *env, Value index_obj, Value size) {
             return item;
         }
 
-        size.assert_type(env, ObjectType::Integer, "Integer");
+        size.assert_integer(env);
 
         auto length = size.integer().to_nat_int_t();
 

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -55,7 +55,7 @@ Optional<nat_int_t> binary_search(Env *env, nat_int_t left, nat_int_t right, std
 
 Value binary_search_integer(Env *env, nat_int_t left, nat_int_t right, Block *block, bool exclude_end) {
     auto result = binary_search(env, left, right, [env, block](nat_int_t middle) -> Value {
-        return block->run(env, { IntegerObject::create(middle) }, nullptr);
+        return block->run(env, { Value::integer(middle) }, nullptr);
     });
 
     if (!result.present())
@@ -64,7 +64,7 @@ Value binary_search_integer(Env *env, nat_int_t left, nat_int_t right, Block *bl
     if (exclude_end && result.value() == right)
         return NilObject::the();
 
-    return IntegerObject::create(result.value());
+    return Value::integer(result.value());
 }
 
 union double_as_integer {

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -116,7 +116,7 @@ Value ArithmeticSequenceObject::iterate(Env *env, std::function<Value(Value)> fu
     }
 
     for (Integer i = 0; infinite || i < steps; ++i) {
-        auto value = _step.send(env, "*"_s, { IntegerObject::create(i) }).send(env, "+"_s, { _begin });
+        auto value = _step.send(env, "*"_s, { i }).send(env, "+"_s, { _begin });
 
         // Ensure that we do not yield a number that exceeds `_end`
         if (!infinite && value.send(env, cmp, { _end }).is_truthy())
@@ -171,7 +171,7 @@ Value ArithmeticSequenceObject::hash(Env *env) {
     else
         add(FalseObject::the());
 
-    return IntegerObject::create(hash_builder.digest());
+    return Value::integer(hash_builder.digest());
 }
 
 Value ArithmeticSequenceObject::inspect(Env *env) {
@@ -225,11 +225,11 @@ Value ArithmeticSequenceObject::last(Env *env, Value n) {
         auto array = new ArrayObject { (size_t)count.to_nat_int_t() };
 
         auto _begin = maybe_to_f(env, m_begin);
-        auto last = _begin.send(env, "+"_s, { step().send(env, "*"_s, { IntegerObject::create(steps) }) });
+        auto last = _begin.send(env, "+"_s, { step().send(env, "*"_s, { steps }) });
         if (last.send(env, ">="_s, { _end }).is_truthy())
             last = last.send(env, "-"_s, { step() });
 
-        auto begin = last.send(env, "-"_s, { step().send(env, "*"_s, { IntegerObject::create(count) }) });
+        auto begin = last.send(env, "-"_s, { step().send(env, "*"_s, { count }) });
 
         for (; count > 0; --count) {
             begin = begin.send(env, "+"_s, { step() });
@@ -238,7 +238,7 @@ Value ArithmeticSequenceObject::last(Env *env, Value n) {
 
         return array;
     } else {
-        auto last = m_begin.send(env, "+"_s, { step().send(env, "*"_s, { IntegerObject::create(steps - 1) }) });
+        auto last = m_begin.send(env, "+"_s, { step().send(env, "*"_s, { steps - 1 }) });
         if (last.send(env, ">"_s, { m_end }).is_truthy())
             last = last.send(env, "-"_s, { step() });
         return last;
@@ -272,6 +272,6 @@ Value ArithmeticSequenceObject::size(Env *env) {
             return Value::integer(0);
     }
 
-    return IntegerObject::create(step_count(env));
+    return step_count(env);
 }
 };

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -112,7 +112,7 @@ Value FiberObject::blocking(Env *env, Block *block) {
 }
 
 Value FiberObject::is_blocking_current() {
-    return current()->is_blocking() ? IntegerObject::create(1) : FalseObject::the();
+    return current()->is_blocking() ? Value::integer(1) : FalseObject::the();
 }
 
 Value FiberObject::ref(Env *env, Value key) {

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -448,14 +448,14 @@ Value FileObject::is_size(Env *env, Value path) {
         return NilObject::the();
     if (sb.st_size == 0) // returns nil when file size is zero.
         return NilObject::the();
-    return IntegerObject::create((nat_int_t)(sb.st_size));
+    return Value::integer((nat_int_t)(sb.st_size));
 }
 
 Value FileObject::size(Env *env, Value path) {
     struct stat sb;
     if (ioutil::object_stat(env, path, &sb) == -1)
         env->raise_errno();
-    return IntegerObject::create((nat_int_t)(sb.st_size));
+    return Value::integer((nat_int_t)(sb.st_size));
 }
 
 nat_int_t FileObject::symlink(Env *env, Value from, Value to) {
@@ -485,7 +485,7 @@ nat_int_t FileObject::link(Env *env, Value from, Value to) {
 nat_int_t FileObject::mkfifo(Env *env, Value path, Value mode) {
     mode_t octmode = 0666;
     if (mode) {
-        mode.assert_type(env, Object::Type::Integer, "Integer");
+        mode.assert_integer(env);
         octmode = (mode_t)mode.integer().to_nat_int_t();
     }
     path = ioutil::convert_using_to_path(env, path);
@@ -758,7 +758,7 @@ Value FileObject::utime(Env *env, Args &&args) {
             env->raise_errno();
         }
     }
-    return IntegerObject::create((nat_int_t)(args.size() - 2));
+    return Value::integer((nat_int_t)(args.size() - 2));
 }
 
 Value FileObject::atime(Env *env) { // inst method

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -8,7 +8,7 @@ namespace Natalie {
 
 Value f_to_i_or_bigint(double value) {
     assert(value == ::round(value));
-    return IntegerObject::create(Integer(value));
+    return Integer(value);
 }
 
 Value FloatObject::is_infinite(Env *env) const {
@@ -39,36 +39,36 @@ bool FloatObject::eql(Value other) const {
     return f->m_double == m_double;
 }
 
-#define ROUNDING_OPERATION(name, libm_name)                                     \
-    Value FloatObject::name(Env *env, Value precision_value) {                  \
-        nat_int_t precision = 0;                                                \
-        if (precision_value) {                                                  \
-            if (precision_value.is_float()) {                                   \
-                precision_value = precision_value->as_float()->to_i(env);       \
-            }                                                                   \
-            precision_value.assert_type(env, Object::Type::Integer, "Integer"); \
-            precision = precision_value.integer().to_nat_int_t();               \
-        }                                                                       \
-        if (precision <= 0 && (is_nan() || is_infinity()))                      \
-            env->raise("FloatDomainError", this->inspect_str(env));             \
-                                                                                \
-        if (is_infinity())                                                      \
-            return new FloatObject { m_double };                                \
-                                                                                \
-        FloatObject *result;                                                    \
-        if (precision == 0)                                                     \
-            return f_to_i_or_bigint(::libm_name(m_double));                     \
-                                                                                \
-        double f = ::pow(10, precision);                                        \
-        double rounded = ::libm_name(m_double * f) / f;                         \
-        if (isinf(f) || isinf(rounded)) {                                       \
-            return new FloatObject { m_double };                                \
-        }                                                                       \
-        if (precision < 0)                                                      \
-            return f_to_i_or_bigint(rounded);                                   \
-                                                                                \
-        /* precision > 0 */                                                     \
-        return new FloatObject { rounded };                                     \
+#define ROUNDING_OPERATION(name, libm_name)                               \
+    Value FloatObject::name(Env *env, Value precision_value) {            \
+        nat_int_t precision = 0;                                          \
+        if (precision_value) {                                            \
+            if (precision_value.is_float()) {                             \
+                precision_value = precision_value->as_float()->to_i(env); \
+            }                                                             \
+            precision_value.assert_integer(env);                          \
+            precision = precision_value.integer().to_nat_int_t();         \
+        }                                                                 \
+        if (precision <= 0 && (is_nan() || is_infinity()))                \
+            env->raise("FloatDomainError", this->inspect_str(env));       \
+                                                                          \
+        if (is_infinity())                                                \
+            return new FloatObject { m_double };                          \
+                                                                          \
+        FloatObject *result;                                              \
+        if (precision == 0)                                               \
+            return f_to_i_or_bigint(::libm_name(m_double));               \
+                                                                          \
+        double f = ::pow(10, precision);                                  \
+        double rounded = ::libm_name(m_double * f) / f;                   \
+        if (isinf(f) || isinf(rounded)) {                                 \
+            return new FloatObject { m_double };                          \
+        }                                                                 \
+        if (precision < 0)                                                \
+            return f_to_i_or_bigint(rounded);                             \
+                                                                          \
+        /* precision > 0 */                                               \
+        return new FloatObject { rounded };                               \
     }
 
 ROUNDING_OPERATION(floor, floor)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -181,17 +181,13 @@ Value FloatObject::cmp(Env *env, Value rhs) {
 }
 
 Value FloatObject::coerce(Env *env, Value arg) {
-    ArrayObject *ary = new ArrayObject {};
-    switch (arg->type()) {
-    case Object::Type::Float:
-        ary->push(arg);
-        break;
-    case Object::Type::Integer:
+    ArrayObject *ary = new ArrayObject { 2 };
+    if (arg.is_integer())
         ary->push(new FloatObject { arg.integer().to_double() });
-        break;
-    default:
+    else if (arg.is_float())
+        ary->push(arg);
+    else
         ary->push(KernelModule::Float(env, arg, true));
-    }
     ary->push(this);
     return ary;
 }

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -34,7 +34,7 @@ void MarkingVisitor::visit(const Value val) {
             visit(val.integer().bigint_pointer());
         break;
     case Value::Type::Pointer:
-        visit(val.object_pointer());
+        visit(val.object());
         break;
     default:
         break;

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -253,7 +253,7 @@ Value HashObject::square_new(Env *env, Args &&args, ClassObject *klass) {
             if (value.is_array()) {
                 HashObject *hash = new HashObject { klass };
                 for (auto &pair : *value->as_array()) {
-                    if (pair->type() != Object::Type::Array) {
+                    if (!pair.is_array()) {
                         env->raise("ArgumentError", "wrong element in array to Hash[]");
                     }
                     size_t size = pair->as_array()->size();

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -198,7 +198,7 @@ Value IntegerObject::pow(Env *env, Integer &self, Integer &arg) {
 }
 
 Value IntegerObject::pow(Env *env, Integer &self, Value arg) {
-    if (arg.is_fast_integer())
+    if (arg.is_integer())
         return pow(env, self, arg.integer());
 
     if ((arg.is_float() || arg.is_rational()) && self < 0) {
@@ -252,7 +252,7 @@ Value IntegerObject::powmod(Env *env, Integer &self, Value exponent, Value mod) 
 
 Value IntegerObject::cmp(Env *env, Integer &self, Value arg) {
     auto is_comparable_with = [](Value arg) -> bool {
-        return arg.is_fast_integer() || arg.is_integer() || (arg.is_float() && !arg->as_float()->is_nan());
+        return arg.is_integer() || (arg.is_float() && !arg->as_float()->is_nan());
     };
 
     // Check if we might want to coerce the value
@@ -277,7 +277,7 @@ Value IntegerObject::cmp(Env *env, Integer &self, Value arg) {
 }
 
 bool IntegerObject::eq(Env *env, Integer &self, Value other) {
-    if (other.is_fast_integer())
+    if (other.is_integer())
         return self == other.integer();
 
     if (other.is_float()) {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -82,7 +82,7 @@ Value IntegerObject::add(Env *env, Integer &self, Value arg) {
             return lhs.send(env, "+"_s, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return create(self + arg.integer());
 }
@@ -99,7 +99,7 @@ Value IntegerObject::sub(Env *env, Integer &self, Value arg) {
             return lhs.send(env, "-"_s, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return create(self - arg.integer());
 }
@@ -115,7 +115,7 @@ Value IntegerObject::mul(Env *env, Integer &self, Value arg) {
         arg = rhs;
     }
 
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     if (self == 0 || arg.integer() == 0)
         return Value::integer(0);
@@ -135,7 +135,7 @@ Value IntegerObject::div(Env *env, Integer &self, Value arg) {
             return lhs.send(env, "/"_s, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     auto other = arg.integer();
     if (other == 0)
@@ -156,7 +156,7 @@ Value IntegerObject::mod(Env *env, Integer &self, Value arg) {
         arg = rhs;
     }
 
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
     argument = arg.integer();
 
     if (argument == 0)
@@ -218,7 +218,7 @@ Value IntegerObject::pow(Env *env, Integer &self, Value arg) {
         arg = rhs;
     }
 
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return pow(env, self, arg.integer());
 }
@@ -424,7 +424,7 @@ Value IntegerObject::bitwise_and(Env *env, Integer &self, Value arg) {
             return lhs.send(env, and_symbol, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return create(self & arg.integer());
 }
@@ -438,7 +438,7 @@ Value IntegerObject::bitwise_or(Env *env, Integer &self, Value arg) {
             return lhs.send(env, or_symbol, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return create(self | arg.integer());
 }
@@ -452,7 +452,7 @@ Value IntegerObject::bitwise_xor(Env *env, Integer &self, Value arg) {
             return lhs.send(env, xor_symbol, { rhs });
         arg = rhs;
     }
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     return create(self ^ arg.integer());
 }
@@ -524,7 +524,7 @@ Value IntegerObject::ceil(Env *env, Integer &self, Value arg) {
     if (arg == nullptr)
         return self;
 
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     auto precision = arg.integer().to_nat_int_t();
     if (precision >= 0)
@@ -540,7 +540,7 @@ Value IntegerObject::floor(Env *env, Integer &self, Value arg) {
     if (arg == nullptr)
         return self;
 
-    arg.assert_type(env, Object::Type::Integer, "Integer");
+    arg.assert_integer(env);
 
     auto precision = arg.integer().to_nat_int_t();
     if (precision >= 0)
@@ -553,7 +553,7 @@ Value IntegerObject::floor(Env *env, Integer &self, Value arg) {
 }
 
 Value IntegerObject::gcd(Env *env, Integer &self, Value divisor) {
-    divisor.assert_type(env, Object::Type::Integer, "Integer");
+    divisor.assert_integer(env);
     return Natalie::gcd(self, divisor.integer());
 }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -747,11 +747,9 @@ Value IoObject::seek(Env *env, Value amount_value, Value whence_value) {
     nat_int_t amount = IntegerObject::convert_to_nat_int_t(env, amount_value);
     int whence = 0;
     if (whence_value) {
-        switch (whence_value->type()) {
-        case Object::Type::Integer:
+        if (whence_value.is_integer()) {
             whence = whence_value.integer().to_nat_int_t();
-            break;
-        case Object::Type::Symbol: {
+        } else if (whence_value.is_symbol()) {
             SymbolObject *whence_sym = whence_value->as_symbol();
             if (whence_sym->string() == "SET") {
                 whence = SEEK_SET;
@@ -762,9 +760,7 @@ Value IoObject::seek(Env *env, Value amount_value, Value whence_value) {
             } else {
                 env->raise("TypeError", "no implicit conversion of Symbol into Integer");
             }
-            break;
-        }
-        default:
+        } else {
             env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value.klass()->inspect_str());
         }
     }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -135,7 +135,7 @@ Value IoObject::dup(Env *env) const {
     auto dup_fd = ::dup(fileno(env));
     if (dup_fd < 0)
         env->raise_errno();
-    auto dup_obj = _new(env, m_klass, { IntegerObject::create(dup_fd) }, nullptr)->as_io();
+    auto dup_obj = _new(env, m_klass, { Value::integer(dup_fd) }, nullptr)->as_io();
     dup_obj->set_close_on_exec(env, TrueObject::the());
     dup_obj->autoclose(env, TrueObject::the());
     return dup_obj;
@@ -175,7 +175,7 @@ Value IoObject::fcntl(Env *env, Value cmd_value, Value arg_value) {
         result = ::fcntl(m_fileno, cmd, arg);
     }
     if (result < 0) env->raise_errno();
-    return IntegerObject::create(result);
+    return Value::integer(result);
 }
 
 int IoObject::fdatasync(Env *env) {
@@ -588,7 +588,7 @@ Value IoObject::gets(Env *env, Value sep, Value limit, Value chomp) {
 
     m_lineno++;
     env->set_last_line(line);
-    env->set_last_lineno(IntegerObject::create(m_lineno));
+    env->set_last_lineno(Value::integer(m_lineno));
     return line;
 }
 
@@ -710,7 +710,7 @@ Value IoObject::pwrite(Env *env, Value data, Value offset) {
     auto result = ::pwrite(m_fileno, str->c_str(), str->bytesize(), offset_int);
     if (result < 0)
         env->raise_errno();
-    return IntegerObject::create(result);
+    return Value::integer(result);
 }
 
 Value IoObject::close(Env *env) {
@@ -794,8 +794,8 @@ Value IoObject::set_encoding(Env *env, Value ext_enc, Value int_enc) {
         if (ext_enc->as_string()->include(":")) {
             auto colon = new StringObject { ":" };
             auto encsplit = ext_enc.to_str(env)->split(env, colon, nullptr)->as_array();
-            ext_enc = encsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(0)), nullptr);
-            int_enc = encsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(1)), nullptr);
+            ext_enc = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(0)), nullptr);
+            int_enc = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(1)), nullptr);
         }
     }
 
@@ -864,7 +864,7 @@ Value IoObject::sysopen(Env *env, Value path, Value flags_obj, Value perm) {
 
     path = ioutil::convert_using_to_path(env, path);
     const auto fd = ::open(path->as_string()->c_str(), flags.flags(), modenum);
-    return IntegerObject::create(fd);
+    return Value::integer(fd);
 }
 
 IoObject *IoObject::to_io(Env *env) {
@@ -1028,7 +1028,7 @@ Value IoObject::sysseek(Env *env, Value amount, Value whence) {
     if (!m_read_buffer.is_empty())
         env->raise("IOError", "sysseek for buffered IO");
     seek(env, amount, whence);
-    return IntegerObject::create(pos(env));
+    return Value::integer(pos(env));
 }
 
 Value IoObject::syswrite(Env *env, Value obj) {
@@ -1212,8 +1212,8 @@ Value IoObject::pipe(Env *env, Value external_encoding, Value internal_encoding,
     if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) < 0)
         env->raise_errno();
 
-    auto io_read = _new(env, klass, { IntegerObject::create(pipefd[0]) }, nullptr);
-    auto io_write = _new(env, klass, { IntegerObject::create(pipefd[1]) }, nullptr);
+    auto io_read = _new(env, klass, { Value::integer(pipefd[0]) }, nullptr);
+    auto io_write = _new(env, klass, { Value::integer(pipefd[1]) }, nullptr);
     io_read->as_io()->set_encoding(env, external_encoding, internal_encoding);
     auto pipes = new ArrayObject { io_read, io_write };
 
@@ -1241,7 +1241,7 @@ Value IoObject::popen(Env *env, Args &&args, Block *block, ClassObject *klass) {
     auto fileptr = popen2(command->c_str(), type->c_str(), pid);
     if (!fileptr)
         env->raise_errno();
-    auto io = _new(env, klass, { IntegerObject::create(::fileno(fileptr)) }, nullptr);
+    auto io = _new(env, klass, { Value::integer(::fileno(fileptr)) }, nullptr);
     io->as_io()->m_fileptr = fileptr;
     io->as_io()->m_pid = pid;
 

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -53,9 +53,9 @@ namespace ioutil {
         case Object::Type::String: {
             auto colon = new StringObject { ":" };
             auto flagsplit = flags_obj->as_string()->split(env, colon, nullptr)->as_array();
-            auto flags_str = flagsplit->fetch(env, IntegerObject::create(static_cast<nat_int_t>(0)), new StringObject { "" }, nullptr)->as_string()->string();
-            auto extenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(1)), nullptr);
-            auto intenc = flagsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(2)), nullptr);
+            auto flags_str = flagsplit->fetch(env, Value::integer(static_cast<nat_int_t>(0)), new StringObject { "" }, nullptr)->as_string()->string();
+            auto extenc = flagsplit->ref(env, Value::integer(static_cast<nat_int_t>(1)), nullptr);
+            auto intenc = flagsplit->ref(env, Value::integer(static_cast<nat_int_t>(2)), nullptr);
             if (!extenc.is_nil()) m_external_encoding = EncodingObject::find_encoding(env, extenc);
             if (!intenc.is_nil()) m_internal_encoding = EncodingObject::find_encoding(env, intenc);
 
@@ -134,8 +134,8 @@ namespace ioutil {
             if (encoding->as_string()->include(":")) {
                 auto colon = new StringObject { ":" };
                 auto encsplit = encoding.to_str(env)->split(env, colon, nullptr)->as_array();
-                encoding = encsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(0)), nullptr);
-                auto internal_encoding = encsplit->ref(env, IntegerObject::create(static_cast<nat_int_t>(1)), nullptr);
+                encoding = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(0)), nullptr);
+                auto internal_encoding = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(1)), nullptr);
                 m_internal_encoding = EncodingObject::find_encoding(env, internal_encoding);
             }
             m_external_encoding = EncodingObject::find_encoding(env, encoding);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -745,7 +745,7 @@ Value KernelModule::initialize_copy(Env *env, Value self, Value object) {
     if (object == self)
         return self;
 
-    self->assert_not_frozen(env);
+    self.assert_not_frozen(env);
     if (self.klass() != object.klass())
         env->raise("TypeError", "initialize_copy should take same class object");
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -685,7 +685,7 @@ Value KernelModule::klass_obj(Env *env, Value self) {
 Value KernelModule::define_singleton_method(Env *env, Value self, Value name, Block *block) {
     env->ensure_block_given(block);
     SymbolObject *name_obj = name.to_symbol(env, Value::Conversion::Strict);
-    self->define_singleton_method(env, name_obj, block);
+    Object::define_singleton_method(env, self, name_obj, block);
     return name_obj;
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -888,8 +888,8 @@ Value KernelModule::protected_methods(Env *env, Value self, Value recur) {
 }
 
 Value KernelModule::public_methods(Env *env, Value self, Value recur) {
-    if (self->singleton_class())
-        return self->singleton_class()->public_instance_methods(env, TrueObject::the());
+    if (self.singleton_class())
+        return self.singleton_class()->public_instance_methods(env, TrueObject::the());
     else
         return self.klass()->public_instance_methods(env, recur);
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -500,7 +500,7 @@ Value KernelModule::sleep(Env *env, Value length) {
     } else if (length.is_rational()) {
         secs = length->as_rational()->to_f(env)->as_float()->to_double();
     } else if (length.respond_to(env, "divmod"_s)) {
-        auto divmod = length.send(env, "divmod"_s, { IntegerObject::create(1) })->as_array();
+        auto divmod = length.send(env, "divmod"_s, { Value::integer(1) })->as_array();
         secs = divmod->at(0).to_f(env)->as_float()->to_double();
         secs += divmod->at(1).to_f(env)->as_float()->to_double();
     } else {
@@ -766,7 +766,6 @@ bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_va
     case Object::Type::Nil:
     case Object::Type::True:
     case Object::Type::False:
-    case Object::Type::Integer:
     case Object::Type::Float:
     case Object::Type::Symbol:
         return false;

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -773,7 +773,7 @@ bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_va
     default:
         break;
     }
-    auto name = name_val->to_instance_variable_name(env);
+    auto name = Object::to_instance_variable_name(env, name_val);
     return self->ivar_defined(env, name);
 }
 
@@ -785,12 +785,12 @@ Value KernelModule::instance_variable_get(Env *env, Value self, Value name_val) 
     default:
         break;
     }
-    auto name = name_val->to_instance_variable_name(env);
+    auto name = Object::to_instance_variable_name(env, name_val);
     return self->ivar_get(env, name);
 }
 
 Value KernelModule::instance_variable_set(Env *env, Value self, Value name_val, Value value) {
-    auto name = name_val->to_instance_variable_name(env);
+    auto name = Object::to_instance_variable_name(env, name_val);
     self->assert_not_frozen(env);
     self->ivar_set(env, name, value);
     return value;
@@ -899,7 +899,7 @@ Value KernelModule::public_methods(Env *env, Value self, Value recur) {
 }
 
 Value KernelModule::remove_instance_variable(Env *env, Value self, Value name_val) {
-    auto name = name_val->to_instance_variable_name(env);
+    auto name = Object::to_instance_variable_name(env, name_val);
     self->assert_not_frozen(env);
     return self->ivar_remove(env, name);
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -778,20 +778,16 @@ bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_va
 }
 
 Value KernelModule::instance_variable_get(Env *env, Value self, Value name_val) {
-    switch (self->type()) {
-    case Object::Type::Integer:
-    case Object::Type::Float:
+    if (self.is_integer() || self.is_float())
         return NilObject::the();
-    default:
-        break;
-    }
+
     auto name = Object::to_instance_variable_name(env, name_val);
     return self->ivar_get(env, name);
 }
 
 Value KernelModule::instance_variable_set(Env *env, Value self, Value name_val, Value value) {
     auto name = Object::to_instance_variable_name(env, name_val);
-    self->assert_not_frozen(env);
+    self.assert_not_frozen(env);
     self->ivar_set(env, name, value);
     return value;
 }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -499,7 +499,7 @@ SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFn
         visibility = MethodVisibility::Private;
     define_method(env, name, method, visibility);
     if (m_module_function)
-        define_singleton_method(env, name, fn, arity);
+        Object::define_singleton_method(env, this, name, fn, arity);
     return name;
 }
 
@@ -508,7 +508,7 @@ SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, Block *b
     Method *method = new Method { name->string(), this, block };
     define_method(env, name, method, m_method_visibility);
     if (m_module_function)
-        define_singleton_method(env, name, block);
+        Object::define_singleton_method(env, this, name, block);
     return name;
 }
 
@@ -1020,7 +1020,7 @@ Value ModuleObject::module_function(Env *env, Args &&args) {
             auto method_info = find_method(env, name);
             assert_method_defined(env, name, method_info);
             auto method = method_info.method();
-            define_singleton_method(env, name, method->fn(), method->arity());
+            Object::define_singleton_method(env, this, name, method->fn(), method->arity());
             m_methods.put(name, MethodInfo(MethodVisibility::Private, method));
         }
     } else {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -822,7 +822,7 @@ Value ModuleObject::attr_reader_block_fn(Env *env, Value self, Args &&args, Bloc
     assert(name_obj);
     assert(name_obj.is_symbol());
     SymbolObject *ivar_name = SymbolObject::intern(TM::String::format("@{}", name_obj->as_symbol()->string()));
-    return self->ivar_get(env, ivar_name);
+    return Object::ivar_get(env, self, ivar_name);
 }
 
 ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
@@ -850,7 +850,7 @@ Value ModuleObject::attr_writer_block_fn(Env *env, Value self, Args &&args, Bloc
     assert(name_obj);
     assert(name_obj.is_symbol());
     SymbolObject *ivar_name = SymbolObject::intern(TM::String::format("@{}", name_obj->as_symbol()->string()));
-    self->ivar_set(env, ivar_name, val);
+    Object::ivar_set(env, self, ivar_name, val);
     return val;
 }
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -622,7 +622,7 @@ void handle_top_level_exception(Env *env, ExceptionObject *exception, bool run_e
         }
     } else if (exception_value.is_a(env, find_top_level_const(env, "SignalException"_s)->as_class())) {
         Value signo = exception->ivar_get(env, "@signo"_s);
-        if (signo->type() == Object::Type::Integer) {
+        if (signo.is_integer()) {
             auto val = signo.integer().to_nat_int_t();
             if (val >= 0 && val <= 255) {
                 clean_up_and_exit(val + 128);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -83,7 +83,7 @@ Env *build_top_env() {
     Object->const_set("Numeric"_s, Numeric);
     Numeric->include_once(env, Comparable);
 
-    ClassObject *Integer = Numeric->subclass(env, "Integer", Object::Type::Integer);
+    ClassObject *Integer = Numeric->subclass(env, "Integer", Object::Type::Object);
     global_env->set_Integer(Integer);
     Object->const_set("Integer"_s, Integer);
 
@@ -718,7 +718,7 @@ void arg_spread(Env *env, const Args &args, const char *arrangement, ...) {
             int *int_ptr = va_arg(va_args, int *); // NOLINT(clang-analyzer-valist.Uninitialized) bug in clang-tidy?
             if (arg_index >= args.size()) env->raise("ArgumentError", "wrong number of arguments (given {}, expected {})", args.size(), arg_index + 1);
             Value obj = args[arg_index++];
-            obj.assert_type(env, Object::Type::Integer, "Integer");
+            obj.assert_integer(env);
             *int_ptr = obj.integer().to_nat_int_t();
             break;
         }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -58,8 +58,8 @@ Env *build_top_env() {
     ClassObject *EnumeratorArithmeticSequence = Enumerator->subclass(env, "ArithmeticSequence", Object::Type::EnumeratorArithmeticSequence);
     Enumerator->const_set("ArithmeticSequence"_s, EnumeratorArithmeticSequence);
 
-    BasicObject->define_singleton_method(env, "new"_s, Object::_new, -1);
-    BasicObject->define_singleton_method(env, "allocate"_s, Object::allocate, -1);
+    Object::define_singleton_method(env, BasicObject, "new"_s, Object::_new, -1);
+    Object::define_singleton_method(env, BasicObject, "allocate"_s, Object::allocate, -1);
 
     ClassObject *NilClass = Object->subclass(env, "NilClass", Object::Type::Nil);
     Object->const_set("NilClass"_s, NilClass);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -696,6 +696,23 @@ Value Object::const_set(Env *env, Value ns, SymbolObject *name, MethodFnPtr auto
         env->raise("TypeError", "{} is not a class/module", ns.inspect_str(env));
 }
 
+bool Object::ivar_defined(Env *env, Value self, SymbolObject *name) {
+    if (self.is_integer() || self.is_float())
+        return false;
+    return self->ivar_defined(env, name);
+}
+
+Value Object::ivar_get(Env *env, Value self, SymbolObject *name) {
+    if (self.is_integer() || self.is_float())
+        return NilObject::the();
+    return self->ivar_get(env, name);
+}
+
+Value Object::ivar_set(Env *env, Value self, SymbolObject *name, Value val) {
+    self.assert_not_frozen(env);
+    return self->ivar_set(env, name, val);
+}
+
 bool Object::ivar_defined(Env *env, SymbolObject *name) {
     if (!name->is_ivar_name())
         env->raise_name_error(name, "`{}' is not allowed as an instance variable name", name->string());

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1148,7 +1148,7 @@ void Object::copy_instance_variables(const Value other) {
     if (other.is_integer())
         return;
 
-    auto ivars = other.object_pointer()->m_ivars;
+    auto ivars = other.object()->m_ivars;
     if (ivars)
         m_ivars = new TM::Hashmap<SymbolObject *, Value> { *ivars };
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -129,7 +129,6 @@ Value Object::create(Env *env, ClassObject *klass) {
     case Object::Type::Env:
     case Object::Type::False:
     case Object::Type::Float:
-    case Object::Type::Integer:
     case Object::Type::Method:
     case Object::Type::Nil:
     case Object::Type::Rational:
@@ -776,8 +775,6 @@ Value Object::ivar_set(Env *env, SymbolObject *name, Value val) {
 }
 
 Value Object::instance_variables(Env *env) {
-    assert(m_type != Type::Integer);
-
     if (m_type == Type::Float || !m_ivars)
         return new ArrayObject;
 
@@ -1067,8 +1064,6 @@ Value Object::duplicate(Env *env) const {
         return new FloatObject { *as_float() };
     case Object::Type::Hash:
         return new HashObject { env, *as_hash() };
-    case Object::Type::Integer:
-        return IntegerObject::integer(static_cast<const IntegerObject *>(this));
     case Object::Type::Module:
         return new ModuleObject { *as_module() };
     case Object::Type::Nil:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -589,12 +589,12 @@ StringObject *Object::as_string_or_raise(Env *env) {
     return static_cast<StringObject *>(this);
 }
 
-SymbolObject *Object::to_instance_variable_name(Env *env) {
-    SymbolObject *symbol = Value(this).to_symbol(env, Value::Conversion::Strict); // TypeError if not Symbol/String
+SymbolObject *Object::to_instance_variable_name(Env *env, Value name) {
+    SymbolObject *symbol = name.to_symbol(env, Value::Conversion::Strict); // TypeError if not Symbol/String
 
     if (!symbol->is_ivar_name()) {
-        if (m_type == Type::String) {
-            env->raise_name_error(as_string(), "`{}' is not allowed as an instance variable name", symbol->string());
+        if (name.is_string()) {
+            env->raise_name_error(name->as_string(), "`{}' is not allowed as an instance variable name", symbol->string());
         } else {
             env->raise_name_error(symbol, "`{}' is not allowed as an instance variable name", symbol->string());
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -643,10 +643,10 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
     return self->m_singleton_class;
 }
 
-ClassObject *Object::subclass(Env *env, const char *name) {
-    if (m_type != Type::Class)
-        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", klass()->inspect_str());
-    return as_class()->subclass(env, name);
+ClassObject *Object::subclass(Env *env, Value superclass, const char *name) {
+    if (!superclass.is_class())
+        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_str());
+    return superclass->as_class()->subclass(env, name);
 }
 
 void Object::extend_once(Env *env, ModuleObject *module) {

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -25,7 +25,7 @@ Value ProcessModule::groups(Env *env) {
         env->raise_errno();
     auto result = new ArrayObject { static_cast<size_t>(size) };
     for (size_t i = 0; i < static_cast<size_t>(size); i++) {
-        result->push(IntegerObject::create(list[i]));
+        result->push(Value::integer(list[i]));
     }
     return result;
 }

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -357,7 +357,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto right = left + 1;
 
         // Find a right border in which we can perform the binary search.
-        while (binary_search_check(env, block->run(env, { IntegerObject::create(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
+        while (binary_search_check(env, block->run(env, { Value::integer(right) }, nullptr)) != BSearchCheckResult::SMALLER) {
             right = left + (right - left) * 2;
         }
 
@@ -367,7 +367,7 @@ Value RangeObject::bsearch(Env *env, Block *block) {
         auto left = right - 1;
 
         // Find a left border in which we can perform the binary search.
-        while (binary_search_check(env, block->run(env, { IntegerObject::create(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
+        while (binary_search_check(env, block->run(env, { Value::integer(left) }, nullptr)) != BSearchCheckResult::BIGGER) {
             left = right - (right - left) * 2;
         }
 

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -255,7 +255,7 @@ String RangeObject::dbg_inspect() const {
         if (v.is_fast_integer()) {
             str.append(v.get_fast_integer());
         } else {
-            auto obj = v.object_or_null();
+            auto obj = v.object();
             assert(obj);
             if (type() != Type::Nil)
                 str.append(obj->dbg_inspect());

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -252,8 +252,8 @@ Value RangeObject::last(Env *env, Value n) {
 String RangeObject::dbg_inspect() const {
     String str;
     auto append = [&](Value v) {
-        if (v.is_fast_integer()) {
-            str.append(v.get_fast_integer());
+        if (v.is_integer()) {
+            str.append(v.integer().to_nat_int_t());
         } else {
             auto obj = v.object();
             assert(obj);
@@ -302,10 +302,10 @@ bool RangeObject::eql(Env *env, Value other_value) {
 }
 
 bool RangeObject::include(Env *env, Value arg) {
-    if (arg.is_fast_integer() && m_begin.is_fast_integer() && m_end.is_fast_integer()) {
-        const auto begin = m_begin.get_fast_integer();
-        const auto end = m_end.get_fast_integer();
-        const auto i = arg.get_fast_integer();
+    if (arg.is_integer() && m_begin.is_integer() && m_end.is_integer()) {
+        const auto begin = m_begin.integer().to_nat_int_t();
+        const auto end = m_end.integer().to_nat_int_t();
+        const auto i = arg.integer().to_nat_int_t();
 
         const auto larger_than_begin = begin <= i;
         const auto smaller_than_end = m_exclude_end ? i < end : i <= end;

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -220,9 +220,7 @@ Value RegexpObject::initialize(Env *env, Value pattern, Value opts) {
 
     nat_int_t options = 0;
     if (opts != nullptr) {
-        if (opts.is_fast_integer()) {
-            options = opts.get_fast_integer();
-        } else if (opts.is_integer()) {
+        if (opts.is_integer()) {
             options = opts.integer().to_nat_int_t();
         } else if (opts.is_string()) {
             for (auto c : *opts->as_string()) {
@@ -519,16 +517,10 @@ bool RegexpObject::has_match(Env *env, Value other, Value start) {
     StringObject *str_obj = other->as_string();
 
     nat_int_t start_index = 0;
-    if (start != nullptr) {
-        if (start.is_fast_integer()) {
-            start_index = start.get_fast_integer();
-        } else if (start.is_integer()) {
-            start_index = start.integer().to_nat_int_t();
-        }
-    }
-    if (start_index < 0) {
+    if (start && start.is_integer())
+        start_index = start.integer().to_nat_int_t();
+    if (start_index < 0)
         start_index += str_obj->length();
-    }
 
     int result = search(env, str_obj, start_index, nullptr, ONIG_OPTION_NONE);
 

--- a/src/signal_module.cpp
+++ b/src/signal_module.cpp
@@ -7,140 +7,140 @@ namespace Natalie {
 Value SignalModule::list(Env *env) {
     return new HashObject { env, {
                                      new StringObject { "EXIT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(0)),
+                                     Value::integer(static_cast<nat_int_t>(0)),
                                      new StringObject { "HUP" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGHUP)),
+                                     Value::integer(static_cast<nat_int_t>(SIGHUP)),
                                      new StringObject { "INT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGINT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGINT)),
                                      new StringObject { "QUIT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGQUIT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGQUIT)),
                                      new StringObject { "ILL" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGILL)),
+                                     Value::integer(static_cast<nat_int_t>(SIGILL)),
 #ifdef SIGTRAP
                                      new StringObject { "TRAP" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGTRAP)),
+                                     Value::integer(static_cast<nat_int_t>(SIGTRAP)),
 #endif
                                      new StringObject { "ABRT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGABRT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGABRT)),
 #ifdef SIGIOT
                                      new StringObject { "IOT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGIOT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGIOT)),
 #endif
 #ifdef SIGEMT
                                      new StringObject { "EMT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGEMT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGEMT)),
 #endif
                                      new StringObject { "FPE" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGFPE)),
+                                     Value::integer(static_cast<nat_int_t>(SIGFPE)),
                                      new StringObject { "KILL" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGKILL)),
+                                     Value::integer(static_cast<nat_int_t>(SIGKILL)),
 #ifdef SIGBUS
                                      new StringObject { "BUS" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGBUS)),
+                                     Value::integer(static_cast<nat_int_t>(SIGBUS)),
 #endif
                                      new StringObject { "SEGV" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGSEGV)),
+                                     Value::integer(static_cast<nat_int_t>(SIGSEGV)),
                                      new StringObject { "SYS" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGSYS)),
+                                     Value::integer(static_cast<nat_int_t>(SIGSYS)),
                                      new StringObject { "PIPE" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGPIPE)),
+                                     Value::integer(static_cast<nat_int_t>(SIGPIPE)),
                                      new StringObject { "ALRM" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGALRM)),
+                                     Value::integer(static_cast<nat_int_t>(SIGALRM)),
                                      new StringObject { "TERM" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGTERM)),
+                                     Value::integer(static_cast<nat_int_t>(SIGTERM)),
 #ifdef SIGURG
                                      new StringObject { "URG" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGURG)),
+                                     Value::integer(static_cast<nat_int_t>(SIGURG)),
 #endif
                                      new StringObject { "STOP" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGSTOP)),
+                                     Value::integer(static_cast<nat_int_t>(SIGSTOP)),
                                      new StringObject { "TSTP" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGTSTP)),
+                                     Value::integer(static_cast<nat_int_t>(SIGTSTP)),
                                      new StringObject { "CONT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGCONT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGCONT)),
                                      new StringObject { "CHLD" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGCHLD)),
+                                     Value::integer(static_cast<nat_int_t>(SIGCHLD)),
                                      new StringObject { "CLD" },
 #ifdef SIGCLD
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGCLD)),
+                                     Value::integer(static_cast<nat_int_t>(SIGCLD)),
 #else
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGCHLD)),
+                                     Value::integer(static_cast<nat_int_t>(SIGCHLD)),
 #endif
                                      new StringObject { "TTIN" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGTTIN)),
+                                     Value::integer(static_cast<nat_int_t>(SIGTTIN)),
                                      new StringObject { "TTOU" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGTTOU)),
+                                     Value::integer(static_cast<nat_int_t>(SIGTTOU)),
 #ifdef SIGIO
                                      new StringObject { "IO" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGIO)),
+                                     Value::integer(static_cast<nat_int_t>(SIGIO)),
 #endif
 #ifdef SIGXCPU
                                      new StringObject { "XCPU" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGXCPU)),
+                                     Value::integer(static_cast<nat_int_t>(SIGXCPU)),
 #endif
 #ifdef SIGXFSZ
                                      new StringObject { "XFSZ" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGXFSZ)),
+                                     Value::integer(static_cast<nat_int_t>(SIGXFSZ)),
 #endif
 #ifdef SIGVTALRM
                                      new StringObject { "VTALRM" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGVTALRM)),
+                                     Value::integer(static_cast<nat_int_t>(SIGVTALRM)),
 #endif
 #ifdef SIGPROF
                                      new StringObject { "PROF" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGPROF)),
+                                     Value::integer(static_cast<nat_int_t>(SIGPROF)),
 #endif
 #ifdef SIGWINCH
                                      new StringObject { "WINCH" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGWINCH)),
+                                     Value::integer(static_cast<nat_int_t>(SIGWINCH)),
 #endif
                                      new StringObject { "USR1" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGUSR1)),
+                                     Value::integer(static_cast<nat_int_t>(SIGUSR1)),
                                      new StringObject { "USR2" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGUSR2)),
+                                     Value::integer(static_cast<nat_int_t>(SIGUSR2)),
 #ifdef SIGLOST
                                      new StringObject { "LOST" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGLOST)),
+                                     Value::integer(static_cast<nat_int_t>(SIGLOST)),
 #endif
 #ifdef SIGMSG
                                      new StringObject { "MSG" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGMSG)),
+                                     Value::integer(static_cast<nat_int_t>(SIGMSG)),
 #endif
 #ifdef SIGPWR
                                      new StringObject { "PWR" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGPWR)),
+                                     Value::integer(static_cast<nat_int_t>(SIGPWR)),
 #endif
 #ifdef SIGPOLL
                                      new StringObject { "POLL" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGPOLL)),
+                                     Value::integer(static_cast<nat_int_t>(SIGPOLL)),
 #endif
 #ifdef SIGDANGER
                                      new StringObject { "DANGER" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGDANGER)),
+                                     Value::integer(static_cast<nat_int_t>(SIGDANGER)),
 #endif
 #ifdef SIGMIGRATE
                                      new StringObject { "MIGRATE" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGMIGRATE)),
+                                     Value::integer(static_cast<nat_int_t>(SIGMIGRATE)),
 #endif
 #ifdef SIGPRE
                                      new StringObject { "PRE" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGPRE)),
+                                     Value::integer(static_cast<nat_int_t>(SIGPRE)),
 #endif
 #ifdef SIGGRANT
                                      new StringObject { "GRANT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGGRANT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGGRANT)),
 #endif
 #ifdef SIGRETRACT
                                      new StringObject { "RETRACT" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGRETRACT)),
+                                     Value::integer(static_cast<nat_int_t>(SIGRETRACT)),
 #ifdef SIGSOUND
 #endif
                                      new StringObject { "SOUND" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGSOUND)),
+                                     Value::integer(static_cast<nat_int_t>(SIGSOUND)),
 #endif
 #ifdef SIGINFO
                                      new StringObject { "INFO" },
-                                     IntegerObject::create(static_cast<nat_int_t>(SIGINFO)),
+                                     Value::integer(static_cast<nat_int_t>(SIGINFO)),
 #endif
                                  } };
 }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2423,8 +2423,8 @@ Value StringObject::refeq(Env *env, Value arg1, Value arg2, Value value) {
     nat_int_t begin;
     nat_int_t end = -1;
     nat_int_t expand_length = 0;
-    if (arg1.is_fast_integer()) {
-        begin = process_begin(arg1.get_fast_integer());
+    if (arg1.is_integer()) {
+        begin = process_begin(arg1.integer().to_nat_int_t());
         end = get_end_by_length(begin, arg2);
     } else if (arg1.is_range()) {
         assert(arg2 == nullptr);

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1102,7 +1102,7 @@ Value StringObject::count(Env *env, Args &&args) {
         if (handler(character))
             total_count++;
     }
-    return IntegerObject::create(total_count);
+    return Value::integer(total_count);
 }
 
 Value StringObject::crypt(Env *env, Value salt) {
@@ -2610,7 +2610,7 @@ Value StringObject::getbyte(Env *env, Value index_obj) const {
     }
 
     unsigned char byte = m_string[index];
-    return IntegerObject::create(Integer(byte));
+    return Integer(byte);
 }
 
 void StringObject::regexp_sub(Env *env, TM::String &out, StringObject *orig_string, RegexpObject *find, Value replacement_value, MatchDataObject **match, StringObject **expanded_replacement, size_t byte_index, Block *block) {
@@ -2822,7 +2822,7 @@ Value StringObject::to_i(Env *env, Value base_obj) const {
 
     nat_int_t number = strtoll(digits_only.c_str(), nullptr, base);
     if (number == NAT_INT_MIN || number == NAT_INT_MAX) {
-        return IntegerObject::create(BigInt(std::move(digits_only), base));
+        return Integer(BigInt(std::move(digits_only), base));
     }
     return Value::integer(number);
 }
@@ -3829,10 +3829,6 @@ void StringObject::append(const FloatObject *f) {
     m_string.append(f->to_s());
 }
 
-void StringObject::append(const IntegerObject *i) {
-    m_string.append(IntegerObject::to_s(i));
-}
-
 void StringObject::append(const String &str) {
     m_string.append(str);
 }
@@ -3866,9 +3862,6 @@ void StringObject::append(Value val) {
         break;
     case Type::Float:
         append(obj->as_float());
-        break;
-    case Type::Integer:
-        append(static_cast<IntegerObject *>(obj));
         break;
     case Type::Nil:
         append("nil");
@@ -3978,11 +3971,11 @@ Value StringObject::convert_integer(Env *env, nat_int_t base) {
     auto convint = strtoll(str.c_str(), &end, base);
     if (convint == NAT_INT_MIN || convint == NAT_INT_MAX) {
         if (signchar == '-') str.prepend_char(signchar);
-        return IntegerObject::create(BigInt(str, base));
+        return Integer(BigInt(str, base));
     }
 
     if (end == NULL || end[0] == '\0') {
-        return IntegerObject::create(Integer(convint * sign));
+        return Integer(convint * sign);
     }
 
     return nullptr;

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -288,7 +288,7 @@ Value TimeObject::usec(Env *env) {
 }
 
 Value TimeObject::utc_offset(Env *env) const {
-    return IntegerObject::create((nat_int_t)m_time.tm_gmtoff);
+    return Value::integer((nat_int_t)m_time.tm_gmtoff);
 }
 
 Value TimeObject::wday(Env *) const {
@@ -414,7 +414,7 @@ nat_int_t TimeObject::normalize_month(Env *env, Value val) {
             val = val.to_int(env);
         }
     }
-    val.assert_type(env, Object::Type::Integer, "Integer");
+    val.assert_integer(env);
     auto month_i = val.integer() - 1;
     if (month_i < 0 || month_i > 11) {
         env->raise("ArgumentError", "mon out of range");

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -10,7 +10,7 @@ namespace Natalie {
     if (is_profiled) {                                                                  \
         auto classnameOf = [](Value val) -> String {                                    \
             if (val.m_type == Type::Integer)                                            \
-                return String("FastInteger");                                           \
+                return String("Integer");                                               \
             auto maybe_classname = val.klass()->name();                                 \
             if (maybe_classname.present())                                              \
                 return maybe_classname.value();                                         \
@@ -150,13 +150,6 @@ Value Value::send(Env *env, SymbolObject *name, Args &&args, Block *block, Value
         return integer_send(env, name, std::move(args), block, sent_from, MethodVisibility::Private);
 
     return m_object->send(env, name, std::move(args), block, sent_from);
-}
-
-nat_int_t Value::as_fast_integer() const {
-    assert(m_type == Type::Integer || (m_type == Type::Pointer && m_object->type() == Object::Type::Integer));
-    if (m_type == Type::Integer)
-        return m_integer.to_nat_int_t();
-    return IntegerObject::to_nat_int_t(static_cast<IntegerObject *>(m_object));
 }
 
 bool Value::operator==(Value other) const {

--- a/test/natalie/libnat_test.rb
+++ b/test/natalie/libnat_test.rb
@@ -55,11 +55,12 @@ describe 'libnat.so' do
     library = Module.new do
       extend FFI::Library
       ffi_lib(temp_path)
-      attach_function :EVAL, [:pointer], :pointer
+      attach_function :EVAL, [:pointer, :pointer], :pointer
     end
 
     env = FFI::Pointer.from_env
-    result = library.EVAL(env).to_obj
+    result_memory = FFI::Pointer.new_value
+    result = library.EVAL(env, result_memory).to_obj
     result.should == 3
   ensure
     File.unlink(temp_path)

--- a/test/support/require/cpp_file.cpp
+++ b/test/support/require/cpp_file.cpp
@@ -7,6 +7,6 @@ Value defn_cpp_file(Env *env, Value self, Args &&, Block *block) {
 }
 
 Value init_cpp_file(Env *env, Value self) {
-    self->define_method(env, "cpp_file"_s, defn_cpp_file, 0);
+    Object::define_method(env, self, "cpp_file"_s, defn_cpp_file, 0);
     return NilObject::the();
 }


### PR DESCRIPTION
This is the last of the big work to eliminate Integer hydration. Integers are no longer created on the heap.

I'm not entirely happy with all the static functions on `Object`, so I may revisit and refactor as I have time and better ideas.

I have half a mind to remove the magic dereferencing of Value and require that we always call `.integer()` or `.object()`, but I want to think on that for a time...