### PR TITLE
Don't convert string views to strings in character classes hash lookups

### DIFF
--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -100,8 +100,8 @@ static auto character_class_handler(Env *env, Args &&args) {
     return [basic_characters, negated_characters](const StringView character) -> bool {
         if (basic_characters.is_empty() && negated_characters.is_empty())
             return false;
-        return ((negated_characters.is_empty() || negated_characters.get(character.to_string()) == nullptr)
-            && (basic_characters.is_empty() || basic_characters.get(character.to_string()) != nullptr));
+        return ((negated_characters.is_empty() || negated_characters.get(character) == nullptr)
+            && (basic_characters.is_empty() || basic_characters.get(character) != nullptr));
     };
 }
 


### PR DESCRIPTION
The changes in #2606 made this possible.