### PR TITLE
Remove fixtures for toplevel_binding spec

### DIFF
--- a/spec/language/predefined/fixtures/toplevel_binding_dynamic.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_dynamic.rb
@@ -1,4 +1,0 @@
-p TOPLEVEL_BINDING.local_variables.sort
-TOPLEVEL_BINDING.local_variable_set(:dynamic_set_main, 2)
-p TOPLEVEL_BINDING.local_variables.sort
-main_script = 3

--- a/spec/language/predefined/fixtures/toplevel_binding_dynamic_required.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_dynamic_required.rb
@@ -1,2 +1,0 @@
-TOPLEVEL_BINDING.local_variable_set(:dynamic_set_required, 1)
-p TOPLEVEL_BINDING.local_variables

--- a/spec/language/predefined/fixtures/toplevel_binding_id.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_id.rb
@@ -1,4 +1,0 @@
-a = TOPLEVEL_BINDING.object_id
-require_relative 'toplevel_binding_id_required'
-c = eval('TOPLEVEL_BINDING.object_id')
-p [a, $b, c].uniq.size

--- a/spec/language/predefined/fixtures/toplevel_binding_id_required.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_id_required.rb
@@ -1,1 +1,0 @@
-$b = TOPLEVEL_BINDING.object_id

--- a/spec/language/predefined/fixtures/toplevel_binding_required_before.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_required_before.rb
@@ -1,2 +1,0 @@
-required = true
-p [:required_before, TOPLEVEL_BINDING.local_variables]

--- a/spec/language/predefined/fixtures/toplevel_binding_values.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_values.rb
@@ -1,9 +1,0 @@
-p TOPLEVEL_BINDING.local_variable_get(:a)
-p TOPLEVEL_BINDING.local_variable_get(:b)
-a = 1
-p TOPLEVEL_BINDING.local_variable_get(:a)
-p TOPLEVEL_BINDING.local_variable_get(:b)
-b = 2
-a = 3
-p TOPLEVEL_BINDING.local_variable_get(:a)
-p TOPLEVEL_BINDING.local_variable_get(:b)

--- a/spec/language/predefined/fixtures/toplevel_binding_variables.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_variables.rb
@@ -1,4 +1,0 @@
-main_script = 1
-require_relative 'toplevel_binding_variables_required'
-eval('eval_var = 3')
-p TOPLEVEL_BINDING.local_variables

--- a/spec/language/predefined/fixtures/toplevel_binding_variables_required.rb
+++ b/spec/language/predefined/fixtures/toplevel_binding_variables_required.rb
@@ -1,2 +1,0 @@
-required = 2
-p [:required_after, TOPLEVEL_BINDING.local_variables]


### PR DESCRIPTION
These have been included in #2627 (the DATA constant), but they are not used in this spec. Remove them for now, we'll add them back once we start working on the spec they belong to.