### PR TITLE
Import specs for CVE-2013-4164

### DIFF
--- a/spec/security/cve_2013_4164_spec.rb
+++ b/spec/security/cve_2013_4164_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../spec_helper'
+
+require 'json'
+
+describe "String#to_f" do
+  it "resists CVE-2013-4164 by converting very long Strings to a Float" do
+    "1.#{'1'*1000000}".to_f.should be_close(1.1111111111111112, TOLERANCE)
+  end
+end
+
+describe "JSON.parse" do
+  # NATFIXME: This one times out
+  xit "resists CVE-2013-4164 by converting very long Strings to a Float" do
+    JSON.parse("[1.#{'1'*1000000}]").first.should be_close(1.1111111111111112, TOLERANCE)
+  end
+end


### PR DESCRIPTION
This is one of the specs with a timeout. Import it to document which one of the two fails.