### PR TITLE
Fix exception argument in kernel coercion methods

### DIFF
--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -130,6 +130,8 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value exception) {
+    if (exception && !exception.is_false() && !exception.is_true())
+        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
     return Complex(env, real, imaginary, exception ? exception.is_true() : true);
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -17,6 +17,12 @@ extern char **environ;
 
 namespace Natalie {
 
+static bool exception_argument_to_bool(Env *env, Value exception) {
+    if (exception && !exception.is_false() && !exception.is_true())
+        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
+    return !exception || exception.is_true();
+}
+
 Value KernelModule::Array(Env *env, Value value) {
     return Natalie::to_ary(env, value, true);
 }
@@ -130,9 +136,7 @@ Value KernelModule::catch_method(Env *env, Value name, Block *block) {
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, Value exception) {
-    if (exception && !exception.is_false() && !exception.is_true())
-        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
-    return Complex(env, real, imaginary, exception ? exception.is_true() : true);
+    return Complex(env, real, imaginary, exception_argument_to_bool(env, exception));
 }
 
 Value KernelModule::Complex(Env *env, Value real, Value imaginary, bool exception) {
@@ -363,12 +367,10 @@ Value KernelModule::exit_bang(Env *env, Value status) {
 }
 
 Value KernelModule::Integer(Env *env, Value value, Value base, Value exception) {
-    if (exception && !exception.is_false() && !exception.is_true())
-        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
     nat_int_t base_int = 0; // default to zero if unset
     if (base)
         base_int = base.to_int(env).to_nat_int_t();
-    return Integer(env, value, base_int, exception ? exception.is_true() : true);
+    return Integer(env, value, base_int, exception_argument_to_bool(env, exception));
 }
 
 Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exception) {
@@ -417,9 +419,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
 }
 
 Value KernelModule::Float(Env *env, Value value, Value exception) {
-    if (exception && !exception.is_false() && !exception.is_true())
-        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
-    return Float(env, value, exception ? exception.is_true() : true);
+    return Float(env, value, exception_argument_to_bool(env, exception));
 }
 
 Value KernelModule::Float(Env *env, Value value, bool exception) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -363,6 +363,8 @@ Value KernelModule::exit_bang(Env *env, Value status) {
 }
 
 Value KernelModule::Integer(Env *env, Value value, Value base, Value exception) {
+    if (exception && !exception.is_false() && !exception.is_true())
+        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
     nat_int_t base_int = 0; // default to zero if unset
     if (base)
         base_int = base.to_int(env).to_nat_int_t();

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -417,6 +417,8 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
 }
 
 Value KernelModule::Float(Env *env, Value value, Value exception) {
+    if (exception && !exception.is_false() && !exception.is_true())
+        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
     return Float(env, value, exception ? exception.is_true() : true);
 }
 

--- a/test/natalie/kernel_complex_test.rb
+++ b/test/natalie/kernel_complex_test.rb
@@ -1,6 +1,12 @@
 require_relative '../spec_helper'
 
 describe 'Kernel.Complex' do
+  it 'only accepts true or false as exception argument' do
+    -> { Complex('1', exception: nil) }.should raise_error(ArgumentError, 'expected true or false as exception: nil')
+    obj = Object.new
+    -> { Complex('1', exception: obj) }.should raise_error(ArgumentError, "expected true or false as exception: #{obj}")
+  end
+
   it 'does not accept anything nun-numeric after the real integer part' do
     -> { Complex('1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "1a"')
     -> { Complex('+1a') }.should raise_error(ArgumentError, 'invalid value for convert(): "+1a"')

--- a/test/natalie/kernel_integer_test.rb
+++ b/test/natalie/kernel_integer_test.rb
@@ -1,6 +1,12 @@
 require_relative '../spec_helper'
 
 describe 'Kernel.Integer' do
+  it 'only accepts true or false as exception argument' do
+    -> { Integer('1', exception: nil) }.should raise_error(ArgumentError, 'expected true or false as exception: nil')
+    obj = Object.new
+    -> { Integer('1', exception: obj) }.should raise_error(ArgumentError, "expected true or false as exception: #{obj}")
+  end
+
   it 'Does not accept a any whitespace after a sign mark' do
     -> { Integer("+\x001".b) }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\x001"')
     -> { Integer("+\t1") }.should raise_error(ArgumentError, 'invalid value for Integer(): "+\\t1"')

--- a/test/natalie/kernel_test.rb
+++ b/test/natalie/kernel_test.rb
@@ -114,6 +114,12 @@ describe 'Kernel' do
   end
 
   describe '#Float' do
+    it 'only accepts true or false as exception argument' do
+      -> { Float('1.0', exception: nil) }.should raise_error(ArgumentError, 'expected true or false as exception: nil')
+      obj = Object.new
+      -> { Float('1.0', exception: obj) }.should raise_error(ArgumentError, "expected true or false as exception: #{obj}")
+    end
+
     it 'raises error with extra keywords' do
       -> { Float(1, foo: 2, bar: 3) }.should raise_error(ArgumentError, 'unknown keywords: :foo, :bar')
     end


### PR DESCRIPTION
It turns out this only allows true and false, not truthy/falsey. This should probably be added to the upstream specs.