### PR TITLE
Fix execution order for ConstantPathWriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1140,13 +1140,15 @@ module Natalie
       end
 
       def transform_constant_path_write_node(node, used:)
-        instructions = [transform_expression(node.value, used: true)]
-        instructions << DupInstruction.new if used
         name, _is_private, prep_instruction = constant_name(node.target)
         # FIXME: is_private shouldn't be ignored I think
-        instructions << prep_instruction
-        instructions << ConstSetInstruction.new(name)
-        instructions
+        [
+          *prep_instruction,
+          transform_expression(node.value, used: true),
+          *(used ? DupInstruction.new : []),
+          MoveRelInstruction.new(used ? 2 : 1),
+          ConstSetInstruction.new(name),
+        ]
       end
 
       def transform_constant_read_node(node, used:)

--- a/spec/language/assignments_spec.rb
+++ b/spec/language/assignments_spec.rb
@@ -40,9 +40,7 @@ describe 'Assignments' do
           ScratchPad.record []
 
           (ScratchPad << :module; m)::A = (ScratchPad << :rhs; :value)
-          NATFIXME 'it evaluates expressions left to right', exception: SpecFailedException do
-            ScratchPad.recorded.should == [:module, :rhs]
-          end
+          ScratchPad.recorded.should == [:module, :rhs]
         end
       end
 

--- a/spec/language/constants_spec.rb
+++ b/spec/language/constants_spec.rb
@@ -151,15 +151,13 @@ describe "Literal (A::X) constant resolution" do
       it "evaluates left-to-right" do
         mod = Module.new
 
-        NATFIXME 'it evaluates left-to-right', exception: SpecFailedException do
-          mod.module_eval <<-EOC
-            order = []
-            ConstantSpecsRHS = Module.new
-            (order << :lhs; ConstantSpecsRHS)::B = (order << :rhs)
-          EOC
+        mod.module_eval <<-EOC
+          order = []
+          ConstantSpecsRHS = Module.new
+          (order << :lhs; ConstantSpecsRHS)::B = (order << :rhs)
+        EOC
 
-          mod::ConstantSpecsRHS::B.should == [:lhs, :rhs]
-        end
+        mod::ConstantSpecsRHS::B.should == [:lhs, :rhs]
       end
     end
 


### PR DESCRIPTION
```ruby
Foo::Bar = (raise "frop"; 1)
```

Code like this should evaluate the LHS first, so this will fail because `Foo` cannot be found, and never raise