### PR TITLE
TEMP: Freeze result of Symbol#to_s

### DIFF
--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -203,8 +203,7 @@ static void emit_object_value(Env *env, Value value, yaml_emitter_t &emitter, ya
 
     auto ivars = value->instance_variables(env)->as_array();
     for (auto ivar : *ivars) {
-        auto name = ivar.to_s(env);
-        name->delete_prefix_in_place(env, new StringObject { "@" });
+        auto name = ivar.to_s(env)->delete_prefix(env, new StringObject { "@" });
         auto val = value->ivar_get(env, ivar->as_symbol());
         emit_value(env, name, emitter, event);
         emit_value(env, val, emitter, event);

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -32,7 +32,7 @@ StringObject *SymbolObject::to_s(Env *env) {
     } else {
         result = new StringObject { m_name, m_encoding };
     }
-    result->set_chilled(StringObject::Chilled::Symbol);
+    result->freeze();
     return result;
 }
 


### PR DESCRIPTION
Just going to use the CI for a bit to find issues like #2582 by making it an error instead of a warning that gets ignored in the CI. This change should **NOT** get merged, but it is an easy way to find the issues that can be fixed.