### PR TITLE
Fix Complex#to_r with imaginary any zero object

### DIFF
--- a/spec/core/complex/to_r_spec.rb
+++ b/spec/core/complex/to_r_spec.rb
@@ -42,9 +42,7 @@ describe "Complex#to_r" do
 
     ruby_version_is '3.4' do
       it "returns a Rational" do
-        NATFIXME 'it returns a Rational', exception: RangeError, message: "can't convert 0+0.0i into Rational" do
-          Complex(0, 0.0).to_r.should == 0r
-        end
+        Complex(0, 0.0).to_r.should == 0r
       end
     end
   end

--- a/src/complex.rb
+++ b/src/complex.rb
@@ -355,7 +355,7 @@ class Complex
 
   def to_r
     imaginary = self.imaginary
-    if not _exact_zero?(imaginary)
+    unless imaginary.zero?
       raise RangeError, "can't convert #{self} into Rational"
     end
 


### PR DESCRIPTION
Ruby 3.4 has relaxed the constraints a bit (but not for methods like `Complex#to_f`, so things are getting a bit inconsistent).