### PR TITLE
Add TM::String::replace_bytes for char* argument

### DIFF
--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -790,6 +790,25 @@ public:
      *
      * ```
      * auto str = String { "foo-bar-baz" };
+     * str.replace_bytes(4, 3, String { "buz" });
+     * assert_str_eq("foo-buz-baz", str);
+     * str.replace_bytes(4, 3, String { "b" });
+     * assert_str_eq("foo-b-baz", str);
+     * str.replace_bytes(4, 1, String { "bar" });
+     * assert_str_eq("foo-bar-baz", str);
+     * str.replace_bytes(10, 1, String { "a" });
+     * assert_str_eq("foo-bar-baa", str);
+     * ```
+     */
+    void replace_bytes(const size_t index, const size_t length, const String &replacement) {
+        replace_bytes(index, length, replacement.c_str(), replacement.size());
+    }
+
+    /**
+     * Replaces the specified index+size bytes with the C string given.
+     *
+     * ```
+     * auto str = String { "foo-bar-baz" };
      * str.replace_bytes(4, 3, "buz");
      * assert_str_eq("foo-buz-baz", str);
      * str.replace_bytes(4, 3, "b");
@@ -800,10 +819,14 @@ public:
      * assert_str_eq("foo-bar-baa", str);
      * ```
      */
-    void replace_bytes(const size_t index, const size_t length, const String &replacement) {
+    void replace_bytes(const size_t index, const size_t length, const char *replacement) {
+        replace_bytes(index, length, replacement, strlen(replacement));
+    }
+
+    void replace_bytes(const size_t index, const size_t length, const char *replacement, const size_t replacement_size) {
         assert(index < m_length);
         assert(index + length <= m_length);
-        const ssize_t diff = replacement.size() - length;
+        const ssize_t diff = replacement_size - length;
         if (diff > 0)
             grow_at_least(m_length + diff);
         if (diff != 0) {
@@ -811,7 +834,7 @@ public:
             const auto dest = src + diff;
             memmove(m_str + dest, m_str + src, m_length - index - length);
         }
-        for (size_t i = 0; i < replacement.size(); i++)
+        for (size_t i = 0; i < replacement_size; i++)
             m_str[index + i] = replacement[i];
         m_length += diff;
         m_str[m_length] = 0;

--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -798,6 +798,8 @@ public:
      * assert_str_eq("foo-bar-baz", str);
      * str.replace_bytes(10, 1, String { "a" });
      * assert_str_eq("foo-bar-baa", str);
+     * str.replace_bytes(10, 1, String { "" });
+     * assert_str_eq("foo-bar-ba", str);
      * ```
      */
     void replace_bytes(const size_t index, const size_t length, const String &replacement) {
@@ -817,6 +819,8 @@ public:
      * assert_str_eq("foo-bar-baz", str);
      * str.replace_bytes(10, 1, "a");
      * assert_str_eq("foo-bar-baa", str);
+     * str.replace_bytes(10, 1, "");
+     * assert_str_eq("foo-bar-ba", str);
      * ```
      */
     void replace_bytes(const size_t index, const size_t length, const char *replacement) {
@@ -834,8 +838,7 @@ public:
             const auto dest = src + diff;
             memmove(m_str + dest, m_str + src, m_length - index - length);
         }
-        for (size_t i = 0; i < replacement_size; i++)
-            m_str[index + i] = replacement[i];
+        memcpy(m_str + index, replacement, replacement_size);
         m_length += diff;
         m_str[m_length] = 0;
     }


### PR DESCRIPTION
This makes it more efficient to call with a C style string by removing the allocation of a new String object.

This should make #2630 a bit more efficient, even with an empty char*, we still perform a heap allocation for the null byte. So we allocate 1 byte and use an 8 byte pointer to address that memory