### PR TITLE
Add lock for build directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
     - spec/**/*.rb
     - vendor/**/*
 
+Layout/CaseIndentation:
+  Enabled: false
+
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
@@ -12,8 +15,7 @@ Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
+  Enabled: false
 
 Layout/HeredocIndentation:
   Enabled: false
@@ -61,6 +63,9 @@ Style/Documentation:
   Enabled: false
 
 Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyElse:
   Enabled: false
 
 Style/FormatString:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ "$NEED_VALGRIND" = "true" ]; then \
   tar xvf valgrind-3.24.0.tar.bz2 && \
   cd valgrind-3.24.0 && \
   ./configure && \
-  make -j 4 && \
+  make -j && \
   make install; \
   fi
 

--- a/Rakefile
+++ b/Rakefile
@@ -489,7 +489,7 @@ file 'build/onigmo/lib/libonigmo.a' do
     sh autogen.sh && \
     ./configure --with-pic --prefix #{build_dir} && \
     git apply #{patch_path} && \
-    make -j 4 && \
+    make -j && \
     make install
   SH
 end
@@ -501,7 +501,7 @@ file 'build/zlib/libz.a' do
   sh <<-SH
     cd #{build_dir} && \
     ./configure && \
-    make -j 4
+    make -j
   SH
 end
 
@@ -600,7 +600,7 @@ file "build/prism/ext/prism/prism.#{DL_EXT}" => Rake::FileList['ext/prism/**/*.{
     make && \
     cd ext/prism && \
     ruby extconf.rb && \
-    make -j 4
+    make -j
   SH
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,17 +35,20 @@ task :clean do
     rm_rf path
   end
   rm_rf 'build/build.log'
+  rm_rf 'build/libnat.rb.cpp'
   rm_rf 'build/generated'
   rm_rf 'build/libnatalie_base.a'
   rm_rf "build/libnatalie_base.#{DL_EXT}"
   rm_rf "build/libnat.#{SO_EXT}"
   rm_rf Rake::FileList['build/*.o']
+  rm_rf 'test/build'
 end
 
 desc 'Remove all generated files'
 task :clobber do
   rm_rf 'build'
   rm_rf '.build'
+  rm_rf 'test/build'
 end
 
 task distclean: :clobber

--- a/bin/natalie
+++ b/bin/natalie
@@ -117,6 +117,10 @@ OptionParser.new do |opts|
     options[:build_dir] = path
   end
 
+  opts.on('--build-quietly', "Don't print any output during build (unless there is an error)") do
+    options[:build_quietly] = true
+  end
+
   opts.on('--keep-cpp', 'Do not delete intermediate cpp file used for compilation') do
     options[:keep_cpp] = true
   end

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -18,19 +18,25 @@ module FileUtils
   def self.mkdir_p(path, mode: nil)
     parts = File.expand_path(path).split(File::SEPARATOR)
 
+    mkdir = lambda do |dir, *args|
+      Dir.mkdir(dir, *args)
+    rescue # rubocop:disable Style/RescueStandardError
+      raise unless File.directory?(dir)
+    end
+
     dir = parts.shift
     parts.each do |part|
       dir = File.join(dir, part)
 
       unless File.directory?(dir)
         if mode
-          Dir.mkdir(dir, mode)
+          mkdir.(dir, mode)
           # mkdir(2) (and thus Ruby's Dir.mkdir) does some masking of the mode,
           # and thus the passed mode above in many cases doesn't have the desired
           # affect. So we call chmod here to set the mode as desired.
           File.chmod(mode, dir)
         else
-          Dir.mkdir(dir)
+          mkdir.(dir)
         end
       end
     end

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -127,6 +127,7 @@ module Natalie
     def debug = options[:debug]
     def build = options[:build]
     def build_dir = options[:build_dir]
+    def build_quietly? = !!options[:build_quietly]
     def keep_cpp? = !!((debug && debug != 'cc-cmd') || options[:keep_cpp])
     def interpret? = !!options[:interpret]
     def dynamic_linking? = !!options[:dynamic_linking]

--- a/lib/natalie/compiler/advisory_lock.rb
+++ b/lib/natalie/compiler/advisory_lock.rb
@@ -1,0 +1,24 @@
+require 'fileutils'
+
+module Natalie
+  class Compiler
+    class AdvisoryLock
+      def initialize(path)
+        @path = path
+      end
+
+      def lock
+        result = nil
+        File.open(@path, File::RDWR | File::CREAT) do |f|
+          f.flock(File::LOCK_EX)
+          result = yield
+        ensure
+          f.flock(File::LOCK_UN)
+        end
+        result
+      ensure
+        File.unlink(@path) rescue nil
+      end
+    end
+  end
+end

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -73,23 +73,23 @@ module Natalie
         check_build
         outs = prepare_out_files
         if single_source?
-          out = merge_out_file_sources(outs)
-          object_path = out.compile_object_file
+          one_out = merge_out_file_sources(outs)
+          object_path = one_out.compile_object_file
           link([object_path])
         else
           object_paths = outs.map do |out|
-            print "compiling #{out.relative_ruby_path}... "
+            build_print "compiling #{out.relative_ruby_path}... "
             object_path = out.compile_object_file
             case out.status
-              when :compiled then puts 'done'
-              when :unchanged then puts 'unchanged'
+              when :compiled then build_puts 'done'
+              when :unchanged then build_puts 'unchanged'
               else raise "unexpected status: #{out.status}"
             end
             object_path
           end
-          puts 'linking...'
+          build_puts 'linking...'
           link(object_paths)
-          puts 'done'
+          build_puts 'done'
         end
       end
 
@@ -99,7 +99,7 @@ module Natalie
           out = merge_out_file_sources(outs)
           [out.write_source_to_tempfile]
         else
-          outs.map { |out| out.write_source_to_tempfile }
+          outs.map(&:write_source_to_tempfile)
         end
       end
 
@@ -226,6 +226,14 @@ module Natalie
 
       def link(paths)
         linker(paths).link
+      end
+
+      def build_puts(str)
+        puts str unless @compiler.build_quietly?
+      end
+
+      def build_print(str)
+        print str unless @compiler.build_quietly?
       end
     end
   end

--- a/lib/natalie/compiler/backends/cpp_backend.rb
+++ b/lib/natalie/compiler/backends/cpp_backend.rb
@@ -143,9 +143,10 @@ module Natalie
                                 .gsub(/[^a-zA-Z0-9_]/, '_') + '_'
         if @var_prefixes_used[var_prefix]
           # This causes some hard-to-debug compilation/linking bugs.
+          p(var_prefix:, path: loaded_file.path, previous_path: @var_prefixes_used[var_prefix].path)
           raise "I don't know what to do when two var_prefixes collide."
         end
-        @var_prefixes_used[var_prefix] = true
+        @var_prefixes_used[var_prefix] = loaded_file
 
         @transform_data = TransformData.new(var_prefix:)
       end

--- a/lib/natalie/compiler/backends/cpp_backend/out_file.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/out_file.rb
@@ -182,6 +182,7 @@ module Natalie
         end
 
         def build_dir = @compiler.build_dir
+        def build_quietly? = @compiler.build_quietly?
         def single_source? = !build_dir
 
         def build_path(extension)

--- a/lib/natalie/compiler/macro_expander.rb
+++ b/lib/natalie/compiler/macro_expander.rb
@@ -264,13 +264,15 @@ module Natalie
       end
 
       def find_file_in_load_path(path)
-        load_path.map { |d| File.join(d, path) }.detect { |p| File.file?(p) }
+        load_path.map { |d| File.expand_path(File.join(d, path)) }.detect { |p| File.file?(p) }
       end
 
       def load_file(path, require_once:, location:)
         return load_cpp_file(path, require_once: require_once, location: location) if path =~ /\.cpp$/
 
-        unless (loaded_file = @required_ruby_files[path])
+        raise "Expected an absolute path, but got: #{path.inspect}" unless File.absolute_path?(path)
+
+        unless @required_ruby_files[path]
           code = File.read(path)
           parser = Natalie::Parser.new(code, path)
           @required_ruby_files[path] = LoadedFile.new(path: path, ast: parser.ast, encoding: parser.encoding)

--- a/lib/socket/constants.rb
+++ b/lib/socket/constants.rb
@@ -1,6 +1,7 @@
 require 'natalie/inline'
 
 __inline__ <<END
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>

--- a/spec/support/cpp_output_specs.rb
+++ b/spec/support/cpp_output_specs.rb
@@ -12,7 +12,7 @@ pool = Concurrent::ThreadPoolExecutor.new(
   max_queue: 0 # unbounded work queue
 )
 
-specs = 'spec/**/*_spec.rb'
+specs = ENV.fetch('GLOB', 'spec/**/*_spec.rb')
 env = { 'DO_NOT_PRINT_CPP_PATH' => 'true' }
 
 errors = []

--- a/test/ruby/ruby_specs_test.rb
+++ b/test/ruby/ruby_specs_test.rb
@@ -37,7 +37,7 @@ describe 'ruby/spec' do
     describe path do
       it 'passes all specs' do
         out_nat = Timeout.timeout(spec_timeout(path), nil, "execution expired running: #{path}") do
-          `#{NAT_BINARY} #{path} 2>&1`
+          `#{NAT_BINARY} --build-dir=test/build --build-quietly #{path} 2>&1`
         end
         puts out_nat if ENV['DEBUG'] || !$?.success?
         expect($?).must_be :success?

--- a/test/support/compare_rubies.rb
+++ b/test/support/compare_rubies.rb
@@ -5,7 +5,7 @@ module CompareRubies
   NAT_BINARY = ENV.fetch('NAT_BINARY', 'bin/natalie')
 
   def run_nat(path, *args)
-    out_nat = sh("#{NAT_BINARY} -I test/support #{path} #{args.join(' ')} 2>&1")
+    out_nat = sh("#{NAT_BINARY} --build-dir=test/build --build-quietly -I test/support #{path} #{args.join(' ')} 2>&1")
     puts out_nat unless $?.success?
     expect($?).must_be :success?
     out_nat
@@ -32,6 +32,8 @@ module CompareRubies
   end
 
   def sh(command)
-    Timeout.timeout(SPEC_TIMEOUT, nil, "execution expired running: #{command}") { `#{command}` }
+    Timeout.timeout(SPEC_TIMEOUT, nil, "execution expired running: #{command}") do
+      `#{command}`
+    end
   end
 end


### PR DESCRIPTION
...so multiple processes can utilize the same build directory without stepping on each other's work.

This also adds the `--build-quietly` option and enables the build directory for our test runs.