### PR TITLE
Lock symbol hashmap when interning a symbol from C++ code

### DIFF
--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -1,7 +1,14 @@
 module Natalie
   class Compiler
     module Flags
-      RELEASE_FLAGS = %w[-pthread -O3 -Wno-unused-value -Wno-trigraphs].freeze
+      RELEASE_FLAGS = %w[
+        -pthread
+        -O3
+        -Wno-unused-value
+        -Wno-trigraphs
+        -Wno-vla-cxx-extension
+        -Wno-unknown-warning-option
+      ].freeze
 
       DEBUG_FLAGS = %w[
         -pthread
@@ -19,6 +26,7 @@ module Natalie
         -Wno-trigraphs
         -DNAT_GC_GUARD
         -Wno-vla-cxx-extension
+        -Wno-unknown-warning-option
       ].freeze
 
       SANITIZE_FLAG = "-fsanitize=#{ENV.fetch('NAT_SANITIZE_FLAG_VALUE', 'address')}".freeze

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -441,7 +441,7 @@ Value StringObject::chr(Env *env) {
 }
 
 SymbolObject *StringObject::to_symbol(Env *env) const {
-    return SymbolObject::intern(m_string, m_encoding.ptr());
+    return SymbolObject::intern_with_lock(m_string, m_encoding.ptr());
 }
 
 Value StringObject::to_sym(Env *env) const {


### PR DESCRIPTION
This was extracted from #2663.

A multi-threaded bit of code that causes the internal runtime code to intern the same symbol at roughly the same time can cause a race condition: two different threads can intern two different symbols with the same name, which obviously defeats the purpose of symbols. 😅 

Here is some code that demonstrates it:

```ruby
threads = Array.new(12) { Thread.new { File.stat('README.md').mtime } }
threads.each(&:join)
```

Result of running this a few times:

```
#<Thread:0x56599a658620 wat.rb:1 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        1: from wat.rb:1:in 'block in block in block'
wat.rb:1:in 'mtime': unexpected unit: :nanosecond (ArgumentError)
Traceback (most recent call last):
        1: from wat.rb:1:in 'block in block in block'
wat.rb:1:in 'mtime': unexpected unit: :nanosecond (ArgumentError)
```

This error happens because [this comparison](https://github.com/natalie-lang/natalie/blob/9ce6403e322e48c5706cc8bd80b1f0805485c4e0/src/time_object.cpp#L444) returns false.

```c++
if (value == "millisecond"_s) {
    return Value::integer(1000);
} else if (value == "microsecond"_s || value == "usec"_s) {
    return Value::integer(1000000);
} else if (value == "nanosecond"_s || value == "nsec"_s) {
    return Value::integer(1000000000);
} else {
    env->raise("ArgumentError", "unexpected unit: {}", value.inspect_str(env));
}
```