### PR TITLE
Fix splat usage in Index{And,Or}WriteNode

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1617,30 +1617,51 @@ module Natalie
       def transform_index_and_write_node(node, used:)
         obj = node.receiver
         key_args = node.arguments&.arguments || []
+        args_array_on_stack = key_args.any? { |a| a.type == :splat_node }
 
         instructions = [
           # stack before: []
           #  stack after: [obj]
           transform_expression(obj, used: true),
+        ]
+        if args_array_on_stack
+          instructions.append(
+            # stack before: [obj]
+            #  stack after: [obj, [*keys]]
+            *transform_array_elements_with_splat(key_args),
 
-          # stack before: [obj]
-          #  stack after: [obj, *keys]
-          key_args.map { |arg| transform_expression(arg, used: true) },
+            # stack before: [obj, [*keys]]
+            #  stack after: [obj, [*keys], obj]
+            DupRelInstruction.new(1),
 
-          # stack before: [obj, *keys]
-          #  stack after: [obj, *keys, obj]
-          DupRelInstruction.new(key_args.size),
+            # stack before: [obj, [*keys], obj]
+            #  stack after: [obj, [*keys], obj, [*keys]]
+            DupRelInstruction.new(1),
+          )
+        else
+          instructions.append(
+            # stack before: [obj]
+            #  stack after: [obj, *keys]
+            key_args.map { |arg| transform_expression(arg, used: true) },
 
-          # stack before: [obj, *keys, obj]
-          #  stack after: [obj, *keys, obj, *keys]
-          key_args.each_with_index.map { |_, index| DupRelInstruction.new(index + key_args.size) },
+            # stack before: [obj, *keys]
+            #  stack after: [obj, *keys, obj]
+            DupRelInstruction.new(key_args.size),
 
-          # stack before: [obj, *keys, obj, *keys]
-          #  stack after: [obj, *keys, old_value]
-          PushArgcInstruction.new(key_args.size),
+            # stack before: [obj, *keys, obj]
+            #  stack after: [obj, *keys, obj, *keys]
+            key_args.each_with_index.map { |_, index| DupRelInstruction.new(index + key_args.size) },
+
+            PushArgcInstruction.new(key_args.size),
+          )
+        end
+        # stack before: [obj, *keys, obj, *keys]
+        #  stack after: [obj, *keys, old_value]
+        instructions.append(
           SendInstruction.new(
             :[],
             receiver_is_self: obj.is_a?(Prism::SelfNode),
+            args_array_on_stack:,
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -1662,14 +1683,22 @@ module Natalie
           # stack before: [obj, *keys]
           #  stack after: [obj, *keys, new_value]
           transform_expression(node.value, used: true),
-
+        )
+        if args_array_on_stack
+          # stack before: [obj, [*keys], new_value]
+          #  stack after: [obj, [*keys, new_value]]
+          instructions << ArrayPushInstruction.new
+        else
+          instructions << PushArgcInstruction.new(key_args.size + 1)
+        end
+        instructions.append(
           # obj[*keys] = new_value
           # stack before: [obj, *keys, new_value]
           #  stack after: [result_of_send]
-          PushArgcInstruction.new(key_args.size + 1),
           SendInstruction.new(
             :[]=,
             receiver_is_self: obj.is_a?(Prism::SelfNode),
+            args_array_on_stack:,
             with_block: false,
             file: @file.path,
             line: node.location.start_line,
@@ -1677,25 +1706,40 @@ module Natalie
 
           # old_value is falsey...
           ElseInstruction.new(:if),
+        )
+        # don't need the extra key(s) after all :-)
+        if args_array_on_stack
+          instructions.append(
+            # stack before: [obj, [*keys], old_value]
+            #  stack after: [obj, old_value]
+            SwapInstruction.new,
+            PopInstruction.new,
 
-          # don't need the extra key(s) after all :-)
-          # stack before: [obj, *keys, old_value]
-          #  stack after: [obj, old_value]
-          key_args.map do
-            [
-              SwapInstruction.new, # move value above duplicated key
-              PopInstruction.new, # get rid of duplicated key
-            ]
-          end,
+            # stack before: [obj, old_value]
+            #  stack after: [old_value]
+            SwapInstruction.new,
+            PopInstruction.new,
+          )
+        else
+          instructions.append(
+            # stack before: [obj, *keys, old_value]
+            #  stack after: [obj, old_value]
+            key_args.map do
+              [
+                SwapInstruction.new, # move value above duplicated key
+                PopInstruction.new, # get rid of duplicated key
+              ]
+            end,
 
-          # don't need the obj now
-          # stack before: [obj, old_value]
-          #  stack after: [old_value]
-          SwapInstruction.new,
-          PopInstruction.new,
+            # don't need the obj now
+            # stack before: [obj, old_value]
+            #  stack after: [old_value]
+            SwapInstruction.new,
+            PopInstruction.new,
+          )
+        end
 
-          EndInstruction.new(:if),
-        ]
+        instructions << EndInstruction.new(:if)
 
         instructions << PopInstruction.new unless used
         instructions

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -228,15 +228,13 @@ describe 'Optional variable assignments' do
       context 'splatted argument' do
         it 'correctly handles it' do
           (@b[*[:m]] ||= 10).should == 10
-          NATFIXME 'correctly handles splatted argument', exception: SpecFailedException do
-            @b[:m].should == 10
+          @b[:m].should == 10
 
-            (@b[*(1; [:n])] ||= 10).should == 10
-            @b[:n].should == 10
+          (@b[*(1; [:n])] ||= 10).should == 10
+          @b[:n].should == 10
 
-            (@b[*begin 1; [:k] end] ||= 10).should == 10
-            @b[:k].should == 10
-          end
+          (@b[*begin 1; [:k] end] ||= 10).should == 10
+          @b[:k].should == 10
         end
 
         it 'calls #to_a only once' do
@@ -248,17 +246,13 @@ describe 'Optional variable assignments' do
 
           ScratchPad.record []
           (@b[*k] ||= 20).should == 20
-          NATFIXME 'calls #to_a only once', exception: SpecFailedException do
-            @b[:k].should == 20
-            ScratchPad.recorded.should == [:to_a]
-          end
+          @b[:k].should == 20
+          ScratchPad.recorded.should == [:to_a]
         end
 
         it 'correctly handles a nested splatted argument' do
           (@b[*[*[:k]]] ||= 20).should == 20
-          NATFIXME 'correctly handles a nested splatted argument', exception: SpecFailedException do
-            @b[:k].should == 20
-          end
+          @b[:k].should == 20
         end
 
         it 'correctly handles multiple nested splatted arguments' do
@@ -277,9 +271,7 @@ describe 'Optional variable assignments' do
           a = klass_with_multiple_parameters.new
 
           (a[*[:a], *[:b], *[:c]] ||= 20).should == 20
-          NATFIXME 'correctly handles multiple nested splatted arguments', exception: SpecFailedException do
-            a[:a, :b, :c].should == 20
-          end
+          a[:a, :b, :c].should == 20
         end
       end
     end

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -521,18 +521,16 @@ describe 'Optional variable assignments' do
       context 'splatted argument' do
         it 'correctly handles it' do
           @b[:m] = 0
-          NATFIXME 'correctly handles splatted argument', exception: SpecFailedException do
-            (@b[*[:m]] &&= 10).should == 10
-            @b[:m].should == 10
+          (@b[*[:m]] &&= 10).should == 10
+          @b[:m].should == 10
 
-            @b[:n] = 0
-            (@b[*(1; [:n])] &&= 10).should == 10
-            @b[:n].should == 10
+          @b[:n] = 0
+          (@b[*(1; [:n])] &&= 10).should == 10
+          @b[:n].should == 10
 
-            @b[:k] = 0
-            (@b[*begin 1; [:k] end] &&= 10).should == 10
-            @b[:k].should == 10
-          end
+          @b[:k] = 0
+          (@b[*begin 1; [:k] end] &&= 10).should == 10
+          @b[:k].should == 10
         end
 
         it 'calls #to_a only once' do
@@ -544,19 +542,15 @@ describe 'Optional variable assignments' do
 
           ScratchPad.record []
           @b[:k] = 10
-          NATFIXME 'calls #to_a only once', exception: SpecFailedException do
-            (@b[*k] &&= 20).should == 20
-            @b[:k].should == 20
-            ScratchPad.recorded.should == [:to_a]
-          end
+          (@b[*k] &&= 20).should == 20
+          @b[:k].should == 20
+          ScratchPad.recorded.should == [:to_a]
         end
 
         it 'correctly handles a nested splatted argument' do
           @b[:k] = 10
-          NATFIXME 'correctly handles a nested splatted argument', exception: SpecFailedException do
-            (@b[*[*[:k]]] &&= 20).should == 20
-            @b[:k].should == 20
-          end
+          (@b[*[*[:k]]] &&= 20).should == 20
+          @b[:k].should == 20
         end
 
         it 'correctly handles multiple nested splatted arguments' do
@@ -575,10 +569,8 @@ describe 'Optional variable assignments' do
           a = klass_with_multiple_parameters.new
 
           a[:a, :b, :c] = 10
-          NATFIXME 'correctly handles multiple nested splatted arguments', exception: SpecFailedException do
-            (a[*[:a], *[:b], *[:c]] &&= 20).should == 20
-            a[:a, :b, :c].should == 20
-          end
+          (a[*[:a], *[:b], *[:c]] &&= 20).should == 20
+          a[:a, :b, :c].should == 20
         end
       end
     end


### PR DESCRIPTION
```ruby
b[*[:foo]] ||= 1
b[*[:foo]] &&= 1
```

They're pretty much the same structure, just with the if/else bodies swapped