### PR TITLE
Fix write nodes with multiple arguments

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1650,7 +1650,7 @@ module Natalie
 
             # stack before: [obj, *keys, obj]
             #  stack after: [obj, *keys, obj, *keys]
-            key_args.each_with_index.map { |_, index| DupRelInstruction.new(index + key_args.size) },
+            key_args.map { DupRelInstruction.new(key_args.size) },
 
             PushArgcInstruction.new(key_args.size),
           )
@@ -1773,7 +1773,7 @@ module Natalie
             DupRelInstruction.new(key_args.size),
 
             # stack: [obj, *keys, obj, *keys]
-            key_args.each_with_index.map { |_, index| DupRelInstruction.new(index + key_args.size) },
+            key_args.map { DupRelInstruction.new(key_args.size) },
 
             # old_value = obj[*keys]
             # stack: [obj, *keys, old_value]
@@ -1859,7 +1859,7 @@ module Natalie
 
             # stack before: [obj, *keys, obj]
             #  stack after: [obj, *keys, obj, *keys]
-            key_args.each_with_index.map { |_, index| DupRelInstruction.new(index + key_args.size) },
+            key_args.map { DupRelInstruction.new(key_args.size) },
 
             # stack before: [obj, *keys, obj, *keys]
             #  stack after: [obj, *keys, old_value]

--- a/spec/language/optional_assignments_spec.rb
+++ b/spec/language/optional_assignments_spec.rb
@@ -484,9 +484,7 @@ describe 'Optional variable assignments' do
 
         ary[foo.pop, foo.pop] &&= 2 # expected `ary[2, 0] &&= 2`
 
-        NATFIXME 'evaluates the index arguments in the correct order', exception: SpecFailedException do
-          ary[2, 0].should == 2
-        end
+        ary[2, 0].should == 2
         ary[6, 0].should == 1 # returns the same element as `ary[0, 2]`
       end
 


### PR DESCRIPTION
This is code like:
```ruby
a[x, y] += z
a[x, y] ||= z
a[x, y] &&= z
```

These all had the same bug (so at least we're consistent (or using copy/paste to write code)). Instead of pushing the arguments `x, y` on the stack, we pushed the first argument every time, so our examples ended up as if they were `a[x, x] = z`. This only happened in the read section of `||=` and `&&=`, the write section worked as intended. The code for `a[x, y] ||= z` passed the spec accidentally: instead of ending up on the designated value that was `nil`, we ended up past the actual array and that did pass the spec.