### PR TITLE
Implement parser for Kernel.Complex with String argument

### DIFF
--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -25,6 +25,7 @@ public:
     static Value catch_method(Env *, Value = nullptr, Block * = nullptr);
     static Value Complex(Env *env, Value real, Value imaginary, Value exception);
     static Value Complex(Env *env, Value real, Value imaginary, bool exception = true);
+    static Value Complex(Env *env, StringObject *real, Value imaginary, bool exception);
     static Value cur_callee(Env *env);
     static Value cur_dir(Env *env);
     static Value exit(Env *env, Value status);

--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -117,11 +117,9 @@ describe "Kernel.Complex()" do
       end
 
       it "does not allow null-byte" do
-        NATFIXME 'does not allow null-byte', exception: SpecFailedException do
-          -> {
-            Complex("1-2i\0")
-          }.should raise_error(ArgumentError, "string contains null byte")
-        end
+        -> {
+          Complex("1-2i\0")
+        }.should raise_error(ArgumentError, "string contains null byte")
       end
     end
 
@@ -166,9 +164,7 @@ describe "Kernel.Complex()" do
       end
 
       it "returns nil when String contains null-byte" do
-        NATFIXME 'returns nil when String contains null-byte', exception: NoMethodError, message: "undefined method 'real' for nil" do
-          Complex("1-2i\0", exception: false).should == nil
-        end
+        Complex("1-2i\0", exception: false).should == nil
       end
     end
   end

--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -81,11 +81,9 @@ describe "Kernel.Complex()" do
       end
 
       it "raises ArgumentError for trailing garbage" do
-        NATFIXME 'raises ArgumentError for trailing garbage', exception: SpecFailedException do
-          -> {
-            Complex("79+4iruby")
-          }.should raise_error(ArgumentError, 'invalid value for convert(): "79+4iruby"')
-        end
+        -> {
+          Complex("79+4iruby")
+        }.should raise_error(ArgumentError, 'invalid value for convert(): "79+4iruby"')
       end
 
       it "does not understand Float::INFINITY" do
@@ -139,9 +137,7 @@ describe "Kernel.Complex()" do
       end
 
       it "returns nil when trailing garbage" do
-        NATFIXME 'returns nil when trailing garbage', exception: NoMethodError, message: "undefined method 'real' for nil" do
-          Complex("79+4iruby", exception: false).should == nil
-        end
+        Complex("79+4iruby", exception: false).should == nil
       end
 
       it "returns nil for Float::INFINITY" do

--- a/spec/core/kernel/Complex_spec.rb
+++ b/spec/core/kernel/Complex_spec.rb
@@ -73,11 +73,9 @@ describe "Kernel.Complex()" do
       end
 
       it "raises ArgumentError for unrecognised Strings" do
-        NATFIXME 'raises ArgumentError for unrecognised Strings', exception: SpecFailedException do
-          -> {
-            Complex("ruby")
-          }.should raise_error(ArgumentError, 'invalid value for convert(): "ruby"')
-        end
+        -> {
+          Complex("ruby")
+        }.should raise_error(ArgumentError, 'invalid value for convert(): "ruby"')
       end
 
       it "raises ArgumentError for trailing garbage" do
@@ -99,11 +97,9 @@ describe "Kernel.Complex()" do
       end
 
       it "does not understand Float::NAN" do
-        NATFIXME 'does not understand Float::NAN', exception: SpecFailedException do
-          -> {
-            Complex("NaN")
-          }.should raise_error(ArgumentError, 'invalid value for convert(): "NaN"')
-        end
+        -> {
+          Complex("NaN")
+        }.should raise_error(ArgumentError, 'invalid value for convert(): "NaN"')
       end
 
       it "does not understand a sequence of _" do
@@ -131,9 +127,7 @@ describe "Kernel.Complex()" do
       end
 
       it "returns nil for unrecognised Strings" do
-        NATFIXME 'returns nil for unrecognised Strings', exception: SpecFailedException do
-          Complex("ruby", exception: false).should == nil
-        end
+        Complex("ruby", exception: false).should == nil
       end
 
       it "returns nil when trailing garbage" do
@@ -141,16 +135,14 @@ describe "Kernel.Complex()" do
       end
 
       it "returns nil for Float::INFINITY" do
-        NATFIXME 'returns nil for Float::INFINITY', exception: NoMethodError, message: "undefined method 'real' for nil" do
+        NATFIXME 'returns nil for Float::INFINITY', exception: SpecFailedException do
           Complex("Infinity", exception: false).should == nil
           Complex("-Infinity", exception: false).should == nil
         end
       end
 
       it "returns nil for Float::NAN" do
-        NATFIXME 'returns nil for Float::NAN', exception: SpecFailedException do
-          Complex("NaN", exception: false).should == nil
-        end
+        Complex("NaN", exception: false).should == nil
       end
 
       it "returns nil when there is a sequence of _" do
@@ -283,7 +275,7 @@ describe "Kernel.Complex()" do
 
     describe "and [anything, non-Numeric] argument" do
       it "swallows an error" do
-        NATFIXME '[anything, non-Numeric] argument', exception: SpecFailedException do
+        NATFIXME '[anything, non-Numeric] argument', exception: NoMethodError, message: "undefined method 'real' for nil" do
           Complex("a",  :sym, exception: false).should == nil
           Complex(:sym, :sym, exception: false).should == nil
           Complex(0,    :sym, exception: false).should == nil
@@ -293,7 +285,7 @@ describe "Kernel.Complex()" do
 
     describe "and non-numeric String arguments" do
       it "swallows an error" do
-        NATFIXME 'non-numeric String arguments', exception: SpecFailedException do
+        NATFIXME 'non-numeric String arguments', exception: NoMethodError, message: "undefined method 'real' for nil" do
           Complex("a", "b", exception: false).should == nil
           Complex("a", 0, exception: false).should == nil
           Complex(0, "b", exception: false).should == nil

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -189,8 +189,29 @@ Value KernelModule::Complex(Env *env, StringObject *real, Value imaginary, bool 
         case State::RealInteger:
             if (*c >= '0' && *c <= '9') {
                 real_end = c;
-            } else {
+            } else if (*c == '_') {
+                // TODO: Skip single underscore, fix in String#to_c as well
                 state = State::Fallback;
+            } else if (*c == '.') {
+                // TODO: Parse float
+                state = State::Fallback;
+            } else if (*c == '/') {
+                // TODO: Parse fraction, fix in String#to_c as well
+                state = State::Fallback;
+            } else if (*c == 'e') {
+                // TODO: Parse scientific notation, fix in String#to_c as well
+                state = State::Fallback;
+            } else if (*c == '@') {
+                // TODO: Parse polar form, fix in String#to_c as well
+                state = State::Fallback;
+            } else if (*c == '+' || *c == '-') {
+                // TODO: Finish real int part, continue with parsing complex part
+                state = State::Fallback;
+            } else if (*c == 'i') {
+                // TODO: Convert real part into imaginary part
+                state = State::Fallback;
+            } else {
+                return error();
             }
             break;
         case State::Fallback:

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -134,10 +134,8 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value excepti
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
-    if (real.is_string()) {
-        // NATFIXME: This is more restrictive than String#to_c, needs its own parser
-        return real->as_string()->send(env, "to_c"_s);
-    }
+    if (real.is_string())
+        return Complex(env, real->as_string(), imaginary, exception);
 
     if (real.is_complex() && imaginary == nullptr) {
         return real;
@@ -155,6 +153,11 @@ Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exceptio
         env->raise("TypeError", "can't convert {} into Complex", real.klass()->inspect_str());
     else
         return nullptr;
+}
+
+Value KernelModule::Complex(Env *env, StringObject *real, Value imaginary, bool exception) {
+    // NATFIXME: This is more restrictive than String#to_c, needs its own parser
+    return real->send(env, "to_c"_s);
 }
 
 Value KernelModule::cur_callee(Env *env) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -172,6 +172,11 @@ Value KernelModule::Complex(Env *env, StringObject *real, Value imaginary, bool 
     const char *real_start = nullptr;
     const char *real_end = nullptr;
     for (const char *c = real->c_str(); c < real->c_str() + real->bytesize(); c++) {
+        if (*c == 0) {
+            if (exception)
+                env->raise("ArgumentError", "string contains null byte");
+            return NilObject::the();
+        }
         switch (state) {
         case State::Start:
             if ((*c >= '0' && *c <= '9') || *c == '+' || *c == '-') {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -202,8 +202,8 @@ Value KernelModule::Complex(Env *env, StringObject *real, Value imaginary, bool 
             } else if (*c == 'i') {
                 new_imag = Value::integer(1);
                 state = State::Finished;
-            } else {
-                state = State::Fallback;
+            } else if (*c != ' ' && *c != '\t' && *c != '\r' && *c != '\n') {
+                return error();
             }
             break;
         case State::Real:

--- a/test/natalie/kernel_complex_test.rb
+++ b/test/natalie/kernel_complex_test.rb
@@ -6,4 +6,18 @@ describe 'Kernel.Complex' do
     -> { Complex('+1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "+1a"')
     -> { Complex('-1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "-1a"')
   end
+
+  it 'does not accept anything nun-numeric after the real float part' do
+    -> { Complex('1.0a') }.should raise_error(ArgumentError, 'invalid value for convert(): "1.0a"')
+    -> { Complex('+1.0a') }.should raise_error(ArgumentError, 'invalid value for convert(): "+1.0a"')
+    -> { Complex('-1.0a') }.should raise_error(ArgumentError, 'invalid value for convert(): "-1.0a"')
+    -> { Complex('1.a') }.should raise_error(ArgumentError, 'invalid value for convert(): "1.a"')
+    -> { Complex('+1.a') }.should raise_error(ArgumentError, 'invalid value for convert(): "+1.a"')
+    -> { Complex('-1.a') }.should raise_error(ArgumentError, 'invalid value for convert(): "-1.a"')
+  end
+
+  it 'does not accept two dots in the real part' do
+    -> { Complex('1.0.') }.should raise_error(ArgumentError, 'invalid value for convert(): "1.0."')
+    -> { Complex('1..0') }.should raise_error(ArgumentError, 'invalid value for convert(): "1..0"')
+  end
 end

--- a/test/natalie/kernel_complex_test.rb
+++ b/test/natalie/kernel_complex_test.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe 'Kernel.Complex' do
+  it 'does not accept anything nun-numeric after the real integer part' do
+    -> { Complex('1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "1a"')
+    -> { Complex('+1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "+1a"')
+    -> { Complex('-1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "-1a"')
+  end
+end


### PR DESCRIPTION
This one is now feature complete with `String#to_c`, which is helpful with all the shared specs that should behave the same.

This contains a lot of code duplication, the next step is probably to add an extra argument to specify the failure behaviour (raise an exception or return the parsed part) and delegate `String#to_c` to `Kernel.Complex`.