### PR TITLE
Add specs for Process.ppid

### DIFF
--- a/spec/core/process/ppid_spec.rb
+++ b/spec/core/process/ppid_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "Process.ppid" do
+  platform_is_not :windows do
+    it "returns the process id of the parent of this process" do
+      NATFIXME 'Natalie puts an extra process in between for compliation, this will not work by design' do
+        ruby_exe("puts Process.ppid").should == "#{Process.pid}\n"
+      end
+    end
+  end
+end

--- a/test/natalie/process_test.rb
+++ b/test/natalie/process_test.rb
@@ -49,4 +49,35 @@ describe 'Process' do
       end
     end
   end
+
+  describe '.ppid' do
+    before :each do
+      @file = tmp('ppid')
+      @exe = tmp('exe')
+      @natalie = ENV.fetch('NAT_BINARY', 'bin/natalie') # Force to use Natalie, not MRI, in the subprocess
+    end
+
+    after :each do
+      rm_r @file
+      rm_r @exe
+    end
+
+    it 'returns the main Natalie process' do
+      pid = spawn(@natalie, '-e', "File.open(#{@file.dump}, 'w') { |f| f.puts(Process.ppid) }")
+      Process.wait(pid)
+      $?.exitstatus.should == 0
+      File.read(@file).chomp.to_i.should == pid
+    end
+
+    it 'returns this process if we create an executable' do
+      pid = spawn(@natalie, '-c', @exe, '-e', "File.open(#{@file.dump}, 'w') { |f| f.puts(Process.ppid) }")
+      Process.wait(pid)
+      $?.exitstatus.should == 0
+
+      pid = spawn(@exe)
+      Process.wait(pid)
+      $?.exitstatus.should == 0
+      File.read(@file).chomp.to_i.should == Process.pid
+    end
+  end
 end


### PR DESCRIPTION
This does not work as regular MRI by design. The method is a call to getppid(3), which returns the parent pid. In the case of Natalie, the regular workflow will return the pid of `bin/natalie`, wich is still running and waiting for the child process to terminate so it can clean up the temporary executable. There is no way around this without getting some RPC in place to let the child process query the parent process so it can find its grandparents pid.

If we create a binary and run that directly, Process.ppid does work as intended.