### PR TITLE
Fix bad cpp output when source code is shorter than before

### DIFF
--- a/lib/natalie/compiler/backends/cpp_backend/out_file.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/out_file.rb
@@ -62,6 +62,7 @@ module Natalie
                   break if existing_source == merged_source
                 end
                 f.rewind
+                f.truncate(0)
                 f.write(merged_source)
               end
             end


### PR DESCRIPTION
This was extracted from #2663.