### PR TITLE
Fix stack scanning by using dummy variable again

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -215,7 +215,6 @@ SUPPORTED_HOST_RUBY_VERSIONS = %w[ruby3.2 ruby3.3 ruby3.4].freeze
 def default_docker_build_args
   [
     "--build-arg IMAGE='ruby:#{ruby_version_number}'",
-    '--build-arg NAT_CXX_FLAGS=-DNAT_GC_GUARD',
     "--build-arg NAT_BUILD_MODE=#{ENV.fetch('NAT_BUILD_MODE', 'release')}",
     "--build-arg NEED_VALGRIND=#{ENV.fetch('NEED_VALGRIND', 'false')}",
   ]

--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -19,6 +19,9 @@
     c &operator=(const c &) = delete
 
 #ifdef NAT_GC_GUARD
+#ifdef __SANITIZE_ADDRESS__
+#error "Do not enable ASan and NAT_GC_GUARD at the same time"
+#endif
 #define NAT_GC_GUARD_VALUE(val)                                                               \
     {                                                                                         \
         Object *ptr;                                                                          \

--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -30,6 +30,8 @@ module Natalie
       SANITIZED_FLAGS = DEBUG_FLAGS + [
         SANITIZE_FLAG,
         '-fno-omit-frame-pointer',
+      ] - %w[
+        -DNAT_GC_GUARD
       ]
 
       COVERAGE_FLAGS = DEBUG_FLAGS + %w[

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -50,7 +50,8 @@ void Heap::gather_roots_from_asan_fake_stack(Hashmap<Cell *> &roots, Cell *poten
 #endif
 
 NO_SANITIZE_ADDRESS TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
-    void *end_of_stack = __builtin_frame_address(0);
+    void *dummy;
+    void *end_of_stack = &dummy;
 
     // step over stack, saving potential pointers
     auto start_of_stack = ThreadObject::current()->start_of_stack();


### PR DESCRIPTION
I removed this in 777f32a3e6173aa098c684a153c9a29eae5ba8f1 in favor of `__builtin_frame_address(0)`, which I thought was equivalent. Apparently, it is not.

In the `HashObject(Env *, size_t, Value *)` constructor I noticed the GC was collecting the HashObject *during* the construction. Clang allocates the memory and stores the pointer in a register. We call `HashObject::put()`, which allocates memory, which can trigger a GC collection. Clang pushes the pointer onto the stack *just outside* the `__builtin_frame_address(0)` boundary.

Example:

```
stack location of HashObject pointer: 0x16fdfbee0
__builtin_frame_address(0) gives us:  0x16fdfbf30
so we think the stack is:             0x16fdfbf30 to 0x16fe00000
but the &dummy trick gives us:        0x16fdfbe08
so the real stack range is:           0x16fdfbe08 to 0x16fe00000
```