### PR TITLE
Throw exception when trying to resume main fiber

### DIFF
--- a/spec/core/fiber/resume_spec.rb
+++ b/spec/core/fiber/resume_spec.rb
@@ -77,8 +77,7 @@ describe "Fiber#resume" do
     end
   end
 
-  # NATFIXME: assertion failure: src/fiber_object.cpp:171: Natalie::Value Natalie::FiberObject::resume(Natalie::Env*, Natalie::Args): Assertion `res == MCO_SUCCESS' failed.
-  xit "raises a FiberError if the Fiber attempts to resume a resuming fiber" do
+  it "raises a FiberError if the Fiber attempts to resume a resuming fiber" do
     root_fiber = Fiber.current
     fiber1 = Fiber.new { root_fiber.resume }
     -> { fiber1.resume }.should raise_error(FiberError, /attempt to resume a resuming fiber/)

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -152,6 +152,8 @@ Value FiberObject::resume(Env *env, Args args) {
         env->raise("FiberError", "dead fiber called");
     if (m_previous_fiber)
         env->raise("FiberError", "attempt to resume the current fiber");
+    if (this == FiberObject::main())
+        env->raise("FiberError", "attempt to resume a resuming fiber");
 
     auto suspending_fiber = m_previous_fiber = current();
 


### PR DESCRIPTION
The underlying issue is that we only call `mco_create` when we explicitly create a fiber, and we never call this for the main fiber. This change resolves the crash of the spec, but it might not be the best solution.