### PR TITLE
Improve memory scanning performance a bit

### DIFF
--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -133,6 +133,8 @@ private:
     size_t m_free_cells { 0 };
     size_t m_total_cells { 0 };
     size_t m_allocations_without_collection_count { 0 };
+    uintptr_t m_lowest_pointer_address { 0 };
+    uintptr_t m_highest_pointer_address { 0 };
 };
 
 }

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -260,13 +260,13 @@ NO_SANITIZE_ADDRESS void Heap::scan_memory(Cell::Visitor &visitor, void *start, 
         Cell *potential_cell = *reinterpret_cast<Cell **>(ptr); // NOLINT
         if (!potential_cell)
             continue;
+        fn(potential_cell); // this must be here for ASan to check if it's on the fake stack
         if ((reinterpret_cast<uintptr_t>(potential_cell) & 0b111) != 0b000)
             continue;
         if (reinterpret_cast<uintptr_t>(potential_cell) < m_lowest_pointer_address || reinterpret_cast<uintptr_t>(potential_cell) > m_highest_pointer_address)
             continue;
         if (is_a_heap_cell_in_use(potential_cell))
             visitor.visit(potential_cell);
-        fn(potential_cell);
     }
 }
 

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -243,6 +243,8 @@ NO_SANITIZE_ADDRESS void Heap::scan_memory(Cell::Visitor &visitor, void *start, 
         Cell *potential_cell = *reinterpret_cast<Cell **>(ptr); // NOLINT
         if (!potential_cell)
             continue;
+        if ((reinterpret_cast<uintptr_t>(potential_cell) & 0b111) != 0b000)
+            continue;
         if (is_a_heap_cell_in_use(potential_cell))
             visitor.visit(potential_cell);
     }
@@ -252,6 +254,8 @@ NO_SANITIZE_ADDRESS void Heap::scan_memory(Cell::Visitor &visitor, void *start, 
     for (auto *ptr = reinterpret_cast<std::byte *>(start); ptr < end; ptr += sizeof(intptr_t)) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(ptr); // NOLINT
         if (!potential_cell)
+            continue;
+        if ((reinterpret_cast<uintptr_t>(potential_cell) & 0b111) != 0b000)
             continue;
         if (is_a_heap_cell_in_use(potential_cell))
             visitor.visit(potential_cell);


### PR DESCRIPTION
This shows small improvement when running a program with lots of GC runs, including the self-hosted compiler.

```
→ hyperfine --warmup 10 'bin/nat_master -c h1 examples/hello.rb' 'bin/nat -c h2 examples/hello.rb'

Benchmark 1: bin/nat_master -c h1 examples/hello.rb
  Time (mean ± σ):     927.4 ms ±  32.2 ms    [User: 720.6 ms, System: 156.1 ms]
  Range (min … max):   881.7 ms … 991.4 ms    10 runs

Benchmark 2: bin/nat -c h2 examples/hello.rb
  Time (mean ± σ):     878.5 ms ±   5.2 ms    [User: 723.1 ms, System: 154.5 ms]
  Range (min … max):   870.5 ms … 884.7 ms    10 runs

Summary
  bin/nat -c h2 examples/hello.rb ran
    1.06 ± 0.04 times faster than bin/nat_master -c h1 examples/hello.rb
```