### PR TITLE
Turn TM::Hashmap inside out

### DIFF
--- a/ext/tm/include/tm/hashmap.hpp
+++ b/ext/tm/include/tm/hashmap.hpp
@@ -88,7 +88,7 @@ struct HashKeyHandler<String> {
      * ```
      */
     static size_t hash(const String &str) {
-        return str.djb2_hash();
+        return djb2_hash(str.c_str(), str.size());
     }
 
     /**
@@ -173,6 +173,15 @@ struct HashKeyHandler<String> {
         return b == a;
     }
 
+    /**
+     * Returns hash value of this String.
+     * This uses the 'djb2' hash algorithm by Dan Bernstein.
+     *
+     * ```
+     * const char *str = "hello";
+     * assert_eq(261238937, HashKeyHandler<String>::djb2_hash(str, strlen(str)));
+     * ```
+     */
     static uint32_t djb2_hash(const char *c, const size_t len) {
         size_t hash = 5381;
         for (size_t i = 0; i < len; ++i)

--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -1732,25 +1732,6 @@ public:
     }
 
     /**
-     * Returns hash value of this String.
-     * This uses the 'djb2' hash algorithm by Dan Bernstein.
-     *
-     * ```
-     * auto str = String("hello");
-     * assert_eq(261238937, str.djb2_hash());
-     * ```
-     */
-    uint32_t djb2_hash() const {
-        size_t hash = 5381;
-        int c;
-        for (size_t i = 0; i < m_length; ++i) {
-            c = (*this)[i];
-            hash = ((hash << 5) + hash) + c;
-        }
-        return hash;
-    }
-
-    /**
      * Prints the full string with printf(), character by character.
      * This method will print the full String, even if null characters
      * are encountered.

--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -252,6 +252,20 @@ public:
      * ```
      * auto str = String("foo-bar-baz");
      * auto view = StringView(&str, 4, 3);
+     * String str2 = view;
+     * assert_str_eq("bar", str2);
+     * ```
+     */
+    operator String() const {
+        return to_string();
+    }
+
+    /**
+     * Returns a new String constructed from this view.
+     *
+     * ```
+     * auto str = String("foo-bar-baz");
+     * auto view = StringView(&str, 4, 3);
      * auto str2 = view.clone();
      * assert_str_eq("bar", str2);
      * ```

--- a/include/natalie/forward.hpp
+++ b/include/natalie/forward.hpp
@@ -30,8 +30,6 @@ class FileObject;
 class FileStatObject;
 class FloatObject;
 class GlobalEnv;
-class HashKey;
-class HashVal;
 class HashObject;
 class IntegerMethods;
 class IoObject;

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -30,6 +30,19 @@ struct HashKey : public Cell {
     }
 };
 
+}
+
+namespace TM {
+
+template <>
+struct HashKeyHandler<Natalie::HashKey *> {
+    static size_t hash(Natalie::HashKey *&);
+};
+
+}
+
+namespace Natalie {
+
 class HashObject : public Object {
 public:
     HashObject()
@@ -88,7 +101,6 @@ public:
         return self.as_hash()->size(env);
     }
 
-    static size_t hash(HashKey *&);
     static bool compare(HashKey *&, HashKey *&, void *);
 
     static bool is_ruby2_keywords_hash(Env *, Value);
@@ -230,7 +242,7 @@ private:
     }
 
     HashKey *m_key_list { nullptr };
-    TM::Hashmap<HashKey *, Value> m_hashmap { hash, compare, 10 }; // TODO: profile and tune this initial capacity
+    TM::Hashmap<HashKey *, Value> m_hashmap { TM::HashKeyHandler<HashKey *>::hash, compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
     bool m_is_comparing_by_identity { false };
     bool m_is_ruby2_keywords_hash { false };

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -241,7 +241,7 @@ private:
     }
 
     HashKey *m_key_list { nullptr };
-    TM::Hashmap<HashKey *, Value> m_hashmap { TM::HashKeyHandler<HashKey *>::compare, 10 }; // TODO: profile and tune this initial capacity
+    TM::Hashmap<HashKey *, Value> m_hashmap { 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
     bool m_is_comparing_by_identity { false };
     bool m_is_ruby2_keywords_hash { false };

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -37,7 +37,7 @@ namespace TM {
 template <>
 struct HashKeyHandler<Natalie::HashKey *> {
     static size_t hash(Natalie::HashKey *);
-    static bool compare(Natalie::HashKey *&, Natalie::HashKey *&, void *);
+    static bool compare(Natalie::HashKey *, Natalie::HashKey *, void *);
 };
 
 }

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -36,7 +36,7 @@ namespace TM {
 
 template <>
 struct HashKeyHandler<Natalie::HashKey *> {
-    static size_t hash(Natalie::HashKey *&);
+    static size_t hash(Natalie::HashKey *);
 };
 
 }
@@ -242,7 +242,7 @@ private:
     }
 
     HashKey *m_key_list { nullptr };
-    TM::Hashmap<HashKey *, Value> m_hashmap { TM::HashKeyHandler<HashKey *>::hash, compare, 10 }; // TODO: profile and tune this initial capacity
+    TM::Hashmap<HashKey *, Value> m_hashmap { compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
     bool m_is_comparing_by_identity { false };
     bool m_is_ruby2_keywords_hash { false };

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -37,6 +37,7 @@ namespace TM {
 template <>
 struct HashKeyHandler<Natalie::HashKey *> {
     static size_t hash(Natalie::HashKey *);
+    static bool compare(Natalie::HashKey *&, Natalie::HashKey *&, void *);
 };
 
 }
@@ -100,8 +101,6 @@ public:
     static Value size_fn(Env *env, Value self, Args &&, Block *) {
         return self.as_hash()->size(env);
     }
-
-    static bool compare(HashKey *&, HashKey *&, void *);
 
     static bool is_ruby2_keywords_hash(Env *, Value);
     static Value ruby2_keywords_hash(Env *, Value);
@@ -242,7 +241,7 @@ private:
     }
 
     HashKey *m_key_list { nullptr };
-    TM::Hashmap<HashKey *, Value> m_hashmap { compare, 10 }; // TODO: profile and tune this initial capacity
+    TM::Hashmap<HashKey *, Value> m_hashmap { TM::HashKeyHandler<HashKey *>::compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
     bool m_is_comparing_by_identity { false };
     bool m_is_ruby2_keywords_hash { false };

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -82,7 +82,7 @@ public:
 
     Value hash(Env *env) {
         assert_initialized(env);
-        auto hash = (m_options & ~RegexOpts::NoEncoding & ~RegexOpts::FixedEncoding) + m_pattern->string().djb2_hash();
+        auto hash = (m_options & ~RegexOpts::NoEncoding & ~RegexOpts::FixedEncoding) + HashKeyHandler<String>::hash(m_pattern->string());
         return Value::integer(hash);
     }
 

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -96,7 +96,7 @@ public:
     }
 
 private:
-    inline static TM::Hashmap<TM::String, SymbolObject *> s_symbols { TM::HashType::String, 1000 };
+    inline static TM::Hashmap<TM::String, SymbolObject *> s_symbols { 1000 };
     inline static regex_t *s_inspect_quote_regex { nullptr };
 
     SymbolObject(const String &name, EncodingObject *encoding)

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -96,7 +96,7 @@ public:
     }
 
 private:
-    inline static TM::Hashmap<const TM::String, SymbolObject *> s_symbols { TM::HashType::String, 1000 };
+    inline static TM::Hashmap<TM::String, SymbolObject *> s_symbols { TM::HashType::String, 1000 };
     inline static regex_t *s_inspect_quote_regex { nullptr };
 
     SymbolObject(const String &name, EncodingObject *encoding)

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -102,7 +102,7 @@ Value EnvObject::dup(Env *env) {
 Value EnvObject::each(Env *env, Block *block) {
     if (block) {
         auto envhash = to_hash(env, nullptr);
-        for (HashObject::Key &node : *envhash.as_hash()) {
+        for (HashKey &node : *envhash.as_hash()) {
             auto name = node.key;
             auto value = node.val;
             block->run(env, Args({ name, value }), nullptr);
@@ -118,7 +118,7 @@ Value EnvObject::each(Env *env, Block *block) {
 Value EnvObject::each_key(Env *env, Block *block) {
     if (block) {
         auto envhash = to_hash(env, nullptr);
-        for (HashObject::Key &node : *envhash.as_hash()) {
+        for (HashKey &node : *envhash.as_hash()) {
             auto name = node.key;
             block->run(env, Args({ name }), nullptr);
         }
@@ -133,7 +133,7 @@ Value EnvObject::each_key(Env *env, Block *block) {
 Value EnvObject::each_value(Env *env, Block *block) {
     if (block) {
         auto envhash = to_hash(env, nullptr);
-        for (HashObject::Key &node : *envhash.as_hash()) {
+        for (HashKey &node : *envhash.as_hash()) {
             auto value = node.val;
             block->run(env, Args({ value }), nullptr);
         }
@@ -273,7 +273,7 @@ Value EnvObject::rehash() const {
 // but is probably more optimal than this solution
 Value EnvObject::clear(Env *env) {
     auto envhash = to_hash(env, nullptr);
-    for (HashObject::Key &node : *envhash.as_hash()) {
+    for (HashKey &node : *envhash.as_hash()) {
         ::unsetenv(node.key.as_string()->c_str());
     }
     return this;
@@ -315,12 +315,12 @@ Value EnvObject::reject_in_place(Env *env, Block *block) {
 
 Value EnvObject::replace(Env *env, Value hash) {
     hash.assert_type(env, Object::Type::Hash, "Hash");
-    for (HashObject::Key &node : *hash.as_hash()) {
+    for (HashKey &node : *hash.as_hash()) {
         node.key.assert_type(env, Object::Type::String, "String");
         node.val.assert_type(env, Object::Type::String, "String");
     }
     clear(env);
-    for (HashObject::Key &node : *hash.as_hash()) {
+    for (HashKey &node : *hash.as_hash()) {
         auto result = ::setenv(node.key.as_string()->c_str(), node.val.as_string()->c_str(), 1);
         if (result == -1)
             env->raise_errno();

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -84,7 +84,7 @@ FiberObject *FiberObject::initialize(Env *env, Value blocking, Value storage, Bl
 
 Value FiberObject::hash(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
-    const auto hash = String::format("{}{}{}", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line).djb2_hash();
+    const auto hash = HashKeyHandler<String>::hash(String::format("{}{}{}", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line));
     return Value::integer(hash);
 }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -5,7 +5,6 @@
 
 namespace TM {
 
-// this is used by the hashmap library and assumes that obj->env has been set
 size_t HashKeyHandler<Natalie::HashKey *>::hash(Natalie::HashKey *key) {
     return key->hash;
 }

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -6,12 +6,12 @@
 namespace Natalie {
 
 // this is used by the hashmap library and assumes that obj->env has been set
-size_t HashObject::hash(Key *&key) {
+size_t HashObject::hash(HashKey *&key) {
     return key->hash;
 }
 
 // this is used by the hashmap library to compare keys
-bool HashObject::compare(Key *&a, Key *&b, void *env) {
+bool HashObject::compare(HashKey *&a, HashKey *&b, void *env) {
     assert(env);
 
     if (object_id(a->key) == object_id(b->key) && a->hash == b->hash)
@@ -48,7 +48,7 @@ bool HashObject::is_comparing_by_identity() const {
 Value HashObject::get(Env *env, Value key) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    Key key_container;
+    HashKey key_container;
     key_container.key = key;
     key_container.hash = generate_key_hash(env, key);
     return m_hashmap.get(&key_container, env);
@@ -86,7 +86,7 @@ void HashObject::put(Env *env, Value key, Value val) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     assert_not_frozen(env);
-    Key key_container;
+    HashKey key_container;
     if (!m_is_comparing_by_identity && key.is_string() && !key->is_frozen()) {
         key = key.as_string()->duplicate(env);
     }
@@ -96,7 +96,7 @@ void HashObject::put(Env *env, Value key, Value val) {
     key_container.hash = hash;
     auto entry = m_hashmap.find_item(&key_container, hash, env);
     if (entry) {
-        ((Key *)entry->key)->val = val;
+        ((HashKey *)entry->key)->val = val;
         entry->value = val;
     } else {
         if (m_is_iterating) {
@@ -110,13 +110,13 @@ void HashObject::put(Env *env, Value key, Value val) {
 Value HashObject::remove(Env *env, Value key) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    Key key_container;
+    HashKey key_container;
     key_container.key = key;
     auto hash = generate_key_hash(env, key);
     key_container.hash = hash;
     auto entry = m_hashmap.find_item(&key_container, hash, env);
     if (entry) {
-        key_list_remove_node((Key *)entry->key);
+        key_list_remove_node((HashKey *)entry->key);
         auto val = entry->value;
         m_hashmap.remove(&key_container, env);
         return val;
@@ -158,11 +158,11 @@ Value HashObject::set_default_proc(Env *env, Value value) {
     return value;
 }
 
-HashObject::Key *HashObject::key_list_append(Env *env, Value key, nat_int_t hash, Value val) {
+Natalie::HashKey *HashObject::key_list_append(Env *env, Value key, nat_int_t hash, Value val) {
     if (m_key_list) {
-        Key *first = m_key_list;
-        Key *last = m_key_list->prev;
-        Key *new_last = new Key {};
+        HashKey *first = m_key_list;
+        HashKey *last = m_key_list->prev;
+        HashKey *new_last = new HashKey {};
         new_last->key = key;
         new_last->val = val;
         // <first> ... <last> <new_last> -|
@@ -175,7 +175,7 @@ HashObject::Key *HashObject::key_list_append(Env *env, Value key, nat_int_t hash
         last->next = new_last;
         return new_last;
     } else {
-        Key *node = new Key {};
+        HashKey *node = new HashKey {};
         node->key = key;
         node->val = val;
         node->prev = node;
@@ -187,9 +187,9 @@ HashObject::Key *HashObject::key_list_append(Env *env, Value key, nat_int_t hash
     }
 }
 
-void HashObject::key_list_remove_node(Key *node) {
-    Key *prev = node->prev;
-    Key *next = node->next;
+void HashObject::key_list_remove_node(HashKey *node) {
+    HashKey *prev = node->prev;
+    HashKey *next = node->next;
     // <prev> <-> <node> <-> <next>
     if (node == next) {
         // <node> -|
@@ -215,7 +215,7 @@ Value HashObject::initialize(Env *env, Value default_value, Value capacity, Bloc
     if (capacity) {
         const auto capacity_int = IntegerMethods::convert_to_native_type<ssize_t>(env, capacity);
         if (capacity_int > 0)
-            m_hashmap = TM::Hashmap<Key *, Value> { hash, compare, static_cast<size_t>(capacity_int) };
+            m_hashmap = TM::Hashmap<HashKey *, Value> { hash, compare, static_cast<size_t>(capacity_int) };
     }
 
     if (block) {
@@ -302,7 +302,7 @@ Value HashObject::inspect(Env *env) {
             return obj.as_string();
         };
 
-        for (HashObject::Key &node : *this) {
+        for (HashKey &node : *this) {
             if (node.key.is_symbol()) {
                 StringObject *key_repr = node.key.as_symbol()->to_s(env);
                 out->append(key_repr);
@@ -443,7 +443,7 @@ bool HashObject::eq(Env *env, Value other_value, SymbolObject *method_name) {
             return true;
 
         Value other_val;
-        for (HashObject::Key &node : *this) {
+        for (HashKey &node : *this) {
             other_val = other->get(env, node.key);
             if (!other_val)
                 return false;
@@ -518,7 +518,7 @@ Value HashObject::each(Env *env, Block *block) {
     Value block_args[2];
     set_is_iterating(true);
     Defer no_longer_iterating([&]() { set_is_iterating(false); });
-    for (HashObject::Key &node : *this) {
+    for (HashKey &node : *this) {
         auto ary = new ArrayObject { { node.key, node.val } };
         Value block_args[1] = { ary };
         block->run(env, Args(1, block_args), nullptr);
@@ -568,7 +568,7 @@ Value HashObject::fetch_values(Env *env, Args &&args, Block *block) {
 
 Value HashObject::keys(Env *env) {
     ArrayObject *array = new ArrayObject { size() };
-    for (HashObject::Key &node : *this) {
+    for (HashKey &node : *this) {
         array->push(node.key);
     }
     return array;
@@ -625,7 +625,7 @@ Value HashObject::to_h(Env *env, Block *block) {
 
 Value HashObject::values(Env *env) {
     ArrayObject *array = new ArrayObject { size() };
-    for (HashObject::Key &node : *this) {
+    for (HashKey &node : *this) {
         array->push(node.val);
     }
     return array;
@@ -640,7 +640,7 @@ Value HashObject::hash(Env *env) {
         HashBuilder hash { 10889, false };
         auto hash_method = "hash"_s;
 
-        for (HashObject::Key &node : *this) {
+        for (HashKey &node : *this) {
             HashBuilder entry_hash {};
             bool any_change = false;
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -11,7 +11,7 @@ size_t HashKeyHandler<Natalie::HashKey *>::hash(Natalie::HashKey *key) {
 }
 
 // this is used by the hashmap library to compare keys
-bool HashKeyHandler<Natalie::HashKey *>::compare(Natalie::HashKey *&a, Natalie::HashKey *&b, void *env) {
+bool HashKeyHandler<Natalie::HashKey *>::compare(Natalie::HashKey *a, Natalie::HashKey *b, void *env) {
     assert(env);
 
     if (Natalie::Object::object_id(a->key) == Natalie::Object::object_id(b->key) && a->hash == b->hash)

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -57,7 +57,7 @@ Value HashObject::get(Env *env, Value key) {
 nat_int_t HashObject::generate_key_hash(Env *env, Value key) const {
     if (m_is_comparing_by_identity && !key.is_float() && !key.is_integer()) {
         auto obj = key.object();
-        return TM::HashmapUtils::hashmap_hash_ptr((uintptr_t)obj);
+        return TM::HashKeyHandler<void *>::hash(obj);
     } else {
         return key.send(env, "hash"_s).integer().to_nat_int_t();
     }

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -6,7 +6,7 @@
 namespace TM {
 
 // this is used by the hashmap library and assumes that obj->env has been set
-size_t HashKeyHandler<Natalie::HashKey *>::hash(Natalie::HashKey *&key) {
+size_t HashKeyHandler<Natalie::HashKey *>::hash(Natalie::HashKey *key) {
     return key->hash;
 }
 
@@ -219,7 +219,7 @@ Value HashObject::initialize(Env *env, Value default_value, Value capacity, Bloc
     if (capacity) {
         const auto capacity_int = IntegerMethods::convert_to_native_type<ssize_t>(env, capacity);
         if (capacity_int > 0)
-            m_hashmap = TM::Hashmap<HashKey *, Value> { TM::HashKeyHandler<HashKey *>::hash, compare, static_cast<size_t>(capacity_int) };
+            m_hashmap = TM::Hashmap<HashKey *, Value> { compare, static_cast<size_t>(capacity_int) };
     }
 
     if (block) {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -3,12 +3,16 @@
 #include "tm/recursion_guard.hpp"
 #include "tm/vector.hpp"
 
-namespace Natalie {
+namespace TM {
 
 // this is used by the hashmap library and assumes that obj->env has been set
-size_t HashObject::hash(HashKey *&key) {
+size_t HashKeyHandler<Natalie::HashKey *>::hash(Natalie::HashKey *&key) {
     return key->hash;
 }
+
+}
+
+namespace Natalie {
 
 // this is used by the hashmap library to compare keys
 bool HashObject::compare(HashKey *&a, HashKey *&b, void *env) {
@@ -215,7 +219,7 @@ Value HashObject::initialize(Env *env, Value default_value, Value capacity, Bloc
     if (capacity) {
         const auto capacity_int = IntegerMethods::convert_to_native_type<ssize_t>(env, capacity);
         if (capacity_int > 0)
-            m_hashmap = TM::Hashmap<HashKey *, Value> { hash, compare, static_cast<size_t>(capacity_int) };
+            m_hashmap = TM::Hashmap<HashKey *, Value> { TM::HashKeyHandler<HashKey *>::hash, compare, static_cast<size_t>(capacity_int) };
     }
 
     if (block) {

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -219,7 +219,7 @@ Value HashObject::initialize(Env *env, Value default_value, Value capacity, Bloc
     if (capacity) {
         const auto capacity_int = IntegerMethods::convert_to_native_type<ssize_t>(env, capacity);
         if (capacity_int > 0)
-            m_hashmap = TM::Hashmap<HashKey *, Value> { TM::HashKeyHandler<HashKey *>::compare, static_cast<size_t>(capacity_int) };
+            m_hashmap = TM::Hashmap<HashKey *, Value> { static_cast<size_t>(capacity_int) };
     }
 
     if (block) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -933,16 +933,16 @@ Value KernelModule::extend(Env *env, Value self, Args &&args) {
 Value KernelModule::hash(Env *env, Value self) {
     switch (self.type()) {
     case Object::Type::Integer:
-        return Value::integer(self.integer().to_string().djb2_hash());
+        return Value::integer(HashKeyHandler<TM::String>::hash(self.integer().to_string()));
     // NOTE: string "foo" and symbol :foo will get the same hash.
     // That's probably ok, but maybe worth revisiting.
     case Object::Type::String:
-        return Value::integer(self.as_string()->string().djb2_hash());
+        return Value::integer(HashKeyHandler<TM::String>::hash(self.as_string()->string()));
     case Object::Type::Symbol:
-        return Value::integer(self.as_symbol()->string().djb2_hash());
+        return Value::integer(HashKeyHandler<TM::String>::hash(self.as_symbol()->string()));
     default: {
         StringObject *inspected = self.send(env, "inspect"_s).as_string();
-        nat_int_t hash_value = inspected->string().djb2_hash();
+        nat_int_t hash_value = HashKeyHandler<TM::String>::hash(inspected->string());
         return Value::integer(hash_value);
     }
     }

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -20,7 +20,7 @@ Value MethodObject::gtgt(Env *env, Value other) {
 }
 
 Value MethodObject::hash() const {
-    return Value::integer(m_method->original_name().djb2_hash());
+    return Value::integer(HashKeyHandler<String>::hash(m_method->original_name()));
 }
 
 Value MethodObject::source_location() {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -55,7 +55,7 @@ static auto character_class_handler(Env *env, Args &&args) {
             if (value == "-" && last_character != StringView() && last_character != "\\") {
                 result = selectors->next_char_result(&index);
                 if (result.second.is_empty()) {
-                    new_selectors.set(value.to_string());
+                    new_selectors.set(value);
                     break;
                 }
 
@@ -66,7 +66,7 @@ static auto character_class_handler(Env *env, Args &&args) {
                 if (last_character.to_string().cmp(next_value.to_string()) == 1)
                     env->raise("ArgumentError", "invalid range \"{}-{}\" in string transliteration", last_character, next_value);
 
-                auto range = RangeObject::create(env, new StringObject { last_character.to_string() }, new StringObject { next_value.to_string() }, false);
+                auto range = RangeObject::create(env, new StringObject { last_character }, new StringObject { next_value }, false);
                 auto all_chars = range->to_a(env).as_array();
                 for (auto character : *all_chars) {
                     auto character_string = character.as_string()->string();
@@ -75,7 +75,7 @@ static auto character_class_handler(Env *env, Args &&args) {
                 last_character = StringView();
             } else {
                 last_character = value;
-                new_selectors.set(value.to_string());
+                new_selectors.set(value);
             }
             result = selectors->next_char_result(&index);
         }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -24,8 +24,8 @@ constexpr bool is_strippable_whitespace(char c) {
 static auto character_class_handler(Env *env, Args &&args) {
     args.ensure_argc_at_least(env, 1);
 
-    auto basic_characters = Hashmap<String>(HashType::String);
-    auto negated_characters = Hashmap<String>(HashType::String);
+    auto basic_characters = Hashmap<String>();
+    auto negated_characters = Hashmap<String>();
 
     // For each argument
     for (size_t i = 0; i < args.size(); ++i) {
@@ -33,7 +33,7 @@ static auto character_class_handler(Env *env, Args &&args) {
 
         // Try convert to string
         auto selectors = arg.to_str(env);
-        auto new_selectors = Hashmap<String>(HashType::String);
+        auto new_selectors = Hashmap<String>();
         StringView last_character = {};
         bool negated = false;
 
@@ -86,7 +86,7 @@ static auto character_class_handler(Env *env, Args &&args) {
                 negated_characters.set(pair.first);
             }
         } else {
-            auto new_basic_characters = Hashmap<String>(HashType::String);
+            auto new_basic_characters = Hashmap<String>();
             for (auto pair : new_selectors) {
                 if (basic_characters.is_empty() || basic_characters.get(pair.first) != nullptr) {
                     new_basic_characters.set(pair.first);

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -107,6 +107,8 @@ def get_class_details_for_path(path)
             superclass = $1
           elsif cursor.kind == :cursor_class_template
             superclass = TEMPLATE_TYPES[cursor.display_name][:superclass]
+          elsif cursor.qualified_name.start_with?('TM::')
+            superclass = nil
           else
             raise 'could not get base class'
           end


### PR DESCRIPTION
The old implementation had two major disadvantages:
* The key type and the hash/compare methods could be defined individually. This resulted in issues with integer keys and pointer type, where the hash was always 0 and the hash map was just a linked list (see #2559)
* The lookup methods required a copy of the object to look up. This is okay with a pointer, but inefficient with a string. As a side effect, it was impossible to do a lookup with a stringview or a char pointer, even though this included the exact same information as the string object.

This change extracts the hash and lookup methods into separate typed structs. A hash for an integer type will now fail to compile, until you implement a specific typed struct for integers. The hash/compare methods can now be defined polymorphically, and arguments to the hash methods are being forwarded, which means things like const references to strings or string views now work without the need to create a copy.

This mostly helps the Symbol lookup, which is a Hashmap with TM::String keys.