### PR TITLE
Import specs for Thread#value

### DIFF
--- a/spec/core/thread/value_spec.rb
+++ b/spec/core/thread/value_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Thread#value" do
+  it "returns the result of the block" do
+    Thread.new { 3 }.value.should == 3
+  end
+
+  it "re-raises an error for an uncaught exception" do
+    t = Thread.new {
+      Thread.current.report_on_exception = false
+      raise "Hello"
+    }
+    -> { t.value }.should raise_error(RuntimeError, "Hello")
+  end
+
+  it "is nil for a killed thread" do
+    t = Thread.new { Thread.current.exit }
+    t.value.should == nil
+  end
+
+  it "returns when the thread finished" do
+    q = Queue.new
+    t = Thread.new {
+      q.pop
+    }
+    # NATFIXME: This code results in a timeout in Natalie. The block_caller method wraps the
+    # block in a supervisor thread and checks the status of this supervisor to become "sleep"
+    # In the case of Natalie, the `t` thread gets into a status sleep, but this does not get
+    # bubbled up to the supervisor thread.
+    # -> { t.value }.should block_caller
+    q.push :result
+    t.value.should == :result
+  end
+end


### PR DESCRIPTION
Comment out a single line that causes a timeout, and add some comments to describe the issue.
The source of the issue is the implementation of Thread#status, and is unrelated to this specific test.
Importing this spec dos document the reason for the timeout.