### PR TITLE
Use CastXML for the gc_lint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,14 @@ RUN if [ "$NEED_VALGRIND" = "true" ]; then \
   make install; \
   fi
 
+ARG NEED_CASTXML=false
+RUN if [ "$NEED_CASTXML" = "true" ]; then \
+  cd /tmp && \
+  wget https://github.com/CastXML/CastXMLSuperbuild/releases/download/v0.6.11.post1/castxml-ubuntu-22.04-x86_64.tar.gz && \
+  tar -C /tmp -xzf /tmp/castxml-ubuntu-22.04-x86_64.tar.gz; \
+  fi
+ENV PATH="/tmp/castxml/bin:${PATH}"
+
 ENV LC_ALL=C.UTF-8
 ENV LLVM_CONFIG=/usr/lib/llvm-14/bin/llvm-config
 

--- a/Rakefile
+++ b/Rakefile
@@ -217,6 +217,7 @@ def default_docker_build_args
     "--build-arg IMAGE='ruby:#{ruby_version_number}'",
     "--build-arg NAT_BUILD_MODE=#{ENV.fetch('NAT_BUILD_MODE', 'release')}",
     "--build-arg NEED_VALGRIND=#{ENV.fetch('NEED_VALGRIND', 'false')}",
+    "--build-arg NEED_CASTXML=#{ENV.fetch('NEED_CASTXML', 'false')}",
   ]
 end
 
@@ -336,7 +337,9 @@ task docker_tidy: :docker_build_clang do
   sh "docker run #{docker_run_flags} --rm --entrypoint rake natalie_clang_#{ruby_version_string} tidy"
 end
 
-task docker_gc_lint: :docker_build_clang do
+task :docker_gc_lint do
+  ENV['NEED_CASTXML'] = 'true'
+  Rake::Task['docker_build_clang'].invoke
   sh "docker run #{docker_run_flags} --rm --entrypoint rake natalie_clang_#{ruby_version_string} gc_lint"
 end
 

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -48,6 +48,8 @@ public:
         visitor.visit(m_begin);
         visitor.visit(m_end);
         visitor.visit(m_step);
+        if (m_step_count)
+            visitor.visit(m_step_count.value());
     }
 
 private:

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -20,10 +20,10 @@
 extern "C" {
 void fiber_wrapper_func(mco_coro *co);
 
-typedef struct {
+struct coroutine_user_data {
     Natalie::Env *env;
     Natalie::FiberObject *fiber;
-} coroutine_user_data;
+};
 }
 
 namespace Natalie {

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -1,17 +1,26 @@
 SKIP_CLASS_MEMBERS = {
-  # NOTE: our smart pointer type gets visited by everything else
+  # our smart pointer type gets visited by everything else
   'Natalie::Value' => '*',
 
-  # NOTE: Args cannot be heap-allocated, so pointers inside are seen on the stack
+  # Args cannot be heap-allocated, so pointers inside are seen on the stack
   'Natalie::Args' => '*',
 
-  # NOTE: each key is already visited via m_hashmap
+  # each key is already visited via m_hashmap
   'Natalie::HashObject' => %w[m_key_list],
 
-  # NOTE: iterators aren't heap-allocated
+  # iterators aren't heap-allocated
   'Natalie::HashObject::iterator' => '*',
   'Natalie::HeapBlock::iterator' => '*',
   'Natalie::StringObject::iterator' => '*',
+
+  # not heap allocated
+  'Natalie::EncodingObject::EncodeOptions' => '*',
+
+  # members visited from GlobalEnv::visit_children()
+  'Natalie::InstanceEvalContext' => '*',
+
+  # these pointers are visited from the stack and from other objects
+  'coroutine_user_data' => '*',
 }
 
 GARBAGE_COLLECTED_BASE_CLASSES = %w[
@@ -21,217 +30,257 @@ GARBAGE_COLLECTED_BASE_CLASSES = %w[
   Natalie::Value
 ]
 
-KNOWN_UNCOLLECTABLE_TYPES = [
-  'bool',
-  'char',
-  'double',
-  'fiber_stack_struct',
-  'int',
-  'long',
-  'long long',
-  'Natalie::Allocator',
-  'Natalie::ArrayPacker::Token',
-  'Natalie::Backtrace::Item',
-  'Natalie::Block::BlockType',
-  'Natalie::Encoding',
-  'Natalie::Enumerator::ArithmeticSequenceObject::Origin',
-  'Natalie::FiberObject::Status',
-  'Natalie::HeapBlock',
-  'Natalie::HeapBlock::FreeCellNode',
-  'Natalie::LocalJumpErrorType',
-  'Natalie::MethodInfo',
-  'Natalie::MethodMissingReason',
-  'Natalie::MethodVisibility',
-  'Natalie::NativeProfilerEvent',
-  'Natalie::NativeProfilerEvent::Type',
-  'Natalie::ObjectType',
-  'Natalie::TimeObject::Mode',
-  'TM::Hashmap',
-  'TM::Optional',
-  'TM::String',
-  'TM::Vector',
-  'tm',
-  'unsigned long',
-  'void',
-]
-
-# I can't get libclang to give good type info for these templates
-TEMPLATE_TYPES = {
-  'ManagedVector<T>' => { canonical_name: 'Natalie::ManagedVector', superclass: 'Natalie::Cell' },
-}
+PATH_PATTERN = %r{^include/natalie}
 
 require 'bundler/inline'
 
 gemfile do
   source 'https://rubygems.org'
-  gem 'ffi-clang', '~> 0.9.0'
+  gem 'nokogiri', '~> 1.18.0'
 end
 
+@locations = {}
 @classes = {}
+@classes_by_name = {}
 @errors = []
+@types = {}
 
-def get_canonical_class_name(cursor)
-  if (override = TEMPLATE_TYPES[cursor.display_name])
-    return override[:canonical_name]
-  end
-  name = cursor.type.canonical.spelling
-  if name != ''
-    name
+def get_type_info(id)
+  return nil if id.nil?
+
+  @types[id] ||= build_type_info(id)
+end
+
+def build_type_info(id)
+  type = @doc.at("##{id}")
+  case type.name
+  when 'PointerType', 'ReferenceType'
+    {
+      kind: type.name,
+      id: type['id'],
+      type: get_type_info(type['type'])
+    }
+  when 'ElaboratedType'
+    # type['qualifier'] = "TM::" (unnecessary?)
+    get_type_info(type['type'])
+  when 'Class', 'Struct'
+    namespace = get_type_info(type['context'])
+    raise "I didn't expect #{namespace.inspect}" unless ['Namespace', 'Class', 'Method'].include?(namespace[:kind])
+    {
+      kind: type.name,
+      id: type['id'],
+      name: [
+        namespace.fetch(:name),
+        type['name'],
+      ].compact.join('::'),
+    }
+  when 'FundamentalType'
+    { kind: type.name, id: type['id'], name: type['name'] }
+  when 'Typedef'
+    # <Typedef id="_2" name="__int128_t" type="_3368" context="_1" location="f0:0" file="f0" line="0"/>
+    # We might need the type info?
+    { kind: type.name, id: type['id'], name: type['name'] }
+  when 'Enumeration'
+    { kind: type.name, id: type['id'], name: type['name'] }
+  when 'CvQualifiedType'
+    # we don't care about const-ness
+    get_type_info(type['type'])
+  when 'Namespace'
+    name = type['name']
+    name = nil if name == '::'
+    { kind: type.name, id: type['id'], name: }
+  when 'ArrayType'
+    { kind: type.name, id: type['id'], type: get_type_info(type['type']) }
+  when 'Method'
+    # A Class inside a Method is really a lambda. :-)
+    # <Method id="_33366" name="srand" returns="_8106" context="_8151" access="public" location="f253:45" file="f253" line="45" static="1" inline="1" mangled="_ZN7Natalie12RandomObject5srandEPNS_3EnvEN2TM8OptionalINS_5ValueEEE">
+    { kind: type.name, id: type['id'], name: type['name'] }
+  when 'FunctionType'
+    { kind: type.name, id: type['id'], name: type['name'] }
   else
-    # cursor_class_template doesn't give us the canonical name, but this works :-/
-    klass = cursor.display_name.sub(/<.*>/, '')
-    klass = '(anon)' if klass == ''
-    parent = cursor
-    while (parent = parent.semantic_parent) && parent.display_name != '' && parent.display_name !~ /\/|\./
-      klass = "#{parent.display_name}::#{klass}"
-    end
-    klass
+    raise "Unknown type for id #{id}: #{type.inspect}"
   end
 end
 
-def get_class_details_for_path(path)
-  code = File.read(path)
-  code_lines = code.split(/\n/)
-  index = FFI::Clang::Index.new
-  translation_unit = index.parse_translation_unit(path, ['-I', 'include', '-std=c++17'])
-  cursor = translation_unit.cursor
+def header_path_to_cpp_path(path)
+  path.sub(%r{^include/natalie/}, 'src/').sub(/\.hpp$/, '.cpp')
+end
 
-  cursor.visit_children do |cursor, parent|
-    if cursor.location&.file == path
-      #p([cursor.kind, cursor.location&.line, cursor&.display_name])
-      if %i[cursor_class_decl cursor_class_template cursor_struct cursor_union].include?(cursor.kind) && cursor.definition?
-        line = code_lines[cursor.location.line - 1]
-        if line =~ /:/
-          base = cursor.type.declaration.filter { |c| c.kind == :cursor_cxx_base_specifier }.first&.spelling
-          if base =~ /^class (.+)/
-            superclass = $1
-          elsif cursor.kind == :cursor_class_template
-            superclass = TEMPLATE_TYPES[cursor.display_name][:superclass]
-          elsif cursor.qualified_name.start_with?('TM::')
-            superclass = nil
-          else
-            raise 'could not get base class'
-          end
-        else
-          superclass = nil
-        end
-        klass = get_canonical_class_name(cursor)
-        @classes[klass] = {
-          kind: cursor.kind,
-          name: klass,
-          path: path,
-          location: cursor.location,
-          superclass: superclass,
-          members: [],
-          visit_children_method: nil,
-        }
-      elsif cursor.kind == :cursor_cxx_method && cursor.display_name =~ /^visit_children\(/
-        lines = code[cursor.extent.start.offset..cursor.extent.end.offset].split("\n")
-        klass = get_canonical_class_name(cursor.semantic_parent)
-        @classes[klass][:visit_children_method] = lines[1...-1]
-      elsif cursor.kind == :cursor_field_decl
-        klass = get_canonical_class_name(cursor.semantic_parent)
-        @classes[klass][:members] << {
-          type: cursor.type.canonical.spelling,
-          name: cursor.display_name,
-        }
+def find_visit_method_code(path)
+  lines = []
+  in_method = false
+  braces = 0
+  File.read(path).each_line(chomp: true) do |line|
+    in_method = true if line =~ /void [A-Za-z:]*visit_children\(.*Visitor &visitor\)/
+    if in_method
+      braces += (line.count('{') - line.count('}'))
+      lines << line
+      if braces.zero?
+        in_method = false
+        break
       end
     end
-    :recurse
   end
+  lines
 end
 
 def garbage_collected?(type)
-  type = lookup_type(type)
-  if GARBAGE_COLLECTED_BASE_CLASSES.include?(type)
-    true
-  elsif (klass = @classes[type])
-    if GARBAGE_COLLECTED_BASE_CLASSES.include?(klass[:superclass])
-      true
-    elsif (superclass = @classes[klass[:superclass]])
-      garbage_collected?(superclass[:name])
-    else
-      raise 'unlikely' if klass[:name].strip =~ /.*Object$/
-      false
-    end
-  else
+  # { kind: "PointerType", id: "_3371", type: { kind: "FundamentalType", id: "_8095", name: "char" } }
+  case type[:kind]
+  when 'PointerType', 'ReferenceType', 'ArrayType'
+    garbage_collected?(type[:type])
+  when 'Class', 'Struct'
+    klass = @classes[type[:id]]
+    GARBAGE_COLLECTED_BASE_CLASSES.include?(type[:name]) || superclass_garbage_collected?(klass) || members_garbage_collected?(klass)
+  when 'Enumeration', 'FundamentalType', 'Typedef', 'FunctionType'
     false
+  else
+    raise "Unhandled type: #{type.inspect}"
   end
 end
 
-def lookup_type(type)
-  type
-    .sub(/const /, '')
-    .sub(/\s*\*?\s*(\[\d*\])?$/, '') # * and []
-    .strip
+def superclass_garbage_collected?(klass)
+  return false unless klass
+  return false unless (superclass = klass[:superclass])
+
+  garbage_collected?(superclass)
 end
 
-def verify_visited(klass, type, name)
-  type = type.sub(/const /, '').strip
-  details = @classes.fetch(klass)
+def members_garbage_collected?(klass)
+  return false unless klass
+  return false unless klass[:members]
+
+  klass[:members].any? do |member|
+    # prevent infinite recursion with self-referential classes
+    return false if @seen_members.key?(member)
+    @seen_members[member] = true
+
+    garbage_collected?(member[:type])
+  end
+end
+
+def verify_visited(id, member)
+  klass = @classes.fetch(id)
+  type = member.fetch(:type)
+  @seen_members = {}
   if garbage_collected?(type)
-    if (method_lines = details[:visit_children_method])
+    if (method_lines = klass[:visit_children_method])
+      name = member.fetch(:name)
       visits_directly = method_lines.grep(/^\s*visitor\.visit\(&?#{name}/).any?
       loops_over = method_lines.grep(/for\s*\(.*:\s*\*?#{name}\)/).any?
       unless visits_directly || loops_over
-        @errors << "#{klass}'s visit_children() method does not visit #{name} (type #{type})!"
+        @errors << "#{klass[:name]}'s visit_children() method does not visit #{name}\n" \
+                   "type: #{type.inspect}\n" \
+                   "method code:\n#{method_lines.any? ? method_lines.join("\n") : '(empty)'}"
       end
     else
-      location = details[:location]
-      @errors << "#{klass} (#{location.file}##{location.line}) does not have a visit_children() method!"
+      @errors << "#{klass[:name]} (#{klass[:path]}##{klass[:line]}) does not have a visit_children() method!"
     end
-  elsif !KNOWN_UNCOLLECTABLE_TYPES.include?(lookup_type(type))
-    puts "CHECK - not a Natalie class? : #{type} (found in #{klass})"
-  end
-end
-
-def verify_visits_superclass(klass)
-  details = @classes.fetch(klass)
-  if details[:superclass] && details[:visit_children_method]
-    superclass = details[:superclass].split('::').last
-    if klass != 'Natalie::Object' && superclass != 'Cell' && details[:visit_children_method].grep(/#{superclass}::visit_children\(visitor\)/).empty?
-      @errors << "#{klass}'s visit_children() method does not call #{superclass}::visit_children()!"
+  else
+    if type[:kind] == 'Class' && type[:name] =~ /Object/ && type[:name] !~ /std::function/
+      raise "Sanity check: #{member.inspect} is probably garbage collected :-)"
     end
   end
 end
 
-paths = (Dir['include/natalie/**/*.hpp'] + Dir['src/**/*.cpp']).to_a
-paths.each_with_index do |path, index|
-  puts "processing file #{index + 1} of #{paths.size} : #{path}"
-  get_class_details_for_path(path)
+def verify_visits_superclass(id)
+  klass = @classes.fetch(id)
+  class_name = klass[:name]
+  if (superclass_id = klass.dig(:superclass, :id)) && klass[:visit_children_method]
+    superclass = @classes[superclass_id]
+    superclass_name_without_namespace = superclass[:name].split('::').last
+    if class_name != 'Natalie::Object' && superclass[:name] != 'Natalie::Cell' && klass[:visit_children_method].grep(/#{superclass_name_without_namespace}::visit_children\(visitor\)/).empty?
+      @errors << "#{class_name}'s visit_children() method does not call #{superclass[:name]}::visit_children()!"
+    end
+  end
 end
 
-@classes.each do |klass, details|
-  next if SKIP_CLASS_MEMBERS[klass] == '*'
+xml = `castxml --castxml-output=1 -o - -I include -I ext/tm/include -I ext/onigmo include/natalie.hpp`
+exit 1 unless $?.success?
 
-  next if %i[cursor_struct cursor_union].include?(details[:kind])
+@doc = Nokogiri::XML(xml)
+
+puts 'preloading locations'
+@doc.css('File').each do |file|
+  next unless Pathname.new(file['name']).relative?
+
+  @locations[file['id']] = file['name']
+end
+
+puts 'preloading classes'
+@doc.css('Class', 'Struct').each do |klass|
+  # <Class id="_6241" name="ArrayObject" context="_1038" location="f178:18" file="f178" line="18" ...>
+
+  next unless (path = @locations[klass['file']])
+
+  type = get_type_info(klass['id'])
+  name = type.fetch(:name)
+  info = {
+    name:,
+    type:,
+    path:,
+    line: klass['line'],
+    superclass: get_type_info(klass['bases']),
+    members: [],
+    visit_children_method: nil,
+  }
+  @classes[klass['id']] = info
+  @classes_by_name[name] = info
+end
+
+puts 'preloading fields'
+@doc.css('Field').each do |field|
+  # <Field id="_22589" name="m_vector" type="_5999" init="{}" context="_6241" access="private" location="f178:225" file="f178" line="225" offset="448"/>
+
+  next unless (klass = @classes[field['context']])
+
+  klass[:members] << {
+    type: get_type_info(field['type']),
+    name: field['name'],
+  }
+end
+
+puts 'preloading methods'
+@doc.css('Method').each do |method|
+  # <Method id="_22586" name="visit_children" returns="_5568" context="_6241" access="public" location="f178:210" file="f178" line="210"
+
+  next unless method['name'] == 'visit_children'
+  next unless (klass = @classes[method['context']])
+
+  path = @locations[method['file']]
+  if method['inline'] == '1'
+    klass[:visit_children_method] = find_visit_method_code(path)
+  else
+    path = header_path_to_cpp_path(path)
+    klass[:visit_children_method] = find_visit_method_code(path)
+  end
+end
+
+puts 'processing data'
+@classes.each do |id, details|
+  class_name = details[:name]
+
+  next if SKIP_CLASS_MEMBERS[class_name] == '*'
+
+  next unless details[:path] =~ PATH_PATTERN
 
   details[:members].each do |member|
-    next if SKIP_CLASS_MEMBERS.fetch(klass, []).include?(member[:name])
+    next if SKIP_CLASS_MEMBERS.fetch(class_name, []).include?(member[:name])
 
-    if member[:type] =~ /^[:\w\*]+ \(\*\)\(.*\)$/
-      # looks like a function pointer type
-      next
-    end
-
-    types = []
-    if member[:type] =~ /<(.*)>/
-      types << member[:type].split('<').first
-      types += $1.split(/\s*,\s*/)
-    else
-      types = [member[:type]]
-    end
-
-    types.each do |t|
-      verify_visited(klass, t, member[:name])
-    end
+    verify_visited(id, member)
   end
 
-  verify_visits_superclass(klass)
+  verify_visits_superclass(id)
 end
 
 if @errors.any?
+  puts
   puts 'Errors:'
-  puts @errors
+  @errors.each do |error|
+    puts error
+    puts
+  end
   exit 1
 end
+
+puts 'done'


### PR DESCRIPTION
It's faster and more accurate for our purposes. Also, ffi-clang was giving different results depending on the version of Clang, and the bindings were crashing on newer versions.

As a bonus, this new script found one potential bug.