### PR TITLE
Use Optional<Value> in place of nullptr (part 4)

### DIFF
--- a/include/natalie/constant.hpp
+++ b/include/natalie/constant.hpp
@@ -15,11 +15,7 @@ public:
         , m_autoload_path(autoload_path) {};
 
     SymbolObject *name() const { return m_name; }
-
-    Value value() const {
-        assert(m_value);
-        return m_value;
-    }
+    Optional<Value> value() const { return m_value; }
 
     bool is_private() const { return m_private; }
     void set_private(bool is_private) { this->m_private = is_private; }
@@ -38,7 +34,7 @@ public:
 
 private:
     SymbolObject *m_name;
-    Value m_value { nullptr };
+    Optional<Value> m_value {};
     bool m_private { false };
     bool m_deprecated { false };
     MethodFnPtr m_autoload_fn { nullptr };

--- a/include/natalie/global_variable_info.hpp
+++ b/include/natalie/global_variable_info.hpp
@@ -10,7 +10,7 @@
 namespace Natalie {
 class GlobalVariableInfo : public Cell {
 public:
-    using read_hook_t = std::function<Value(Env *, GlobalVariableInfo &)>;
+    using read_hook_t = std::function<Optional<Value>(Env *, GlobalVariableInfo &)>;
     using write_hook_t = Value (*)(Env *, Value, GlobalVariableInfo &);
 
     GlobalVariableInfo(Optional<Value> value, bool readonly)

--- a/include/natalie/global_variable_info/access_hooks.hpp
+++ b/include/natalie/global_variable_info/access_hooks.hpp
@@ -5,14 +5,14 @@
 namespace Natalie {
 
 namespace GlobalVariableAccessHooks::ReadHooks {
-    Value getpid(Env *, GlobalVariableInfo &);
-    Value last_exception(Env *, GlobalVariableInfo &);
-    Value last_exception_backtrace(Env *, GlobalVariableInfo &);
-    Value last_match(Env *, GlobalVariableInfo &);
-    Value last_match_pre_match(Env *, GlobalVariableInfo &);
-    Value last_match_post_match(Env *, GlobalVariableInfo &);
-    Value last_match_last_group(Env *, GlobalVariableInfo &);
-    Value last_match_to_s(Env *, GlobalVariableInfo &);
+    Optional<Value> getpid(Env *, GlobalVariableInfo &);
+    Optional<Value> last_exception(Env *, GlobalVariableInfo &);
+    Optional<Value> last_exception_backtrace(Env *, GlobalVariableInfo &);
+    Optional<Value> last_match(Env *, GlobalVariableInfo &);
+    Optional<Value> last_match_pre_match(Env *, GlobalVariableInfo &);
+    Optional<Value> last_match_post_match(Env *, GlobalVariableInfo &);
+    Optional<Value> last_match_last_group(Env *, GlobalVariableInfo &);
+    Optional<Value> last_match_to_s(Env *, GlobalVariableInfo &);
 }
 
 namespace GlobalVariableAccessHooks::WriteHooks {

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -96,7 +96,7 @@ public:
     const Vector<ModuleObject *> &included_modules() { return m_included_modules; }
     bool does_include_module(Env *, Value);
 
-    virtual Value cvar_get_or_null(Env *, SymbolObject *) override;
+    virtual Optional<Value> cvar_get_maybe(Env *, SymbolObject *) override;
     virtual Value cvar_set(Env *, SymbolObject *, Value) override;
     bool class_variable_defined(Env *, Value);
     Value class_variable_get(Env *, Value);
@@ -195,7 +195,7 @@ protected:
     ClassObject *m_superclass { nullptr };
     ModuleObject *m_owner { nullptr };
     TM::Hashmap<SymbolObject *, MethodInfo> m_methods {};
-    TM::Hashmap<SymbolObject *, Value> m_class_vars {};
+    TM::Hashmap<SymbolObject *, Optional<Value>> m_class_vars {};
     Vector<ModuleObject *> m_included_modules {};
     MethodVisibility m_method_visibility { MethodVisibility::Public };
     bool m_module_function { false };

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -56,7 +56,7 @@ public:
     Optional<Value> const_find_with_autoload(Env *, Value, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
     Optional<Value> const_find(Env *, SymbolObject *, ConstLookupSearchMode = ConstLookupSearchMode::Strict, ConstLookupFailureMode = ConstLookupFailureMode::ConstMissing);
 
-    Value const_get(SymbolObject *) const;
+    Optional<Value> const_get(SymbolObject *) const;
     Value const_get(Env *, Value, Optional<Value> = {});
     Value const_fetch(SymbolObject *) const;
     Value const_set(SymbolObject *, Value);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -111,8 +111,8 @@ public:
     Value instance_variables(Env *);
 
     Value cvar_get(Env *, SymbolObject *);
-    virtual Value cvar_get_or_raise(Env *, SymbolObject *);
-    virtual Value cvar_get_or_null(Env *, SymbolObject *);
+    Value cvar_get_or_raise(Env *, SymbolObject *);
+    virtual Optional<Value> cvar_get_maybe(Env *, SymbolObject *);
     virtual Value cvar_set(Env *, SymbolObject *, Value);
 
     static SymbolObject *define_method(Env *, Value, SymbolObject *, MethodFnPtr, int);

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -180,11 +180,11 @@ private:
             rlimit_str->append(rlimit_symbol->string());
             rlimit_symbol = rlimit_str->to_symbol(env);
             auto ProcessMod = GlobalEnv::the()->Object()->const_fetch("Process"_s).as_module();
-            Value rlimval = ProcessMod->const_get(rlimit_symbol);
-            if (!rlimval || !rlimval.is_integer()) {
+            auto rlimval = ProcessMod->const_get(rlimit_symbol);
+            if (!rlimval || !rlimval.value().is_integer()) {
                 env->raise("ArgumentError", "invalid resource {}", rlimit_symbol->string());
             }
-            val = rlimval;
+            val = rlimval.value();
         }
 
         resource = IntegerMethods::convert_to_nat_int_t(env, val);

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -64,8 +64,8 @@ private:
 
     static void assert_no_bad_value(Env *, Value, Value);
 
-    Value m_begin { nullptr };
-    Value m_end { nullptr };
+    Value m_begin { Value::nil() };
+    Value m_end { Value::nil() };
     bool m_exclude_end { false };
 
     template <typename Function>

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -67,7 +67,8 @@ public:
     virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         visitor.visit(m_integer);
-        visitor.visit(m_subsec);
+        if (m_subsec)
+            visitor.visit(m_subsec.value());
     }
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -93,7 +94,7 @@ private:
 
     Integer m_integer;
     Mode m_mode;
-    Value m_subsec;
+    Optional<Value> m_subsec;
     struct tm m_time;
     char *m_zone { nullptr };
 };

--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -91,7 +91,7 @@ module FFI
 
     def self.new_value
       __inline__ <<~END
-        auto *v = new Value { nullptr };
+        auto *v = new Value;
         return self.send(env, "new"_s, { Value::integer((uintptr_t)v) });
       END
     end

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -37,13 +37,13 @@ class Fiddle
 
   class Pointer
     __define_method__ :to_s, <<-END
-      auto len = args.size() > 0 ? args[0] : nullptr;
-      if (len)
+      auto len = args.at(0, Value::nil());
+      if (!len.is_nil())
         len.assert_integer(env);
       auto ptr_obj = self->ivar_get(env, "@ptr"_s);
       ptr_obj.assert_type(env, Object::Type::VoidP, "VoidP");
       auto ptr = (const char *)ptr_obj.as_void_p()->void_ptr();
-      if (len)
+      if (!len.is_nil())
         return new StringObject { ptr, (size_t)len.integer().to_nat_int_t() };
       return new StringObject { ptr };
     END

--- a/lib/natalie/compiler/instructions/class_variable_get_instruction.rb
+++ b/lib/natalie/compiler/instructions/class_variable_get_instruction.rb
@@ -18,7 +18,7 @@ module Natalie
 
       def generate(transform)
         if @default_to_nil
-          transform.exec_and_push(:cvar, "self->cvar_get_or_null(env, #{transform.intern(@name)}) ?: Value::nil()")
+          transform.exec_and_push(:cvar, "self->cvar_get_maybe(env, #{transform.intern(@name)}).value_or(Value::nil())")
         else
           transform.exec_and_push(:cvar, "self->cvar_get(env, #{transform.intern(@name)})")
         end

--- a/lib/rbconfig/sizeof.rb
+++ b/lib/rbconfig/sizeof.rb
@@ -6,7 +6,7 @@ module RbConfig
   LIMITS = {}
 
   __inline__ <<~CPP
-    auto SIZEOF = self.as_module()->const_get("SIZEOF"_s).as_hash();
+    auto SIZEOF = self.as_module()->const_fetch("SIZEOF"_s).as_hash();
     SIZEOF->put(env, new StringObject { "double" }, Value::integer(sizeof(double)));
     SIZEOF->put(env, new StringObject { "float" }, Value::integer(sizeof(float)));
     SIZEOF->put(env, new StringObject { "int" }, Value::integer(sizeof(int)));
@@ -14,7 +14,7 @@ module RbConfig
     SIZEOF->put(env, new StringObject { "short" }, Value::integer(sizeof(short)));
     SIZEOF->put(env, new StringObject { "void*" }, Value::integer(sizeof(void *)));
 
-    auto LIMITS = self.as_module()->const_get("LIMITS"_s).as_hash();
+    auto LIMITS = self.as_module()->const_fetch("LIMITS"_s).as_hash();
     LIMITS->put(env, new StringObject { "CHAR_MIN" }, Value::integer(std::numeric_limits<char>::min()));
     LIMITS->put(env, new StringObject { "CHAR_MAX" }, Value::integer(std::numeric_limits<char>::max()));
     LIMITS->put(env, new StringObject { "SHRT_MIN" }, Value::integer(std::numeric_limits<short>::min()));

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -65,7 +65,7 @@ Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
             env->raise("ArgumentError", "bad value for range");
         }
 
-        auto Numeric = GlobalEnv::the()->Object()->const_get("Numeric"_s);
+        auto Numeric = GlobalEnv::the()->Object()->const_fetch("Numeric"_s);
         if (!arg.is_a(env, Numeric))
             env->raise("ArgumentError", "No implicit conversion of {} into Integer", arg.klass()->inspect_str());
 

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -238,7 +238,7 @@ Value Addrinfo_initialize(Env *env, Value self, Args &&args, Block *block) {
     bool socktype_hack = false;
 
     StringObject *unix_path = nullptr;
-    Value port = nullptr;
+    Optional<Value> port;
     StringObject *host = nullptr;
 
     if (!afamily)
@@ -291,7 +291,7 @@ Value Addrinfo_initialize(Env *env, Value self, Args &&args, Block *block) {
 
     } else {
         assert(host);
-        assert(port);
+        assert(port.present());
 
         if (host->is_empty())
             host = new StringObject { "0.0.0.0" };
@@ -317,7 +317,7 @@ Value Addrinfo_initialize(Env *env, Value self, Args &&args, Block *block) {
         if (socktype_hack && hints.ai_socktype == 0)
             hints.ai_socktype = SOCK_DGRAM;
 
-        const char *service_str = IntegerMethods::to_s(env, port.integer()).as_string()->c_str();
+        const char *service_str = IntegerMethods::to_s(env, port.value().integer()).as_string()->c_str();
 
         switch (hints.ai_socktype) {
         case SOCK_RAW:

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -415,7 +415,7 @@ Value YAML_load(Env *env, Value self, Args &&args, Block *) {
         yaml_parser_set_input_string(&parser, reinterpret_cast<const unsigned char *>(str->c_str()), str->bytesize());
     }
 
-    Value result = nullptr;
+    Optional<Value> result;
     while (true) {
         yaml_token_t token;
         Defer token_deleter { [&token]() { yaml_token_delete(&token); } };
@@ -425,7 +425,7 @@ Value YAML_load(Env *env, Value self, Args &&args, Block *) {
         result = load_value(env, parser, token);
     }
 
-    if (result == nullptr)
+    if (!result)
         env->raise("NotImplementedError", "TODO: Implement YAML.load");
-    return result;
+    return result.value();
 }

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -244,11 +244,11 @@ static void emit_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_even
         emit_value(env, value.as_time(), emitter, event);
     } else if (value.is_true()) {
         emit_value(env, value.as_true(), emitter, event);
-    } else if (GlobalEnv::the()->Object()->defined(env, "Date"_s, false) && value.is_a(env, GlobalEnv::the()->Object()->const_get("Date"_s).as_class())) {
+    } else if (GlobalEnv::the()->Object()->defined(env, "Date"_s, false) && value.is_a(env, GlobalEnv::the()->Object()->const_fetch("Date"_s).as_class())) {
         emit_value(env, value.send(env, "to_s"_s).as_string(), emitter, event);
-    } else if (GlobalEnv::the()->Object()->defined(env, "OpenStruct"_s, false) && value.is_a(env, GlobalEnv::the()->Object()->const_get("OpenStruct"_s).as_class())) {
+    } else if (GlobalEnv::the()->Object()->defined(env, "OpenStruct"_s, false) && value.is_a(env, GlobalEnv::the()->Object()->const_fetch("OpenStruct"_s).as_class())) {
         emit_openstruct_value(env, value, emitter, event);
-    } else if (value.is_a(env, GlobalEnv::the()->Object()->const_get("Struct"_s).as_class())) {
+    } else if (value.is_a(env, GlobalEnv::the()->Object()->const_fetch("Struct"_s).as_class())) {
         emit_struct_value(env, value, emitter, event);
     } else {
         emit_object_value(env, value, emitter, event);

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -53,11 +53,11 @@ static constexpr size_t ZLIB_BUF_SIZE = 16384;
 
 Value Zlib_deflate_initialize(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_between(env, 0, 4);
-    auto Zlib = GlobalEnv::the()->Object()->const_get("Zlib"_s).as_module();
-    auto level = args.at(0, Zlib->const_get("DEFAULT_COMPRESSION"_s)).integer_or_raise(env);
-    auto window_bits = args.at(1, Zlib->const_get("MAX_WBITS"_s)).integer_or_raise(env);
-    auto mem_level = args.at(2, Zlib->const_get("DEF_MEM_LEVEL"_s)).integer_or_raise(env);
-    auto strategy = args.at(3, Zlib->const_get("DEFAULT_STRATEGY"_s)).integer_or_raise(env);
+    auto Zlib = GlobalEnv::the()->Object()->const_fetch("Zlib"_s).as_module();
+    auto level = args.at(0, Zlib->const_fetch("DEFAULT_COMPRESSION"_s)).integer_or_raise(env);
+    auto window_bits = args.at(1, Zlib->const_fetch("MAX_WBITS"_s)).integer_or_raise(env);
+    auto mem_level = args.at(2, Zlib->const_fetch("DEF_MEM_LEVEL"_s)).integer_or_raise(env);
+    auto strategy = args.at(3, Zlib->const_fetch("DEFAULT_STRATEGY"_s)).integer_or_raise(env);
 
     auto stream = new z_stream {};
     self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_deflate_stream_cleanup));
@@ -155,7 +155,7 @@ Value Zlib_deflate_params(Env *env, Value self, Args &&args, Block *) {
 
     auto original_stream = self.send(env, "finish"_s);
 
-    auto Zlib = GlobalEnv::the()->Object()->const_get("Zlib"_s);
+    auto Zlib = GlobalEnv::the()->Object()->const_fetch("Zlib"_s);
     auto inflated = Zlib.send(env, "inflate"_s, { original_stream });
 
     if (const auto ret = deflateReset(strm); ret != Z_OK)

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -840,7 +840,7 @@ Value ArrayObject::shift(Env *env, Optional<Value> count) {
         return Value::nil();
 
     size_t shift_count = 1;
-    Value result = nullptr;
+    Value result;
     if (count) {
         auto count_signed = IntegerMethods::convert_to_nat_int_t(env, count.value());
 

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -11,7 +11,8 @@ void Constant::autoload(Env *env, Value self) {
 
 void Constant::visit_children(Visitor &visitor) const {
     visitor.visit(m_name);
-    visitor.visit(m_value);
+    if (m_value)
+        visitor.visit(m_value.value());
     visitor.visit(m_autoload_path);
 }
 

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -75,8 +75,7 @@ Value FileObject::absolute_path(Env *env, Value path, Optional<Value> dir_arg) {
     if ((!dir_arg || dir_arg.value().is_nil()) && path.as_string()->eq(env, new StringObject { "~" }))
         return path;
 
-    auto File = GlobalEnv::the()->Object()->const_get("File"_s);
-    assert(File);
+    auto File = GlobalEnv::the()->Object()->const_fetch("File"_s);
     auto dir = dir_arg && !dir_arg.value().is_nil() ? dir_arg.value() : DirObject::pwd(env);
     return File.send(env, "join"_s, { dir, path });
 }

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -119,7 +119,7 @@ void GlobalEnv::global_set_write_hook(Env *env, SymbolObject *name, GlobalVariab
 }
 
 bool GlobalEnv::show_deprecation_warnings(Env *env) {
-    return Object()->const_get("Warning"_s).send(env, "[]"_s, { "deprecated"_s }).is_truthy();
+    return Object()->const_fetch("Warning"_s).send(env, "[]"_s, { "deprecated"_s }).is_truthy();
 }
 
 void GlobalEnv::set_interned_strings(StringObject **interned_strings, const size_t interned_strings_size) {

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -11,12 +11,8 @@ void GlobalVariableInfo::set_object(Env *env, Value value) {
 }
 
 Optional<Value> GlobalVariableInfo::object(Env *env) {
-    if (m_read_hook) {
-        auto result = m_read_hook(env, *this);
-        if (result)
-            return result;
-        return Optional<Value> {};
-    }
+    if (m_read_hook)
+        return m_read_hook(env, *this);
     return m_value;
 }
 

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -5,52 +5,52 @@ namespace Natalie {
 
 namespace GlobalVariableAccessHooks::ReadHooks {
 
-    Value getpid(Env *env, GlobalVariableInfo &info) {
+    Optional<Value> getpid(Env *env, GlobalVariableInfo &info) {
         auto pid = Value::integer(::getpid());
         info.set_object(env, pid);
         info.set_read_hook(nullptr);
         return pid;
     }
 
-    Value last_exception(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_exception(Env *env, GlobalVariableInfo &) {
         return env->exception_object();
     }
 
-    Value last_exception_backtrace(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_exception_backtrace(Env *env, GlobalVariableInfo &) {
         if (!env->exception_object().is_exception())
-            return nullptr;
+            return {};
         return env->exception_object().as_exception()->backtrace(env);
     }
 
-    Value last_match(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_match(Env *env, GlobalVariableInfo &) {
         return env->last_match();
     }
 
-    Value last_match_pre_match(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_match_pre_match(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
         if (last_match.is_nil())
-            return nullptr;
+            return {};
         return last_match.as_match_data()->pre_match(env);
     }
 
-    Value last_match_post_match(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_match_post_match(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
         if (last_match.is_nil())
-            return nullptr;
+            return {};
         return last_match.as_match_data()->post_match(env);
     }
 
-    Value last_match_last_group(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_match_last_group(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
         if (last_match.is_nil())
-            return nullptr;
+            return {};
         return last_match.as_match_data()->captures(env).as_array()->compact(env).as_array()->last();
     }
 
-    Value last_match_to_s(Env *env, GlobalVariableInfo &) {
+    Optional<Value> last_match_to_s(Env *env, GlobalVariableInfo &) {
         auto last_match = env->last_match();
         if (last_match.is_nil())
-            return nullptr;
+            return {};
         return last_match.as_match_data()->to_s(env);
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -50,7 +50,7 @@ Value IoObject::initialize(Env *env, Args &&args, Block *block) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_between(env, 1, 2);
     Value file_number = args.at(0);
-    Value flags_obj = args.at(1, nullptr);
+    Value flags_obj = args.at(1, Value::nil());
     const ioutil::flags_struct wanted_flags { env, flags_obj, kwargs };
     nat_int_t fileno = file_number.to_int(env).to_nat_int_t();
     assert(fileno >= INT_MIN && fileno <= INT_MAX);

--- a/src/math.rb
+++ b/src/math.rb
@@ -182,7 +182,7 @@ module Math
           }
       }
       if (value->is_nan()) {
-          return GlobalEnv::the()->Float()->const_get("NAN"_s);
+          return GlobalEnv::the()->Float()->const_fetch("NAN"_s);
       }
       int exponent;
       auto significand = std::frexp(value->to_double(), &exponent);

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -371,14 +371,14 @@ Value ModuleObject::eval_body(Env *env, Value (*fn)(Env *, Value)) {
     return result;
 }
 
-Value ModuleObject::cvar_get_or_null(Env *env, SymbolObject *name) {
+Optional<Value> ModuleObject::cvar_get_maybe(Env *env, SymbolObject *name) {
     if (!name->is_cvar_name())
         env->raise_name_error(name, "`{}' is not allowed as a class variable name", name->string());
 
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ModuleObject *module = this;
-    Value val = nullptr;
+    Optional<Value> val;
     while (module) {
         val = module->m_class_vars.get(name, env);
         if (val)
@@ -398,7 +398,7 @@ Value ModuleObject::cvar_get_or_null(Env *env, SymbolObject *name) {
             return val;
     }
 
-    return nullptr;
+    return {};
 }
 
 Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
@@ -410,7 +410,7 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 
         ModuleObject *current = module;
 
-        Value exists = nullptr;
+        Optional<Value> exists;
         while (current) {
             exists = current->m_class_vars.get(name, env);
             if (exists) {
@@ -441,17 +441,17 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 bool ModuleObject::class_variable_defined(Env *env, Value name) {
     auto *name_sym = name.to_symbol(env, Value::Conversion::Strict);
 
-    return cvar_get_or_null(env, name_sym);
+    return cvar_get_maybe(env, name_sym).present();
 }
 
 Value ModuleObject::class_variable_get(Env *env, Value name) {
     auto *name_sym = name.to_symbol(env, Value::Conversion::Strict);
 
-    auto val = cvar_get_or_null(env, name_sym);
+    auto val = cvar_get_maybe(env, name_sym);
     if (!val) {
         env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_str());
     }
-    return val;
+    return val.value();
 }
 
 Value ModuleObject::class_variable_set(Env *env, Value name, Value value) {
@@ -484,13 +484,13 @@ Value ModuleObject::remove_class_variable(Env *env, Value name) {
 
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    auto val = cvar_get_or_null(env, name_sym);
+    auto val = cvar_get_maybe(env, name_sym);
     if (!val)
         env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_str());
 
     m_class_vars.remove(name_sym);
 
-    return val;
+    return val.value();
 }
 
 SymbolObject *ModuleObject::define_method(Env *env, SymbolObject *name, MethodFnPtr fn, int arity) {
@@ -1149,7 +1149,8 @@ void ModuleObject::visit_children(Visitor &visitor) const {
     }
     for (auto pair : m_class_vars) {
         visitor.visit(pair.first);
-        visitor.visit(pair.second);
+        if (pair.second)
+            visitor.visit(pair.second.value());
     }
     for (auto module : m_included_modules) {
         visitor.visit(module);

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -80,12 +80,11 @@ Value ModuleObject::extend_object(Env *env, Value obj) {
     return obj;
 }
 
-Value ModuleObject::const_get(SymbolObject *name) const {
+Optional<Value> ModuleObject::const_get(SymbolObject *name) const {
     auto constant = m_constants.get(name);
-    if (constant)
-        return constant->value();
-    else
-        return nullptr;
+    if (!constant)
+        return {};
+    return constant->value();
 }
 
 Value ModuleObject::const_get(Env *env, Value name, Optional<Value> inherited) {
@@ -96,7 +95,7 @@ Value ModuleObject::const_get(Env *env, Value name, Optional<Value> inherited) {
             env->raise("NameError", "uninitialized constant {}", symbol->string());
         return send(env, "const_missing"_s, { name });
     }
-    return constant;
+    return constant.value();
 }
 
 Value ModuleObject::const_fetch(SymbolObject *name) const {
@@ -105,7 +104,7 @@ Value ModuleObject::const_fetch(SymbolObject *name) const {
         TM::String::format("Constant {} is missing!\n", name->string()).print();
         abort();
     }
-    return constant;
+    return constant.value();
 }
 
 Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject **found_in_module, ConstLookupSearchMode search_mode) {
@@ -323,7 +322,7 @@ Value ModuleObject::remove_const(Env *env, Value name) {
     if (!constant)
         env->raise("NameError", "constant {} not defined", name_as_sym->string());
     remove_const(name_as_sym);
-    return constant->value();
+    return constant->value().value();
 }
 
 Value ModuleObject::constants(Env *env, Optional<Value> inherit) const {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -391,9 +391,9 @@ Value Object::cvar_get(Env *env, SymbolObject *name) {
 }
 
 Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
-    Value val = cvar_get_or_null(env, name);
+    auto val = cvar_get_maybe(env, name);
     if (val) {
-        return val;
+        return val.value();
     } else {
         ModuleObject *module;
         if (m_type == Type::Module || m_type == Type::Class)
@@ -404,8 +404,8 @@ Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
     }
 }
 
-Value Object::cvar_get_or_null(Env *env, SymbolObject *name) {
-    return m_klass->cvar_get_or_null(env, name);
+Optional<Value> Object::cvar_get_maybe(Env *env, SymbolObject *name) {
+    return m_klass->cvar_get_maybe(env, name);
 }
 
 Value Object::cvar_set(Env *env, SymbolObject *name, Value val) {

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -72,7 +72,7 @@ Value ProcessModule::kill(Env *env, Args &&args) {
         }
     }
     if (pid_contains_self) {
-        auto signal_exception = GlobalEnv::the()->Object()->const_get("SignalException"_s).as_class();
+        auto signal_exception = GlobalEnv::the()->Object()->const_fetch("SignalException"_s).as_class();
         auto exception = _new(env, signal_exception, { signal }, nullptr).as_exception();
         env->raise_exception(exception);
     }

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -172,7 +172,7 @@ Value RangeObject::each(Env *env, Block *block) {
     auto break_value = iterate_over_range(env, [&](Value item) -> Value {
         Value args[] = { item };
         block->run(env, Args(1, args), nullptr);
-        return nullptr;
+        return {};
     });
     if (break_value)
         return break_value.value();
@@ -188,7 +188,6 @@ Value RangeObject::first(Env *env, Optional<Value> n) {
         nat_int_t count = IntegerMethods::convert_to_nat_int_t(env, n.value());
         if (count < 0) {
             env->raise("ArgumentError", "negative array size (or size too big)");
-            return nullptr;
         }
 
         ArrayObject *ary = new ArrayObject { (size_t)count };
@@ -197,7 +196,7 @@ Value RangeObject::first(Env *env, Optional<Value> n) {
 
             ary->push(item);
             count--;
-            return nullptr;
+            return {};
         });
 
         return ary;
@@ -334,7 +333,7 @@ bool RangeObject::include(Env *env, Value arg) {
         if (arg.send(env, eqeq, { item }).is_truthy())
             return item;
 
-        return nullptr;
+        return {};
     });
 
     return found_item.present();
@@ -431,7 +430,7 @@ Value RangeObject::step(Env *env, Optional<Value> n_arg, Block *block) {
                 block->run(env, { item }, nullptr);
 
             index += 1;
-            return nullptr;
+            return {};
         });
     }
 


### PR DESCRIPTION
This work gets all of the tests in `test/natalie` passing with `Value` having this assertion:

```cpp
Value(Object *object)
    m_value { reinterpret_cast<uintptr_t>(object) } {
    assert(object != nullptr);
}
```

(not committed in this PR)