### PR TITLE
Clarify spec error for Regexp.last_match

### DIFF
--- a/spec/core/regexp/last_match_spec.rb
+++ b/spec/core/regexp/last_match_spec.rb
@@ -28,18 +28,15 @@ describe "Regexp.last_match" do
 
     it "raises an IndexError when given a missing name" do
       /(?<test>[A-Z]+.*)/ =~ "TEST123"
-      NATFIXME "this error gets thrown, but when in a proc it doesn't get bubbled up properly", exception: SpecFailedException do
+      NATFIXME 'Regexp globals are not accessible from a block', exception: SpecFailedException do
         -> { Regexp.last_match(:missing) }.should raise_error(IndexError)
       end
 
       # NATFIXME: Alternate implementation of the test
-      error = begin
+      -> {
+        /(?<test>[A-Z]+.*)/ =~ "TEST123"
         Regexp.last_match(:missing)
-        nil
-      rescue IndexError => e
-        e
-      end
-      error.should be_kind_of(IndexError)
+      }.should raise_error(IndexError)
     end
   end
 
@@ -61,18 +58,15 @@ describe "Regexp.last_match" do
     it "raises a TypeError when unable to coerce" do
       obj = Object.new
       /(?<test>[A-Z]+.*)/ =~ "TEST123"
-      NATFIXME "this error gets thrown, but when in a proc it doesn't get bubbled up properly", exception: SpecFailedException do
+      NATFIXME 'Regexp globals are not accessible from a block', exception: SpecFailedException do
         -> { Regexp.last_match(obj) }.should raise_error(TypeError)
       end
 
       # NATFIXME: Alternate implementation of the test
-      error = begin
+      -> {
+        /(?<test>[A-Z]+.*)/ =~ "TEST123"
         Regexp.last_match(obj)
-        nil
-      rescue TypeError => e
-        e
-      end
-      error.should be_kind_of(TypeError)
+      }.should raise_error(TypeError)
     end
   end
 end


### PR DESCRIPTION
The issue is not related to errors bubbling up, but simply because we set our regexp globals as block local, which should be treated as scope local.

A simple example:
```ruby
/foo/ =~ 'foobar'
-> { p Regexp.last_match }.call
```
This prints the MatchData object in MRI, but Natalie prints a nil.

We have the same issue the other way around:
```ruby
-> { /foo/ =~ 'foobar' }.call
p Regexp.last_match
```

Rewrite the failing specs into a form that works that is closer to the original spec.

There is some logic conserning caller scopes and outer blocks in the lookups, but that might have to be redone. This issue is not limited to this spec, but it occurs everywhere we use any global references to regex results.