### PR TITLE
Refactor String#to_f

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -102,6 +102,7 @@
 #include "natalie/module_object.hpp"
 #include "natalie/native_profiler.hpp"
 #include "natalie/nil_methods.hpp"
+#include "natalie/number_parser.hpp"
 #include "natalie/object.hpp"
 #include "natalie/proc_object.hpp"
 #include "natalie/process_module.hpp"

--- a/include/natalie/forward.hpp
+++ b/include/natalie/forward.hpp
@@ -39,6 +39,7 @@ class MethodObject;
 class ModuleObject;
 class NatalieProfiler;
 class NatalieProfilerEvent;
+class NumberParser;
 class ParserObject;
 class ProcObject;
 class RandomObject;

--- a/include/natalie/number_parser.hpp
+++ b/include/natalie/number_parser.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "natalie/forward.hpp"
+#include "tm/string.hpp"
+
+namespace Natalie {
+
+class NumberParser {
+public:
+    NumberParser(const StringObject *str);
+
+    static FloatObject *string_to_f(const StringObject *str);
+
+private:
+    const TM::String m_str;
+};
+
+}

--- a/include/natalie/number_parser.hpp
+++ b/include/natalie/number_parser.hpp
@@ -1,18 +1,12 @@
 #pragma once
 
 #include "natalie/forward.hpp"
-#include "tm/string.hpp"
 
 namespace Natalie {
 
 class NumberParser {
 public:
-    NumberParser(const StringObject *str);
-
     static FloatObject *string_to_f(const StringObject *str);
-
-private:
-    const TM::String m_str;
 };
 
 }

--- a/include/natalie/number_parser.hpp
+++ b/include/natalie/number_parser.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "natalie/forward.hpp"
+#include "tm/non_null_ptr.hpp"
 
 namespace Natalie {
 
 class NumberParser {
 public:
-    static FloatObject *string_to_f(const StringObject *str);
+    static FloatObject *string_to_f(TM::NonNullPtr<const StringObject> str);
 };
 
 }

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -30,24 +30,12 @@ describe "String#to_f" do
   it "allows for varying signs" do
     "+123.45e1".to_f.should == +123.45e1
     "-123.45e1".to_f.should == -123.45e1
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "123.45e+1".to_f.should == 123.45e+1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "123.45e-1".to_f.should == 123.45e-1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "+123.45e+1".to_f.should == +123.45e+1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "+123.45e-1".to_f.should == +123.45e-1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "-123.45e+1".to_f.should == -123.45e+1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "-123.45e-1".to_f.should == -123.45e-1
-    end
+    "123.45e+1".to_f.should == 123.45e+1
+    "123.45e-1".to_f.should == 123.45e-1
+    "+123.45e+1".to_f.should == +123.45e+1
+    "+123.45e-1".to_f.should == +123.45e-1
+    "-123.45e+1".to_f.should == -123.45e+1
+    "-123.45e-1".to_f.should == -123.45e-1
   end
 
   it "allows for underscores, even in the decimal side" do

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -102,19 +102,13 @@ describe "String#to_f" do
   end
 
   it "takes an optional sign" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "-45.67 degrees".to_f.should == -45.67
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "+45.67 degrees".to_f.should == 45.67
-    end
+    "-45.67 degrees".to_f.should == -45.67
+    "+45.67 degrees".to_f.should == 45.67
     NATFIXME 'it takes an optional sign', exception: SpecFailedException do
       "-5_5e-5_0".to_f.should == -55e-50
     end
     "-".to_f.should == 0.0
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      (1.0 / "-0".to_f).to_s.should == "-Infinity"
-    end
+    (1.0 / "-0".to_f).to_s.should == "-Infinity"
   end
 
   it "treats a second 'e' as terminal" do

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -39,9 +39,7 @@ describe "String#to_f" do
   end
 
   it "allows for underscores, even in the decimal side" do
-    NATFIXME 'it allows for underscores, even in the decimal side', exception: SpecFailedException do
-      "1_234_567.890_1".to_f.should == 1_234_567.890_1
-    end
+    "1_234_567.890_1".to_f.should == 1_234_567.890_1
   end
 
   it "returns 0 for strings with leading underscores" do
@@ -80,9 +78,7 @@ describe "String#to_f" do
   it "takes an optional sign" do
     "-45.67 degrees".to_f.should == -45.67
     "+45.67 degrees".to_f.should == 45.67
-    NATFIXME 'it takes an optional sign', exception: SpecFailedException do
-      "-5_5e-5_0".to_f.should == -55e-50
-    end
+    "-5_5e-5_0".to_f.should == -55e-50
     "-".to_f.should == 0.0
     (1.0 / "-0".to_f).to_s.should == "-Infinity"
   end

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -5,16 +5,12 @@ require_relative 'fixtures/classes'
 
 describe "String#to_f" do
   it "treats leading characters of self as a floating point number" do
-   NATFIXME 'Reworking the parser', exception: SpecFailedException do
-     "123.45e1".to_f.should == 1234.5
-   end
+   "123.45e1".to_f.should == 1234.5
    "45.67 degrees".to_f.should == 45.67
    "0".to_f.should == 0.0
 
    ".5".to_f.should == 0.5
-   NATFIXME 'Reworking the parser', exception: SpecFailedException do
-     ".5e1".to_f.should == 5.0
-   end
+   ".5e1".to_f.should == 5.0
    "5.".to_f.should == 5.0
    "5e".to_f.should == 5.0
    "5E".to_f.should == 5.0
@@ -27,21 +23,13 @@ describe "String#to_f" do
   end
 
   it "allows for varying case" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "123.45e1".to_f.should == 1234.5
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "123.45E1".to_f.should == 1234.5
-    end
+    "123.45e1".to_f.should == 1234.5
+    "123.45E1".to_f.should == 1234.5
   end
 
   it "allows for varying signs" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "+123.45e1".to_f.should == +123.45e1
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "-123.45e1".to_f.should == -123.45e1
-    end
+    "+123.45e1".to_f.should == +123.45e1
+    "-123.45e1".to_f.should == -123.45e1
     NATFIXME 'Reworking the parser', exception: SpecFailedException do
       "123.45e+1".to_f.should == 123.45e+1
     end
@@ -112,9 +100,7 @@ describe "String#to_f" do
   end
 
   it "treats a second 'e' as terminal" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "1.234e1e2".to_f.should == 1.234e1
-    end
+    "1.234e1e2".to_f.should == 1.234e1
   end
 
   it "treats a second '.' as terminal" do
@@ -122,9 +108,7 @@ describe "String#to_f" do
   end
 
   it "treats a '.' after an 'e' as terminal" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "1.234e1.9".to_f.should == 1.234e1
-    end
+    "1.234e1.9".to_f.should == 1.234e1
   end
 
   it "returns 0.0 if the conversion fails" do

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -133,28 +133,14 @@ describe "String#to_f" do
   end
 
   it "ignores leading and trailing whitespace" do
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "  1.2".to_f.should == 1.2
-    end
+    "  1.2".to_f.should == 1.2
     "1.2  ".to_f.should == 1.2
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      " 1.2 ".to_f.should == 1.2
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "\t1.2".to_f.should == 1.2
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "\n1.2".to_f.should == 1.2
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "\v1.2".to_f.should == 1.2
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "\f1.2".to_f.should == 1.2
-    end
-    NATFIXME 'Reworking the parser', exception: SpecFailedException do
-      "\r1.2".to_f.should == 1.2
-    end
+    " 1.2 ".to_f.should == 1.2
+    "\t1.2".to_f.should == 1.2
+    "\n1.2".to_f.should == 1.2
+    "\v1.2".to_f.should == 1.2
+    "\f1.2".to_f.should == 1.2
+    "\r1.2".to_f.should == 1.2
   end
 
   it "treats non-printable ASCII characters as terminals" do

--- a/spec/core/string/to_f_spec.rb
+++ b/spec/core/string/to_f_spec.rb
@@ -5,39 +5,61 @@ require_relative 'fixtures/classes'
 
 describe "String#to_f" do
   it "treats leading characters of self as a floating point number" do
-   "123.45e1".to_f.should == 1234.5
+   NATFIXME 'Reworking the parser', exception: SpecFailedException do
+     "123.45e1".to_f.should == 1234.5
+   end
    "45.67 degrees".to_f.should == 45.67
    "0".to_f.should == 0.0
 
    ".5".to_f.should == 0.5
-   ".5e1".to_f.should == 5.0
+   NATFIXME 'Reworking the parser', exception: SpecFailedException do
+     ".5e1".to_f.should == 5.0
+   end
    "5.".to_f.should == 5.0
    "5e".to_f.should == 5.0
    "5E".to_f.should == 5.0
   end
 
   it "treats special float value strings as characters" do
-    NATFIXME 'it treats special float value strings as characters', exception: SpecFailedException do
-      "NaN".to_f.should == 0
-      "Infinity".to_f.should == 0
-      "-Infinity".to_f.should == 0
-    end
+    "NaN".to_f.should == 0
+    "Infinity".to_f.should == 0
+    "-Infinity".to_f.should == 0
   end
 
   it "allows for varying case" do
-    "123.45e1".to_f.should == 1234.5
-    "123.45E1".to_f.should == 1234.5
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "123.45e1".to_f.should == 1234.5
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "123.45E1".to_f.should == 1234.5
+    end
   end
 
   it "allows for varying signs" do
-    "+123.45e1".to_f.should == +123.45e1
-    "-123.45e1".to_f.should == -123.45e1
-    "123.45e+1".to_f.should == 123.45e+1
-    "123.45e-1".to_f.should == 123.45e-1
-    "+123.45e+1".to_f.should == +123.45e+1
-    "+123.45e-1".to_f.should == +123.45e-1
-    "-123.45e+1".to_f.should == -123.45e+1
-    "-123.45e-1".to_f.should == -123.45e-1
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "+123.45e1".to_f.should == +123.45e1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "-123.45e1".to_f.should == -123.45e1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "123.45e+1".to_f.should == 123.45e+1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "123.45e-1".to_f.should == 123.45e-1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "+123.45e+1".to_f.should == +123.45e+1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "+123.45e-1".to_f.should == +123.45e-1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "-123.45e+1".to_f.should == -123.45e+1
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "-123.45e-1".to_f.should == -123.45e-1
+    end
   end
 
   it "allows for underscores, even in the decimal side" do
@@ -67,9 +89,7 @@ describe "String#to_f" do
     "010".to_f.should == 10
     "0o10".to_f.should == 0
     "0d10".to_f.should == 0
-    NATFIXME 'it does not allow prefixes to autodetect the base', exception: SpecFailedException do
-      "0x10".to_f.should == 0
-    end
+    "0x10".to_f.should == 0
   end
 
   it "treats any non-numeric character other than '.', 'e' and '_' as terminals" do
@@ -82,17 +102,25 @@ describe "String#to_f" do
   end
 
   it "takes an optional sign" do
-    "-45.67 degrees".to_f.should == -45.67
-    "+45.67 degrees".to_f.should == 45.67
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "-45.67 degrees".to_f.should == -45.67
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "+45.67 degrees".to_f.should == 45.67
+    end
     NATFIXME 'it takes an optional sign', exception: SpecFailedException do
       "-5_5e-5_0".to_f.should == -55e-50
     end
     "-".to_f.should == 0.0
-    (1.0 / "-0".to_f).to_s.should == "-Infinity"
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      (1.0 / "-0".to_f).to_s.should == "-Infinity"
+    end
   end
 
   it "treats a second 'e' as terminal" do
-    "1.234e1e2".to_f.should == 1.234e1
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "1.234e1e2".to_f.should == 1.234e1
+    end
   end
 
   it "treats a second '.' as terminal" do
@@ -100,7 +128,9 @@ describe "String#to_f" do
   end
 
   it "treats a '.' after an 'e' as terminal" do
-    "1.234e1.9".to_f.should == 1.234e1
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "1.234e1.9".to_f.should == 1.234e1
+    end
   end
 
   it "returns 0.0 if the conversion fails" do
@@ -109,14 +139,28 @@ describe "String#to_f" do
   end
 
   it "ignores leading and trailing whitespace" do
-    "  1.2".to_f.should == 1.2
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "  1.2".to_f.should == 1.2
+    end
     "1.2  ".to_f.should == 1.2
-    " 1.2 ".to_f.should == 1.2
-    "\t1.2".to_f.should == 1.2
-    "\n1.2".to_f.should == 1.2
-    "\v1.2".to_f.should == 1.2
-    "\f1.2".to_f.should == 1.2
-    "\r1.2".to_f.should == 1.2
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      " 1.2 ".to_f.should == 1.2
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "\t1.2".to_f.should == 1.2
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "\n1.2".to_f.should == 1.2
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "\v1.2".to_f.should == 1.2
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "\f1.2".to_f.should == 1.2
+    end
+    NATFIXME 'Reworking the parser', exception: SpecFailedException do
+      "\r1.2".to_f.should == 1.2
+    end
   end
 
   it "treats non-printable ASCII characters as terminals" do

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -7,6 +7,7 @@ namespace {
         Number,
         Period,
         Sign,
+        Whitespace,
         Invalid,
         End,
     };
@@ -19,6 +20,10 @@ namespace {
 
     bool is_numeric(const char c) {
         return c >= '0' && c <= '9';
+    }
+
+    bool is_whitespace(const char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
     }
 
     class Tokenizer {
@@ -34,6 +39,11 @@ namespace {
                 while (is_numeric(m_curr[size]))
                     size++;
                 return make_token(TokenType::Number, size);
+            } else if (is_whitespace(*m_curr)) {
+                size_t size = 1;
+                while (is_whitespace(m_curr[size]))
+                    size++;
+                return make_token(TokenType::Whitespace, size);
             } else if (*m_curr == '.') {
                 return make_token(TokenType::Period, 1);
             } else if (*m_curr == '+' || *m_curr == '-') {
@@ -61,6 +71,9 @@ namespace {
         double operator()() {
             const auto token = scan();
             switch (token.type) {
+            case TokenType::Whitespace:
+                // Skip and continue
+                return operator()();
             case TokenType::Sign:
                 parse_sign(token);
                 break;

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -6,6 +6,7 @@ namespace {
     enum class TokenType {
         Number,
         Period,
+        Sign,
         Invalid,
         End,
     };
@@ -35,6 +36,8 @@ namespace {
                 return make_token(TokenType::Number, size);
             } else if (*m_curr == '.') {
                 return make_token(TokenType::Period, 1);
+            } else if (*m_curr == '+' || *m_curr == '-') {
+                return make_token(TokenType::Sign, 1);
             } else {
                 return make_token(TokenType::Invalid, 1);
             }
@@ -58,6 +61,9 @@ namespace {
         double operator()() {
             const auto token = scan();
             switch (token.type) {
+            case TokenType::Sign:
+                parse_sign(token);
+                break;
             case TokenType::Number:
                 parse_decimal(token);
                 break;
@@ -80,6 +86,18 @@ namespace {
         Token scan() { return m_tokenizer.scan(); }
         void append_char(const char c) { m_result.append_char(c); }
         void append(const Token &token) { m_result.append(token.start, token.size); }
+
+        void parse_sign(const Token &token) {
+            const auto next_token = scan();
+            if (next_token.type == TokenType::Number) {
+                append(token);
+                parse_decimal(next_token);
+            } else if (next_token.type == TokenType::Period) {
+                append(token);
+                append_char('0');
+                parse_fractional(next_token);
+            }
+        }
 
         void parse_decimal(const Token &token) {
             append(token);

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -75,7 +75,7 @@ namespace {
         FloatParser(const TM::String &str)
             : m_tokenizer { Tokenizer { str } } { }
 
-        double operator()() {
+        TM::Optional<double> operator()() {
             advance();
             switch (current().type) {
             case TokenType::Whitespace:
@@ -96,7 +96,7 @@ namespace {
             case TokenType::Invalid:
             case TokenType::End:
             case TokenType::NotYetScanned:
-                return 0.0;
+                return {};
             }
 
             return strtod(m_result.c_str(), nullptr);
@@ -196,7 +196,7 @@ namespace {
 
 FloatObject *NumberParser::string_to_f(TM::NonNullPtr<const StringObject> str) {
     FloatParser float_parser { str->string() };
-    return new FloatObject { float_parser() };
+    return new FloatObject { float_parser().value_or(0.0) };
 }
 
 }

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -32,7 +32,7 @@ namespace {
     class Tokenizer {
     public:
         Tokenizer(const TM::String &str)
-            : m_curr { str.c_str() } { }
+            : m_str { str.c_str() } { }
 
         Token current() { return m_current; }
 
@@ -53,30 +53,30 @@ namespace {
         }
 
     private:
-        const char *m_curr { nullptr };
+        const char *m_str { nullptr };
         Token m_current { TokenType::NotYetScanned, nullptr, 0 };
         Token m_next { TokenType::NotYetScanned, nullptr, 0 };
 
         Token scan() {
-            if (*m_curr == '\0') {
+            if (*m_str == '\0') {
                 return make_token(TokenType::End, 0);
-            } else if (is_numeric(*m_curr)) {
+            } else if (is_numeric(*m_str)) {
                 size_t size = 1;
-                while (is_numeric(m_curr[size]))
+                while (is_numeric(m_str[size]))
                     size++;
                 return make_token(TokenType::Number, size);
-            } else if (is_whitespace(*m_curr)) {
+            } else if (is_whitespace(*m_str)) {
                 size_t size = 1;
-                while (is_whitespace(m_curr[size]))
+                while (is_whitespace(m_str[size]))
                     size++;
                 return make_token(TokenType::Whitespace, size);
-            } else if (*m_curr == '.') {
+            } else if (*m_str == '.') {
                 return make_token(TokenType::Period, 1);
-            } else if (*m_curr == '+' || *m_curr == '-') {
+            } else if (*m_str == '+' || *m_str == '-') {
                 return make_token(TokenType::Sign, 1);
-            } else if (*m_curr == 'e' || *m_curr == 'E') {
+            } else if (*m_str == 'e' || *m_str == 'E') {
                 return make_token(TokenType::ScientificE, 1);
-            } else if (*m_curr == '_') {
+            } else if (*m_str == '_') {
                 return make_token(TokenType::Underscore, 1);
             } else {
                 return make_token(TokenType::Invalid, 1);
@@ -84,8 +84,8 @@ namespace {
         }
 
         Token make_token(TokenType type, size_t size) {
-            Token token { type, m_curr, size };
-            m_curr += size;
+            Token token { type, m_str, size };
+            m_str += size;
             return token;
         }
     };

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -2,13 +2,89 @@
 
 namespace Natalie {
 
+namespace {
+    enum class TokenType {
+        Number,
+        Period,
+        Invalid,
+        End,
+    };
+
+    struct Token {
+        TokenType type;
+        const char *start;
+        size_t size;
+    };
+
+    bool is_numeric(const char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    class Tokenizer {
+    public:
+        Tokenizer(const TM::String &str)
+            : m_curr { str.c_str() } { }
+
+        TM::Vector<Token> scan() {
+            TM::Vector<Token> res {};
+            while (true) {
+                if (*m_curr == '\0') {
+                    res.push({ TokenType::End, m_curr, 0 });
+                    break;
+                } else if (is_numeric(*m_curr)) {
+                    size_t size = 1;
+                    while (is_numeric(m_curr[size]))
+                        size++;
+                    res.push({ TokenType::Number, m_curr, size });
+                    m_curr += size;
+                } else if (*m_curr == '.') {
+                    res.push({ TokenType::Period, m_curr, 1 });
+                    m_curr++;
+                } else {
+                    res.push({ TokenType::Invalid, m_curr, 1 });
+                    m_curr++;
+                }
+            }
+            return res;
+        }
+
+    private:
+        const char *m_curr { nullptr };
+    };
+}
+
 NumberParser::NumberParser(const StringObject *str)
     : m_str { str->string() } { }
 
 FloatObject *NumberParser::string_to_f(const StringObject *str) {
-    auto parser = NumberParser { str };
-    auto result = strtod(parser.m_str.c_str(), nullptr);
-    return new FloatObject { result };
+    NumberParser parser { str };
+    const auto tokens = Tokenizer(parser.m_str).scan();
+    switch (tokens[0].type) {
+    case TokenType::Number: {
+        if (tokens[1].type == TokenType::Period && tokens[2].type == TokenType::Number) {
+            TM::String value { tokens[0].start, tokens[0].size + tokens[1].size + tokens[2].size };
+            auto result = strtod(value.c_str(), nullptr);
+            return new FloatObject { result };
+        } else {
+            TM::String value { tokens[0].start, tokens[0].size };
+            auto result = strtod(value.c_str(), nullptr);
+            return new FloatObject { result };
+        }
+    }
+    case TokenType::Period:
+        if (tokens[1].type == TokenType::Number) {
+            TM::String value { tokens[0].start, tokens[0].size + tokens[1].size };
+            auto result = strtod(value.c_str(), nullptr);
+            return new FloatObject { result };
+        } else {
+            return new FloatObject { 0.0 };
+        }
+    case TokenType::Invalid:
+    case TokenType::End:
+        return new FloatObject { 0.0 };
+    }
+
+    NAT_UNREACHABLE();
 }
 
 }

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -7,6 +7,7 @@ namespace {
         Number,
         Period,
         Sign,
+        ScientificE,
         Whitespace,
         Invalid,
         End,
@@ -48,6 +49,8 @@ namespace {
                 return make_token(TokenType::Period, 1);
             } else if (*m_curr == '+' || *m_curr == '-') {
                 return make_token(TokenType::Sign, 1);
+            } else if (*m_curr == 'e' || *m_curr == 'E') {
+                return make_token(TokenType::ScientificE, 1);
             } else {
                 return make_token(TokenType::Invalid, 1);
             }
@@ -84,6 +87,7 @@ namespace {
                 append_char('0');
                 parse_fractional(token);
                 break;
+            case TokenType::ScientificE:
             case TokenType::Invalid:
             case TokenType::End:
                 return 0.0;
@@ -115,11 +119,23 @@ namespace {
         void parse_decimal(const Token &token) {
             append(token);
             const auto next_token = scan();
-            if (next_token.type == TokenType::Period)
+            if (next_token.type == TokenType::Period) {
                 parse_fractional(next_token);
+            } else if (next_token.type == TokenType::ScientificE) {
+                parse_scientific_e(next_token);
+            }
         }
 
         void parse_fractional(const Token &token) {
+            if (const auto next_token = scan(); next_token.type == TokenType::Number) {
+                append(token);
+                append(next_token);
+            }
+            if (const auto next_token = scan(); next_token.type == TokenType::ScientificE)
+                parse_scientific_e(next_token);
+        }
+
+        void parse_scientific_e(const Token &token) {
             const auto next_token = scan();
             if (next_token.type == TokenType::Number) {
                 append(token);

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -140,6 +140,13 @@ namespace {
             if (next_token.type == TokenType::Number) {
                 append(token);
                 append(next_token);
+            } else if (next_token.type == TokenType::Sign) {
+                const auto next_next_token = scan();
+                if (next_next_token.type == TokenType::Number) {
+                    append(token);
+                    append(next_token);
+                    append(next_next_token);
+                }
             }
         }
     };

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -1,0 +1,14 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+NumberParser::NumberParser(const StringObject *str)
+    : m_str { str->string() } { }
+
+FloatObject *NumberParser::string_to_f(const StringObject *str) {
+    auto parser = NumberParser { str };
+    auto result = strtod(parser.m_str.c_str(), nullptr);
+    return new FloatObject { result };
+}
+
+}

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -102,8 +102,10 @@ namespace {
             parse_decimal_sign();
         }
 
-        TM::Optional<double> result() {
+        TM::Optional<double> result(const bool strict) {
             if (m_result.is_empty())
+                return {};
+            if (strict && current().type != TokenType::End)
                 return {};
             return strtod(m_result.c_str(), nullptr);
         }
@@ -179,7 +181,7 @@ namespace {
 FloatObject *NumberParser::string_to_f(TM::NonNullPtr<const StringObject> str) {
     FloatParser float_parser { str->string() };
     float_parser.parse();
-    return new FloatObject { float_parser.result().value_or(0.0) };
+    return new FloatObject { float_parser.result(false).value_or(0.0) };
 }
 
 }

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -169,7 +169,7 @@ namespace {
     };
 }
 
-FloatObject *NumberParser::string_to_f(const StringObject *str) {
+FloatObject *NumberParser::string_to_f(TM::NonNullPtr<const StringObject> str) {
     FloatParser float_parser { str->string() };
     return new FloatObject { float_parser() };
 }

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -34,6 +34,29 @@ namespace {
         Tokenizer(const TM::String &str)
             : m_curr { str.c_str() } { }
 
+        Token current() { return m_current; }
+
+        Token peek() {
+            assert(m_current.type != TokenType::NotYetScanned);
+            if (m_next.type == TokenType::NotYetScanned)
+                m_next = scan();
+            return m_next;
+        }
+
+        void advance() {
+            if (m_next.type == TokenType::NotYetScanned) {
+                m_current = scan();
+            } else {
+                m_current = m_next;
+                m_next = Token { TokenType::NotYetScanned, nullptr, 0 };
+            }
+        }
+
+    private:
+        const char *m_curr { nullptr };
+        Token m_current { TokenType::NotYetScanned, nullptr, 0 };
+        Token m_next { TokenType::NotYetScanned, nullptr, 0 };
+
         Token scan() {
             if (*m_curr == '\0') {
                 return make_token(TokenType::End, 0);
@@ -60,9 +83,6 @@ namespace {
             }
         }
 
-    private:
-        const char *m_curr { nullptr };
-
         Token make_token(TokenType type, size_t size) {
             Token token { type, m_curr, size };
             m_curr += size;
@@ -84,27 +104,11 @@ namespace {
 
     private:
         Tokenizer m_tokenizer;
-        Token m_current { TokenType::NotYetScanned, nullptr, 0 };
-        Token m_next { TokenType::NotYetScanned, nullptr, 0 };
         TM::String m_result {};
 
-        Token current() { return m_current; }
-
-        Token peek() {
-            assert(m_current.type != TokenType::NotYetScanned);
-            if (m_next.type == TokenType::NotYetScanned)
-                m_next = m_tokenizer.scan();
-            return m_next;
-        }
-
-        void advance() {
-            if (m_next.type == TokenType::NotYetScanned) {
-                m_current = m_tokenizer.scan();
-            } else {
-                m_current = m_next;
-                m_next = Token { TokenType::NotYetScanned, nullptr, 0 };
-            }
-        }
+        Token current() { return m_tokenizer.current(); }
+        Token peek() { return m_tokenizer.peek(); }
+        void advance() { m_tokenizer.advance(); }
 
         void append_char(const char c) { m_result.append_char(c); }
         void append() { m_result.append(current().start, current().size); }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3,6 +3,7 @@
 #include "natalie.hpp"
 #include "natalie/crypt.h"
 #include "natalie/integer_methods.hpp"
+#include "natalie/number_parser.hpp"
 #include "natalie/object_type.hpp"
 #include "natalie/string_unpacker.hpp"
 #include "string.h"
@@ -2740,8 +2741,7 @@ Value StringObject::to_c(Env *env) {
 }
 
 Value StringObject::to_f(Env *env) const {
-    auto result = strtod(c_str(), nullptr);
-    return new FloatObject { result };
+    return NumberParser::string_to_f(this);
 }
 
 Value StringObject::to_i(Env *env, Optional<Value> base_obj) const {


### PR DESCRIPTION
This introduces a NumberParser class with a generic framework for parsing numbers, which can be used in all other number coercion methods as well.
Next step is to use this parser in Kernel.Float as well, but it turns out this one behaves slightly different: "0x10" is a valid float according to Kernel.Float (with the value 16.0), but String#to_f does not accept the hex prefix. Ruby, I want to love you, but why? So the next step is probably going to rewrite half of it.