### PR TITLE
Use tagged pointer for storing Integer value

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -506,8 +506,8 @@ file 'build/generated/numbers.rb' do |t|
     f1.puts '#include <stdio.h>'
     f1.puts '#include "natalie/constants.hpp"'
     f1.puts 'int main() {'
-    f1.puts '  printf("NAT_MAX_FIXNUM = %lli\n", NAT_MAX_FIXNUM);'
-    f1.puts '  printf("NAT_MIN_FIXNUM = %lli\n", NAT_MIN_FIXNUM);'
+    f1.puts '  printf("NAT_MAX_FIXNUM = %lli\n", Natalie::NAT_MAX_FIXNUM);'
+    f1.puts '  printf("NAT_MIN_FIXNUM = %lli\n", Natalie::NAT_MIN_FIXNUM);'
     f1.puts '}'
     f1.close
     sh "#{cxx} #{include_flags.join(' ')} -std=#{STANDARD} -o #{f2.path} #{f1.path}"

--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -5,6 +5,7 @@
 #include <ctype.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -1736,10 +1737,10 @@ public:
      *
      * ```
      * auto str = String("hello");
-     * assert_eq(210714636441, str.djb2_hash());
+     * assert_eq(261238937, str.djb2_hash());
      * ```
      */
-    size_t djb2_hash() const {
+    uint32_t djb2_hash() const {
         size_t hash = 5381;
         int c;
         for (size_t i = 0; i < m_length; ++i) {

--- a/include/natalie/constants.hpp
+++ b/include/natalie/constants.hpp
@@ -2,16 +2,17 @@
 #pragma once
 #include "natalie/types.hpp"
 #include <limits.h>
+#include <limits>
 
 namespace Natalie {
 
 constexpr nat_int_t highest_fixnum() {
-    auto bits = sizeof(nat_int_t) * 8 - 2;
+    auto bits = std::numeric_limits<nat_int_t>::digits - 1;
     return (1LL << bits) - 1;
 }
 
 constexpr nat_int_t lowest_fixnum() {
-    auto bits = sizeof(nat_int_t) * 8 - 2;
+    auto bits = std::numeric_limits<nat_int_t>::digits - 1;
     return -(1LL << bits);
 }
 
@@ -19,7 +20,8 @@ constexpr nat_int_t NAT_MAX_FIXNUM = highest_fixnum();
 constexpr nat_int_t NAT_MIN_FIXNUM = lowest_fixnum();
 
 constexpr nat_int_t lowest_squarable_fixnum() {
-    nat_int_t mask = (nat_int_t)1 << (sizeof(nat_int_t) * 8 - 2);
+    auto bits = std::numeric_limits<nat_int_t>::digits - 1;
+    nat_int_t mask = ((nat_int_t)1) << bits;
     nat_int_t max_sqrt = 0;
     while (mask > 0) {
         nat_int_t current_sum = max_sqrt + mask;

--- a/include/natalie/constants.hpp
+++ b/include/natalie/constants.hpp
@@ -3,10 +3,20 @@
 #include "natalie/types.hpp"
 #include <limits.h>
 
-#define NAT_MAX_FIXNUM LLONG_MAX
-#define NAT_MIN_FIXNUM LLONG_MIN + 1
-
 namespace Natalie {
+
+constexpr nat_int_t highest_fixnum() {
+    auto bits = sizeof(nat_int_t) * 8 - 2;
+    return (1LL << bits) - 1;
+}
+
+constexpr nat_int_t lowest_fixnum() {
+    auto bits = sizeof(nat_int_t) * 8 - 2;
+    return -(1LL << bits);
+}
+
+constexpr nat_int_t NAT_MAX_FIXNUM = highest_fixnum();
+constexpr nat_int_t NAT_MIN_FIXNUM = lowest_fixnum();
 
 constexpr nat_int_t lowest_squarable_fixnum() {
     nat_int_t mask = (nat_int_t)1 << (sizeof(nat_int_t) * 8 - 2);

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "natalie/bigint.hpp"
+#include "natalie/constants.hpp"
 #include "natalie/macros.hpp"
 #include "natalie/types.hpp"
 #include "tm/string.hpp"
@@ -11,10 +12,33 @@ namespace Natalie {
 
 class Integer {
 public:
+    Integer(nat_int_t other) {
+        if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
+            m_value = (other << 1) | 0x1;
+        else
+            m_value = (uintptr_t) new BigInt(other);
+    }
+
+    Integer(long other) {
+        if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
+            m_value = (static_cast<nat_int_t>(other) << 1) | 0x1;
+        else
+            m_value = (uintptr_t) new BigInt(other);
+    }
+
+    Integer(int other) {
+        m_value = (static_cast<nat_int_t>(other) << 1) | 0x1;
+    }
+
+    // This is hacky, but we need an Integer representation that
+    // is all zeros so Value nullptr works. :-)
+    static Integer null() {
+        auto i = Integer(0);
+        i.m_value = 0;
+        return i;
+    }
+
     Integer() { }
-    Integer(nat_int_t);
-    Integer(int);
-    Integer(long);
     Integer(double);
     Integer(const BigInt &);
     Integer(BigInt &&);
@@ -114,18 +138,18 @@ public:
     // Other
     explicit operator bool() const { return *this == 0; }
     bool is_zero() const { return *this == 0; }
-    bool is_fixnum() const { return !m_is_bignum; }
-    bool is_bignum() const { return m_is_bignum; }
+    bool is_fixnum() const { return (m_value & 0x1) == 0x1; }
+    bool is_bignum() const { return (m_value & 0x1) == 0x0; }
     bool is_negative() const;
     BigInt to_bigint() const {
         if (is_bignum())
-            return *m_bignum;
+            return *(BigInt *)m_value;
         else
-            return BigInt(m_fixnum);
+            return BigInt(to_nat_int_t());
     }
     nat_int_t to_nat_int_t() const {
         if (is_fixnum())
-            return m_fixnum;
+            return static_cast<nat_int_t>(m_value) >> 1;
         else
             NAT_UNREACHABLE();
     }
@@ -133,21 +157,19 @@ public:
     TM::String to_string() const;
 
     Integer bit_length() const;
-    // TM::String to_binary() const;
 
     BigInt *bigint_pointer() const {
-        if (!m_is_bignum)
+        if (!is_bignum())
             return nullptr;
-        return m_bignum;
+        return (BigInt *)m_value;
     }
 
 private:
-    union {
-        nat_int_t m_fixnum { 0 };
-        BigInt *m_bignum;
-    };
-
-    bool m_is_bignum { false };
+    // The least significant bit is used to tag the pointer as either
+    // an immediate value (63 bits) or a pointer to a BigInt.
+    // If bit is 1, then shift the value to the right to get the actual
+    // 63-bit number. If the bit is 0, then treat the value as a BigInt*.
+    uintptr_t m_value { 0x1 };
 };
 
 Integer operator+(const long long &, const Integer &);

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -150,6 +150,8 @@ public:
     nat_int_t to_nat_int_t() const {
         if (is_fixnum())
             return static_cast<nat_int_t>(m_value) >> 1;
+        else if (*this >= LLONG_MIN && *this <= LLONG_MAX)
+            return ((BigInt *)m_value)->to_long_long();
         else
             NAT_UNREACHABLE();
     }

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -15,20 +15,20 @@ class Integer {
 public:
     Integer(nat_int_t other) {
         if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
-            m_value = (other << 1) | 0x1;
+            m_value = left_shift_with_undefined_behavior(other, 1) | 0x1;
         else
             m_value = (uintptr_t) new BigInt(other);
     }
 
     Integer(long other) {
         if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
-            m_value = (static_cast<nat_int_t>(other) << 1) | 0x1;
+            m_value = left_shift_with_undefined_behavior(static_cast<nat_int_t>(other), 1) | 0x1;
         else
             m_value = (uintptr_t) new BigInt(other);
     }
 
     Integer(int other) {
-        m_value = (static_cast<nat_int_t>(other) << 1) | 0x1;
+        m_value = left_shift_with_undefined_behavior(static_cast<nat_int_t>(other), 1) | 0x1;
     }
 
     // This is hacky, but we need an Integer representation that
@@ -178,6 +178,9 @@ public:
     }
 
 private:
+    __attribute__((no_sanitize("undefined"))) static nat_int_t left_shift_with_undefined_behavior(nat_int_t x, nat_int_t y) {
+        return x << y; // NOLINT
+    }
     // The least significant bit is used to tag the pointer as either
     // an immediate value (63 bits) or a pointer to a BigInt.
     // If bit is 1, then shift the value to the right to get the actual

--- a/include/natalie/integer.hpp
+++ b/include/natalie/integer.hpp
@@ -4,6 +4,7 @@
 #include "natalie/constants.hpp"
 #include "natalie/macros.hpp"
 #include "natalie/types.hpp"
+#include "tm/optional.hpp"
 #include "tm/string.hpp"
 
 #include <math.h>
@@ -141,12 +142,17 @@ public:
     bool is_fixnum() const { return (m_value & 0x1) == 0x1; }
     bool is_bignum() const { return (m_value & 0x1) == 0x0; }
     bool is_negative() const;
+    Integer bit_length() const;
+    double to_double() const;
+    TM::String to_string() const;
+
     BigInt to_bigint() const {
         if (is_bignum())
             return *(BigInt *)m_value;
         else
             return BigInt(to_nat_int_t());
     }
+
     nat_int_t to_nat_int_t() const {
         if (is_fixnum())
             return static_cast<nat_int_t>(m_value) >> 1;
@@ -155,10 +161,15 @@ public:
         else
             NAT_UNREACHABLE();
     }
-    double to_double() const;
-    TM::String to_string() const;
 
-    Integer bit_length() const;
+    TM::Optional<nat_int_t> to_nat_int_t_or_none() const {
+        if (is_fixnum())
+            return static_cast<nat_int_t>(m_value) >> 1;
+        else if (*this >= LLONG_MIN && *this <= LLONG_MAX)
+            return ((BigInt *)m_value)->to_long_long();
+        else
+            return TM::Optional<nat_int_t> {};
+    }
 
     BigInt *bigint_pointer() const {
         if (!is_bignum())

--- a/include/natalie/integer_methods.hpp
+++ b/include/natalie/integer_methods.hpp
@@ -44,7 +44,7 @@ public:
     template <class T>
     static T convert_to_native_type(Env *env, Value arg) {
         auto integer = arg.to_int(env);
-        if (is_bignum(integer))
+        if (is_bignum(integer) && (integer < LLONG_MIN || integer > LLONG_MAX))
             env->raise("RangeError", "bignum too big to convert into '{}'", typeinfo<T>().name());
         const auto result = integer.to_nat_int_t();
         if (!std::numeric_limits<T>::is_signed && result < 0)

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -202,9 +202,6 @@ public:
     String dbg_inspect() const;
 
 private:
-    template <typename Callback>
-    Value on_object_value(Callback &&callback);
-
     Type m_type { Type::Pointer };
 
     union {

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -208,7 +208,7 @@ private:
     Type m_type { Type::Pointer };
 
     union {
-        Integer m_integer { 0 };
+        Integer m_integer { Integer::null() };
         Object *m_object;
     };
 };

--- a/spec/core/random/bytes_spec.rb
+++ b/spec/core/random/bytes_spec.rb
@@ -17,7 +17,7 @@ describe "Random#bytes" do
   end
 
   it "returns the same numeric output for a given huge seed across all implementations and platforms" do
-    NATFIXME 'Support huge seed', exception: RangeError, message: "bignum too big to convert into 'long'" do
+    NATFIXME 'Support huge seed', exception: RangeError, message: /bignum too big to convert/ do
       rnd = Random.new(2 ** (63 * 4))
       rnd.bytes(2).should == "_\x91"
       rnd.bytes(1000) # skip some

--- a/spec/library/securerandom/random_number_spec.rb
+++ b/spec/library/securerandom/random_number_spec.rb
@@ -18,7 +18,7 @@ describe "SecureRandom.random_number" do
 
   it "generates a random (potentially bignum) integer value for bignum argument" do
     max = 12345678901234567890
-    NATFIXME 'it generates a random (potentially bignum) integer value for bignum argument', exception: RangeError, message: "bignum too big to convert into 'long'" do
+    NATFIXME 'it generates a random (potentially bignum) integer value for bignum argument', exception: RangeError, message: /bignum too big to convert/ do
       11.times do
         num = SecureRandom.random_number max
         num.should be_kind_of(Integer)

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -246,9 +246,7 @@ Value ArrayObject::ref(Env *env, Value index_obj, Value size) {
             index_obj = index_obj.send(env, "to_int"_s);
 
         if (index_obj.is_integer()) {
-            IntegerMethods::assert_fixnum(env, index_obj.integer());
-
-            auto index = _resolve_index(index_obj.integer().to_nat_int_t());
+            auto index = _resolve_index(IntegerMethods::convert_to_nat_int_t(env, index_obj));
             if (index < 0 || index >= (nat_int_t)m_vector.size())
                 return NilObject::the();
             return m_vector[index];

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -550,6 +550,8 @@ Value ArrayObject::fill(Env *env, Value obj, Value start_obj, Value length_obj, 
 
             if (length_obj && !length_obj.is_nil()) {
                 auto length = IntegerMethods::convert_to_nat_int_t(env, length_obj);
+                if (length >= 2LL << 60)
+                    env->raise("ArgumentError", "argument too big");
 
                 if (length <= 0)
                     return this;

--- a/src/array_packer/integer_handler.cpp
+++ b/src/array_packer/integer_handler.cpp
@@ -1,5 +1,6 @@
 #include "natalie/array_packer/integer_handler.hpp"
 #include "natalie/integer_methods.hpp"
+#include <limits>
 
 namespace Natalie {
 
@@ -109,156 +110,167 @@ namespace ArrayPacker {
     }
 
     void IntegerHandler::pack_c() {
-        nat_int_t source;
-        if (m_source.is_bignum())
+        auto source = m_source.to_nat_int_t_or_none();
+        if (!source)
             source = (m_source % 256).to_nat_int_t();
-        else
-            source = m_source.to_nat_int_t();
-
-        m_packed.append_char(static_cast<signed char>(source));
+        m_packed.append_char(static_cast<signed char>(source.value()));
     }
 
     void IntegerHandler::pack_I() {
-        unsigned int source;
-        if (m_source.is_bignum())
-            source = (m_source % BigInt(::pow(2, 8 * sizeof(unsigned int)))).to_nat_int_t();
+        auto source = m_source.to_nat_int_t_or_none();
+        unsigned int source_cast;
+        if (source)
+            source_cast = (unsigned int)source.value();
         else
-            source = (unsigned int)m_source.to_nat_int_t();
+            source_cast = (m_source % BigInt(::pow(2, std::numeric_limits<unsigned int>::digits))).to_nat_int_t();
 
-        append_bytes((const char *)(&source), sizeof(source));
+        append_bytes((const char *)(&source_cast), sizeof(source_cast));
     }
 
     void IntegerHandler::pack_i() {
-        signed int source;
-        if (m_source.is_bignum())
-            source = (m_source % BigInt(::pow(2, 8 * sizeof(signed int)))).to_nat_int_t();
+        auto source = m_source.to_nat_int_t_or_none();
+        signed int source_cast;
+        if (source)
+            source_cast = (signed int)source.value();
         else
-            source = (signed int)m_source.to_nat_int_t();
+            source_cast = (m_source % BigInt(::pow(2, std::numeric_limits<signed int>::digits))).to_nat_int_t();
 
-        append_bytes((const char *)(&source), sizeof(source));
+        append_bytes((const char *)(&source_cast), sizeof(source_cast));
     }
 
     void IntegerHandler::pack_J() {
-        if (m_source.is_bignum()) {
-            pack_bignum(sizeof(uintptr_t) * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (uintptr_t)source.value();
+            append_bytes((const char *)(&source_cast), sizeof(source_cast));
         } else {
-            auto source = (uintptr_t)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), sizeof(source));
+            pack_bignum(sizeof(uintptr_t) * 8);
         }
     }
 
     void IntegerHandler::pack_j() {
-        if (m_source.is_bignum()) {
-            pack_bignum(sizeof(intptr_t) * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (intptr_t)source.value();
+            append_bytes((const char *)(&source_cast), sizeof(source_cast));
         } else {
-            auto source = (intptr_t)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), sizeof(source));
+            pack_bignum(sizeof(intptr_t) * 8);
         }
     }
 
     void IntegerHandler::pack_L() {
         auto size = m_token.native_size ? sizeof(unsigned long) : sizeof(unsigned int);
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (unsigned long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (unsigned long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_l() {
         auto size = m_token.native_size ? sizeof(long) : sizeof(int);
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_N() {
         m_token.endianness = Endianness::Big;
+        auto source = m_source.to_nat_int_t_or_none();
         auto size = 4;
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        if (source) {
+            auto source_cast = (unsigned long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (unsigned long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_n() {
         m_token.endianness = Endianness::Big;
+        auto source = m_source.to_nat_int_t_or_none();
         auto size = 2;
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        if (source) {
+            auto source_cast = (long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_Q() {
         auto size = sizeof(uint64_t);
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (uint64_t)source.value();
+            append_bytes((const char *)&source_cast, size);
         } else {
-            auto source = (uint64_t)m_source.to_nat_int_t();
-            append_bytes((const char *)&source, size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_q() {
         auto size = sizeof(int64_t);
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto source_cast = (int64_t)source.value();
+            append_bytes((const char *)&source_cast, size);
         } else {
-            auto source = (int64_t)m_source.to_nat_int_t();
-            append_bytes((const char *)&source, size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_S() {
-        unsigned short source;
-        if (m_source.is_bignum())
-            source = (m_source % BigInt(::pow(2, 8 * sizeof(signed int)))).to_nat_int_t();
+        auto source = m_source.to_nat_int_t_or_none();
+        unsigned short source_cast;
+        if (source)
+            source_cast = (unsigned short)source.value();
         else
-            source = (unsigned short)m_source.to_nat_int_t();
+            source_cast = (m_source % BigInt(::pow(2, std::numeric_limits<signed int>::digits))).to_nat_int_t();
 
         auto size = m_token.native_size ? sizeof(unsigned short) : 2;
-        append_bytes((const char *)&source, size);
+        append_bytes((const char *)&source_cast, size);
     }
 
     void IntegerHandler::pack_s() {
-        signed short source;
-        if (m_source.is_bignum())
-            source = (m_source % BigInt(::pow(2, 8 * sizeof(signed int)))).to_nat_int_t();
+        auto source = m_source.to_nat_int_t_or_none();
+        signed short source_cast;
+        if (source)
+            source_cast = (signed short)source.value();
         else
-            source = (signed short)m_source.to_nat_int_t();
+            source_cast = (m_source % BigInt(::pow(2, std::numeric_limits<signed int>::digits))).to_nat_int_t();
 
         auto size = m_token.native_size ? sizeof(signed short) : 2;
-        append_bytes((const char *)&source, size);
+        append_bytes((const char *)&source_cast, size);
     }
 
     void IntegerHandler::pack_V() {
         m_token.endianness = Endianness::Little;
+        auto source = m_source.to_nat_int_t_or_none();
         auto size = 4;
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        if (source) {
+            auto source_cast = (unsigned long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (unsigned long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
     void IntegerHandler::pack_v() {
         m_token.endianness = Endianness::Little;
+        auto source = m_source.to_nat_int_t_or_none();
         auto size = 2;
-        if (m_source.is_bignum()) {
-            pack_bignum(size * 8);
+        if (source) {
+            auto source_cast = (long long)source.value();
+            append_bytes((const char *)(&source_cast), size);
         } else {
-            auto source = (long long)m_source.to_nat_int_t();
-            append_bytes((const char *)(&source), size);
+            pack_bignum(size * 8);
         }
     }
 
@@ -268,7 +280,16 @@ namespace ArrayPacker {
 
         TM::Vector<char> bytes {};
         size_t size = 0;
-        if (m_source.is_bignum()) {
+        auto source = m_source.to_nat_int_t_or_none();
+        if (source) {
+            auto num = source.value();
+            do {
+                bytes[size] = num & 0x7f;
+                num = num >> 7;
+                if (size > 0) bytes[size] |= 0x80;
+                size++;
+            } while (num > 0);
+        } else {
             auto num = m_source.to_bigint();
             do {
                 bytes[size] = (num & 0x7f).to_long();
@@ -276,14 +297,6 @@ namespace ArrayPacker {
                 if (size > 0) bytes[size] |= 0x80;
                 size++;
             } while (num > 0ll);
-        } else {
-            auto num = m_source.to_nat_int_t();
-            do {
-                bytes[size] = num & 0x7f;
-                num = num >> 7;
-                if (size > 0) bytes[size] |= 0x80;
-                size++;
-            } while (num > 0);
         }
         for (ssize_t i = size - 1; i >= 0; i--) {
             m_packed.append_char(bytes[i]);

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -3,61 +3,36 @@
 #include "natalie/macros.hpp"
 
 namespace Natalie {
-Integer::Integer(nat_int_t other)
-    : m_fixnum(other)
-    , m_is_bignum(false) {
-}
-
-Integer::Integer(int other)
-    : m_fixnum(other)
-    , m_is_bignum(false) {
-}
-
-Integer::Integer(long other)
-    : m_fixnum(other)
-    , m_is_bignum(false) {
-}
 
 Integer::Integer(double other) {
     assert(other == ::floor(other));
-    if (other <= (double)NAT_MIN_FIXNUM || other >= (double)NAT_MAX_FIXNUM) {
-        m_bignum = new BigInt(other);
-        m_is_bignum = true;
-    } else {
-        m_fixnum = static_cast<nat_int_t>(other);
-        m_is_bignum = false;
-    }
+    auto i = (nat_int_t)other;
+    if (i >= NAT_MIN_FIXNUM && i <= NAT_MAX_FIXNUM)
+        m_value = (i << 1) | 0x1;
+    else
+        m_value = (uintptr_t) new BigInt(other);
 }
 
 Integer::Integer(const TM::String &other) {
     auto bigint = BigInt(other);
-    if (bigint >= NAT_MIN_FIXNUM && bigint <= NAT_MAX_FIXNUM) {
-        m_is_bignum = false;
-        m_fixnum = bigint.to_long_long();
-    } else {
-        m_is_bignum = true;
-        m_bignum = new BigInt(bigint);
-    }
+    if (bigint >= NAT_MIN_FIXNUM && bigint <= NAT_MAX_FIXNUM)
+        m_value = (bigint.to_long_long() << 1) | 0x1;
+    else
+        m_value = (uintptr_t) new BigInt(bigint);
 }
 
 Integer::Integer(const BigInt &other) {
-    if (other <= NAT_MAX_FIXNUM && other >= NAT_MIN_FIXNUM) {
-        m_fixnum = other.to_long_long();
-        m_is_bignum = false;
-    } else {
-        m_bignum = new BigInt(other);
-        m_is_bignum = true;
-    }
+    if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
+        m_value = (other.to_long_long() << 1) | 0x1;
+    else
+        m_value = (uintptr_t) new BigInt(other);
 }
 
 Integer::Integer(BigInt &&other) {
-    if (other <= NAT_MAX_FIXNUM && other >= NAT_MIN_FIXNUM) {
-        m_fixnum = other.to_long_long();
-        m_is_bignum = false;
-    } else {
-        m_bignum = new BigInt(std::move(other));
-        m_is_bignum = true;
-    }
+    if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
+        m_value = (other.to_long_long() << 1) | 0x1;
+    else
+        m_value = (uintptr_t) new BigInt(std::move(other));
 }
 
 Integer &Integer::operator+=(const Integer &other) {
@@ -113,7 +88,7 @@ Integer Integer::operator-(const Integer &other) const {
     if (overflowed)
         return to_bigint() - other.to_bigint();
 
-    return m_fixnum - other.m_fixnum;
+    return to_nat_int_t() - other.to_nat_int_t();
 }
 
 bool Integer::will_multiplication_overflow(nat_int_t a, nat_int_t b) {
@@ -136,7 +111,7 @@ Integer Integer::operator*(const Integer &other) const {
         return to_bigint() * other.to_bigint();
     }
 
-    return m_fixnum * other.m_fixnum;
+    return to_nat_int_t() * other.to_nat_int_t();
 }
 
 Integer Integer::operator/(const Integer &other) const {
@@ -206,8 +181,8 @@ Integer &Integer::operator--() {
 bool Integer::operator<(const Integer &other) const {
     if (is_bignum()) {
         if (other.is_bignum())
-            return *m_bignum < *other.m_bignum;
-        else if (m_bignum->is_negative())
+            return *(BigInt *)m_value < *(BigInt *)other.m_value;
+        else if (is_negative())
             return true;
         else
             return false;
@@ -218,7 +193,7 @@ bool Integer::operator<(const Integer &other) const {
             return true;
     }
 
-    return m_fixnum < other.m_fixnum;
+    return to_nat_int_t() < other.to_nat_int_t();
 }
 
 bool Integer::operator<=(const Integer &other) const {
@@ -236,14 +211,14 @@ bool Integer::operator>=(const Integer &other) const {
 bool Integer::operator==(const Integer &other) const {
     if (is_bignum()) {
         if (other.is_bignum())
-            return *m_bignum == *other.m_bignum;
+            return *(BigInt *)m_value == *(BigInt *)other.m_value;
         else
             return false;
     } else if (other.is_bignum()) {
         return false;
     }
 
-    return m_fixnum == other.m_fixnum;
+    return to_nat_int_t() == other.to_nat_int_t();
 }
 
 bool Integer::operator!=(const Integer &other) const {
@@ -355,7 +330,7 @@ double Integer::to_double() const {
     if (is_bignum())
         return to_bigint().to_double();
     else
-        return static_cast<double>(m_fixnum);
+        return static_cast<double>(to_nat_int_t());
 }
 
 TM::String Integer::to_string() const {

--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -8,7 +8,7 @@ Integer::Integer(double other) {
     assert(other == ::floor(other));
     auto i = (nat_int_t)other;
     if (i >= NAT_MIN_FIXNUM && i <= NAT_MAX_FIXNUM)
-        m_value = (i << 1) | 0x1;
+        m_value = left_shift_with_undefined_behavior(i, 1) | 0x1;
     else
         m_value = (uintptr_t) new BigInt(other);
 }
@@ -16,21 +16,21 @@ Integer::Integer(double other) {
 Integer::Integer(const TM::String &other) {
     auto bigint = BigInt(other);
     if (bigint >= NAT_MIN_FIXNUM && bigint <= NAT_MAX_FIXNUM)
-        m_value = (bigint.to_long_long() << 1) | 0x1;
+        m_value = left_shift_with_undefined_behavior(bigint.to_long_long(), 1) | 0x1;
     else
         m_value = (uintptr_t) new BigInt(bigint);
 }
 
 Integer::Integer(const BigInt &other) {
     if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
-        m_value = (other.to_long_long() << 1) | 0x1;
+        m_value = left_shift_with_undefined_behavior(other.to_long_long(), 1) | 0x1;
     else
         m_value = (uintptr_t) new BigInt(other);
 }
 
 Integer::Integer(BigInt &&other) {
     if (other >= NAT_MIN_FIXNUM && other <= NAT_MAX_FIXNUM)
-        m_value = (other.to_long_long() << 1) | 0x1;
+        m_value = left_shift_with_undefined_behavior(other.to_long_long(), 1) | 0x1;
     else
         m_value = (uintptr_t) new BigInt(std::move(other));
 }

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -710,8 +710,7 @@ Value IntegerMethods::ref(Env *env, Integer &self, Value offset_obj, Value size_
 
 nat_int_t IntegerMethods::convert_to_nat_int_t(Env *env, Value arg) {
     auto integer = arg.to_int(env);
-    assert_fixnum(env, integer);
-    return integer.to_nat_int_t();
+    return convert_to_native_type<nat_int_t>(env, integer);
 }
 
 int IntegerMethods::convert_to_int(Env *env, Value arg) {

--- a/test/natalie/array_test.rb
+++ b/test/natalie/array_test.rb
@@ -1237,10 +1237,10 @@ describe 'array' do
       it 'handles bignums' do
         %w[j J].each do |directive|
           [0xdef0_abcd_3412_7856].pack(directive).should == "Vx\x124\xCD\xAB\xF0\xDE".b
-          [fixnum_max + 1].pack(directive).should == "\x00\x00\x00\x00\x00\x00\x00\x80".b
-          [fixnum_max + 2].pack(directive).should == "\x01\x00\x00\x00\x00\x00\x00\x80".b
-          [-fixnum_max - 1].pack(directive).should == "\x00\x00\x00\x00\x00\x00\x00\x80".b
-          [-fixnum_max - 2].pack(directive).should == "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F".b
+          [fixnum_max + 1].pack(directive).should == "\x00\x00\x00\x00\x00\x00\x00@".b
+          [fixnum_max + 2].pack(directive).should == "\x01\x00\x00\x00\x00\x00\x00@".b
+          [-fixnum_max - 1].pack(directive).should == "\x00\x00\x00\x00\x00\x00\x00\xC0".b
+          [-fixnum_max - 2].pack(directive).should == "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xBF".b
 
           little_endian do
             [0xdef0_abcd_3412_7856].pack(directive + '>').should == "\xDE\xF0\xAB\xCD4\x12xV".b

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -233,11 +233,11 @@ def bignum_value(plus = 0)
 end
 
 def fixnum_max
-  9_223_372_036_854_775_807
+  (2**62) - 1
 end
 
 def fixnum_min
-  -9_223_372_036_854_775_807
+  -(2**62)
 end
 
 def max_long


### PR DESCRIPTION
This is to match how MRI stores integers, thought it's only in the `Integer` class for now. In a future PR, I'll see if we can make `Value` a tagged pointer as well.

Integers that can be represented in 63 bits are encoded directly in the 64-bit pointer. Larger ints are created as BigInt and the pointer stored.

This took some adjustments to various bits of code that assumed all bigints could not be represented in a 64-bit int type. (Some bigints can fit in a `nat_int_t`.)