### PR TITLE
Build object files in parallel

### DIFF
--- a/ext/tm/include/tm/recursion_guard.hpp
+++ b/ext/tm/include/tm/recursion_guard.hpp
@@ -65,7 +65,7 @@ private:
         s_did_run.remove(m_instance);
     }
 
-    static inline TM::Hashmap<void *> s_did_run {};
+    static inline thread_local TM::Hashmap<void *> s_did_run {};
 };
 
 class PairedRecursionGuard {

--- a/lib/thread_pool.rb
+++ b/lib/thread_pool.rb
@@ -1,0 +1,26 @@
+class ThreadPool
+  def initialize(size)
+    @size = size
+    @jobs = Thread::Queue.new
+    @pool =
+      Array.new(@size) do
+        Thread.new do
+          catch(:exit) do
+            loop do
+              job, args = @jobs.pop
+              job.call(*args)
+            end
+          end
+        end
+      end
+  end
+
+  def schedule(*args, &block)
+    @jobs << [block, args]
+  end
+
+  def shutdown
+    @size.times { schedule { throw :exit } }
+    @pool.map(&:join)
+  end
+end

--- a/src/dir.rb
+++ b/src/dir.rb
@@ -60,12 +60,12 @@ class Dir
           yield dir_to_match if patterns.any? { |pattern| File.fnmatch(pattern, dir_to_match, flags) }
 
           Dir
-            .children(dir)
+            .children(File.join(base, dir))
             &.each do |path|
               relative_path = File.join(dir, path)
               relative_path.sub!(%r{^\./}, '') unless dot_slash
               path_to_match = is_absolute ? File.join(base, relative_path) : relative_path
-              if File.directory?(relative_path)
+              if File.directory?(File.join(base, relative_path))
                 recurse.(relative_path)
               elsif patterns.any? { |pattern| File.fnmatch(pattern, path_to_match, flags) }
                 yield path_to_match
@@ -75,7 +75,7 @@ class Dir
           :noop
         end
 
-      Dir.chdir(base) { recurse.('.') }
+      recurse.('.')
 
       nil
     end


### PR DESCRIPTION
Extracted from #2663.

On a multi-core machine this can dramatically speed up compilation when using a build directory.