### PR TITLE
Implement first version of Dir.mktmpdir

### DIFF
--- a/lib/tmpdir.cpp
+++ b/lib/tmpdir.cpp
@@ -1,8 +1,24 @@
 #include "natalie.hpp"
 
+#include <stdio.h>
 #include <stdlib.h>
 
 using namespace Natalie;
+
+Value Dir_mktmpdir(Env *env, Value self, Args &&args, Block *) {
+    if (args.size() != 0)
+        env->raise("ArgumentError", "TODO: Support arguments");
+    String tmpdir = self->send(env, "tmpdir"_s)->as_string()->string();
+    tmpdir.append("/XXXXXX");
+    auto fh = mkstemp(&tmpdir[0]);
+    if (fh < 0)
+        env->raise_errno();
+    close(fh);
+    unlink(tmpdir.c_str());
+    auto result = new StringObject { std::move(tmpdir) };
+    self->send(env, "mkdir"_s, { result });
+    return result;
+}
 
 Value Dir_tmpdir(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);

--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -3,7 +3,9 @@
 require 'natalie/inline'
 require 'etc.cpp' # For Dir.tmp fallback to Etc.systmpdir
 require 'tmpdir.cpp'
+require 'fileutils'
 
 class Dir
+  __bind_static_method__ :mktmpdir, :Dir_mktmpdir
   __bind_static_method__ :tmpdir, :Dir_tmpdir
 end

--- a/spec/core/kernel/system_spec.rb
+++ b/spec/core/kernel/system_spec.rb
@@ -1,0 +1,144 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe :kernel_system, shared: true do
+  it "executes the specified command in a subprocess" do
+    -> { @object.system("echo a") }.should output_to_fd("a\n")
+
+    $?.should be_an_instance_of Process::Status
+    $?.should.success?
+  end
+
+  it "returns true when the command exits with a zero exit status" do
+    @object.system(ruby_cmd('exit 0')).should == true
+
+    $?.should be_an_instance_of Process::Status
+    $?.should.success?
+    $?.exitstatus.should == 0
+  end
+
+  it "returns false when the command exits with a non-zero exit status" do
+    @object.system(ruby_cmd('exit 1')).should == false
+
+    $?.should be_an_instance_of Process::Status
+    $?.should_not.success?
+    $?.exitstatus.should == 1
+  end
+
+  it "raises RuntimeError when `exception: true` is given and the command exits with a non-zero exit status" do
+    -> { @object.system(ruby_cmd('exit 1'), exception: true) }.should raise_error(RuntimeError)
+  end
+
+  it "raises Errno::ENOENT when `exception: true` is given and the specified command does not exist" do
+    NATFIXME 'it raises Errno::ENOENT when `exception: true` is given and the specified command does not exist', exception: SpecFailedException do
+      -> { @object.system('feature_14386', exception: true) }.should raise_error(Errno::ENOENT)
+    end
+  end
+
+  it "returns nil when command execution fails" do
+    @object.system("sad").should be_nil
+
+    $?.should be_an_instance_of Process::Status
+    $?.pid.should be_kind_of(Integer)
+    $?.should_not.success?
+  end
+
+  it "does not write to stderr when command execution fails" do
+    -> { @object.system("sad") }.should output_to_fd("", STDERR)
+  end
+
+  platform_is_not :windows do
+    before :each do
+      @shell = ENV['SHELL']
+    end
+
+    after :each do
+      ENV['SHELL'] = @shell
+    end
+
+    it "executes with `sh` if the command contains shell characters" do
+      NATFIXME 'it executes with `sh` if the command contains shell characters', exception: SpecFailedException do
+        -> { @object.system("echo $0") }.should output_to_fd("sh\n")
+      end
+    end
+
+    it "ignores SHELL env var and always uses `sh`" do
+      ENV['SHELL'] = "/bin/fakeshell"
+      NATFIXME 'it ignores SHELL env var and always uses `sh`', exception: SpecFailedException do
+        -> { @object.system("echo $0") }.should output_to_fd("sh\n")
+      end
+    end
+  end
+
+  platform_is_not :windows do
+    before :each do
+      require 'tmpdir'
+      @shell_command = File.join(Dir.mktmpdir, "noshebang.cmd")
+      File.write(@shell_command, %[echo "$PATH"\n], perm: 0o700)
+    end
+
+    after :each do
+      File.unlink(@shell_command)
+      Dir.rmdir(File.dirname(@shell_command))
+    end
+
+    it "executes with `sh` if the command is executable but not binary and there is no shebang" do
+      NATFIXME 'it executes with `sh` if the command is executable but not binary and there is no shebang', exception: SpecFailedException do
+        -> { @object.system(@shell_command) }.should output_to_fd(ENV['PATH'] + "\n")
+      end
+    end
+  end
+
+  before :each do
+    ENV['TEST_SH_EXPANSION'] = 'foo'
+    @shell_var = '$TEST_SH_EXPANSION'
+    platform_is :windows do
+      @shell_var = '%TEST_SH_EXPANSION%'
+    end
+  end
+
+  after :each do
+    ENV.delete('TEST_SH_EXPANSION')
+  end
+
+  it "expands shell variables when given a single string argument" do
+    NATFIXME 'it expands shell variables when given a single string argument', exception: SpecFailedException do
+      -> { @object.system("echo #{@shell_var}") }.should output_to_fd("foo\n")
+    end
+  end
+
+  platform_is_not :windows do
+    it "does not expand shell variables when given multiples arguments" do
+      NATFIXME 'it does not expand shell variables when given multiples arguments', exception: SpecFailedException do
+        -> { @object.system("echo", @shell_var) }.should output_to_fd("#{@shell_var}\n")
+      end
+    end
+  end
+
+  platform_is :windows do
+    it "does expand shell variables when given multiples arguments" do
+      # See https://bugs.ruby-lang.org/issues/12231
+      -> { @object.system("echo", @shell_var) }.should output_to_fd("foo\n")
+    end
+  end
+
+  platform_is :windows do
+    it "runs commands starting with any number of @ using shell" do
+      `#{ruby_cmd("p system 'does_not_exist'")} 2>NUL`.chomp.should == "nil"
+      @object.system('@does_not_exist 2>NUL').should == false
+      @object.system("@@@#{ruby_cmd('exit 0')}").should == true
+    end
+  end
+end
+
+describe "Kernel#system" do
+  it "is a private method" do
+    Kernel.should have_private_instance_method(:system)
+  end
+
+  it_behaves_like :kernel_system, :system, KernelSpecs::Method.new
+end
+
+describe "Kernel.system" do
+  it_behaves_like :kernel_system, :system, Kernel
+end

--- a/spec/core/kernel/system_spec.rb
+++ b/spec/core/kernel/system_spec.rb
@@ -3,7 +3,9 @@ require_relative 'fixtures/classes'
 
 describe :kernel_system, shared: true do
   it "executes the specified command in a subprocess" do
-    -> { @object.system("echo a") }.should output_to_fd("a\n")
+    NATFIXME 'it executes the specified command in a subprocess', exception: SpecFailedException do
+      -> { @object.system("echo a") }.should output_to_fd("a\n")
+    end
 
     $?.should be_an_instance_of Process::Status
     $?.should.success?
@@ -26,7 +28,9 @@ describe :kernel_system, shared: true do
   end
 
   it "raises RuntimeError when `exception: true` is given and the command exits with a non-zero exit status" do
-    -> { @object.system(ruby_cmd('exit 1'), exception: true) }.should raise_error(RuntimeError)
+    NATFIXME 'it raises RuntimeError when `exception: true` is given and the command exits with a non-zero exit status', exception: SpecFailedException do
+      -> { @object.system(ruby_cmd('exit 1'), exception: true) }.should raise_error(RuntimeError)
+    end
   end
 
   it "raises Errno::ENOENT when `exception: true` is given and the specified command does not exist" do
@@ -133,7 +137,9 @@ end
 
 describe "Kernel#system" do
   it "is a private method" do
-    Kernel.should have_private_instance_method(:system)
+    NATFIXME 'it is a private method', exception: SpecFailedException do
+      Kernel.should have_private_instance_method(:system)
+    end
   end
 
   it_behaves_like :kernel_system, :system, KernelSpecs::Method.new

--- a/spec/core/kernel/system_spec.rb
+++ b/spec/core/kernel/system_spec.rb
@@ -137,9 +137,7 @@ end
 
 describe "Kernel#system" do
   it "is a private method" do
-    NATFIXME 'it is a private method', exception: SpecFailedException do
-      Kernel.should have_private_instance_method(:system)
-    end
+    Kernel.should have_private_instance_method(:system)
   end
 
   it_behaves_like :kernel_system, :system, KernelSpecs::Method.new

--- a/spec/library/tmpdir/dir/mktmpdir_spec.rb
+++ b/spec/library/tmpdir/dir/mktmpdir_spec.rb
@@ -1,0 +1,117 @@
+require_relative '../../../spec_helper'
+require "tmpdir"
+
+describe "Dir.mktmpdir when passed no arguments" do
+  after :each do
+    Dir.rmdir @tmpdir if File.directory? @tmpdir
+  end
+
+  it "returns the path to the created tmp-dir" do
+    Dir.stub!(:mkdir)
+    Dir.should_receive(:tmpdir).and_return("/tmp")
+    @tmpdir = Dir.mktmpdir
+    @tmpdir.should =~ /^\/tmp\//
+  end
+
+  it "creates a new writable directory in the path provided by Dir.tmpdir" do
+    Dir.should_receive(:tmpdir).and_return(tmp(""))
+    @tmpdir = Dir.mktmpdir
+    File.directory?(@tmpdir).should be_true
+    File.writable?(@tmpdir).should be_true
+  end
+end
+
+describe "Dir.mktmpdir when passed a block" do
+  before :each do
+    @real_tmp_root = tmp('')
+    Dir.stub!(:tmpdir).and_return(@real_tmp_root)
+    FileUtils.stub!(:remove_entry)
+    FileUtils.stub!(:remove_entry_secure)
+  end
+
+  after :each do
+    Dir.rmdir @tmpdir if File.directory? @tmpdir
+  end
+
+  it "yields the path to the passed block" do
+    Dir.stub!(:mkdir)
+    called = nil
+    Dir.mktmpdir do |path|
+      @tmpdir = path
+      called = true
+      path.should.start_with?(@real_tmp_root)
+    end
+    called.should be_true
+  end
+
+  it "creates the tmp-dir before yielding" do
+    Dir.should_receive(:tmpdir).and_return(tmp(""))
+    Dir.mktmpdir do |path|
+      @tmpdir = path
+      File.directory?(path).should be_true
+      File.writable?(path).should be_true
+    end
+  end
+
+  it "removes the tmp-dir after executing the block" do
+    Dir.stub!(:mkdir)
+    Dir.mktmpdir do |path|
+      @tmpdir = path
+      FileUtils.should_receive(:remove_entry).with(path)
+    end
+  end
+
+  it "returns the blocks return value" do
+    Dir.stub!(:mkdir)
+    result = Dir.mktmpdir do |path|
+      @tmpdir = path
+      :test
+    end
+    result.should equal(:test)
+  end
+end
+
+describe "Dir.mktmpdir when passed [String]" do
+  before :each do
+    Dir.stub!(:mkdir)
+    Dir.stub!(:tmpdir).and_return("/tmp")
+  end
+
+  after :each do
+    Dir.rmdir @tmpdir if File.directory? @tmpdir
+  end
+
+  it "uses the passed String as a prefix to the tmp-directory" do
+    prefix = "before"
+    @tmpdir = Dir.mktmpdir(prefix)
+    @tmpdir.should =~ /^\/tmp\/#{prefix}/
+  end
+end
+
+describe "Dir.mktmpdir when passed [Array]" do
+  before :each do
+    Dir.stub!(:mkdir)
+    Dir.stub!(:tmpdir).and_return("/tmp")
+    FileUtils.stub!(:remove_entry_secure)
+  end
+
+  after :each do
+    Dir.rmdir @tmpdir if File.directory? @tmpdir
+  end
+
+  it "uses the first element of the passed Array as a prefix and the second element as a suffix to the tmp-directory" do
+    prefix = "before"
+    suffix = "after"
+
+    @tmpdir = Dir.mktmpdir([prefix, suffix])
+    @tmpdir.should =~ /#{suffix}$/
+  end
+end
+
+describe "Dir.mktmpdir when passed [Object]" do
+  it "raises an ArgumentError" do
+    -> { Dir.mktmpdir(Object.new) }.should raise_error(ArgumentError)
+    -> { Dir.mktmpdir(:symbol) }.should raise_error(ArgumentError)
+    -> { Dir.mktmpdir(10) }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/library/tmpdir/dir/mktmpdir_spec.rb
+++ b/spec/library/tmpdir/dir/mktmpdir_spec.rb
@@ -6,7 +6,9 @@ describe "Dir.mktmpdir when passed no arguments" do
     Dir.rmdir @tmpdir if File.directory? @tmpdir
   end
 
-  it "returns the path to the created tmp-dir" do
+  # NATFIXME: Fix the stub! method, this now removes the method for the
+  # duration of this spec.
+  xit "returns the path to the created tmp-dir" do
     Dir.stub!(:mkdir)
     Dir.should_receive(:tmpdir).and_return("/tmp")
     @tmpdir = Dir.mktmpdir
@@ -21,7 +23,9 @@ describe "Dir.mktmpdir when passed no arguments" do
   end
 end
 
-describe "Dir.mktmpdir when passed a block" do
+# NATFIXME: Skip for now, we don't support the block, which means we don't
+# clean up the tempdir and get errors from the spec runner
+xdescribe "Dir.mktmpdir when passed a block" do
   before :each do
     @real_tmp_root = tmp('')
     Dir.stub!(:tmpdir).and_return(@real_tmp_root)
@@ -83,8 +87,10 @@ describe "Dir.mktmpdir when passed [String]" do
 
   it "uses the passed String as a prefix to the tmp-directory" do
     prefix = "before"
-    @tmpdir = Dir.mktmpdir(prefix)
-    @tmpdir.should =~ /^\/tmp\/#{prefix}/
+    NATFIXME 'Support arguments', exception: ArgumentError, message: 'TODO: Support arguments' do
+      @tmpdir = Dir.mktmpdir(prefix)
+      @tmpdir.should =~ /^\/tmp\/#{prefix}/
+    end
   end
 end
 
@@ -103,8 +109,10 @@ describe "Dir.mktmpdir when passed [Array]" do
     prefix = "before"
     suffix = "after"
 
-    @tmpdir = Dir.mktmpdir([prefix, suffix])
-    @tmpdir.should =~ /#{suffix}$/
+    NATFIXME 'Support arguments', exception: ArgumentError, message: 'TODO: Support arguments' do
+      @tmpdir = Dir.mktmpdir([prefix, suffix])
+      @tmpdir.should =~ /#{suffix}$/
+    end
   end
 end
 

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -881,4 +881,5 @@ module Kernel
   rescue
     nil
   end
+  module_function :system
 end


### PR DESCRIPTION
This is a very crude first version that does not support arguments or blocks.
A few specs are failing due to how our spec runner works, the `stub!` methods removes them for the duration of the file or the describe block, not the test itself (this can be reproduced by running this spec file in MRI). We should probably fix that before we continue with this lib.
The specs for Kernel.system have been added too, these had a dependency on `mktmpdir` and no longer crash.