### PR TITLE
Store real end of stack when thread suspends for amd64

### DIFF
--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -959,6 +959,11 @@ void gc_signal_handler(int signal, siginfo_t *, void *ucontext) {
         }
         memcpy(ctx, ucontext, sizeof(ucontext_t));
         thread->set_suspend_status(ThreadObject::SuspendStatus::Suspended);
+
+#if defined(__x86_64__)
+        thread->set_end_of_stack(reinterpret_cast<void *>(ctx->uc_mcontext.gregs[REG_RSP]));
+#endif
+
 #ifdef NAT_DEBUG_THREADS
         char msg[] = "THREAD DEBUG: Thread suspended\n";
         assert(::write(STDERR_FILENO, msg, sizeof(msg)) != -1);


### PR DESCRIPTION
This reduces the amount of memory the GC needs to scan during pauses. Before, we were scanning the full 8 Mb or whatever of stack space for each thread; now we just scan what is actually in use.

Using this code as a benchmark:

```ruby
threads = 1000.times.map do
  Thread.new do
    sleep
  end
end

Thread.pass until threads.all?(&:stop?)

10.times do
  print '.'
  GC.start
end

puts 'GC done'

threads.each(&:wakeup)
threads.each(&:join)
```

The results are dramatic:

```sh
→ time ./t1
..........GC done
./t1  13.95s user 1.26s system 101% cpu 14.956 total

→ time ./t2
..........GC done
./t2  0.09s user 0.22s system 210% cpu 0.147 total
```

Caveats:

This doesn't help on Darwin, as we use a different technique to suspend Darwin threads.

I don't have an Arm processor with Linux, so I'm not sure what kind of code we'd need for that. We can add other architectures later.