### PR TITLE
Fixes to StringView::operator==

### DIFF
--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -216,12 +216,13 @@ public:
      *
      * assert(StringView() == StringView());
      * assert(StringView() == StringView(&str2, 0, 0));
+     * assert(StringView(&str2, 0, 0) == StringView());
      * ```
      */
     bool operator==(const StringView &other) const {
         if (m_length != other.m_length)
             return false;
-        if (!m_string && other.m_length == 0)
+        if (m_length == 0)
             return true;
         if (!m_string)
             return false;

--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -215,17 +215,18 @@ public:
      * assert_not(view1 == view2);
      *
      * assert(StringView() == StringView());
+     * assert(StringView() == StringView(&str2, 0, 0));
      * ```
      */
     bool operator==(const StringView &other) const {
-        if (m_string == other.m_string) // shortcut
-            return m_offset == other.m_offset && m_length == other.m_length;
+        if (m_length != other.m_length)
+            return false;
         if (!m_string && other.m_length == 0)
             return true;
         if (!m_string)
             return false;
-        if (m_length != other.m_length)
-            return false;
+        if (m_string == other.m_string) // shortcut
+            return m_offset == other.m_offset;
         return memcmp(m_string->c_str() + m_offset, other.m_string->c_str(), sizeof(char) * m_length) == 0;
     }
 

--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -222,6 +222,10 @@ public:
      * auto view3 = StringView(&str3, 0, 3);
      * auto view3b = StringView(&str3, 3, 3);
      * assert(view3 == view3b);
+     *
+     * auto view4 = StringView(&str3, 1, 2);
+     * auto view4b = StringView(&str3, 4, 2);
+     * assert(view4 == view4b);
      * ```
      */
     bool operator==(const StringView &other) const {
@@ -231,7 +235,7 @@ public:
             return true;
         if (m_string == other.m_string && m_offset == other.m_offset) // shortcut
             return true;
-        return memcmp(m_string->c_str() + m_offset, other.m_string->c_str(), sizeof(char) * m_length) == 0;
+        return memcmp(m_string->c_str() + m_offset, other.m_string->c_str() + other.m_offset, sizeof(char) * m_length) == 0;
     }
 
     bool operator!=(const StringView &other) const {

--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -224,8 +224,6 @@ public:
             return false;
         if (m_length == 0)
             return true;
-        if (!m_string)
-            return false;
         if (m_string == other.m_string) // shortcut
             return m_offset == other.m_offset;
         return memcmp(m_string->c_str() + m_offset, other.m_string->c_str(), sizeof(char) * m_length) == 0;

--- a/ext/tm/include/tm/string_view.hpp
+++ b/ext/tm/include/tm/string_view.hpp
@@ -217,6 +217,11 @@ public:
      * assert(StringView() == StringView());
      * assert(StringView() == StringView(&str2, 0, 0));
      * assert(StringView(&str2, 0, 0) == StringView());
+     *
+     * auto str3 = String("abcabc");
+     * auto view3 = StringView(&str3, 0, 3);
+     * auto view3b = StringView(&str3, 3, 3);
+     * assert(view3 == view3b);
      * ```
      */
     bool operator==(const StringView &other) const {
@@ -224,8 +229,8 @@ public:
             return false;
         if (m_length == 0)
             return true;
-        if (m_string == other.m_string) // shortcut
-            return m_offset == other.m_offset;
+        if (m_string == other.m_string && m_offset == other.m_offset) // shortcut
+            return true;
         return memcmp(m_string->c_str() + m_offset, other.m_string->c_str(), sizeof(char) * m_length) == 0;
     }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3140,7 +3140,7 @@ Value StringObject::squeeze_in_place(Env *env, Args &&selectors) {
         const auto old_index = index;
         auto character = next_char(&index);
 
-        if (last_character.to_string() == character.to_string() && handler(character)) {
+        if (last_character == character && handler(character)) {
             m_string.replace_bytes(old_index, character.size(), "");
             index = old_index;
         } else {
@@ -3160,7 +3160,7 @@ Value StringObject::squeeze_in_place_without_selectors(Env *env) {
         const auto old_index = index;
         auto character = next_char(&index);
 
-        if (last_character.to_string() == character.to_string()) {
+        if (last_character == character) {
             m_string.replace_bytes(old_index, character.size(), "");
             index = old_index;
         } else {


### PR DESCRIPTION
Beside the issue found in #2630, there were two other bugs in the code, so I'm surprised we never had other issues with this operation.
Beside those bugs, the order of operation has been shuffled a bit, to make the operation more efficient and remove some duplicate checks.