### PR TITLE
Print large objects and "inspect"-related refactoring

### DIFF
--- a/ext/tm/include/tm/hashmap.hpp
+++ b/ext/tm/include/tm/hashmap.hpp
@@ -579,6 +579,17 @@ public:
     size_t size() const { return m_size; }
 
     /**
+     * Returns the number of storage slots available.
+     *
+     * ```
+     * auto map = Hashmap<String, Thing>();
+     * map.put("foo", Thing(1));
+     * assert_eq(32, map.capacity());
+     * ```
+     */
+    size_t capacity() const { return m_capacity; }
+
+    /**
      * Returns true if there are zero values stored in the Hashmap.
      *
      * ```

--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -866,6 +866,20 @@ public:
     }
 
     /**
+     * Adds the given character at the end of the string, the given number of times.
+     *
+     * ```
+     * String str;
+     * str.append_char('o', 3);
+     * assert_str_eq("ooo", str);
+     * ```
+     */
+    void append_char(const char c, int count) {
+        for (int i = 0; i < count; i++)
+            append_char(c);
+    }
+
+    /**
      * Adds the given signed character at the end of the string.
      *
      * ```

--- a/include/natalie/abstract_method_object.hpp
+++ b/include/natalie/abstract_method_object.hpp
@@ -24,8 +24,8 @@ public:
         visitor.visit(m_method);
     }
 
-    virtual TM::String dbg_inspect() const override {
-        return TM::String::format("<AbstractMethodObject {h} method={}>", this, m_method ? m_method->dbg_inspect() : "null");
+    virtual TM::String dbg_inspect(int indent = 0) const override {
+        return TM::String::format("<AbstractMethodObject {h} method={}>", this, m_method ? m_method->dbg_inspect(indent) : "null");
     }
 
 protected:

--- a/include/natalie/abstract_method_object.hpp
+++ b/include/natalie/abstract_method_object.hpp
@@ -24,8 +24,8 @@ public:
         visitor.visit(m_method);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<AbstractMethodObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<AbstractMethodObject {h} method={}>", this, m_method ? m_method->dbg_inspect() : "null");
     }
 
 protected:

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -215,11 +215,6 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        size_t size = m_vector.size();
-        snprintf(buf, len, "<ArrayObject %p size=%zu>", this, size);
-    }
-
     virtual bool is_large() override {
         return m_vector.capacity() >= 100;
     }

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -213,7 +213,7 @@ public:
         }
     }
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     virtual bool is_large() override {
         return m_vector.capacity() >= 100;

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -220,6 +220,10 @@ public:
         snprintf(buf, len, "<ArrayObject %p size=%zu>", this, size);
     }
 
+    virtual bool is_large() override {
+        return m_vector.capacity() >= 100;
+    }
+
 private:
     Vector<Value> m_vector {};
 

--- a/include/natalie/backtrace.hpp
+++ b/include/natalie/backtrace.hpp
@@ -21,7 +21,7 @@ public:
     ArrayObject *to_ruby_array();
     ArrayObject *to_ruby_backtrace_locations_array();
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Backtrace {h} size={}>", this, m_items.size());
     }
 

--- a/include/natalie/backtrace.hpp
+++ b/include/natalie/backtrace.hpp
@@ -21,8 +21,8 @@ public:
     ArrayObject *to_ruby_array();
     ArrayObject *to_ruby_backtrace_locations_array();
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Backtrace %p size=%ld>", this, m_items.size());
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Backtrace {h} size={}>", this, m_items.size());
     }
 
 private:

--- a/include/natalie/bigint.hpp
+++ b/include/natalie/bigint.hpp
@@ -299,8 +299,8 @@ public:
         return b;
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<BigInt %p value=%s>", this, to_string().c_str());
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<BigInt {h} value={}>", this, to_string());
     }
 
 private:

--- a/include/natalie/bigint.hpp
+++ b/include/natalie/bigint.hpp
@@ -299,7 +299,7 @@ public:
         return b;
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<BigInt {h} value={}>", this, to_string());
     }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -59,7 +59,7 @@ public:
         visitor.visit(m_self);
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Block {h} fn={h}>", this, reinterpret_cast<void *>(m_fn));
     }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -59,8 +59,8 @@ public:
         visitor.visit(m_self);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Block %p fn=%p>", this, m_fn);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Block {h} fn={h}>", this, reinterpret_cast<void *>(m_fn));
     }
 
 private:

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -61,7 +61,7 @@ public:
 
     virtual String backtrace_name() const override final;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<ClassObject {h} name=\"{}\">", this, m_name.value_or("none"));
     }
 

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -61,11 +61,8 @@ public:
 
     virtual String backtrace_name() const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        if (m_name)
-            snprintf(buf, len, "<ClassObject %p name=%s>", this, m_name.value().c_str());
-        else
-            snprintf(buf, len, "<ClassObject %p name=(none)>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<ClassObject {h} name=\"{}\">", this, m_name.value_or("none"));
     }
 
 private:

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -162,7 +162,7 @@ public:
     static Value casefold_full(nat_int_t codepoint);
     static Value casefold_simple(nat_int_t codepoint);
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<EncodingObject {h} name={}>", this, m_names[0]);
     }
 

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -162,8 +162,8 @@ public:
     static Value casefold_full(nat_int_t codepoint);
     static Value casefold_simple(nat_int_t codepoint);
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<EncodingObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<EncodingObject {h} name={}>", this, m_names[0]);
     }
 
 private:

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -39,8 +39,8 @@ public:
         return Value::integer(1);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Enumerator::ArithmeticSequence %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Enumerator::ArithmeticSequence {h}>", this);
     }
 
     virtual void visit_children(Visitor &visitor) const override {

--- a/include/natalie/enumerator/arithmetic_sequence_object.hpp
+++ b/include/natalie/enumerator/arithmetic_sequence_object.hpp
@@ -39,7 +39,7 @@ public:
         return Value::integer(1);
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Enumerator::ArithmeticSequence {h}>", this);
     }
 

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -186,8 +186,8 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Env %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Env {h} outer={h}>", this, m_outer);
     }
 
     Value output_file_separator();

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -186,7 +186,7 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override final;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Env {h} outer={h}>", this, m_outer);
     }
 

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -54,8 +54,8 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<ExceptionObject %p message=?>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<ExceptionObject {h} message={}>", this, m_message.dbg_inspect());
     }
 
     void set_local_jump_error_type(LocalJumpErrorType type) { m_local_jump_error_type = type; }

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -54,8 +54,8 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual TM::String dbg_inspect() const override {
-        return TM::String::format("<ExceptionObject {h} message={}>", this, m_message.dbg_inspect());
+    virtual TM::String dbg_inspect(int indent = 0) const override {
+        return TM::String::format("<ExceptionObject {h} message={}>", this, m_message.dbg_inspect(indent));
     }
 
     void set_local_jump_error_type(LocalJumpErrorType type) { m_local_jump_error_type = type; }

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -107,15 +107,8 @@ public:
     void visit_children_from_stack(Visitor &) const;
     void visit_children_from_asan_fake_stack(Visitor &, Cell *) const;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        auto size = m_coroutine ? m_coroutine->stack_size : 0;
-        snprintf(
-            buf,
-            len,
-            "<FiberObject %p stack=%p..%p>",
-            this,
-            m_end_of_stack,
-            m_start_of_stack);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<FiberObject {h} stack={h}..{h}>", this, m_end_of_stack, m_start_of_stack);
     }
 
     static FiberObject *current() { return tl_current_thread->current_fiber(); }

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -107,7 +107,7 @@ public:
     void visit_children_from_stack(Visitor &) const;
     void visit_children_from_asan_fake_stack(Visitor &, Cell *) const;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<FiberObject {h} stack={h}..{h}>", this, m_end_of_stack, m_start_of_stack);
     }
 

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -98,8 +98,8 @@ public:
 
     static StringObject *path(Env *env, Value path); // path class method
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<FileObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<FileObject {h} fileno={}>", this, fileno());
     }
 
     IoObject *as_io() { return static_cast<IoObject *>(this); }

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -98,7 +98,7 @@ public:
 
     static StringObject *path(Env *env, Value path); // path class method
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<FileObject {h} fileno={}>", this, fileno());
     }
 

--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -163,7 +163,7 @@ public:
         klass->const_set("RADIX"_s, new FloatObject { double { std::numeric_limits<double>::radix } });
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<FloatObject {h} float={}>", this, m_double);
     }
 

--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -163,8 +163,8 @@ public:
         klass->const_set("RADIX"_s, new FloatObject { double { std::numeric_limits<double>::radix } });
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<FloatObject %p float=%f>", this, m_double);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<FloatObject {h} float={}>", this, m_double);
     }
 
 private:

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -30,7 +30,7 @@ public:
     virtual void visit_children(Visitor &) const {
     }
 
-    virtual TM::String dbg_inspect() const {
+    virtual TM::String dbg_inspect(int indent = 0) const {
         return TM::String::format("<Cell {h} size={}>", this, sizeof(*this));
     }
 

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -8,6 +8,7 @@
 
 #include "natalie/forward.hpp"
 #include "natalie/macros.hpp"
+#include "tm/string.hpp"
 
 namespace Natalie {
 
@@ -29,16 +30,8 @@ public:
     virtual void visit_children(Visitor &) const {
     }
 
-    // only for debugging the GC
-    virtual void gc_inspect(char *buf, size_t len) const {
-        snprintf(buf, len, "<Cell %p size=%zu>", this, sizeof(*this));
-    }
-
-    // only for debugging the GC
-    virtual void gc_print() const {
-        char buf[1000];
-        gc_inspect(buf, 1000);
-        printf("%s\n", buf);
+    virtual TM::String dbg_inspect() const {
+        return TM::String::format("<Cell {h} size={}>", this, sizeof(*this));
     }
 
     virtual bool is_collectible() {

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -45,6 +45,10 @@ public:
         return true;
     }
 
+    virtual bool is_large() {
+        return false;
+    }
+
     bool is_marked() const {
         return m_marked;
     }

--- a/include/natalie/gc/heap.hpp
+++ b/include/natalie/gc/heap.hpp
@@ -67,7 +67,7 @@ public:
     }
 
     size_t total_allocations() const;
-    void dump() const;
+    void dump(bool only_large = false) const;
 
     template <typename F>
     auto with_gc_disabled(F func) {

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -120,7 +120,7 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override final;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<GlobalEnv {h}>", this);
     }
 

--- a/include/natalie/global_env.hpp
+++ b/include/natalie/global_env.hpp
@@ -120,8 +120,8 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<GlobalEnv %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<GlobalEnv {h}>", this);
     }
 
 private:

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -218,10 +218,6 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<HashObject %p size=%zu>", this, size());
-    }
-
     virtual bool is_large() override {
         return m_hashmap.capacity() >= 100;
     }

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -222,6 +222,10 @@ public:
         snprintf(buf, len, "<HashObject %p size=%zu>", this, size());
     }
 
+    virtual bool is_large() override {
+        return m_hashmap.capacity() >= 100;
+    }
+
 private:
     void key_list_remove_node(HashKey *);
     HashKey *key_list_append(Env *, Value, nat_int_t, Value);

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -216,7 +216,7 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     virtual bool is_large() override {
         return m_hashmap.capacity() >= 100;

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -140,6 +140,10 @@ public:
 
     static void build_constants(Env *env, ClassObject *klass);
 
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<IoObject {h} fileno={}>", this, m_fileno);
+    }
+
 protected:
     void raise_if_closed(Env *) const;
     int write(Env *, Value);

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -140,7 +140,7 @@ public:
 
     static void build_constants(Env *env, ClassObject *klass);
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<IoObject {h} fileno={}>", this, m_fileno);
     }
 

--- a/include/natalie/managed_vector.hpp
+++ b/include/natalie/managed_vector.hpp
@@ -23,7 +23,7 @@ public:
         }
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         size_t the_size = TM::Vector<T>::size();
         return TM::String::format("<ManagedVector {h} size={}>", this, the_size);
     }

--- a/include/natalie/managed_vector.hpp
+++ b/include/natalie/managed_vector.hpp
@@ -23,9 +23,9 @@ public:
         }
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
+    virtual TM::String dbg_inspect() const override {
         size_t the_size = TM::Vector<T>::size();
-        snprintf(buf, len, "<ManagedVector %p size=%zu>", this, the_size);
+        return TM::String::format("<ManagedVector {h} size={}>", this, the_size);
     }
 };
 

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -65,10 +65,6 @@ public:
     ArrayObject *values_at(Env *, Args &&);
     Value ref(Env *, Value, Optional<Value> = {});
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<MatchDataObject %p>", this);
-    }
-
     virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);
         visitor.visit(m_string);

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -71,7 +71,7 @@ public:
         visitor.visit(m_regexp);
     }
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     /**
      * If the underlying string that this MatchDataObject references is going to

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -86,8 +86,8 @@ public:
         visitor.visit(m_original_method);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Method %p name='%s' fn=%p>", this, m_name.c_str(), m_fn);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Method {h} name=\"{}\" fn={h}>", this, m_name, reinterpret_cast<void *>(m_fn));
     }
 
 private:

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -86,7 +86,7 @@ public:
         visitor.visit(m_original_method);
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Method {h} name=\"{}\" fn={h}>", this, m_name, reinterpret_cast<void *>(m_fn));
     }
 

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -49,8 +49,8 @@ public:
         visitor.visit(m_method_missing_name);
     }
 
-    virtual TM::String dbg_inspect() const override {
-        return TM::String::format("<MethodObject {h} method={}>", this, m_object.dbg_inspect());
+    virtual TM::String dbg_inspect(int indent = 0) const override {
+        return TM::String::format("<MethodObject {h} method={}>", this, m_object.dbg_inspect(indent));
     }
 
 private:

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -26,7 +26,7 @@ public:
         auto the_owner = owner();
         auto name = m_method_missing_name ? m_method_missing_name->string() : m_method->name();
         if (the_owner->type() == Type::Class && static_cast<ClassObject *>(the_owner)->is_singleton())
-            return StringObject::format("#<Method: {}.{}(*)>", m_object.inspect_str(env), name);
+            return StringObject::format("#<Method: {}.{}(*)>", m_object.inspected(env), name);
         else
             return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_string(), name);
     }

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -28,7 +28,7 @@ public:
         if (the_owner->type() == Type::Class && static_cast<ClassObject *>(the_owner)->is_singleton())
             return StringObject::format("#<Method: {}.{}(*)>", m_object.inspect_str(env), name);
         else
-            return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_str(), name);
+            return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_string(), name);
     }
 
     virtual ProcObject *to_proc(Env *env) override {

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -49,8 +49,8 @@ public:
         visitor.visit(m_method_missing_name);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<MethodObject %p method=", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<MethodObject {h} method={}>", this, m_object.dbg_inspect());
     }
 
 private:

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -28,7 +28,7 @@ public:
         if (the_owner->type() == Type::Class && static_cast<ClassObject *>(the_owner)->is_singleton())
             return StringObject::format("#<Method: {}.{}(*)>", m_object.inspected(env), name);
         else
-            return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_string(), name);
+            return StringObject::format("#<Method: {}#{}(*)>", owner()->inspect_module(), name);
     }
 
     virtual ProcObject *to_proc(Env *env) override {

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -174,7 +174,7 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<ModuleObject {h} name=\"{}\">", this, m_name.value_or("none"));
     }
 

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -130,7 +130,7 @@ public:
 
     bool is_method_defined(Env *, Value) const;
 
-    String inspect_str() const;
+    String inspect_string() const;
     Value inspect(Env *) const;
     Value name(Env *) const;
     Optional<String> name() { return m_name; }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -130,7 +130,7 @@ public:
 
     bool is_method_defined(Env *, Value) const;
 
-    String inspect_string() const;
+    String inspect_module() const;
     Value inspect(Env *) const;
     Value name(Env *) const;
     Optional<String> name() { return m_name; }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -132,7 +132,6 @@ public:
 
     String inspect_str() const;
     Value inspect(Env *) const;
-    String dbg_inspect() const override;
     Value name(Env *) const;
     Optional<String> name() { return m_name; }
     virtual String backtrace_name() const;
@@ -175,11 +174,8 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        if (m_name)
-            snprintf(buf, len, "<ModuleObject %p name=%s>", this, m_name.value().c_str());
-        else
-            snprintf(buf, len, "<ModuleObject %p name=(none)>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<ModuleObject {h} name=\"{}\">", this, m_name.value_or("none"));
     }
 
 private:

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -190,7 +190,7 @@ public:
     void assert_not_frozen(Env *);
     void assert_not_frozen(Env *, Value);
 
-    String inspect_str(Env *env) { return Value(this).inspect_str(env); }
+    String inspected(Env *env) { return Value(this).inspected(env); }
 
     Value enum_for(Env *env, const char *method, Args &&args = {});
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -196,9 +196,7 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override;
 
-    virtual String dbg_inspect() const;
-
-    virtual void gc_inspect(char *buf, size_t len) const override;
+    virtual String dbg_inspect() const override;
 
 protected:
     ClassObject *m_klass { nullptr };

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -196,7 +196,7 @@ public:
 
     virtual void visit_children(Visitor &visitor) const override;
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
 protected:
     ClassObject *m_klass { nullptr };

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -64,8 +64,8 @@ public:
         visitor.visit(m_block);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<ProcObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<ProcObject {h} block={}>", this, m_block ? m_block->dbg_inspect() : "null");
     }
 
 private:

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -64,8 +64,8 @@ public:
         visitor.visit(m_block);
     }
 
-    virtual TM::String dbg_inspect() const override {
-        return TM::String::format("<ProcObject {h} block={}>", this, m_block ? m_block->dbg_inspect() : "null");
+    virtual TM::String dbg_inspect(int indent = 0) const override {
+        return TM::String::format("<ProcObject {h} block={}>", this, m_block ? m_block->dbg_inspect(indent) : "null");
     }
 
 private:

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -34,7 +34,7 @@ public:
     Value rand(Env *, Optional<Value>);
     Value seed() const { return Value::integer(m_seed); }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<Random {h} seed={}>", this, m_seed);
     }
 

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -34,8 +34,8 @@ public:
     Value rand(Env *, Optional<Value>);
     Value seed() const { return Value::integer(m_seed); }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<Random %p seed=%lld>", this, m_seed);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<Random {h} seed={}>", this, m_seed);
     }
 
     static Value new_seed(Env *env) {

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -51,10 +51,6 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<RangeObject %p>", this);
-    }
-
 private:
     RangeObject(Value begin, Value end, bool exclude_end)
         : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s).as_class() }

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -49,7 +49,7 @@ public:
         visitor.visit(m_end);
     }
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
 private:
     RangeObject(Value begin, Value end, bool exclude_end)

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -54,7 +54,7 @@ public:
         visitor.visit(m_denominator);
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<RationalObject {h} {}/{}>", this, m_numerator.to_string(), m_denominator.to_string());
     }
 

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -54,8 +54,8 @@ public:
         visitor.visit(m_denominator);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<RationalObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<RationalObject {h} {}/{}>", this, m_numerator.to_string(), m_denominator.to_string());
     }
 
 private:

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -190,7 +190,7 @@ public:
     Value source(Env *env) const;
     Value to_s(Env *env) const;
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -192,10 +192,6 @@ public:
 
     virtual String dbg_inspect() const override;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<RegexpObject %p>", this);
-    }
-
     virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);
         if (m_pattern)

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -465,7 +465,7 @@ public:
         }
     }
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     virtual void visit_children(Visitor &visitor) const override final {
         Object::visit_children(visitor);

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -472,10 +472,6 @@ public:
         visitor.visit(m_encoding.ptr());
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<StringObject %p str='%s'>", this, m_string.c_str());
-    }
-
     virtual bool is_large() override {
         return m_string.capacity() >= 100;
     }

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -476,6 +476,10 @@ public:
         snprintf(buf, len, "<StringObject %p str='%s'>", this, m_string.c_str());
     }
 
+    virtual bool is_large() override {
+        return m_string.capacity() >= 100;
+    }
+
     class iterator {
     public:
         iterator(const StringObject *string, StringView view)

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -84,12 +84,6 @@ public:
         visitor.visit(m_encoding);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        // NOTE: this won't properly print the null character '\0', but since this is only used
-        // for debugging, we probably don't care.
-        snprintf(buf, len, "<SymbolObject %p name='%s'>", this, m_name.c_str());
-    }
-
     virtual bool is_collectible() override {
         return false;
     }

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -76,7 +76,7 @@ public:
 
     bool should_be_quoted() const;
 
-    virtual String dbg_inspect() const override;
+    virtual String dbg_inspect(int indent = 0) const override;
 
     virtual void visit_children(Visitor &visitor) const override {
         Object::visit_children(visitor);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -199,14 +199,8 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(
-            buf,
-            len,
-            "<ThreadObject %p stack=%p..%p>",
-            this,
-            m_end_of_stack,
-            m_start_of_stack);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<ThreadObject {h} stack={h}..{h}>", this, m_end_of_stack, m_start_of_stack);
     }
 
     static Value pass(Env *env);

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -199,7 +199,7 @@ public:
 
     virtual void visit_children(Visitor &) const override final;
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<ThreadObject {h} stack={h}..{h}>", this, m_end_of_stack, m_start_of_stack);
     }
 

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -71,8 +71,8 @@ public:
             visitor.visit(m_subsec.value());
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<TimeObject %p>", this);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<TimeObject {h} integer={}>", this, m_integer.to_string());
     }
 
 private:

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -71,7 +71,7 @@ public:
             visitor.visit(m_subsec.value());
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<TimeObject {h} integer={}>", this, m_integer.to_string());
     }
 

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -56,8 +56,8 @@ public:
         visitor.visit(m_method);
     }
 
-    virtual void gc_inspect(char *buf, size_t len) const override {
-        snprintf(buf, len, "<UnboundMethodObject %p method=%p>", this, m_method);
+    virtual TM::String dbg_inspect() const override {
+        return TM::String::format("<UnboundMethodObject {h} method={h}>", this, m_method);
     }
 
 private:

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -19,7 +19,7 @@ public:
         if (owner()->type() != Type::Class || obj.is_a(env, owner())) {
             return new MethodObject { obj, m_method };
         } else {
-            env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_str());
+            env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_string());
         }
     }
 
@@ -44,9 +44,9 @@ public:
 
     Value inspect(Env *env) {
         if (owner() != m_module_or_class) {
-            return StringObject::format("#<UnboundMethod: {}({})#{}(*)>", m_module_or_class->inspect_str(), owner()->inspect_str(), m_method->name());
+            return StringObject::format("#<UnboundMethod: {}({})#{}(*)>", m_module_or_class->inspect_string(), owner()->inspect_string(), m_method->name());
         } else {
-            return StringObject::format("#<UnboundMethod: {}#{}(*)>", owner()->inspect_str(), m_method->name());
+            return StringObject::format("#<UnboundMethod: {}#{}(*)>", owner()->inspect_string(), m_method->name());
         }
     }
 

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -56,7 +56,7 @@ public:
         visitor.visit(m_method);
     }
 
-    virtual TM::String dbg_inspect() const override {
+    virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<UnboundMethodObject {h} method={h}>", this, m_method);
     }
 

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -19,7 +19,7 @@ public:
         if (owner()->type() != Type::Class || obj.is_a(env, owner())) {
             return new MethodObject { obj, m_method };
         } else {
-            env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_string());
+            env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_module());
         }
     }
 
@@ -44,9 +44,9 @@ public:
 
     Value inspect(Env *env) {
         if (owner() != m_module_or_class) {
-            return StringObject::format("#<UnboundMethod: {}({})#{}(*)>", m_module_or_class->inspect_string(), owner()->inspect_string(), m_method->name());
+            return StringObject::format("#<UnboundMethod: {}({})#{}(*)>", m_module_or_class->inspect_module(), owner()->inspect_module(), m_method->name());
         } else {
-            return StringObject::format("#<UnboundMethod: {}#{}(*)>", owner()->inspect_string(), m_method->name());
+            return StringObject::format("#<UnboundMethod: {}#{}(*)>", owner()->inspect_module(), m_method->name());
         }
     }
 

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -227,7 +227,7 @@ public:
     SymbolObject *to_symbol(Env *, Conversion);
 
     String inspect_str(Env *);
-    String dbg_inspect() const;
+    String dbg_inspect(int indent = 0) const;
 
 private:
     friend MarkingVisitor;

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -226,7 +226,7 @@ public:
 
     SymbolObject *to_symbol(Env *, Conversion);
 
-    String inspect_str(Env *);
+    String inspected(Env *);
     String dbg_inspect(int indent = 0) const;
 
 private:

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -211,7 +211,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
             else if (val.is_nil())
                 arg_values[i].vp = nullptr;
             else
-                env->raise("ArgumentError", "Expected Pointer but got {} for arg {}", val.inspect_str(env), (int)i);
+                env->raise("ArgumentError", "Expected Pointer but got {} for arg {}", val.inspected(env), (int)i);
             arg_pointers[i] = &(arg_values[i].vp);
         } else if (type == bool_sym) {
             if (val == Value::True())
@@ -267,7 +267,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
                 if (mapped_value.is_nil() && val.is_integer())
                     mapped_value = val;
                 if (mapped_value.is_nil()) {
-                    env->raise("ArgumentError", "invalid enum value, {}", val.inspect_str(env));
+                    env->raise("ArgumentError", "invalid enum value, {}", val.inspected(env));
                 } else {
                     const auto int_val = mapped_value.integer_or_raise(env).to_nat_int_t();
                     if (int_val < std::numeric_limits<int32_t>::min() || int_val > std::numeric_limits<int32_t>::max())
@@ -277,7 +277,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
                     arg_pointers[i] = &(arg_values[i].s32);
                 }
             } else {
-                env->raise("StandardError", "I don't yet know how to handle argument type {} (arg {})", type.inspect_str(env), (int)i);
+                env->raise("StandardError", "I don't yet know how to handle argument type {} (arg {})", type.inspected(env), (int)i);
             }
         }
     }
@@ -460,7 +460,7 @@ Value FFI_MemoryPointer_initialize(Env *env, Value self, Args &&args, Block *blo
         } else if (sym == "pointer"_s) {
             size = sizeof(void *);
         } else {
-            env->raise("TypeError", "unknown size argument for FFI#initialize: {}", args.at(0).inspect_str(env));
+            env->raise("TypeError", "unknown size argument for FFI#initialize: {}", args.at(0).inspected(env));
         }
     } else {
         size = IntegerMethods::convert_to_native_type<size_t>(env, args.at(0));
@@ -506,7 +506,7 @@ Value FFI_Pointer_initialize(Env *env, Value self, Args &&args, Block *) {
         if (type == "pointer"_s)
             type_size = sizeof(void *);
         else
-            NAT_NOT_YET_IMPLEMENTED("I don't yet know how to handle type %s in FFI::Pointer.new", type.inspect_str(env).c_str());
+            NAT_NOT_YET_IMPLEMENTED("I don't yet know how to handle type %s in FFI::Pointer.new", type.inspected(env).c_str());
     } else {
         type = Value::nil();
         address = args.at(0);

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -279,7 +279,7 @@ Value OpenSSL_Digest_initialize(Env *env, Value self, Args &&args, Block *) {
     if (name.is_a(env, digest_klass))
         name = name.send(env, "name"_s);
     if (!name.is_string())
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/Digest)", name.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/Digest)", name.klass()->inspect_module());
 
     const EVP_MD *md = EVP_get_digestbyname(name.as_string()->c_str());
     if (!md)
@@ -508,7 +508,7 @@ Value OpenSSL_SSL_SSLContext_setup(Env *env, Value self, Args &&args, Block *) {
     if (!cert_store.is_nil()) {
         auto Store = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Store"_s }).as_class();
         if (!cert_store.is_a(env, Store))
-            env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/STORE)", cert_store.klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/STORE)", cert_store.klass()->inspect_module());
         auto store = static_cast<X509_STORE *>(cert_store->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
         SSL_CTX_set1_cert_store(ctx, store);
     }
@@ -520,13 +520,13 @@ Value OpenSSL_SSL_SSLSocket_initialize(Env *env, Value self, Args &&args, Block 
     args.ensure_argc_between(env, 1, 2);
     auto io = args.at(0);
     if (!io.is_io())
-        env->raise("TypeError", "wrong argument type {} (expected File)", io.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected File)", io.klass()->inspect_module());
     auto context = args.at(1, Value::nil());
     auto SSLContext = fetch_nested_const({ "OpenSSL"_s, "SSL"_s, "SSLContext"_s });
     if (context.is_nil())
         context = Object::_new(env, SSLContext, {}, nullptr);
     else if (!context.is_a(env, SSLContext.as_class()))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/SSL/CTX)", context.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/SSL/CTX)", context.klass()->inspect_module());
     context.send(env, "setup"_s);
     auto *ctx = static_cast<SSL_CTX *>(context->ivar_get(env, "@ctx"_s).as_void_p()->void_ptr());
     SSL *ssl = SSL_new(ctx);
@@ -741,7 +741,7 @@ Value OpenSSL_X509_Certificate_set_issuer(Env *env, Value self, Args &&args, Blo
 
     auto Name = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Name"_s }).as_class();
     if (!issuer.is_a(env, Name))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", issuer.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", issuer.klass()->inspect_module());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto name = static_cast<X509_NAME *>(issuer->ivar_get(env, "@name"_s).as_void_p()->void_ptr());
@@ -844,7 +844,7 @@ Value OpenSSL_X509_Certificate_set_public_key(Env *env, Value self, Args &&args,
 
     auto PKey = fetch_nested_const({ "OpenSSL"_s, "PKey"_s, "PKey"_s }).as_class();
     if (!public_key.is_a(env, PKey))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", public_key.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", public_key.klass()->inspect_module());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto pkey = static_cast<EVP_PKEY *>(public_key->ivar_get(env, "@pkey"_s).as_void_p()->void_ptr());
@@ -891,7 +891,7 @@ Value OpenSSL_X509_Certificate_sign(Env *env, Value self, Args &&args, Block *) 
 
     auto PKey = fetch_nested_const({ "OpenSSL"_s, "PKey"_s, "PKey"_s }).as_class();
     if (!key.is_a(env, PKey))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", key.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", key.klass()->inspect_module());
     if (key.send(env, "private?"_s).is_falsey())
         env->raise("ArgumentError", "private key is needed");
     auto Digest = fetch_nested_const({ "OpenSSL"_s, "Digest"_s }).as_class();
@@ -926,7 +926,7 @@ Value OpenSSL_X509_Certificate_set_subject(Env *env, Value self, Args &&args, Bl
 
     auto Name = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Name"_s }).as_class();
     if (!subject.is_a(env, Name))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", subject.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", subject.klass()->inspect_module());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto name = static_cast<X509_NAME *>(subject->ivar_get(env, "@name"_s).as_void_p()->void_ptr());
@@ -1326,7 +1326,7 @@ Value OpenSSL_X509_Store_add_cert(Env *env, Value self, Args &&args, Block *) {
 
     auto Certificate = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Certificate"_s }).as_class();
     if (!cert.is_a(env, Certificate))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_module());
 
     auto store = static_cast<X509_STORE *>(self->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
     auto x509 = static_cast<X509 *>(cert->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
@@ -1352,7 +1352,7 @@ Value OpenSSL_X509_Store_verify(Env *env, Value self, Args &&args, Block *) {
 
     auto Certificate = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Certificate"_s }).as_class();
     if (!cert.is_a(env, Certificate))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_module());
 
     auto store = static_cast<X509_STORE *>(self->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
     X509_STORE_CTX *ctx = X509_STORE_CTX_new();

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -279,7 +279,7 @@ Value OpenSSL_Digest_initialize(Env *env, Value self, Args &&args, Block *) {
     if (name.is_a(env, digest_klass))
         name = name.send(env, "name"_s);
     if (!name.is_string())
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/Digest)", name.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/Digest)", name.klass()->inspect_string());
 
     const EVP_MD *md = EVP_get_digestbyname(name.as_string()->c_str());
     if (!md)
@@ -508,7 +508,7 @@ Value OpenSSL_SSL_SSLContext_setup(Env *env, Value self, Args &&args, Block *) {
     if (!cert_store.is_nil()) {
         auto Store = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Store"_s }).as_class();
         if (!cert_store.is_a(env, Store))
-            env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/STORE)", cert_store.klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/STORE)", cert_store.klass()->inspect_string());
         auto store = static_cast<X509_STORE *>(cert_store->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
         SSL_CTX_set1_cert_store(ctx, store);
     }
@@ -520,13 +520,13 @@ Value OpenSSL_SSL_SSLSocket_initialize(Env *env, Value self, Args &&args, Block 
     args.ensure_argc_between(env, 1, 2);
     auto io = args.at(0);
     if (!io.is_io())
-        env->raise("TypeError", "wrong argument type {} (expected File)", io.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected File)", io.klass()->inspect_string());
     auto context = args.at(1, Value::nil());
     auto SSLContext = fetch_nested_const({ "OpenSSL"_s, "SSL"_s, "SSLContext"_s });
     if (context.is_nil())
         context = Object::_new(env, SSLContext, {}, nullptr);
     else if (!context.is_a(env, SSLContext.as_class()))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/SSL/CTX)", context.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/SSL/CTX)", context.klass()->inspect_string());
     context.send(env, "setup"_s);
     auto *ctx = static_cast<SSL_CTX *>(context->ivar_get(env, "@ctx"_s).as_void_p()->void_ptr());
     SSL *ssl = SSL_new(ctx);
@@ -741,7 +741,7 @@ Value OpenSSL_X509_Certificate_set_issuer(Env *env, Value self, Args &&args, Blo
 
     auto Name = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Name"_s }).as_class();
     if (!issuer.is_a(env, Name))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", issuer.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", issuer.klass()->inspect_string());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto name = static_cast<X509_NAME *>(issuer->ivar_get(env, "@name"_s).as_void_p()->void_ptr());
@@ -844,7 +844,7 @@ Value OpenSSL_X509_Certificate_set_public_key(Env *env, Value self, Args &&args,
 
     auto PKey = fetch_nested_const({ "OpenSSL"_s, "PKey"_s, "PKey"_s }).as_class();
     if (!public_key.is_a(env, PKey))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", public_key.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", public_key.klass()->inspect_string());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto pkey = static_cast<EVP_PKEY *>(public_key->ivar_get(env, "@pkey"_s).as_void_p()->void_ptr());
@@ -891,7 +891,7 @@ Value OpenSSL_X509_Certificate_sign(Env *env, Value self, Args &&args, Block *) 
 
     auto PKey = fetch_nested_const({ "OpenSSL"_s, "PKey"_s, "PKey"_s }).as_class();
     if (!key.is_a(env, PKey))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", key.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/EVP_PKEY)", key.klass()->inspect_string());
     if (key.send(env, "private?"_s).is_falsey())
         env->raise("ArgumentError", "private key is needed");
     auto Digest = fetch_nested_const({ "OpenSSL"_s, "Digest"_s }).as_class();
@@ -926,7 +926,7 @@ Value OpenSSL_X509_Certificate_set_subject(Env *env, Value self, Args &&args, Bl
 
     auto Name = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Name"_s }).as_class();
     if (!subject.is_a(env, Name))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", subject.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509/NAME)", subject.klass()->inspect_string());
 
     auto x509 = static_cast<X509 *>(self->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
     auto name = static_cast<X509_NAME *>(subject->ivar_get(env, "@name"_s).as_void_p()->void_ptr());
@@ -1326,7 +1326,7 @@ Value OpenSSL_X509_Store_add_cert(Env *env, Value self, Args &&args, Block *) {
 
     auto Certificate = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Certificate"_s }).as_class();
     if (!cert.is_a(env, Certificate))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_string());
 
     auto store = static_cast<X509_STORE *>(self->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
     auto x509 = static_cast<X509 *>(cert->ivar_get(env, "@x509"_s).as_void_p()->void_ptr());
@@ -1352,7 +1352,7 @@ Value OpenSSL_X509_Store_verify(Env *env, Value self, Args &&args, Block *) {
 
     auto Certificate = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Certificate"_s }).as_class();
     if (!cert.is_a(env, Certificate))
-        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected OpenSSL/X509)", cert.klass()->inspect_string());
 
     auto store = static_cast<X509_STORE *>(self->ivar_get(env, "@store"_s).as_void_p()->void_ptr());
     X509_STORE_CTX *ctx = X509_STORE_CTX_new();

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -69,7 +69,7 @@ Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
 
         auto Numeric = GlobalEnv::the()->Object()->const_fetch("Numeric"_s);
         if (!arg.is_a(env, Numeric))
-            env->raise("ArgumentError", "No implicit conversion of {} into Integer", arg.klass()->inspect_string());
+            env->raise("ArgumentError", "No implicit conversion of {} into Integer", arg.klass()->inspect_module());
 
         if (!arg.is_integer() && arg.respond_to(env, "to_int"_s))
             arg = arg.to_int(env);

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -69,7 +69,7 @@ Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
 
         auto Numeric = GlobalEnv::the()->Object()->const_fetch("Numeric"_s);
         if (!arg.is_a(env, Numeric))
-            env->raise("ArgumentError", "No implicit conversion of {} into Integer", arg.klass()->inspect_str());
+            env->raise("ArgumentError", "No implicit conversion of {} into Integer", arg.klass()->inspect_string());
 
         if (!arg.is_integer() && arg.respond_to(env, "to_int"_s))
             arg = arg.to_int(env);

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -33,7 +33,7 @@ Value SecureRandom_random_number(Env *env, Value self, Args &&args, Block *) {
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
             if (min.is_numeric() && max.is_numeric()) {
                 if (min.send(env, ">"_s, { max }).is_true()) {
-                    env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
+                    env->raise("ArgumentError", "invalid argument - {}", arg.inspected(env));
                 }
 
                 if (min.is_float() || max.is_float()) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -722,7 +722,7 @@ Value IPSocket_addr(Env *env, Value self, Args &&args, Block *) {
     else if (reverse_lookup == "numeric"_s)
         reverse_lookup = Value::False();
     else if (!reverse_lookup.is_true() && !reverse_lookup.is_false() && reverse_lookup != "hostname"_s)
-        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspect_str(env));
+        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspected(env));
 
     switch (addr.ss_family) {
     case AF_INET: {
@@ -770,7 +770,7 @@ Value IPSocket_peeraddr(Env *env, Value self, Args &&args, Block *) {
     } else if (reverse_lookup == "numeric"_s) {
         reverse_lookup = Value::False();
     } else if (!reverse_lookup.is_true() && !reverse_lookup.is_false() && reverse_lookup != "hostname"_s) {
-        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspect_str(env));
+        env->raise("ArgumentError", "invalid reverse_lookup flag: {}", reverse_lookup.inspected(env));
     }
 
     auto getsockname_result = getpeername(

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -45,12 +45,12 @@ Value Socket_const_name_to_i(Env *env, Value self, Args &&args, Block *) {
         if (!value)
             value = Socket->const_find(env, "SHORT_CONSTANTS"_s).value().as_hash_or_raise(env)->get(env, sym);
         if (!value)
-            env->raise_name_error(sym, "uninitialized constant {}::{}", Socket->inspect_str(), sym->string());
+            env->raise_name_error(sym, "uninitialized constant {}::{}", Socket->inspect_string(), sym->string());
         return value.value();
     } else {
         if (default_zero)
             return Value::integer(0);
-        env->raise("TypeError", "{} can't be coerced into String or Integer", name.klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into String or Integer", name.klass()->inspect_string());
     }
 }
 
@@ -631,7 +631,7 @@ Value BasicSocket_setsockopt(Env *env, Value self, Args &&args, Block *block) {
             int val = 0;
             data = new StringObject { (const char *)(&val), sizeof(int) };
         } else {
-            env->raise("TypeError", "{} can't be coerced into String", data_obj.klass()->inspect_str());
+            env->raise("TypeError", "{} can't be coerced into String", data_obj.klass()->inspect_string());
         }
     } else {
         args.ensure_argc_is(env, 1);

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -45,12 +45,12 @@ Value Socket_const_name_to_i(Env *env, Value self, Args &&args, Block *) {
         if (!value)
             value = Socket->const_find(env, "SHORT_CONSTANTS"_s).value().as_hash_or_raise(env)->get(env, sym);
         if (!value)
-            env->raise_name_error(sym, "uninitialized constant {}::{}", Socket->inspect_string(), sym->string());
+            env->raise_name_error(sym, "uninitialized constant {}::{}", Socket->inspect_module(), sym->string());
         return value.value();
     } else {
         if (default_zero)
             return Value::integer(0);
-        env->raise("TypeError", "{} can't be coerced into String or Integer", name.klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into String or Integer", name.klass()->inspect_module());
     }
 }
 
@@ -631,7 +631,7 @@ Value BasicSocket_setsockopt(Env *env, Value self, Args &&args, Block *block) {
             int val = 0;
             data = new StringObject { (const char *)(&val), sizeof(int) };
         } else {
-            env->raise("TypeError", "{} can't be coerced into String", data_obj.klass()->inspect_string());
+            env->raise("TypeError", "{} can't be coerced into String", data_obj.klass()->inspect_module());
         }
     } else {
         args.ensure_argc_is(env, 1);

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -26,7 +26,7 @@ Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
             suffix = arr->at(1).to_str(env);
     }
     if (!basename.is_string()) {
-        env->raise("ArgumentError", "unexpected prefix: {}", basename.inspect_str(env));
+        env->raise("ArgumentError", "unexpected prefix: {}", basename.inspected(env));
     }
     if (!tmpdir.is_nil()) {
         tmpdir.assert_type(env, Object::Type::String, "String");

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -111,7 +111,7 @@ static void emit_value(Env *env, RangeObject *value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_value(Env *env, RegexpObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    auto str = value->inspect_str(env);
+    auto str = value->inspected(env);
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/regexp",
         (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_PLAIN_SCALAR_STYLE);
     emit(env, emitter, event);

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -28,14 +28,14 @@ static void emit_value(Env *env, ArrayObject *value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_value(Env *env, ClassObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    auto str = value->inspect_str();
+    auto str = value->inspect_string();
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/class",
         (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_SINGLE_QUOTED_SCALAR_STYLE);
     emit(env, emitter, event);
 }
 
 static void emit_value(Env *env, ExceptionObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    const auto mapping_header = String::format("!ruby/exception:{}", value->klass()->inspect_str());
+    const auto mapping_header = String::format("!ruby/exception:{}", value->klass()->inspect_string());
     yaml_mapping_start_event_initialize(&event, nullptr, (yaml_char_t *)(mapping_header.c_str()),
         0, YAML_ANY_MAPPING_STYLE);
     emit(env, emitter, event);
@@ -87,7 +87,7 @@ static void emit_value(Env *env, Integer value, yaml_emitter_t &emitter, yaml_ev
 }
 
 static void emit_value(Env *env, ModuleObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    auto str = value->inspect_str();
+    auto str = value->inspect_string();
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/module",
         (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_SINGLE_QUOTED_SCALAR_STYLE);
     emit(env, emitter, event);
@@ -182,7 +182,7 @@ static void emit_struct_value(Env *env, Value value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_object_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    const auto mapping_header = String::format("!ruby/object:{}", value.klass()->inspect_str());
+    const auto mapping_header = String::format("!ruby/object:{}", value.klass()->inspect_string());
     yaml_mapping_start_event_initialize(&event, nullptr, (yaml_char_t *)(mapping_header.c_str()),
         0, YAML_ANY_MAPPING_STYLE);
     emit(env, emitter, event);

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -28,14 +28,14 @@ static void emit_value(Env *env, ArrayObject *value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_value(Env *env, ClassObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    auto str = value->inspect_string();
+    auto str = value->inspect_module();
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/class",
         (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_SINGLE_QUOTED_SCALAR_STYLE);
     emit(env, emitter, event);
 }
 
 static void emit_value(Env *env, ExceptionObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    const auto mapping_header = String::format("!ruby/exception:{}", value->klass()->inspect_string());
+    const auto mapping_header = String::format("!ruby/exception:{}", value->klass()->inspect_module());
     yaml_mapping_start_event_initialize(&event, nullptr, (yaml_char_t *)(mapping_header.c_str()),
         0, YAML_ANY_MAPPING_STYLE);
     emit(env, emitter, event);
@@ -87,7 +87,7 @@ static void emit_value(Env *env, Integer value, yaml_emitter_t &emitter, yaml_ev
 }
 
 static void emit_value(Env *env, ModuleObject *value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    auto str = value->inspect_string();
+    auto str = value->inspect_module();
     yaml_scalar_event_initialize(&event, nullptr, (yaml_char_t *)"!ruby/module",
         (yaml_char_t *)(str.c_str()), str.size(), 0, 0, YAML_SINGLE_QUOTED_SCALAR_STYLE);
     emit(env, emitter, event);
@@ -182,7 +182,7 @@ static void emit_struct_value(Env *env, Value value, yaml_emitter_t &emitter, ya
 }
 
 static void emit_object_value(Env *env, Value value, yaml_emitter_t &emitter, yaml_event_t &event) {
-    const auto mapping_header = String::format("!ruby/object:{}", value.klass()->inspect_string());
+    const auto mapping_header = String::format("!ruby/object:{}", value.klass()->inspect_module());
     yaml_mapping_start_event_initialize(&event, nullptr, (yaml_char_t *)(mapping_header.c_str()),
         0, YAML_ANY_MAPPING_STYLE);
     emit(env, emitter, event);

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -174,7 +174,7 @@ Value ArrayObject::inspect(Env *env) {
             if (inspected_repr.is_string())
                 out->append(inspected_repr.as_string());
             else
-                out->append_sprintf("#<%s:%#x>", inspected_repr.klass()->inspect_str().c_str(), inspected_repr.object_id());
+                out->append_sprintf("#<%s:%#x>", inspected_repr.klass()->inspect_string().c_str(), inspected_repr.object_id());
 
             if (i < size() - 1) {
                 out->append(", ");
@@ -760,7 +760,7 @@ Value ArrayObject::dig(Env *env, Args &&args) {
         return val;
 
     if (!val.respond_to(env, dig))
-        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_str());
+        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_string());
 
     return val.send(env, dig, std::move(args));
 }
@@ -984,7 +984,7 @@ Value ArrayObject::pack(Env *env, Value directives, Optional<Value> buffer_arg) 
     if (buffer_arg) {
         auto buffer = buffer_arg.value();
         if (!buffer.is_string())
-            env->raise("TypeError", "buffer must be String, not {}", buffer.klass()->inspect_str());
+            env->raise("TypeError", "buffer must be String, not {}", buffer.klass()->inspect_string());
         return ArrayPacker::Packer { this, directives_string }.pack(env, buffer.as_string());
     } else {
         StringObject *start_buffer = new StringObject { "", Encoding::ASCII_8BIT };
@@ -1049,7 +1049,7 @@ bool array_sort_compare(Env *env, Value a, Value b, Block *block) {
             Value zero = Value::integer(0);
             return compare.send(env, "<"_s, { zero }).is_truthy();
         } else {
-            env->raise("ArgumentError", "comparison of {} with 0 failed", compare.klass()->inspect_str());
+            env->raise("ArgumentError", "comparison of {} with 0 failed", compare.klass()->inspect_string());
         }
     } else {
         Value compare = a.send(env, "<=>"_s, { b });
@@ -1057,7 +1057,7 @@ bool array_sort_compare(Env *env, Value a, Value b, Block *block) {
             return compare.integer() < 0;
         }
         // TODO: Ruby sometimes prints b as the value (for example for integers) and sometimes as class
-        env->raise("ArgumentError", "comparison of {} with {} failed", a.klass()->inspect_str(), b.klass()->inspect_str());
+        env->raise("ArgumentError", "comparison of {} with {} failed", a.klass()->inspect_string(), b.klass()->inspect_string());
     }
 }
 
@@ -1083,7 +1083,7 @@ bool array_sort_by_compare(Env *env, Value a, Value b, Block *block) {
     if (compare.is_integer()) {
         return compare.integer() < 0;
     }
-    env->raise("ArgumentError", "comparison of {} with {} failed", a_res.klass()->inspect_str(), b_res.klass()->inspect_str());
+    env->raise("ArgumentError", "comparison of {} with {} failed", a_res.klass()->inspect_string(), b_res.klass()->inspect_string());
 }
 
 Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
@@ -1212,8 +1212,8 @@ Value ArrayObject::max(Env *env, Optional<Value> count, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_str(),
-                min.klass()->inspect_str());
+                item.klass()->inspect_string(),
+                min.klass()->inspect_string());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int > 0;
@@ -1262,8 +1262,8 @@ Value ArrayObject::min(Env *env, Optional<Value> count, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_str(),
-                min.klass()->inspect_str());
+                item.klass()->inspect_string(),
+                min.klass()->inspect_string());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int < 0;
@@ -1312,8 +1312,8 @@ Value ArrayObject::minmax(Env *env, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_str(),
-                min.klass()->inspect_str());
+                item.klass()->inspect_string(),
+                min.klass()->inspect_string());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int;
@@ -1614,7 +1614,7 @@ bool ArrayObject::intersects(Env *env, Value arg) {
 
 Value ArrayObject::union_of(Env *env, Value arg) {
     if (!arg.is_array())
-        env->raise("TypeError", "no implicit conversion of {} into Array", arg.klass()->inspect_str());
+        env->raise("TypeError", "no implicit conversion of {} into Array", arg.klass()->inspect_string());
 
     auto *result = new ArrayObject();
     auto add_value = [&result, &env](Value &val) {
@@ -2052,8 +2052,8 @@ Value ArrayObject::try_convert(Env *env, Value val) {
         return conversion;
     }
 
-    auto original_item_class_name = val.klass()->inspect_str();
-    auto new_item_class_name = conversion.klass()->inspect_str();
+    auto original_item_class_name = val.klass()->inspect_string();
+    auto new_item_class_name = conversion.klass()->inspect_string();
     env->raise(
         "TypeError",
         "can't convert {} to Array ({}#to_ary gives {})",

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -174,7 +174,7 @@ Value ArrayObject::inspect(Env *env) {
             if (inspected_repr.is_string())
                 out->append(inspected_repr.as_string());
             else
-                out->append_sprintf("#<%s:%#x>", inspected_repr.klass()->inspect_string().c_str(), inspected_repr.object_id());
+                out->append_sprintf("#<%s:%#x>", inspected_repr.klass()->inspect_module().c_str(), inspected_repr.object_id());
 
             if (i < size() - 1) {
                 out->append(", ");
@@ -760,7 +760,7 @@ Value ArrayObject::dig(Env *env, Args &&args) {
         return val;
 
     if (!val.respond_to(env, dig))
-        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_string());
+        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_module());
 
     return val.send(env, dig, std::move(args));
 }
@@ -984,7 +984,7 @@ Value ArrayObject::pack(Env *env, Value directives, Optional<Value> buffer_arg) 
     if (buffer_arg) {
         auto buffer = buffer_arg.value();
         if (!buffer.is_string())
-            env->raise("TypeError", "buffer must be String, not {}", buffer.klass()->inspect_string());
+            env->raise("TypeError", "buffer must be String, not {}", buffer.klass()->inspect_module());
         return ArrayPacker::Packer { this, directives_string }.pack(env, buffer.as_string());
     } else {
         StringObject *start_buffer = new StringObject { "", Encoding::ASCII_8BIT };
@@ -1049,7 +1049,7 @@ bool array_sort_compare(Env *env, Value a, Value b, Block *block) {
             Value zero = Value::integer(0);
             return compare.send(env, "<"_s, { zero }).is_truthy();
         } else {
-            env->raise("ArgumentError", "comparison of {} with 0 failed", compare.klass()->inspect_string());
+            env->raise("ArgumentError", "comparison of {} with 0 failed", compare.klass()->inspect_module());
         }
     } else {
         Value compare = a.send(env, "<=>"_s, { b });
@@ -1057,7 +1057,7 @@ bool array_sort_compare(Env *env, Value a, Value b, Block *block) {
             return compare.integer() < 0;
         }
         // TODO: Ruby sometimes prints b as the value (for example for integers) and sometimes as class
-        env->raise("ArgumentError", "comparison of {} with {} failed", a.klass()->inspect_string(), b.klass()->inspect_string());
+        env->raise("ArgumentError", "comparison of {} with {} failed", a.klass()->inspect_module(), b.klass()->inspect_module());
     }
 }
 
@@ -1083,7 +1083,7 @@ bool array_sort_by_compare(Env *env, Value a, Value b, Block *block) {
     if (compare.is_integer()) {
         return compare.integer() < 0;
     }
-    env->raise("ArgumentError", "comparison of {} with {} failed", a_res.klass()->inspect_string(), b_res.klass()->inspect_string());
+    env->raise("ArgumentError", "comparison of {} with {} failed", a_res.klass()->inspect_module(), b_res.klass()->inspect_module());
 }
 
 Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
@@ -1212,8 +1212,8 @@ Value ArrayObject::max(Env *env, Optional<Value> count, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_string(),
-                min.klass()->inspect_string());
+                item.klass()->inspect_module(),
+                min.klass()->inspect_module());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int > 0;
@@ -1262,8 +1262,8 @@ Value ArrayObject::min(Env *env, Optional<Value> count, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_string(),
-                min.klass()->inspect_string());
+                item.klass()->inspect_module(),
+                min.klass()->inspect_module());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int < 0;
@@ -1312,8 +1312,8 @@ Value ArrayObject::minmax(Env *env, Block *block) {
             env->raise(
                 "ArgumentError",
                 "comparison of {} with {} failed",
-                item.klass()->inspect_string(),
-                min.klass()->inspect_string());
+                item.klass()->inspect_module(),
+                min.klass()->inspect_module());
 
         auto nat_int = IntegerMethods::convert_to_nat_int_t(env, compare);
         return nat_int;
@@ -1614,7 +1614,7 @@ bool ArrayObject::intersects(Env *env, Value arg) {
 
 Value ArrayObject::union_of(Env *env, Value arg) {
     if (!arg.is_array())
-        env->raise("TypeError", "no implicit conversion of {} into Array", arg.klass()->inspect_string());
+        env->raise("TypeError", "no implicit conversion of {} into Array", arg.klass()->inspect_module());
 
     auto *result = new ArrayObject();
     auto add_value = [&result, &env](Value &val) {
@@ -2052,8 +2052,8 @@ Value ArrayObject::try_convert(Env *env, Value val) {
         return conversion;
     }
 
-    auto original_item_class_name = val.klass()->inspect_string();
-    auto new_item_class_name = conversion.klass()->inspect_string();
+    auto original_item_class_name = val.klass()->inspect_module();
+    auto new_item_class_name = conversion.klass()->inspect_module();
     env->raise(
         "TypeError",
         "can't convert {} to Array ({}#to_ary gives {})",

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -186,7 +186,7 @@ Value ArrayObject::inspect(Env *env) {
 }
 
 String ArrayObject::dbg_inspect() const {
-    String str("[");
+    auto str = String::format("<ArrayObject {h} data=[", this);
     size_t index = 0;
     for (size_t index = 0; index < size(); index++) {
         auto item = (*this)[index];
@@ -194,7 +194,7 @@ String ArrayObject::dbg_inspect() const {
         if (index < size() - 1)
             str.append(", ");
     }
-    str.append("]");
+    str.append("]>");
     return str;
 }
 

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -185,14 +185,15 @@ Value ArrayObject::inspect(Env *env) {
     });
 }
 
-String ArrayObject::dbg_inspect() const {
-    auto str = String::format("<ArrayObject {h} data=[", this);
-    size_t index = 0;
+String ArrayObject::dbg_inspect(int indent) const {
+    auto str = String::format("<ArrayObject {h} size={} data=[", this, size());
     for (size_t index = 0; index < size(); index++) {
+        str.append_char('\n');
+        str.append_char(' ', indent + 2);
         auto item = (*this)[index];
-        str.append(item.dbg_inspect());
+        str.append(item.dbg_inspect(indent + 2));
         if (index < size() - 1)
-            str.append(", ");
+            str.append_char(',');
     }
     str.append("]>");
     return str;

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -274,7 +274,7 @@ Value ArrayObject::refeq(Env *env, Value index_obj, Value size, Optional<Value> 
             start = IntegerMethods::convert_to_nat_int_t(env, begin_obj);
             if (start < 0) {
                 if ((size_t)(-start) > this->size())
-                    env->raise("RangeError", "{} out of range", range->inspect_str(env));
+                    env->raise("RangeError", "{} out of range", range->inspected(env));
                 start = this->size() + start;
             }
         }
@@ -530,7 +530,7 @@ Value ArrayObject::fill(Env *env, Optional<Value> obj_arg, Optional<Value> start
                 if (start < 0)
                     start += size();
                 if (start < 0)
-                    env->raise("RangeError", "{} out of range", start_obj.inspect_str(env));
+                    env->raise("RangeError", "{} out of range", start_obj.inspected(env));
             }
 
             auto end = start_obj.as_range()->end();
@@ -2077,7 +2077,7 @@ Value ArrayObject::values_at(Env *env, Args &&args) {
             } else {
                 begin = IntegerMethods::convert_to_nat_int_t(env, begin_value);
                 if (begin < -1 * (nat_int_t)(this->size())) {
-                    env->raise("RangeError", "{} out of range", arg.as_range()->inspect_str(env));
+                    env->raise("RangeError", "{} out of range", arg.as_range()->inspected(env));
                 }
                 if (begin < 0)
                     break;

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -54,7 +54,7 @@ namespace ArrayPacker {
                         string = string_object->string();
                     }
                 } else {
-                    env->raise("TypeError", "no implicit conversion of {} into String", item.klass()->inspect_string());
+                    env->raise("TypeError", "no implicit conversion of {} into String", item.klass()->inspect_module());
                     NAT_UNREACHABLE();
                 }
 

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -54,7 +54,7 @@ namespace ArrayPacker {
                         string = string_object->string();
                     }
                 } else {
-                    env->raise("TypeError", "no implicit conversion of {} into String", item.klass()->inspect_str());
+                    env->raise("TypeError", "no implicit conversion of {} into String", item.klass()->inspect_string());
                     NAT_UNREACHABLE();
                 }
 

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -25,7 +25,7 @@ BSearchCheckResult binary_search_check(Env *env, Value block_result) {
 
         return BSearchCheckResult::BIGGER;
     } else {
-        env->raise("TypeError", "wrong argument type {} (must be numeric, true, false or nil)", block_result.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (must be numeric, true, false or nil)", block_result.klass()->inspect_string());
     }
 }
 

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -25,7 +25,7 @@ BSearchCheckResult binary_search_check(Env *env, Value block_result) {
 
         return BSearchCheckResult::BIGGER;
     } else {
-        env->raise("TypeError", "wrong argument type {} (must be numeric, true, false or nil)", block_result.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (must be numeric, true, false or nil)", block_result.klass()->inspect_module());
     }
 }
 

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -7,7 +7,7 @@ Value ClassObject::initialize(Env *env, Optional<Value> superclass_arg, Block *b
         env->raise("TypeError", "already initialized class");
     auto superclass = superclass_arg.value_or(GlobalEnv::the()->Object());
     if (!superclass.is_class())
-        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_string());
+        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_module());
     superclass.as_class()->initialize_subclass(this, env, "", superclass.as_class()->object_type());
     ModuleObject::initialize(env, block);
     return this;
@@ -75,7 +75,7 @@ ClassObject *ClassObject::bootstrap_basic_object(Env *env, ClassObject *Class) {
 
 String ClassObject::backtrace_name() const {
     if (!m_name)
-        return inspect_string();
+        return inspect_module();
     return String::format("<class:{}>", m_name.value());
 }
 

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -7,7 +7,7 @@ Value ClassObject::initialize(Env *env, Optional<Value> superclass_arg, Block *b
         env->raise("TypeError", "already initialized class");
     auto superclass = superclass_arg.value_or(GlobalEnv::the()->Object());
     if (!superclass.is_class())
-        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_str());
+        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_string());
     superclass.as_class()->initialize_subclass(this, env, "", superclass.as_class()->object_type());
     ModuleObject::initialize(env, block);
     return this;
@@ -75,7 +75,7 @@ ClassObject *ClassObject::bootstrap_basic_object(Env *env, ClassObject *Class) {
 
 String ClassObject::backtrace_name() const {
     if (!m_name)
-        return inspect_str();
+        return inspect_string();
     return String::format("<class:{}>", m_name.value());
 }
 

--- a/src/complex_object.cpp
+++ b/src/complex_object.cpp
@@ -3,7 +3,7 @@
 namespace Natalie {
 
 Value ComplexObject::inspect(Env *env) {
-    return StringObject::format("({}+{}i)", m_real.inspect_str(env), m_imaginary.inspect_str(env));
+    return StringObject::format("({}+{}i)", m_real.inspected(env), m_imaginary.inspected(env));
 }
 
 }

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -89,7 +89,7 @@ nat_int_t DirObject::set_pos(Env *env, Value position) {
 
 StringObject *DirObject::inspect(Env *env) {
     StringObject *out = new StringObject { "#<" };
-    out->append(klass()->inspect_string());
+    out->append(klass()->inspect_module());
     out->append(":");
     out->append(path(env));
     out->append(">");

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -89,7 +89,7 @@ nat_int_t DirObject::set_pos(Env *env, Value position) {
 
 StringObject *DirObject::inspect(Env *env) {
     StringObject *out = new StringObject { "#<" };
-    out->append(klass()->inspect_str());
+    out->append(klass()->inspect_string());
     out->append(":");
     out->append(path(env));
     out->append(">");

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -284,7 +284,7 @@ Value EncodingObject::find(Env *env, Value name) {
                 return encoding;
         }
     }
-    env->raise("ArgumentError", "unknown encoding name - {}", name.inspect_str(env));
+    env->raise("ArgumentError", "unknown encoding name - {}", name.inspected(env));
 }
 
 // Lookup an EncodingObject by its string-name, or return null.
@@ -314,7 +314,7 @@ EncodingObject *EncodingObject::find_encoding(Env *env, Value encoding) {
 
     auto enc = EncodingObject::find_encoding_by_name(env, String("BINARY"));
     if (!enc)
-        env->raise("ArgumentError", "unknown encoding name - {}", encoding.inspect_str(env));
+        env->raise("ArgumentError", "unknown encoding name - {}", encoding.inspected(env));
 
     return enc;
 }

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -177,7 +177,7 @@ Value ArithmeticSequenceObject::hash(Env *env) {
 Value ArithmeticSequenceObject::inspect(Env *env) {
     switch (m_origin) {
     case Origin::Range: {
-        auto range_inspect = RangeObject::create(env, m_begin, m_end, m_exclude_end)->inspect_str(env);
+        auto range_inspect = RangeObject::create(env, m_begin, m_end, m_exclude_end)->inspected(env);
         auto string = StringObject::format("(({}).{}", range_inspect, m_range_origin_method);
 
         if (has_step()) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -117,7 +117,7 @@ void Env::raise_exception(ExceptionObject *exception) {
 }
 
 void Env::raise_key_error(Value receiver, Value key) {
-    auto message = new StringObject { String::format("key not found: {}", key.inspect_str(this)) };
+    auto message = new StringObject { String::format("key not found: {}", key.inspected(this)) };
     auto key_error_class = GlobalEnv::the()->Object()->const_fetch("KeyError"_s).as_class();
     ExceptionObject *exception = new ExceptionObject { key_error_class, message };
     exception->ivar_set(this, "@receiver"_s, receiver);
@@ -158,15 +158,15 @@ void Env::raise_invalid_byte_sequence_error(const EncodingObject *encoding) {
 void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissingReason reason) {
     String inspect_string;
     if (receiver.is_nil() || receiver.is_true() || receiver.is_false()) {
-        inspect_string = receiver.inspect_str(this);
+        inspect_string = receiver.inspected(this);
     } else if (receiver.is_integer()) {
         inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
     } else if (receiver->is_main_object()) {
         inspect_string = "main";
     } else if (receiver.is_class()) {
-        inspect_string = String::format("class {}", receiver.inspect_str(this));
+        inspect_string = String::format("class {}", receiver.inspected(this));
     } else if (receiver.is_module()) {
-        inspect_string = String::format("module {}", receiver.inspect_str(this));
+        inspect_string = String::format("module {}", receiver.inspected(this));
     } else {
         inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
     }
@@ -209,7 +209,7 @@ void Env::raise_not_comparable_error(Value lhs, Value rhs) {
     String lhs_class = lhs.klass()->inspect_string();
     String rhs_inspect;
     if (rhs.is_integer() || rhs.is_float() || rhs.is_falsey()) {
-        rhs_inspect = rhs.inspect_str(this);
+        rhs_inspect = rhs.inspected(this);
     } else {
         rhs_inspect = rhs.klass()->inspect_string();
     }
@@ -274,12 +274,12 @@ void Env::ensure_no_missing_keywords(HashObject *kwargs, std::initializer_list<c
     if (missing.is_empty())
         return;
     if (missing.size() == 1)
-        raise("ArgumentError", "missing keyword: {}", missing[0]->inspect_str(this));
+        raise("ArgumentError", "missing keyword: {}", missing[0]->inspected(this));
     String message { "missing keywords: " };
-    message.append(missing[0]->inspect_str(this));
+    message.append(missing[0]->inspected(this));
     for (size_t i = 1; i < missing.size(); i++) {
         message.append(", ");
-        message.append(missing[i]->inspect_str(this));
+        message.append(missing[i]->inspected(this));
     }
     raise("ArgumentError", std::move(message));
 }
@@ -289,12 +289,12 @@ void Env::ensure_no_extra_keywords(HashObject *kwargs) {
         return;
     auto it = kwargs->begin();
     if (kwargs->size() == 1)
-        raise("ArgumentError", "unknown keyword: {}", it->key.inspect_str(this));
+        raise("ArgumentError", "unknown keyword: {}", it->key.inspected(this));
     String message { "unknown keywords: " };
-    message.append(it->key.inspect_str(this));
+    message.append(it->key.inspected(this));
     for (it++; it != kwargs->end(); it++) {
         message.append(", ");
-        message.append(it->key.inspect_str(this));
+        message.append(it->key.inspected(this));
     }
     raise("ArgumentError", std::move(message));
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -160,7 +160,7 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
     if (receiver.is_nil() || receiver.is_true() || receiver.is_false()) {
         inspect_string = receiver.inspect_str(this);
     } else if (receiver.is_integer()) {
-        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_str());
+        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
     } else if (receiver->is_main_object()) {
         inspect_string = "main";
     } else if (receiver.is_class()) {
@@ -168,7 +168,7 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
     } else if (receiver.is_module()) {
         inspect_string = String::format("module {}", receiver.inspect_str(this));
     } else {
-        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_str());
+        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
     }
     String message;
     switch (reason) {
@@ -206,12 +206,12 @@ void Env::raise_name_error(StringObject *name, String message) {
 }
 
 void Env::raise_not_comparable_error(Value lhs, Value rhs) {
-    String lhs_class = lhs.klass()->inspect_str();
+    String lhs_class = lhs.klass()->inspect_string();
     String rhs_inspect;
     if (rhs.is_integer() || rhs.is_float() || rhs.is_falsey()) {
         rhs_inspect = rhs.inspect_str(this);
     } else {
-        rhs_inspect = rhs.klass()->inspect_str();
+        rhs_inspect = rhs.klass()->inspect_string();
     }
 
     String message = String::format("comparison of {} with {} failed", lhs_class, rhs_inspect);
@@ -224,7 +224,7 @@ void Env::raise_type_error(const Value obj, const char *expected) {
         lowercase_expected->downcase_in_place(this);
         raise("TypeError", "no implicit conversion from nil to {}", lowercase_expected->string());
     } else {
-        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_str(), expected);
+        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_string(), expected);
     }
 }
 
@@ -238,7 +238,7 @@ void Env::raise_type_error2(const Value obj, const char *expected) {
     else if (obj.is_false())
         raise("TypeError", "no implicit conversion of false into {}", expected);
     else
-        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_str(), expected);
+        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_string(), expected);
 }
 
 bool Env::has_catch(Value value) const {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -156,30 +156,30 @@ void Env::raise_invalid_byte_sequence_error(const EncodingObject *encoding) {
 }
 
 void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissingReason reason) {
-    String inspect_string;
+    String inspect_module;
     if (receiver.is_nil() || receiver.is_true() || receiver.is_false()) {
-        inspect_string = receiver.inspected(this);
+        inspect_module = receiver.inspected(this);
     } else if (receiver.is_integer()) {
-        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
+        inspect_module = String::format("an instance of {}", receiver.klass()->inspect_module());
     } else if (receiver->is_main_object()) {
-        inspect_string = "main";
+        inspect_module = "main";
     } else if (receiver.is_class()) {
-        inspect_string = String::format("class {}", receiver.inspected(this));
+        inspect_module = String::format("class {}", receiver.inspected(this));
     } else if (receiver.is_module()) {
-        inspect_string = String::format("module {}", receiver.inspected(this));
+        inspect_module = String::format("module {}", receiver.inspected(this));
     } else {
-        inspect_string = String::format("an instance of {}", receiver.klass()->inspect_string());
+        inspect_module = String::format("an instance of {}", receiver.klass()->inspect_module());
     }
     String message;
     switch (reason) {
     case MethodMissingReason::Private:
-        message = String::format("private method '{}' called for {}", name->string(), inspect_string);
+        message = String::format("private method '{}' called for {}", name->string(), inspect_module);
         break;
     case MethodMissingReason::Protected:
-        message = String::format("protected method '{}' called for {}", name->string(), inspect_string);
+        message = String::format("protected method '{}' called for {}", name->string(), inspect_module);
         break;
     case MethodMissingReason::Undefined:
-        message = String::format("undefined method '{}' for {}", name->string(), inspect_string);
+        message = String::format("undefined method '{}' for {}", name->string(), inspect_module);
         break;
     default:
         NAT_UNREACHABLE();
@@ -206,12 +206,12 @@ void Env::raise_name_error(StringObject *name, String message) {
 }
 
 void Env::raise_not_comparable_error(Value lhs, Value rhs) {
-    String lhs_class = lhs.klass()->inspect_string();
+    String lhs_class = lhs.klass()->inspect_module();
     String rhs_inspect;
     if (rhs.is_integer() || rhs.is_float() || rhs.is_falsey()) {
         rhs_inspect = rhs.inspected(this);
     } else {
-        rhs_inspect = rhs.klass()->inspect_string();
+        rhs_inspect = rhs.klass()->inspect_module();
     }
 
     String message = String::format("comparison of {} with {} failed", lhs_class, rhs_inspect);
@@ -224,7 +224,7 @@ void Env::raise_type_error(const Value obj, const char *expected) {
         lowercase_expected->downcase_in_place(this);
         raise("TypeError", "no implicit conversion from nil to {}", lowercase_expected->string());
     } else {
-        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_string(), expected);
+        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_module(), expected);
     }
 }
 
@@ -238,7 +238,7 @@ void Env::raise_type_error2(const Value obj, const char *expected) {
     else if (obj.is_false())
         raise("TypeError", "no implicit conversion of false into {}", expected);
     else
-        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_string(), expected);
+        raise("TypeError", "no implicit conversion of {} into {}", obj.klass()->inspect_module(), expected);
 }
 
 bool Env::has_catch(Value value) const {

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -46,7 +46,7 @@ Value EnvObject::to_hash(Env *env, Block *block) {
             if (!transformed.is_array() && transformed.respond_to(env, "to_ary"_s))
                 transformed = transformed.to_ary(env);
             if (!transformed.is_array())
-                env->raise("TypeError", "wrong element type {} (expected array)", transformed.klass()->inspect_str());
+                env->raise("TypeError", "wrong element type {} (expected array)", transformed.klass()->inspect_string());
             if (transformed.as_array()->size() != 2)
                 env->raise("ArgumentError", "element has wrong array length (expected 2, was {})", transformed.as_array()->size());
             name = transformed.as_array()->at(0);

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -46,7 +46,7 @@ Value EnvObject::to_hash(Env *env, Block *block) {
             if (!transformed.is_array() && transformed.respond_to(env, "to_ary"_s))
                 transformed = transformed.to_ary(env);
             if (!transformed.is_array())
-                env->raise("TypeError", "wrong element type {} (expected array)", transformed.klass()->inspect_string());
+                env->raise("TypeError", "wrong element type {} (expected array)", transformed.klass()->inspect_module());
             if (transformed.as_array()->size() != 2)
                 env->raise("ArgumentError", "element has wrong array length (expected 2, was {})", transformed.as_array()->size());
             name = transformed.as_array()->at(0);

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -99,7 +99,7 @@ bool ExceptionObject::eq(Env *env, Value other) {
 }
 
 Value ExceptionObject::inspect(Env *env) {
-    auto klassname = m_klass->inspect_str();
+    auto klassname = m_klass->inspect_string();
     auto msgstr = send(env, "to_s"_s);
     msgstr.assert_type(env, Object::Type::String, "String");
     if (msgstr.as_string()->is_empty())
@@ -111,7 +111,7 @@ Value ExceptionObject::inspect(Env *env) {
 
 StringObject *ExceptionObject::to_s(Env *env) {
     if (m_message.is_nil()) {
-        return new StringObject { m_klass->inspect_str() };
+        return new StringObject { m_klass->inspect_string() };
     } else if (m_message.is_string()) {
         return m_message.as_string();
     }
@@ -134,7 +134,7 @@ Value ExceptionObject::detailed_message(Env *env, Args &&args) {
         if (klass() == find_top_level_const(env, "RuntimeError"_s).as_class()) {
             message->set_str("unhandled exception");
         } else {
-            message->set_str(klass()->inspect_str().c_str());
+            message->set_str(klass()->inspect_string().c_str());
         }
         if (highlight)
             message = StringObject::format("\e[1;4m{}\e[m", message);
@@ -145,7 +145,7 @@ Value ExceptionObject::detailed_message(Env *env, Args &&args) {
         return message;
 
     const char *fmt = highlight ? "\e[1m{} (\e[1;4m{}\e[m\e[1m)\e[m" : "{} ({})";
-    return StringObject::format(fmt, message, klass()->inspect_str());
+    return StringObject::format(fmt, message, klass()->inspect_string());
 }
 
 Value ExceptionObject::backtrace(Env *env) {

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -99,7 +99,7 @@ bool ExceptionObject::eq(Env *env, Value other) {
 }
 
 Value ExceptionObject::inspect(Env *env) {
-    auto klassname = m_klass->inspect_string();
+    auto klassname = m_klass->inspect_module();
     auto msgstr = send(env, "to_s"_s);
     msgstr.assert_type(env, Object::Type::String, "String");
     if (msgstr.as_string()->is_empty())
@@ -111,7 +111,7 @@ Value ExceptionObject::inspect(Env *env) {
 
 StringObject *ExceptionObject::to_s(Env *env) {
     if (m_message.is_nil()) {
-        return new StringObject { m_klass->inspect_string() };
+        return new StringObject { m_klass->inspect_module() };
     } else if (m_message.is_string()) {
         return m_message.as_string();
     }
@@ -134,7 +134,7 @@ Value ExceptionObject::detailed_message(Env *env, Args &&args) {
         if (klass() == find_top_level_const(env, "RuntimeError"_s).as_class()) {
             message->set_str("unhandled exception");
         } else {
-            message->set_str(klass()->inspect_string().c_str());
+            message->set_str(klass()->inspect_module().c_str());
         }
         if (highlight)
             message = StringObject::format("\e[1;4m{}\e[m", message);
@@ -145,7 +145,7 @@ Value ExceptionObject::detailed_message(Env *env, Args &&args) {
         return message;
 
     const char *fmt = highlight ? "\e[1m{} (\e[1;4m{}\e[m\e[1m)\e[m" : "{} ({})";
-    return StringObject::format(fmt, message, klass()->inspect_string());
+    return StringObject::format(fmt, message, klass()->inspect_module());
 }
 
 Value ExceptionObject::backtrace(Env *env) {

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -84,13 +84,13 @@ FiberObject *FiberObject::initialize(Env *env, Optional<Value> blocking_kwarg, O
 
 Value FiberObject::hash(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
-    const auto hash = HashKeyHandler<String>::hash(String::format("{}{}{}", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line));
+    const auto hash = HashKeyHandler<String>::hash(String::format("{}{}{}", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line));
     return Value::integer(hash);
 }
 
 Value FiberObject::inspect(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
-    return StringObject::format("#<{}:{}{} ({})>", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line, status(env));
+    return StringObject::format("#<{}:{}{} ({})>", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line, status(env));
 }
 
 bool FiberObject::is_alive() const {
@@ -120,7 +120,7 @@ Value FiberObject::ref(Env *env, Value key) {
     if (key.is_string() || key.respond_to(env, to_str))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_string());
     auto fiber = current();
     while ((fiber->m_storage == nullptr || !fiber->m_storage->has_key(env, key)) && fiber->m_previous_fiber != nullptr)
         fiber = fiber->m_previous_fiber;
@@ -134,7 +134,7 @@ Value FiberObject::refeq(Env *env, Value key, Value value) {
     if (key.is_string() || key.respond_to(env, to_str))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_string());
     if (current()->m_storage == nullptr)
         current()->m_storage = new HashObject {};
     if (value.is_nil()) {

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -84,13 +84,13 @@ FiberObject *FiberObject::initialize(Env *env, Optional<Value> blocking_kwarg, O
 
 Value FiberObject::hash(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
-    const auto hash = HashKeyHandler<String>::hash(String::format("{}{}{}", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line));
+    const auto hash = HashKeyHandler<String>::hash(String::format("{}{}{}", m_klass->inspect_module(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line));
     return Value::integer(hash);
 }
 
 Value FiberObject::inspect(Env *env) {
     const TM::String file_and_line { m_file && m_line ? TM::String::format(" {}:{}", *m_file, *m_line) : "" };
-    return StringObject::format("#<{}:{}{} ({})>", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line, status(env));
+    return StringObject::format("#<{}:{}{} ({})>", m_klass->inspect_module(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), file_and_line, status(env));
 }
 
 bool FiberObject::is_alive() const {
@@ -120,7 +120,7 @@ Value FiberObject::ref(Env *env, Value key) {
     if (key.is_string() || key.respond_to(env, to_str))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_module());
     auto fiber = current();
     while ((fiber->m_storage == nullptr || !fiber->m_storage->has_key(env, key)) && fiber->m_previous_fiber != nullptr)
         fiber = fiber->m_previous_fiber;
@@ -134,7 +134,7 @@ Value FiberObject::refeq(Env *env, Value key, Value value) {
     if (key.is_string() || key.respond_to(env, to_str))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_module());
     if (current()->m_storage == nullptr)
         current()->m_storage = new HashObject {};
     if (value.is_nil()) {

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -656,7 +656,7 @@ Value FileObject::lutime(Env *env, Args &&args) {
             t.tv_sec = static_cast<time_t>(tmp);
             t.tv_usec = (tmp - t.tv_sec) * 1000000;
         } else {
-            env->raise("TypeError", "can't convert {} into time", v.klass()->inspect_str());
+            env->raise("TypeError", "can't convert {} into time", v.klass()->inspect_string());
         }
     };
     time_convert(args.at(0), tv[0]);

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -656,7 +656,7 @@ Value FileObject::lutime(Env *env, Args &&args) {
             t.tv_sec = static_cast<time_t>(tmp);
             t.tv_usec = (tmp - t.tv_sec) * 1000000;
         } else {
-            env->raise("TypeError", "can't convert {} into time", v.klass()->inspect_string());
+            env->raise("TypeError", "can't convert {} into time", v.klass()->inspect_module());
         }
     };
     time_convert(args.at(0), tv[0]);

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -51,7 +51,7 @@ bool FloatObject::eql(Value other) const {
             precision = precision_value.integer().to_nat_int_t();        \
         }                                                                \
         if (precision <= 0 && (is_nan() || is_infinity()))               \
-            env->raise("FloatDomainError", inspect_str(env));            \
+            env->raise("FloatDomainError", inspected(env));              \
                                                                          \
         if (is_infinity())                                               \
             return new FloatObject { m_double };                         \

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -329,7 +329,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
     if (is_nan()) env->raise("FloatDomainError", "NaN");
     if (is_infinity()) env->raise("FloatDomainError", "Infinity");
 
-    if (!arg.is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg.klass()->inspect_string());
+    if (!arg.is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg.klass()->inspect_module());
     if (arg.is_float() && arg.as_float()->is_nan()) env->raise("FloatDomainError", "NaN");
     if (arg.is_float() && arg.as_float()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
     if (arg.is_integer() && arg.integer().is_zero()) env->raise("ZeroDivisionError", "divided by 0");
@@ -390,29 +390,29 @@ Value FloatObject::arg(Env *env) {
     }
 }
 
-#define NAT_DEFINE_FLOAT_COMPARISON_METHOD(name, op)                                                         \
-    bool FloatObject::name(Env *env, Value rhs) {                                                            \
-        Value lhs = this;                                                                                    \
-                                                                                                             \
-        if (!rhs.is_float()) {                                                                               \
-            auto coerced = Natalie::coerce(env, rhs, lhs);                                                   \
-            lhs = coerced.first;                                                                             \
-            rhs = coerced.second;                                                                            \
-        }                                                                                                    \
-                                                                                                             \
-        if (!lhs.is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs }).is_truthy(); \
-        if (!rhs.is_float()) {                                                                               \
-            env->raise("ArgumentError", "comparison of Float with {} failed", rhs.klass()->inspect_string());   \
-        }                                                                                                    \
-                                                                                                             \
-        if (lhs.as_float()->is_nan() || rhs.as_float()->is_nan()) {                                          \
-            return false;                                                                                    \
-        }                                                                                                    \
-                                                                                                             \
-        double lhs_d = lhs.as_float()->to_double();                                                          \
-        double rhs_d = rhs.as_float()->to_double();                                                          \
-                                                                                                             \
-        return lhs_d op rhs_d;                                                                               \
+#define NAT_DEFINE_FLOAT_COMPARISON_METHOD(name, op)                                                          \
+    bool FloatObject::name(Env *env, Value rhs) {                                                             \
+        Value lhs = this;                                                                                     \
+                                                                                                              \
+        if (!rhs.is_float()) {                                                                                \
+            auto coerced = Natalie::coerce(env, rhs, lhs);                                                    \
+            lhs = coerced.first;                                                                              \
+            rhs = coerced.second;                                                                             \
+        }                                                                                                     \
+                                                                                                              \
+        if (!lhs.is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs }).is_truthy();  \
+        if (!rhs.is_float()) {                                                                                \
+            env->raise("ArgumentError", "comparison of Float with {} failed", rhs.klass()->inspect_module()); \
+        }                                                                                                     \
+                                                                                                              \
+        if (lhs.as_float()->is_nan() || rhs.as_float()->is_nan()) {                                           \
+            return false;                                                                                     \
+        }                                                                                                     \
+                                                                                                              \
+        double lhs_d = lhs.as_float()->to_double();                                                           \
+        double rhs_d = rhs.as_float()->to_double();                                                           \
+                                                                                                              \
+        return lhs_d op rhs_d;                                                                                \
     }
 
 NAT_DEFINE_FLOAT_COMPARISON_METHOD(lt, <)

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -329,7 +329,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
     if (is_nan()) env->raise("FloatDomainError", "NaN");
     if (is_infinity()) env->raise("FloatDomainError", "Infinity");
 
-    if (!arg.is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg.klass()->inspect_str());
+    if (!arg.is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg.klass()->inspect_string());
     if (arg.is_float() && arg.as_float()->is_nan()) env->raise("FloatDomainError", "NaN");
     if (arg.is_float() && arg.as_float()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
     if (arg.is_integer() && arg.integer().is_zero()) env->raise("ZeroDivisionError", "divided by 0");
@@ -402,7 +402,7 @@ Value FloatObject::arg(Env *env) {
                                                                                                              \
         if (!lhs.is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs }).is_truthy(); \
         if (!rhs.is_float()) {                                                                               \
-            env->raise("ArgumentError", "comparison of Float with {} failed", rhs.klass()->inspect_str());   \
+            env->raise("ArgumentError", "comparison of Float with {} failed", rhs.klass()->inspect_string());   \
         }                                                                                                    \
                                                                                                              \
         if (lhs.as_float()->is_nan() || rhs.as_float()->is_nan()) {                                          \

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -235,12 +235,12 @@ void Heap::dump(bool only_large) const {
             for (auto cell : *block) {
                 if (only_large && !cell->is_large())
                     continue;
-                cell->gc_print();
+                fprintf(stderr, "%s\n", cell->dbg_inspect().c_str());
                 allocation_count++;
             }
         }
     }
-    printf("Total allocations: %lld\n", allocation_count);
+    fprintf(stderr, "Total allocations: %lld\n", allocation_count);
 }
 
 NO_SANITIZE_ADDRESS void Heap::scan_memory(Cell::Visitor &visitor, void *start, void *end) {

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -227,12 +227,14 @@ size_t Heap::total_allocations() const {
     return count;
 }
 
-void Heap::dump() const {
+void Heap::dump(bool only_large) const {
     nat_int_t allocation_count = 0;
     for (auto allocator : m_allocators) {
         for (auto block_pair : *allocator) {
             auto *block = block_pair.first;
             for (auto cell : *block) {
+                if (only_large && !cell->is_large())
+                    continue;
                 cell->gc_print();
                 allocation_count++;
             }

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -112,9 +112,9 @@ void GlobalEnv::global_set_write_hook(Env *env, SymbolObject *name, GlobalVariab
 
     auto info = m_global_variables.get(name, env);
     if (!info)
-        env->raise("ScriptError", "Trying to add a write hook to undefined global variable {}", name->inspect_str(env));
+        env->raise("ScriptError", "Trying to add a write hook to undefined global variable {}", name->inspected(env));
     if (info->is_readonly())
-        env->raise("ScriptError", "Trying to add a write hook to readonly global variable {}", name->inspect_str(env));
+        env->raise("ScriptError", "Trying to add a write hook to readonly global variable {}", name->inspected(env));
     info->set_write_hook(write_hook);
 }
 

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -74,7 +74,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
         if (v.is_nil())
             return Value::nil();
         if (!v.is_match_data())
-            env->raise("TypeError", "wrong argument type {} (expected MatchData)", v.klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected MatchData)", v.klass()->inspect_string());
         auto match = v.as_match_data();
         env->set_last_match(match);
         return match;
@@ -82,7 +82,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
 
     Value set_stdout(Env *env, Value v, GlobalVariableInfo &) {
         if (!v.respond_to(env, "write"_s))
-            env->raise("TypeError", "$stdout must have write method, {} given", v.klass()->inspect_str());
+            env->raise("TypeError", "$stdout must have write method, {} given", v.klass()->inspect_string());
         return v;
     }
 

--- a/src/global_variable_info/access_hooks.cpp
+++ b/src/global_variable_info/access_hooks.cpp
@@ -74,7 +74,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
         if (v.is_nil())
             return Value::nil();
         if (!v.is_match_data())
-            env->raise("TypeError", "wrong argument type {} (expected MatchData)", v.klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected MatchData)", v.klass()->inspect_module());
         auto match = v.as_match_data();
         env->set_last_match(match);
         return match;
@@ -82,7 +82,7 @@ namespace GlobalVariableAccessHooks::WriteHooks {
 
     Value set_stdout(Env *env, Value v, GlobalVariableInfo &) {
         if (!v.respond_to(env, "write"_s))
-            env->raise("TypeError", "$stdout must have write method, {} given", v.klass()->inspect_string());
+            env->raise("TypeError", "$stdout must have write method, {} given", v.klass()->inspect_module());
         return v;
     }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -326,15 +326,17 @@ Value HashObject::inspect(Env *env) {
     });
 }
 
-String HashObject::dbg_inspect() const {
-    auto str = String::format("<HashObject {h} {", this);
+String HashObject::dbg_inspect(int indent) const {
+    auto str = String::format("<HashObject {h} size={} {", this, size());
     size_t index = 0;
     for (auto pair : *this) {
-        str.append(pair.key.dbg_inspect());
+        str.append_char('\n');
+        str.append_char(' ', indent + 2);
+        str.append(pair.key.dbg_inspect(indent + 2));
         str.append(" => ");
-        str.append(pair.val.dbg_inspect());
+        str.append(pair.val.dbg_inspect(indent + 2));
         if (index < size() - 1)
-            str.append(", ");
+            str.append_char(',');
         index++;
     }
     str.append("}>");

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -299,7 +299,7 @@ Value HashObject::inspect(Env *env) {
             else
                 obj = new StringObject("?");
             if (!obj.is_string())
-                obj = StringObject::format("#<{}:{}>", obj.klass()->inspect_str(), String::hex(object_id(obj), String::HexFormat::LowercaseAndPrefixed));
+                obj = StringObject::format("#<{}:{}>", obj.klass()->inspect_string(), String::hex(object_id(obj), String::HexFormat::LowercaseAndPrefixed));
             return obj.as_string();
         };
 
@@ -422,7 +422,7 @@ Value HashObject::dig(Env *env, Args &&args) {
         return val;
 
     if (!val.respond_to(env, dig))
-        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_str());
+        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_string());
 
     return val.send(env, dig, std::move(args));
 }
@@ -615,7 +615,7 @@ Value HashObject::to_h(Env *env, Block *block) {
         if (!result.is_array() && result.respond_to(env, "to_ary"_s))
             result = result.to_ary(env);
         if (!result.is_array())
-            env->raise("TypeError", "wrong element type {} (expected array)", result.klass()->inspect_str());
+            env->raise("TypeError", "wrong element type {} (expected array)", result.klass()->inspect_string());
         auto result_array = result.as_array();
         if (result_array->size() != 2)
             env->raise("ArgumentError", "element has wrong array length (expected 2, was {})", result_array->size());

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -327,7 +327,7 @@ Value HashObject::inspect(Env *env) {
 }
 
 String HashObject::dbg_inspect() const {
-    String str("{");
+    auto str = String::format("<HashObject {h} {", this);
     size_t index = 0;
     for (auto pair : *this) {
         str.append(pair.key.dbg_inspect());
@@ -337,7 +337,7 @@ String HashObject::dbg_inspect() const {
             str.append(", ");
         index++;
     }
-    str.append("}");
+    str.append("}>");
     return str;
 }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -299,7 +299,7 @@ Value HashObject::inspect(Env *env) {
             else
                 obj = new StringObject("?");
             if (!obj.is_string())
-                obj = StringObject::format("#<{}:{}>", obj.klass()->inspect_string(), String::hex(object_id(obj), String::HexFormat::LowercaseAndPrefixed));
+                obj = StringObject::format("#<{}:{}>", obj.klass()->inspect_module(), String::hex(object_id(obj), String::HexFormat::LowercaseAndPrefixed));
             return obj.as_string();
         };
 
@@ -422,7 +422,7 @@ Value HashObject::dig(Env *env, Args &&args) {
         return val;
 
     if (!val.respond_to(env, dig))
-        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_string());
+        env->raise("TypeError", "{} does not have #dig method", val.klass()->inspect_module());
 
     return val.send(env, dig, std::move(args));
 }
@@ -615,7 +615,7 @@ Value HashObject::to_h(Env *env, Block *block) {
         if (!result.is_array() && result.respond_to(env, "to_ary"_s))
             result = result.to_ary(env);
         if (!result.is_array())
-            env->raise("TypeError", "wrong element type {} (expected array)", result.klass()->inspect_string());
+            env->raise("TypeError", "wrong element type {} (expected array)", result.klass()->inspect_module());
         auto result_array = result.as_array();
         if (result_array->size() != 2)
             env->raise("ArgumentError", "element has wrong array length (expected 2, was {})", result_array->size());

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -287,7 +287,7 @@ bool IntegerMethods::lt(Env *env, Integer self, Value other) {
         return result.first.send(env, "<"_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspected(env));
 }
 
 bool IntegerMethods::lte(Env *env, Integer self, Value other) {
@@ -312,7 +312,7 @@ bool IntegerMethods::lte(Env *env, Integer self, Value other) {
         return result.first.send(env, "<="_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspected(env));
 }
 
 bool IntegerMethods::gt(Env *env, Integer self, Value other) {
@@ -337,7 +337,7 @@ bool IntegerMethods::gt(Env *env, Integer self, Value other) {
         return result.first.send(env, ">"_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspected(env));
 }
 
 bool IntegerMethods::gte(Env *env, Integer self, Value other) {
@@ -362,7 +362,7 @@ bool IntegerMethods::gte(Env *env, Integer self, Value other) {
         return result.first.send(env, ">="_s, { result.second }).is_truthy();
     }
 
-    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspect_str(env));
+    env->raise("ArgumentError", "comparison of Integer with {} failed", other.inspected(env));
 }
 
 Value IntegerMethods::times(Env *env, Integer self, Block *block) {
@@ -488,7 +488,7 @@ Value IntegerMethods::coerce(Env *env, Value self, Value arg) {
             arg = arg.send(env, "to_f"_s);
         }
         if (!arg.is_float())
-            env->raise("TypeError", "can't convert {} into Float", arg.inspect_str(env));
+            env->raise("TypeError", "can't convert {} into Float", arg.inspected(env));
 
         ary->push(arg);
         ary->push(self.send(env, "to_f"_s));

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -68,7 +68,7 @@ Value IoObject::initialize(Env *env, Args &&args, Block *block) {
     m_autoclose = wanted_flags.autoclose();
     m_path = wanted_flags.path();
     if (block)
-        env->warn("{}::new() does not take block; use {}::open() instead", m_klass->inspect_str(), m_klass->inspect_str());
+        env->warn("{}::new() does not take block; use {}::open() instead", m_klass->inspect_string(), m_klass->inspect_string());
     return this;
 }
 
@@ -223,7 +223,7 @@ Value IoObject::inspect() const {
     } else {
         details = TM::String::format("fd {}", m_fileno);
     }
-    return StringObject::format("#<{}:{}>", klass()->inspect_str(), details);
+    return StringObject::format("#<{}:{}>", klass()->inspect_string(), details);
 }
 
 bool IoObject::is_autoclose(Env *env) const {
@@ -762,7 +762,7 @@ Value IoObject::seek(Env *env, Value amount_value, Optional<Value> whence_arg) {
                 env->raise("TypeError", "no implicit conversion of Symbol into Integer");
             }
         } else {
-            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value.klass()->inspect_str());
+            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value.klass()->inspect_string());
         }
     }
     if (whence == SEEK_CUR && !m_read_buffer.is_empty())
@@ -888,9 +888,9 @@ Value IoObject::try_convert(Env *env, Value val) {
         if (!io.is_io())
             env->raise(
                 "TypeError", "can't convert {} to IO ({}#to_io gives {})",
-                val.klass()->inspect_str(),
-                val.klass()->inspect_str(),
-                io.klass()->inspect_str());
+                val.klass()->inspect_string(),
+                val.klass()->inspect_string(),
+                io.klass()->inspect_string());
         return io;
     }
     return Value::nil();

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -96,7 +96,7 @@ Value IoObject::advise(Env *env, Value advice, Optional<Value> offset, Optional<
     } else if (advice == "dontneed"_s) {
         advice_i = POSIX_FADV_DONTNEED;
     } else {
-        env->raise("NotImplementedError", "Unsupported advice: {}", advice.inspect_str(env));
+        env->raise("NotImplementedError", "Unsupported advice: {}", advice.inspected(env));
     }
     if (::posix_fadvise(m_fileno, offset_i, len_i, advice_i) != 0)
         env->raise_errno();
@@ -291,7 +291,7 @@ Value IoObject::read_file(Env *env, Args &&args) {
     file->set_encoding(env, flags.external_encoding(), flags.internal_encoding());
     if (!offset.is_nil()) {
         if (offset.is_integer() && offset.integer().is_negative())
-            env->raise("ArgumentError", "negative offset {} given", offset.inspect_str(env));
+            env->raise("ArgumentError", "negative offset {} given", offset.inspected(env));
         file->set_pos(env, offset);
     }
     auto data = file->read(env, length);
@@ -667,7 +667,7 @@ void IoObject::puts(Env *env, Value val) {
         if (str.is_string()) {
             this->putstr(env, str.as_string());
         } else { // to_s did not return a string, so inspect val instead.
-            this->putstr(env, new StringObject { val.inspect_str(env) });
+            this->putstr(env, new StringObject { val.inspected(env) });
         }
     }
 }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -68,7 +68,7 @@ Value IoObject::initialize(Env *env, Args &&args, Block *block) {
     m_autoclose = wanted_flags.autoclose();
     m_path = wanted_flags.path();
     if (block)
-        env->warn("{}::new() does not take block; use {}::open() instead", m_klass->inspect_string(), m_klass->inspect_string());
+        env->warn("{}::new() does not take block; use {}::open() instead", m_klass->inspect_module(), m_klass->inspect_module());
     return this;
 }
 
@@ -223,7 +223,7 @@ Value IoObject::inspect() const {
     } else {
         details = TM::String::format("fd {}", m_fileno);
     }
-    return StringObject::format("#<{}:{}>", klass()->inspect_string(), details);
+    return StringObject::format("#<{}:{}>", klass()->inspect_module(), details);
 }
 
 bool IoObject::is_autoclose(Env *env) const {
@@ -762,7 +762,7 @@ Value IoObject::seek(Env *env, Value amount_value, Optional<Value> whence_arg) {
                 env->raise("TypeError", "no implicit conversion of Symbol into Integer");
             }
         } else {
-            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value.klass()->inspect_string());
+            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value.klass()->inspect_module());
         }
     }
     if (whence == SEEK_CUR && !m_read_buffer.is_empty())
@@ -888,9 +888,9 @@ Value IoObject::try_convert(Env *env, Value val) {
         if (!io.is_io())
             env->raise(
                 "TypeError", "can't convert {} to IO ({}#to_io gives {})",
-                val.klass()->inspect_string(),
-                val.klass()->inspect_string(),
-                io.klass()->inspect_string());
+                val.klass()->inspect_module(),
+                val.klass()->inspect_module(),
+                io.klass()->inspect_module());
         return io;
     }
     return Value::nil();

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -97,7 +97,7 @@ namespace ioutil {
             break;
         }
         default:
-            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj.klass()->inspect_str());
+            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj.klass()->inspect_string());
         }
     }
 

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -97,7 +97,7 @@ namespace ioutil {
             break;
         }
         default:
-            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj.klass()->inspect_string());
+            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj.klass()->inspect_module());
         }
     }
 

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -125,9 +125,9 @@ namespace ioutil {
         if (m_external_encoding) {
             env->raise("ArgumentError", "encoding specified twice");
         } else if (m_kwargs->has_key(env, "external_encoding"_s)) {
-            env->warn("Ignoring encoding parameter '{}', external_encoding is used", encoding.inspect_str(env));
+            env->warn("Ignoring encoding parameter '{}', external_encoding is used", encoding.inspected(env));
         } else if (m_kwargs->has_key(env, "internal_encoding"_s)) {
-            env->warn("Ignoring encoding parameter '{}', internal_encoding is used", encoding.inspect_str(env));
+            env->warn("Ignoring encoding parameter '{}', internal_encoding is used", encoding.inspected(env));
         } else if (encoding.is_encoding()) {
             m_external_encoding = encoding.as_encoding();
         } else {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -168,7 +168,7 @@ Value KernelModule::Complex(Env *env, Value real, Optional<Value> imaginary, boo
     }
 
     if (exception)
-        env->raise("TypeError", "can't convert {} into Complex", real.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into Complex", real.klass()->inspect_module());
 
     return Value::nil();
 }
@@ -477,7 +477,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
         }
     }
     if (exception)
-        env->raise("TypeError", "can't convert {} into Integer", value.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into Integer", value.klass()->inspect_module());
     else
         return Value::nil();
 }
@@ -502,7 +502,7 @@ Value KernelModule::Float(Env *env, Value value, bool exception) {
         }
     }
     if (exception)
-        env->raise("TypeError", "can't convert {} into Float", value.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into Float", value.klass()->inspect_module());
 
     return Value::nil();
 }
@@ -663,7 +663,7 @@ Value KernelModule::Rational(Env *env, Value x, Optional<Value> y_arg, bool exce
             return Value::nil();
 
         if (x.is_nil())
-            env->raise("TypeError", "can't convert {} into Rational", x.klass()->inspect_string());
+            env->raise("TypeError", "can't convert {} into Rational", x.klass()->inspect_module());
 
         if (x.respond_to(env, "to_r"_s)) {
             auto result = x->public_send(env, "to_r"_s);
@@ -728,7 +728,7 @@ Value KernelModule::sleep(Env *env, Optional<Value> length_arg) {
         secs = divmod->at(0).to_f(env)->to_double();
         secs += divmod->at(1).to_f(env)->to_double();
     } else {
-        env->raise("TypeError", "can't convert {} into time interval", length.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into time interval", length.klass()->inspect_module());
     }
 
     if (secs < 0.0)
@@ -842,7 +842,7 @@ Value KernelModule::String(Env *env, Value value) {
     auto to_s = "to_s"_s;
 
     if (!respond_to_method(env, value, Value(to_s), true) || !value.respond_to(env, to_s))
-        env->raise("TypeError", "can't convert {} into String", value.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into String", value.klass()->inspect_module());
 
     value = value.send(env, to_s);
     value.assert_type(env, Object::Type::String, "String");
@@ -946,7 +946,7 @@ Value KernelModule::extend(Env *env, Value self, Args &&args) {
         if (args[i].type() == Object::Type::Module) {
             args[i].as_module()->send(env, "extend_object"_s, { self });
         } else {
-            env->raise("TypeError", "wrong argument type {} (expected Module)", args[i].klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected Module)", args[i].klass()->inspect_module());
         }
     }
     return self;
@@ -985,7 +985,7 @@ Value KernelModule::inspect(Env *env, Value value) {
     if (value.is_module() && value.as_module()->name())
         return new StringObject { value.as_module()->name().value() };
     else
-        return StringObject::format("#<{}:{}>", value.klass()->inspect_string(), value->pointer_id());
+        return StringObject::format("#<{}:{}>", value.klass()->inspect_module(), value->pointer_id());
 }
 
 bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_val) {
@@ -1063,7 +1063,7 @@ Value KernelModule::method(Env *env, Value self, Value name) {
                 }
             }
         }
-        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspected(env), self.klass()->inspect_string());
+        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspected(env), self.klass()->inspect_module());
     }
     return new MethodObject { self, method_info.method() };
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -168,7 +168,7 @@ Value KernelModule::Complex(Env *env, Value real, Optional<Value> imaginary, boo
     }
 
     if (exception)
-        env->raise("TypeError", "can't convert {} into Complex", real.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into Complex", real.klass()->inspect_string());
 
     return Value::nil();
 }
@@ -477,7 +477,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
         }
     }
     if (exception)
-        env->raise("TypeError", "can't convert {} into Integer", value.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into Integer", value.klass()->inspect_string());
     else
         return Value::nil();
 }
@@ -502,7 +502,7 @@ Value KernelModule::Float(Env *env, Value value, bool exception) {
         }
     }
     if (exception)
-        env->raise("TypeError", "can't convert {} into Float", value.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into Float", value.klass()->inspect_string());
 
     return Value::nil();
 }
@@ -663,7 +663,7 @@ Value KernelModule::Rational(Env *env, Value x, Optional<Value> y_arg, bool exce
             return Value::nil();
 
         if (x.is_nil())
-            env->raise("TypeError", "can't convert {} into Rational", x.klass()->inspect_str());
+            env->raise("TypeError", "can't convert {} into Rational", x.klass()->inspect_string());
 
         if (x.respond_to(env, "to_r"_s)) {
             auto result = x->public_send(env, "to_r"_s);
@@ -728,7 +728,7 @@ Value KernelModule::sleep(Env *env, Optional<Value> length_arg) {
         secs = divmod->at(0).to_f(env)->to_double();
         secs += divmod->at(1).to_f(env)->to_double();
     } else {
-        env->raise("TypeError", "can't convert {} into time interval", length.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into time interval", length.klass()->inspect_string());
     }
 
     if (secs < 0.0)
@@ -842,7 +842,7 @@ Value KernelModule::String(Env *env, Value value) {
     auto to_s = "to_s"_s;
 
     if (!respond_to_method(env, value, Value(to_s), true) || !value.respond_to(env, to_s))
-        env->raise("TypeError", "can't convert {} into String", value.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into String", value.klass()->inspect_string());
 
     value = value.send(env, to_s);
     value.assert_type(env, Object::Type::String, "String");
@@ -946,7 +946,7 @@ Value KernelModule::extend(Env *env, Value self, Args &&args) {
         if (args[i].type() == Object::Type::Module) {
             args[i].as_module()->send(env, "extend_object"_s, { self });
         } else {
-            env->raise("TypeError", "wrong argument type {} (expected Module)", args[i].klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected Module)", args[i].klass()->inspect_string());
         }
     }
     return self;
@@ -985,7 +985,7 @@ Value KernelModule::inspect(Env *env, Value value) {
     if (value.is_module() && value.as_module()->name())
         return new StringObject { value.as_module()->name().value() };
     else
-        return StringObject::format("#<{}:{}>", value.klass()->inspect_str(), value->pointer_id());
+        return StringObject::format("#<{}:{}>", value.klass()->inspect_string(), value->pointer_id());
 }
 
 bool KernelModule::instance_variable_defined(Env *env, Value self, Value name_val) {
@@ -1063,7 +1063,7 @@ Value KernelModule::method(Env *env, Value self, Value name) {
                 }
             }
         }
-        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), self.klass()->inspect_str());
+        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), self.klass()->inspect_string());
     }
     return new MethodObject { self, method_info.method() };
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -22,7 +22,7 @@ static bool exception_argument_to_bool(Env *env, Optional<Value> exception_arg) 
         return true;
     auto exception = exception_arg.value();
     if (!exception.is_false() && !exception.is_true())
-        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspect_str(env));
+        env->raise("ArgumentError", "expected true or false as exception: {}", exception.inspected(env));
     return exception.is_true();
 }
 
@@ -441,7 +441,7 @@ Value KernelModule::Integer(Env *env, Value value, nat_int_t base, bool exceptio
     if (value.is_string()) {
         auto result = value.as_string()->convert_integer(env, base);
         if (result.is_nil() && exception) {
-            env->raise("ArgumentError", "invalid value for Integer(): {}", value.inspect_str(env));
+            env->raise("ArgumentError", "invalid value for Integer(): {}", value.inspected(env));
         }
         return result;
     }
@@ -492,7 +492,7 @@ Value KernelModule::Float(Env *env, Value value, bool exception) {
     } else if (value.is_string()) {
         auto result = value.as_string()->convert_float();
         if (result.is_nil() && exception) {
-            env->raise("ArgumentError", "invalid value for Float(): {}", value.inspect_str(env));
+            env->raise("ArgumentError", "invalid value for Float(): {}", value.inspected(env));
         }
         return result;
     } else if (!value.is_nil() && value.respond_to(env, "to_f"_s)) {
@@ -889,7 +889,7 @@ Value KernelModule::this_method(Env *env) {
 Value KernelModule::throw_method(Env *env, Value name, Optional<Value> value) {
     if (!env->has_catch(name)) {
         auto klass = GlobalEnv::the()->Object()->const_fetch("UncaughtThrowError"_s).as_class();
-        auto message = StringObject::format("uncaught throw {}", name.inspect_str(env));
+        auto message = StringObject::format("uncaught throw {}", name.inspected(env));
         auto exception = Object::_new(env, klass, { name, value.value_or(Value::nil()), message }, nullptr).as_exception();
         env->raise_exception(exception);
     }
@@ -1063,7 +1063,7 @@ Value KernelModule::method(Env *env, Value self, Value name) {
                 }
             }
         }
-        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), self.klass()->inspect_string());
+        env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspected(env), self.klass()->inspect_string());
     }
     return new MethodObject { self, method_info.method() };
 }

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -426,7 +426,7 @@ Value MatchDataObject::ref(Env *env, Value index_value, Optional<Value> size_arg
 String MatchDataObject::dbg_inspect() const {
     auto str = group(0);
     assert(!str.is_nil());
-    return String::format("#<MatchData \"{}\">", str.as_string()->c_str());
+    return String::format("#<MatchData \"{}\">", str.as_string());
 }
 
 }

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -175,7 +175,7 @@ Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
     }
 
     if (!keys.is_array())
-        env->raise("TypeError", "wrong argument type {} (expected Array)", keys.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Array)", keys.klass()->inspect_module());
 
     auto result = new HashObject {};
     if (keys.as_array()->size() > static_cast<size_t>(onig_number_of_names(m_regexp->m_regex)))
@@ -183,7 +183,7 @@ Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
 
     for (auto name : *keys.as_array()) {
         if (!name.is_symbol())
-            env->raise("TypeError", "wrong argument type {} (expected Symbol)", name.klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected Symbol)", name.klass()->inspect_module());
         const auto &str = name.as_symbol()->string();
         auto index = onig_name_to_backref_number(m_regexp->m_regex, reinterpret_cast<const UChar *>(str.c_str()), reinterpret_cast<const UChar *>(str.c_str() + str.size()), m_region);
         if (index < 0)

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -423,7 +423,7 @@ Value MatchDataObject::ref(Env *env, Value index_value, Optional<Value> size_arg
     return group(index);
 }
 
-String MatchDataObject::dbg_inspect() const {
+String MatchDataObject::dbg_inspect(int indent) const {
     auto str = group(0);
     assert(!str.is_nil());
     return String::format("#<MatchData \"{}\">", str.as_string());

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -424,9 +424,19 @@ Value MatchDataObject::ref(Env *env, Value index_value, Optional<Value> size_arg
 }
 
 String MatchDataObject::dbg_inspect(int indent) const {
-    auto str = group(0);
-    assert(!str.is_nil());
-    return String::format("#<MatchData \"{}\">", str.as_string());
+    auto str = String::format("<MatchDataObject string={} regexp={} indices=[",
+        m_string ? m_string->dbg_inspect() : "null",
+        m_regexp ? m_regexp->dbg_inspect() : "null",
+        m_region ? m_region->num_regs : -1);
+    if (m_region) {
+        for (int i = 0; i < m_region->num_regs; i++) {
+            if (i > 0)
+                str.append(", ");
+            str.append(String::format("{}..{}", m_region->beg[i], m_region->end[i]));
+        }
+    }
+    str.append("]>");
+    return str;
 }
 
 }

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -226,7 +226,7 @@ Value MatchDataObject::inspect(Env *env) {
             }
             out->append_char(':');
         }
-        out->append(this->group(i).inspect_str(env));
+        out->append(this->group(i).inspected(env));
     }
     out->append_char('>');
     return out;
@@ -341,7 +341,7 @@ ArrayObject *MatchDataObject::values_at(Env *env, Args &&args) {
         if (key.is_range()) {
             auto range = key.as_range();
             if (range->begin().is_integer() && range->begin().integer() < -static_cast<nat_int_t>(size()))
-                env->raise("RangeError", "{} out of range", range->inspect_str(env));
+                env->raise("RangeError", "{} out of range", range->inspected(env));
             auto append = ref(env, range);
             result->concat(env, { append });
             if (range->begin().is_integer()) {

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -175,7 +175,7 @@ Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
     }
 
     if (!keys.is_array())
-        env->raise("TypeError", "wrong argument type {} (expected Array)", keys.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Array)", keys.klass()->inspect_string());
 
     auto result = new HashObject {};
     if (keys.as_array()->size() > static_cast<size_t>(onig_number_of_names(m_regexp->m_regex)))
@@ -183,7 +183,7 @@ Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
 
     for (auto name : *keys.as_array()) {
         if (!name.is_symbol())
-            env->raise("TypeError", "wrong argument type {} (expected Symbol)", name.klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected Symbol)", name.klass()->inspect_string());
         const auto &str = name.as_symbol()->string();
         auto index = onig_name_to_backref_number(m_regexp->m_regex, reinterpret_cast<const UChar *>(str.c_str()), reinterpret_cast<const UChar *>(str.c_str() + str.size()), m_region);
         if (index < 0)

--- a/src/math.rb
+++ b/src/math.rb
@@ -175,8 +175,8 @@ module Math
           value = KernelModule::Float(env, x).as_float();
       } catch (ExceptionObject *exception) {
           ClassObject *klass = exception->klass();
-          if (klass->inspect_str() == "ArgumentError") {
-              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_str());
+          if (klass->inspect_string() == "ArgumentError") {
+              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_string());
           } else {
               env->raise_exception(exception);
           }
@@ -242,8 +242,8 @@ module Math
           value = KernelModule::Float(env, x).as_float();
       } catch (ExceptionObject *exception) {
           ClassObject *klass = exception->klass();
-          if (klass->inspect_str() == "ArgumentError") {
-              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_str());
+          if (klass->inspect_string() == "ArgumentError") {
+              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_string());
           } else {
               env->raise_exception(exception);
           }

--- a/src/math.rb
+++ b/src/math.rb
@@ -175,8 +175,8 @@ module Math
           value = KernelModule::Float(env, x).as_float();
       } catch (ExceptionObject *exception) {
           ClassObject *klass = exception->klass();
-          if (klass->inspect_string() == "ArgumentError") {
-              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_string());
+          if (klass->inspect_module() == "ArgumentError") {
+              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_module());
           } else {
               env->raise_exception(exception);
           }
@@ -242,8 +242,8 @@ module Math
           value = KernelModule::Float(env, x).as_float();
       } catch (ExceptionObject *exception) {
           ClassObject *klass = exception->klass();
-          if (klass->inspect_string() == "ArgumentError") {
-              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_string());
+          if (klass->inspect_module() == "ArgumentError") {
+              env->raise("TypeError", "can't convert {} into Float", x.klass()->inspect_module());
           } else {
               env->raise_exception(exception);
           }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -1058,7 +1058,7 @@ Value ModuleObject::public_constant(Env *env, Args &&args) {
 bool ModuleObject::const_defined(Env *env, Value name_value, Optional<Value> inherited) {
     auto name = name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!name) {
-        env->raise("TypeError", "no implicit conversion of {} to String", name_value.inspect_str(env));
+        env->raise("TypeError", "no implicit conversion of {} to String", name_value.inspected(env));
     }
     if (inherited && inherited.value().is_falsey()) {
         return !!m_constants.get(name);
@@ -1069,11 +1069,11 @@ bool ModuleObject::const_defined(Env *env, Value name_value, Optional<Value> inh
 Value ModuleObject::alias_method(Env *env, Value new_name_value, Value old_name_value) {
     auto new_name = new_name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!new_name) {
-        env->raise("TypeError", "{} is not a symbol", new_name_value.inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", new_name_value.inspected(env));
     }
     auto old_name = old_name_value.to_symbol(env, Value::Conversion::NullAllowed);
     if (!old_name) {
-        env->raise("TypeError", "{} is not a symbol", old_name_value.inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", old_name_value.inspected(env));
     }
     make_method_alias(env, new_name, old_name);
     return new_name;
@@ -1104,7 +1104,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
     if (name.is_string()) {
         name = name.as_string()->to_sym(env);
     } else if (!name.is_symbol()) {
-        env->raise("TypeError", "{} is not a symbol nor a string", name.inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol nor a string", name.inspected(env));
     }
 
     auto method_wrapper = [](Env *env, Value self, Args &&args, Block *block) -> Value {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -121,13 +121,13 @@ Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject
         = [&](Constant *constant) {
               if (search_mode == ConstLookupSearchMode::Strict && constant->is_private()) {
                   if (search_parent && search_parent != GlobalEnv::the()->Object())
-                      env->raise_name_error(name, "private constant {}::{} referenced", search_parent->inspect_str(), name->string());
+                      env->raise_name_error(name, "private constant {}::{} referenced", search_parent->inspect_string(), name->string());
                   else
                       env->raise_name_error(name, "private constant ::{} referenced", name->string());
               }
               if (constant->is_deprecated()) {
                   if (search_parent && search_parent != GlobalEnv::the()->Object())
-                      env->deprecation_warn("constant {}::{} is deprecated", search_parent->inspect_str(), name->string());
+                      env->deprecation_warn("constant {}::{} is deprecated", search_parent->inspect_string(), name->string());
                   else
                       env->deprecation_warn("constant ::{} is deprecated", name->string());
               }
@@ -259,7 +259,7 @@ Optional<Value> ModuleObject::handle_missing_constant(Env *env, Value name, Cons
         auto name_str = name.to_s(env);
         if (this == GlobalEnv::the()->Object())
             env->raise_name_error(name_str, "uninitialized constant {}", name_str->string());
-        env->raise_name_error(name_str, "uninitialized constant {}::{}", inspect_str(), name_str->string());
+        env->raise_name_error(name_str, "uninitialized constant {}::{}", inspect_string(), name_str->string());
     }
 
     return send(env, "const_missing"_s, { name });
@@ -446,7 +446,7 @@ Value ModuleObject::class_variable_get(Env *env, Value name) {
 
     auto val = cvar_get_maybe(env, name_sym);
     if (!val) {
-        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_str());
+        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_string());
     }
     return val.value();
 }
@@ -483,7 +483,7 @@ Value ModuleObject::remove_class_variable(Env *env, Value name) {
 
     auto val = cvar_get_maybe(env, name_sym);
     if (!val)
-        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_str());
+        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_string());
 
     m_class_vars.remove(name_sym);
 
@@ -597,9 +597,9 @@ MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, const 
 void ModuleObject::assert_method_defined(Env *env, SymbolObject *name, MethodInfo method_info) {
     if (!method_info.is_defined()) {
         if (type() == Type::Class)
-            env->raise_name_error(name, "undefined method `{}' for class `{}'", name->string(), inspect_str());
+            env->raise_name_error(name, "undefined method `{}' for class `{}'", name->string(), inspect_string());
         else
-            env->raise_name_error(name, "undefined method `{}' for module `{}'", name->string(), inspect_str());
+            env->raise_name_error(name, "undefined method `{}' for module `{}'", name->string(), inspect_string());
     }
 }
 
@@ -620,14 +620,14 @@ Value ModuleObject::public_instance_method(Env *env, Value name_value) {
         return new UnboundMethodObject { this, method_info.method() };
     case MethodVisibility::Protected:
         if (type() == Type::Class)
-            env->raise_name_error(name, "method `{}' for class `{}' is protected", name->string(), inspect_str());
+            env->raise_name_error(name, "method `{}' for class `{}' is protected", name->string(), inspect_string());
         else
-            env->raise_name_error(name, "method `{}' for module `{}' is protected", name->string(), inspect_str());
+            env->raise_name_error(name, "method `{}' for module `{}' is protected", name->string(), inspect_string());
     case MethodVisibility::Private:
         if (type() == Type::Class)
-            env->raise_name_error(name, "method `{}' for class `{}' is private", name->string(), inspect_str());
+            env->raise_name_error(name, "method `{}' for class `{}' is private", name->string(), inspect_string());
         else
-            env->raise_name_error(name, "method `{}' for module `{}' is private", name->string(), inspect_str());
+            env->raise_name_error(name, "method `{}' for module `{}' is private", name->string(), inspect_string());
     default:
         NAT_UNREACHABLE();
     }
@@ -734,10 +734,10 @@ bool ModuleObject::is_method_defined(Env *env, Value name_value) const {
     return !!find_method(env, name);
 }
 
-String ModuleObject::inspect_str() const {
+String ModuleObject::inspect_string() const {
     if (m_name) {
         if (owner() && owner() != GlobalEnv::the()->Object()) {
-            return String::format("{}::{}", owner()->inspect_str(), m_name.value());
+            return String::format("{}::{}", owner()->inspect_string(), m_name.value());
         } else {
             return String(m_name.value());
         }
@@ -746,12 +746,12 @@ String ModuleObject::inspect_str() const {
     } else if (type() == Type::Module && m_name) {
         return String(m_name.value());
     } else {
-        return String::format("#<{}:{}>", klass()->inspect_str(), pointer_id());
+        return String::format("#<{}:{}>", klass()->inspect_string(), pointer_id());
     }
 }
 
 Value ModuleObject::inspect(Env *env) const {
-    return new StringObject { inspect_str() };
+    return new StringObject { inspect_string() };
 }
 
 Value ModuleObject::name(Env *env) const {
@@ -773,7 +773,7 @@ Value ModuleObject::name(Env *env) const {
 
 String ModuleObject::backtrace_name() const {
     if (!m_name)
-        return inspect_str();
+        return inspect_string();
     return String::format("<module:{}>", m_name.value());
 }
 
@@ -904,14 +904,14 @@ Value ModuleObject::define_method(Env *env, Value name_value, Optional<Value> me
             } else if (method_value.is_unbound_method()) {
                 method = method_value.as_unbound_method()->method();
             } else {
-                env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod)", method_value.klass()->inspect_str());
+                env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod)", method_value.klass()->inspect_string());
             }
             ModuleObject *owner = method->owner();
             if (owner != this && owner->type() == Type::Class && !owner->is_subclass_of(this)) {
                 if (owner->as_class()->is_singleton())
                     env->raise("TypeError", "can't bind singleton method to a different class");
                 else
-                    env->raise("TypeError", "bind argument must be a subclass of {}", owner->inspect_str());
+                    env->raise("TypeError", "bind argument must be a subclass of {}", owner->inspect_string());
             }
             define_method(env, name, method->fn(), method->arity());
         }
@@ -1027,7 +1027,7 @@ Value ModuleObject::deprecate_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
         constant->set_deprecated(true);
     }
     return this;
@@ -1038,7 +1038,7 @@ Value ModuleObject::private_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
         constant->set_private(true);
     }
     return this;
@@ -1049,7 +1049,7 @@ Value ModuleObject::public_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_str(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
         constant->set_private(false);
     }
     return this;
@@ -1084,7 +1084,7 @@ Value ModuleObject::remove_method(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto method = m_methods.get(name, env);
         if (!method)
-            env->raise_name_error(name, "method `{}' not defined in {}", name->string(), this->inspect_str());
+            env->raise_name_error(name, "method `{}' not defined in {}", name->string(), this->inspect_string());
         m_methods.remove(name, env);
     }
     return this;

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -754,12 +754,6 @@ Value ModuleObject::inspect(Env *env) const {
     return new StringObject { inspect_str() };
 }
 
-String ModuleObject::dbg_inspect() const {
-    if (m_name)
-        return String::format("\"{}\"", m_name.value());
-    return Object::dbg_inspect();
-}
-
 Value ModuleObject::name(Env *env) const {
     if (m_name) {
         String name = m_name.value();

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -121,13 +121,13 @@ Constant *ModuleObject::find_constant(Env *env, SymbolObject *name, ModuleObject
         = [&](Constant *constant) {
               if (search_mode == ConstLookupSearchMode::Strict && constant->is_private()) {
                   if (search_parent && search_parent != GlobalEnv::the()->Object())
-                      env->raise_name_error(name, "private constant {}::{} referenced", search_parent->inspect_string(), name->string());
+                      env->raise_name_error(name, "private constant {}::{} referenced", search_parent->inspect_module(), name->string());
                   else
                       env->raise_name_error(name, "private constant ::{} referenced", name->string());
               }
               if (constant->is_deprecated()) {
                   if (search_parent && search_parent != GlobalEnv::the()->Object())
-                      env->deprecation_warn("constant {}::{} is deprecated", search_parent->inspect_string(), name->string());
+                      env->deprecation_warn("constant {}::{} is deprecated", search_parent->inspect_module(), name->string());
                   else
                       env->deprecation_warn("constant ::{} is deprecated", name->string());
               }
@@ -259,7 +259,7 @@ Optional<Value> ModuleObject::handle_missing_constant(Env *env, Value name, Cons
         auto name_str = name.to_s(env);
         if (this == GlobalEnv::the()->Object())
             env->raise_name_error(name_str, "uninitialized constant {}", name_str->string());
-        env->raise_name_error(name_str, "uninitialized constant {}::{}", inspect_string(), name_str->string());
+        env->raise_name_error(name_str, "uninitialized constant {}::{}", inspect_module(), name_str->string());
     }
 
     return send(env, "const_missing"_s, { name });
@@ -446,7 +446,7 @@ Value ModuleObject::class_variable_get(Env *env, Value name) {
 
     auto val = cvar_get_maybe(env, name_sym);
     if (!val) {
-        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_string());
+        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_module());
     }
     return val.value();
 }
@@ -483,7 +483,7 @@ Value ModuleObject::remove_class_variable(Env *env, Value name) {
 
     auto val = cvar_get_maybe(env, name_sym);
     if (!val)
-        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_string());
+        env->raise_name_error(name_sym, "uninitialized class variable {} in {}", name_sym->string(), inspect_module());
 
     m_class_vars.remove(name_sym);
 
@@ -597,9 +597,9 @@ MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, const 
 void ModuleObject::assert_method_defined(Env *env, SymbolObject *name, MethodInfo method_info) {
     if (!method_info.is_defined()) {
         if (type() == Type::Class)
-            env->raise_name_error(name, "undefined method `{}' for class `{}'", name->string(), inspect_string());
+            env->raise_name_error(name, "undefined method `{}' for class `{}'", name->string(), inspect_module());
         else
-            env->raise_name_error(name, "undefined method `{}' for module `{}'", name->string(), inspect_string());
+            env->raise_name_error(name, "undefined method `{}' for module `{}'", name->string(), inspect_module());
     }
 }
 
@@ -620,14 +620,14 @@ Value ModuleObject::public_instance_method(Env *env, Value name_value) {
         return new UnboundMethodObject { this, method_info.method() };
     case MethodVisibility::Protected:
         if (type() == Type::Class)
-            env->raise_name_error(name, "method `{}' for class `{}' is protected", name->string(), inspect_string());
+            env->raise_name_error(name, "method `{}' for class `{}' is protected", name->string(), inspect_module());
         else
-            env->raise_name_error(name, "method `{}' for module `{}' is protected", name->string(), inspect_string());
+            env->raise_name_error(name, "method `{}' for module `{}' is protected", name->string(), inspect_module());
     case MethodVisibility::Private:
         if (type() == Type::Class)
-            env->raise_name_error(name, "method `{}' for class `{}' is private", name->string(), inspect_string());
+            env->raise_name_error(name, "method `{}' for class `{}' is private", name->string(), inspect_module());
         else
-            env->raise_name_error(name, "method `{}' for module `{}' is private", name->string(), inspect_string());
+            env->raise_name_error(name, "method `{}' for module `{}' is private", name->string(), inspect_module());
     default:
         NAT_UNREACHABLE();
     }
@@ -734,10 +734,10 @@ bool ModuleObject::is_method_defined(Env *env, Value name_value) const {
     return !!find_method(env, name);
 }
 
-String ModuleObject::inspect_string() const {
+String ModuleObject::inspect_module() const {
     if (m_name) {
         if (owner() && owner() != GlobalEnv::the()->Object()) {
-            return String::format("{}::{}", owner()->inspect_string(), m_name.value());
+            return String::format("{}::{}", owner()->inspect_module(), m_name.value());
         } else {
             return String(m_name.value());
         }
@@ -746,12 +746,12 @@ String ModuleObject::inspect_string() const {
     } else if (type() == Type::Module && m_name) {
         return String(m_name.value());
     } else {
-        return String::format("#<{}:{}>", klass()->inspect_string(), pointer_id());
+        return String::format("#<{}:{}>", klass()->inspect_module(), pointer_id());
     }
 }
 
 Value ModuleObject::inspect(Env *env) const {
-    return new StringObject { inspect_string() };
+    return new StringObject { inspect_module() };
 }
 
 Value ModuleObject::name(Env *env) const {
@@ -773,7 +773,7 @@ Value ModuleObject::name(Env *env) const {
 
 String ModuleObject::backtrace_name() const {
     if (!m_name)
-        return inspect_string();
+        return inspect_module();
     return String::format("<module:{}>", m_name.value());
 }
 
@@ -904,14 +904,14 @@ Value ModuleObject::define_method(Env *env, Value name_value, Optional<Value> me
             } else if (method_value.is_unbound_method()) {
                 method = method_value.as_unbound_method()->method();
             } else {
-                env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod)", method_value.klass()->inspect_string());
+                env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod)", method_value.klass()->inspect_module());
             }
             ModuleObject *owner = method->owner();
             if (owner != this && owner->type() == Type::Class && !owner->is_subclass_of(this)) {
                 if (owner->as_class()->is_singleton())
                     env->raise("TypeError", "can't bind singleton method to a different class");
                 else
-                    env->raise("TypeError", "bind argument must be a subclass of {}", owner->inspect_string());
+                    env->raise("TypeError", "bind argument must be a subclass of {}", owner->inspect_module());
             }
             define_method(env, name, method->fn(), method->arity());
         }
@@ -1027,7 +1027,7 @@ Value ModuleObject::deprecate_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_module(), name->string());
         constant->set_deprecated(true);
     }
     return this;
@@ -1038,7 +1038,7 @@ Value ModuleObject::private_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_module(), name->string());
         constant->set_private(true);
     }
     return this;
@@ -1049,7 +1049,7 @@ Value ModuleObject::public_constant(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto constant = m_constants.get(name);
         if (!constant)
-            env->raise_name_error(name, "constant {}::{} not defined", inspect_string(), name->string());
+            env->raise_name_error(name, "constant {}::{} not defined", inspect_module(), name->string());
         constant->set_private(false);
     }
     return this;
@@ -1084,7 +1084,7 @@ Value ModuleObject::remove_method(Env *env, Args &&args) {
         auto name = args[i].to_symbol(env, Value::Conversion::Strict);
         auto method = m_methods.get(name, env);
         if (!method)
-            env->raise_name_error(name, "method `{}' not defined in {}", name->string(), this->inspect_string());
+            env->raise_name_error(name, "method `{}' not defined in {}", name->string(), this->inspect_module());
         m_methods.remove(name, env);
     }
     return this;

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -545,7 +545,7 @@ Value is_case_equal(Env *env, Value case_value, Value when_value, bool is_splat)
             auto original_class = when_value.klass();
             when_value = when_value.send(env, "to_a"_s);
             if (!when_value.is_array()) {
-                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", original_class->inspect_string(), original_class->inspect_string(), when_value.klass()->inspect_string());
+                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", original_class->inspect_module(), original_class->inspect_module(), when_value.klass()->inspect_module());
             }
         }
         if (when_value.is_array()) {
@@ -598,7 +598,7 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception, Thread
     auto formatted = StringObject::format(
         "{} ({})",
         exception->to_s(env)->c_str(),
-        exception->klass()->inspect_string());
+        exception->klass()->inspect_module());
     out.send(env, "puts"_s, { formatted });
 }
 
@@ -647,8 +647,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
             if (array.is_array()) {
                 return array.as_array();
             } else if (raise_for_non_array) {
-                auto class_name = obj.klass()->inspect_string();
-                env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, array.klass()->inspect_string());
+                auto class_name = obj.klass()->inspect_module();
+                env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, array.klass()->inspect_module());
             }
         }
     }
@@ -659,8 +659,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
             if (array.is_array()) {
                 return array.as_array();
             } else if (raise_for_non_array) {
-                auto class_name = obj.klass()->inspect_string();
-                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_string());
+                auto class_name = obj.klass()->inspect_module();
+                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_module());
             }
         }
     }
@@ -682,8 +682,8 @@ Value to_ary_for_masgn(Env *env, Value obj) {
         if (array.is_array()) {
             return array->duplicate(env).as_array();
         } else if (!array.is_nil()) {
-            auto class_name = obj.klass()->inspect_string();
-            env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_string());
+            auto class_name = obj.klass()->inspect_module();
+            env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_module());
         }
     }
 
@@ -863,7 +863,7 @@ Value super(Env *env, Value self, Args &&args, Block *block) {
     auto super_method = klass->find_method(env, SymbolObject::intern(after_method->name()), after_method);
     if (!super_method.is_defined()) {
         if (self.is_module()) {
-            env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self.as_module()->inspect_string(), self.klass()->inspect_string());
+            env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self.as_module()->inspect_module(), self.klass()->inspect_module());
         } else {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self.inspected(env));
         }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -576,7 +576,7 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception, Thread
     auto out = env->global_get("$stderr"_s);
 
     if (thread) {
-        auto formatted = StringObject::format("{} terminated with exception (report_on_exception is true):", thread->inspect_str(env));
+        auto formatted = StringObject::format("{} terminated with exception (report_on_exception is true):", thread->inspected(env));
         out.send(env, "puts"_s, { formatted });
     }
 
@@ -865,7 +865,7 @@ Value super(Env *env, Value self, Args &&args, Block *block) {
         if (self.is_module()) {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self.as_module()->inspect_string(), self.klass()->inspect_string());
         } else {
-            env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self.inspect_str(env));
+            env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self.inspected(env));
         }
     }
     assert(super_method.method() != current_method);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -545,7 +545,7 @@ Value is_case_equal(Env *env, Value case_value, Value when_value, bool is_splat)
             auto original_class = when_value.klass();
             when_value = when_value.send(env, "to_a"_s);
             if (!when_value.is_array()) {
-                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", original_class->inspect_str(), original_class->inspect_str(), when_value.klass()->inspect_str());
+                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", original_class->inspect_string(), original_class->inspect_string(), when_value.klass()->inspect_string());
             }
         }
         if (when_value.is_array()) {
@@ -598,7 +598,7 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception, Thread
     auto formatted = StringObject::format(
         "{} ({})",
         exception->to_s(env)->c_str(),
-        exception->klass()->inspect_str());
+        exception->klass()->inspect_string());
     out.send(env, "puts"_s, { formatted });
 }
 
@@ -647,8 +647,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
             if (array.is_array()) {
                 return array.as_array();
             } else if (raise_for_non_array) {
-                auto class_name = obj.klass()->inspect_str();
-                env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, array.klass()->inspect_str());
+                auto class_name = obj.klass()->inspect_string();
+                env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, array.klass()->inspect_string());
             }
         }
     }
@@ -659,8 +659,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
             if (array.is_array()) {
                 return array.as_array();
             } else if (raise_for_non_array) {
-                auto class_name = obj.klass()->inspect_str();
-                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_str());
+                auto class_name = obj.klass()->inspect_string();
+                env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_string());
             }
         }
     }
@@ -682,8 +682,8 @@ Value to_ary_for_masgn(Env *env, Value obj) {
         if (array.is_array()) {
             return array->duplicate(env).as_array();
         } else if (!array.is_nil()) {
-            auto class_name = obj.klass()->inspect_str();
-            env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_str());
+            auto class_name = obj.klass()->inspect_string();
+            env->raise("TypeError", "can't convert {} to Array ({}#to_a gives {})", class_name, class_name, array.klass()->inspect_string());
         }
     }
 
@@ -863,7 +863,7 @@ Value super(Env *env, Value self, Args &&args, Block *block) {
     auto super_method = klass->find_method(env, SymbolObject::intern(after_method->name()), after_method);
     if (!super_method.is_defined()) {
         if (self.is_module()) {
-            env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self.as_module()->inspect_str(), self.klass()->inspect_str());
+            env->raise("NoMethodError", "super: no superclass method '{}' for {}:{}", current_method->original_name(), self.as_module()->inspect_string(), self.klass()->inspect_string());
         } else {
             env->raise("NoMethodError", "super: no superclass method '{}' for {}", current_method->original_name(), self.inspect_str(env));
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -216,7 +216,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
     if (self.is_module()) {
         name = String::format("#<Class:{}>", self.as_module()->inspect_string());
     } else if (self.respond_to(env, "inspect"_s)) {
-        name = String::format("#<Class:{}>", self.inspect_str(env));
+        name = String::format("#<Class:{}>", self.inspected(env));
     }
 
     ClassObject *singleton_superclass;
@@ -278,7 +278,7 @@ Value Object::const_set(Env *env, Value ns, SymbolObject *name, Value val) {
     else if (ns == GlobalEnv::the()->main_obj())
         return GlobalEnv::the()->Object()->const_set(name, val);
     else
-        env->raise("TypeError", "{} is not a class/module", ns.inspect_str(env));
+        env->raise("TypeError", "{} is not a class/module", ns.inspected(env));
 }
 
 Value Object::const_set(Env *env, Value ns, SymbolObject *name, MethodFnPtr autoload_fn, StringObject *autoload_path) {
@@ -287,7 +287,7 @@ Value Object::const_set(Env *env, Value ns, SymbolObject *name, MethodFnPtr auto
     else if (ns == GlobalEnv::the()->main_obj())
         return GlobalEnv::the()->Object()->const_set(name, autoload_fn, autoload_path);
     else
-        env->raise("TypeError", "{} is not a class/module", ns.inspect_str(env));
+        env->raise("TypeError", "{} is not a class/module", ns.inspected(env));
 }
 
 bool Object::ivar_defined(Env *env, Value self, SymbolObject *name) {
@@ -793,7 +793,7 @@ Value Object::instance_exec(Env *env, Value self, Args &&args, Block *block) {
 
 void Object::assert_not_frozen(Env *env) {
     if (is_frozen()) {
-        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_string(), inspect_str(env));
+        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_string(), inspected(env));
     } else if (m_type == Type::String && static_cast<StringObject *>(this)->is_chilled()) {
         if (static_cast<StringObject *>(this)->chilled() == StringObject::Chilled::String) {
             env->deprecation_warn("literal string will be frozen in the future");
@@ -807,7 +807,7 @@ void Object::assert_not_frozen(Env *env) {
 void Object::assert_not_frozen(Env *env, Value receiver) {
     if (is_frozen()) {
         auto FrozenError = GlobalEnv::the()->Object()->const_fetch("FrozenError"_s);
-        String message = String::format("can't modify frozen {}: {}", klass()->inspect_string(), inspect_str(env));
+        String message = String::format("can't modify frozen {}: {}", klass()->inspect_string(), inspected(env));
         auto kwargs = new HashObject(env, { "receiver"_s, receiver });
         auto args = Args({ new StringObject { message }, kwargs }, true);
         ExceptionObject *error = FrozenError.send(env, "new"_s, std::move(args)).as_exception();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -161,7 +161,7 @@ Value Object::allocate(Env *env, Value klass_value, Args &&args, Block *block) {
 
     ClassObject *klass = klass_value.as_class();
     if (!klass->respond_to(env, "allocate"_s))
-        env->raise("TypeError", "calling {}.allocate is prohibited", klass->inspect_string());
+        env->raise("TypeError", "calling {}.allocate is prohibited", klass->inspect_module());
 
     Optional<Value> obj;
     switch (klass->object_type()) {
@@ -175,7 +175,7 @@ Value Object::allocate(Env *env, Value klass_value, Args &&args, Block *block) {
     }
 
     if (!obj)
-        env->raise("TypeError", "allocator undefined for {}", klass->inspect_string());
+        env->raise("TypeError", "allocator undefined for {}", klass->inspect_module());
 
     return obj.value();
 }
@@ -214,7 +214,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
 
     String name;
     if (self.is_module()) {
-        name = String::format("#<Class:{}>", self.as_module()->inspect_string());
+        name = String::format("#<Class:{}>", self.as_module()->inspect_module());
     } else if (self.respond_to(env, "inspect"_s)) {
         name = String::format("#<Class:{}>", self.inspected(env));
     }
@@ -242,7 +242,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
 
 ClassObject *Object::subclass(Env *env, Value superclass, const char *name) {
     if (!superclass.is_class())
-        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_string());
+        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_module());
     return superclass.as_class()->subclass(env, name);
 }
 
@@ -398,7 +398,7 @@ Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
             module = static_cast<ModuleObject *>(this);
         else
             module = m_klass;
-        env->raise_name_error(name, "uninitialized class variable {} in {}", name->string(), module->inspect_string());
+        env->raise_name_error(name, "uninitialized class variable {} in {}", name->string(), module->inspect_module());
     }
 }
 
@@ -564,7 +564,7 @@ Value Object::method_missing(Env *env, Value self, Args &&args, Block *block) {
     if (args.size() == 0) {
         env->raise("ArgError", "no method name given");
     } else if (!args[0].is_symbol()) {
-        env->raise("ArgError", "method name must be a Symbol but {} is given", args[0].klass()->inspect_string());
+        env->raise("ArgError", "method name must be a Symbol but {} is given", args[0].klass()->inspect_module());
     } else {
         auto name = args[0].as_symbol();
         env = env->caller();
@@ -653,7 +653,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::MatchData:
         return new MatchDataObject { *static_cast<const MatchDataObject *>(this) };
     default:
-        fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_string().c_str(), static_cast<int>(m_type));
+        fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_module().c_str(), static_cast<int>(m_type));
         abort();
     }
 }
@@ -665,7 +665,7 @@ Value Object::clone(Env *env, Optional<Value> freeze_arg) {
         if (freeze.is_false()) {
             freeze_bool = false;
         } else if (!freeze.is_true() && !freeze.is_nil()) {
-            env->raise("ArgumentError", "unexpected value for freeze: {}", freeze.klass()->inspect_string());
+            env->raise("ArgumentError", "unexpected value for freeze: {}", freeze.klass()->inspect_module());
         }
     }
 
@@ -748,7 +748,7 @@ ProcObject *Object::to_proc(Env *env) {
     if (respond_to(env, to_proc_symbol)) {
         return send(env, to_proc_symbol).as_proc();
     } else {
-        env->raise("TypeError", "wrong argument type {} (expected Proc)", m_klass->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Proc)", m_klass->inspect_module());
     }
 }
 
@@ -793,7 +793,7 @@ Value Object::instance_exec(Env *env, Value self, Args &&args, Block *block) {
 
 void Object::assert_not_frozen(Env *env) {
     if (is_frozen()) {
-        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_string(), inspected(env));
+        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_module(), inspected(env));
     } else if (m_type == Type::String && static_cast<StringObject *>(this)->is_chilled()) {
         if (static_cast<StringObject *>(this)->chilled() == StringObject::Chilled::String) {
             env->deprecation_warn("literal string will be frozen in the future");
@@ -807,7 +807,7 @@ void Object::assert_not_frozen(Env *env) {
 void Object::assert_not_frozen(Env *env, Value receiver) {
     if (is_frozen()) {
         auto FrozenError = GlobalEnv::the()->Object()->const_fetch("FrozenError"_s);
-        String message = String::format("can't modify frozen {}: {}", klass()->inspect_string(), inspected(env));
+        String message = String::format("can't modify frozen {}: {}", klass()->inspect_module(), inspected(env));
         auto kwargs = new HashObject(env, { "receiver"_s, receiver });
         auto args = Args({ new StringObject { message }, kwargs }, true);
         ExceptionObject *error = FrozenError.send(env, "new"_s, std::move(args)).as_exception();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -832,9 +832,9 @@ bool Object::neq(Env *env, Value self, Value other) {
     return self.send(env, "=="_s, { other }).is_falsey();
 }
 
-String Object::dbg_inspect() const {
-    auto klass = m_klass->name();
-    return String::format("<{} {h}>", klass.value_or("Object"), this);
+String Object::dbg_inspect(int indent) const {
+    auto name = m_klass->name();
+    return String::format("<{} {h}>", name.value_or("Object"), this);
 }
 
 Value Object::enum_for(Env *env, const char *method, Args &&args) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -834,10 +834,7 @@ bool Object::neq(Env *env, Value self, Value other) {
 
 String Object::dbg_inspect() const {
     auto klass = m_klass->name();
-    return String::format(
-        "#<{}:{}>",
-        klass ? *klass : "Object",
-        String::hex(reinterpret_cast<nat_int_t>(this), String::HexFormat::LowercaseAndPrefixed));
+    return String::format("<{} {h}>", klass.value_or("Object"), this);
 }
 
 Value Object::enum_for(Env *env, const char *method, Args &&args) {
@@ -859,10 +856,6 @@ void Object::visit_children(Visitor &visitor) const {
                 visitor.visit(pair.second.value());
         }
     }
-}
-
-void Object::gc_inspect(char *buf, size_t len) const {
-    snprintf(buf, len, "<Object %p type=%d class=%p>", this, (int)m_type, m_klass);
 }
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -161,7 +161,7 @@ Value Object::allocate(Env *env, Value klass_value, Args &&args, Block *block) {
 
     ClassObject *klass = klass_value.as_class();
     if (!klass->respond_to(env, "allocate"_s))
-        env->raise("TypeError", "calling {}.allocate is prohibited", klass->inspect_str());
+        env->raise("TypeError", "calling {}.allocate is prohibited", klass->inspect_string());
 
     Optional<Value> obj;
     switch (klass->object_type()) {
@@ -175,7 +175,7 @@ Value Object::allocate(Env *env, Value klass_value, Args &&args, Block *block) {
     }
 
     if (!obj)
-        env->raise("TypeError", "allocator undefined for {}", klass->inspect_str());
+        env->raise("TypeError", "allocator undefined for {}", klass->inspect_string());
 
     return obj.value();
 }
@@ -214,7 +214,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
 
     String name;
     if (self.is_module()) {
-        name = String::format("#<Class:{}>", self.as_module()->inspect_str());
+        name = String::format("#<Class:{}>", self.as_module()->inspect_string());
     } else if (self.respond_to(env, "inspect"_s)) {
         name = String::format("#<Class:{}>", self.inspect_str(env));
     }
@@ -242,7 +242,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
 
 ClassObject *Object::subclass(Env *env, Value superclass, const char *name) {
     if (!superclass.is_class())
-        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_str());
+        env->raise("TypeError", "superclass must be an instance of Class (given an instance of {})", superclass.klass()->inspect_string());
     return superclass.as_class()->subclass(env, name);
 }
 
@@ -398,7 +398,7 @@ Value Object::cvar_get_or_raise(Env *env, SymbolObject *name) {
             module = static_cast<ModuleObject *>(this);
         else
             module = m_klass;
-        env->raise_name_error(name, "uninitialized class variable {} in {}", name->string(), module->inspect_str());
+        env->raise_name_error(name, "uninitialized class variable {} in {}", name->string(), module->inspect_string());
     }
 }
 
@@ -564,7 +564,7 @@ Value Object::method_missing(Env *env, Value self, Args &&args, Block *block) {
     if (args.size() == 0) {
         env->raise("ArgError", "no method name given");
     } else if (!args[0].is_symbol()) {
-        env->raise("ArgError", "method name must be a Symbol but {} is given", args[0].klass()->inspect_str());
+        env->raise("ArgError", "method name must be a Symbol but {} is given", args[0].klass()->inspect_string());
     } else {
         auto name = args[0].as_symbol();
         env = env->caller();
@@ -653,7 +653,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::MatchData:
         return new MatchDataObject { *static_cast<const MatchDataObject *>(this) };
     default:
-        fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_str().c_str(), static_cast<int>(m_type));
+        fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_string().c_str(), static_cast<int>(m_type));
         abort();
     }
 }
@@ -665,7 +665,7 @@ Value Object::clone(Env *env, Optional<Value> freeze_arg) {
         if (freeze.is_false()) {
             freeze_bool = false;
         } else if (!freeze.is_true() && !freeze.is_nil()) {
-            env->raise("ArgumentError", "unexpected value for freeze: {}", freeze.klass()->inspect_str());
+            env->raise("ArgumentError", "unexpected value for freeze: {}", freeze.klass()->inspect_string());
         }
     }
 
@@ -748,7 +748,7 @@ ProcObject *Object::to_proc(Env *env) {
     if (respond_to(env, to_proc_symbol)) {
         return send(env, to_proc_symbol).as_proc();
     } else {
-        env->raise("TypeError", "wrong argument type {} (expected Proc)", m_klass->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Proc)", m_klass->inspect_string());
     }
 }
 
@@ -793,7 +793,7 @@ Value Object::instance_exec(Env *env, Value self, Args &&args, Block *block) {
 
 void Object::assert_not_frozen(Env *env) {
     if (is_frozen()) {
-        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_str(), inspect_str(env));
+        env->raise("FrozenError", "can't modify frozen {}: {}", klass()->inspect_string(), inspect_str(env));
     } else if (m_type == Type::String && static_cast<StringObject *>(this)->is_chilled()) {
         if (static_cast<StringObject *>(this)->chilled() == StringObject::Chilled::String) {
             env->deprecation_warn("literal string will be frozen in the future");
@@ -807,7 +807,7 @@ void Object::assert_not_frozen(Env *env) {
 void Object::assert_not_frozen(Env *env, Value receiver) {
     if (is_frozen()) {
         auto FrozenError = GlobalEnv::the()->Object()->const_fetch("FrozenError"_s);
-        String message = String::format("can't modify frozen {}: {}", klass()->inspect_str(), inspect_str(env));
+        String message = String::format("can't modify frozen {}: {}", klass()->inspect_string(), inspect_str(env));
         auto kwargs = new HashObject(env, { "receiver"_s, receiver });
         auto args = Args({ new StringObject { message }, kwargs }, true);
         ExceptionObject *error = FrozenError.send(env, "new"_s, std::move(args)).as_exception();

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -96,7 +96,7 @@ StringObject *ProcObject::to_s(Env *env) {
         suffix.append(" (lambda)");
     if (m_block->self().is_symbol())
         suffix.append(String::format(" (&:{})", m_block->self().as_symbol()->string()));
-    auto str = String::format("#<{}:{}{}>", m_klass->inspect_str(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
+    auto str = String::format("#<{}:{}{}>", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
     return new StringObject { std::move(str), Encoding::ASCII_8BIT };
 }
 

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -96,7 +96,7 @@ StringObject *ProcObject::to_s(Env *env) {
         suffix.append(" (lambda)");
     if (m_block->self().is_symbol())
         suffix.append(String::format(" (&:{})", m_block->self().as_symbol()->string()));
-    auto str = String::format("#<{}:{}{}>", m_klass->inspect_string(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
+    auto str = String::format("#<{}:{}{}>", m_klass->inspect_module(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
     return new StringObject { std::move(str), Encoding::ASCII_8BIT };
 }
 

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -59,7 +59,7 @@ Value ProcessModule::kill(Env *env, Args &&args) {
             env->raise("ArgumentError", "unsupported signal `SIG{}'", signame.to_s(env)->string());
         signo = IntegerMethods::convert_to_nat_int_t(env, signo_val);
     } else {
-        env->raise("ArgumentError", "bad signal type {}", signal.klass()->inspect_string());
+        env->raise("ArgumentError", "bad signal type {}", signal.klass()->inspect_module());
     }
     const auto own_pid = getpid();
     for (Value pid : *pids) {

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -88,7 +88,7 @@ long ProcessModule::maxgroups() {
 Value ProcessModule::setmaxgroups(Env *env, Value val) {
     Value int_val = val.to_int(env);
     if (int_val.send(env, "positive?"_s).is_falsey())
-        env->raise("ArgumentError", "maxgroups {} should be positive", int_val.inspect_str(env));
+        env->raise("ArgumentError", "maxgroups {} should be positive", int_val.inspected(env));
     const long actual_maxgroups = sysconf(_SC_NGROUPS_MAX);
     globals::maxgroups = std::min(IntegerMethods::convert_to_native_type<long>(env, int_val), actual_maxgroups);
     return val;

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -59,7 +59,7 @@ Value ProcessModule::kill(Env *env, Args &&args) {
             env->raise("ArgumentError", "unsupported signal `SIG{}'", signame.to_s(env)->string());
         signo = IntegerMethods::convert_to_nat_int_t(env, signo_val);
     } else {
-        env->raise("ArgumentError", "bad signal type {}", signal.klass()->inspect_str());
+        env->raise("ArgumentError", "bad signal type {}", signal.klass()->inspect_string());
     }
     const auto own_pid = getpid();
     for (Value pid : *pids) {

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -41,7 +41,7 @@ Value RandomObject::rand(Env *env, Optional<Value> max_arg) {
         if (arg.is_float()) {
             double max = arg.as_float()->to_double();
             if (max <= 0) {
-                env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
+                env->raise("ArgumentError", "invalid argument - {}", arg.inspected(env));
             }
             return generate_random(0.0, max);
         } else if (arg.is_range()) {
@@ -51,7 +51,7 @@ Value RandomObject::rand(Env *env, Optional<Value> max_arg) {
             // I'm not sure how we should handle those though (coerce via to_int or to_f?)
             if (min.is_numeric() && max.is_numeric()) {
                 if (min.send(env, ">"_s, { max }).is_true()) {
-                    env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
+                    env->raise("ArgumentError", "invalid argument - {}", arg.inspected(env));
                 }
 
                 if (min.is_float() || max.is_float()) {
@@ -93,7 +93,7 @@ Value RandomObject::rand(Env *env, Optional<Value> max_arg) {
 
         nat_int_t max = IntegerMethods::convert_to_nat_int_t(env, arg);
         if (max <= 0) {
-            env->raise("ArgumentError", "invalid argument - {}", arg.inspect_str(env));
+            env->raise("ArgumentError", "invalid argument - {}", arg.inspected(env));
         }
         return generate_random(0, max - 1);
     } else {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -216,13 +216,13 @@ Value RangeObject::inspect(Env *env) {
             if (m_begin.is_nil()) {
                 return new StringObject { "nil...nil" };
             } else {
-                return StringObject::format("{}...", m_begin.inspect_str(env));
+                return StringObject::format("{}...", m_begin.inspected(env));
             }
         } else {
             if (m_begin.is_nil()) {
-                return StringObject::format("...{}", m_end.inspect_str(env));
+                return StringObject::format("...{}", m_end.inspected(env));
             } else {
-                return StringObject::format("{}...{}", m_begin.inspect_str(env), m_end.inspect_str(env));
+                return StringObject::format("{}...{}", m_begin.inspected(env), m_end.inspected(env));
             }
         }
     } else {
@@ -230,13 +230,13 @@ Value RangeObject::inspect(Env *env) {
             if (m_begin.is_nil()) {
                 return new StringObject { "nil..nil" };
             } else {
-                return StringObject::format("{}..", m_begin.inspect_str(env));
+                return StringObject::format("{}..", m_begin.inspected(env));
             }
         } else {
             if (m_begin.is_nil()) {
-                return StringObject::format("..{}", m_end.inspect_str(env));
+                return StringObject::format("..{}", m_end.inspected(env));
             } else {
-                return StringObject::format("{}..{}", m_begin.inspect_str(env), m_end.inspect_str(env));
+                return StringObject::format("{}..{}", m_begin.inspected(env), m_end.inspected(env));
             }
         }
     }

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -36,7 +36,7 @@ Optional<Value> RangeObject::iterate_over_range(Env *env, Function &&func) {
 
     auto succ = "succ"_s;
     if (!m_begin.respond_to(env, succ))
-        env->raise("TypeError", "can't iterate from {}", m_begin.klass()->inspect_str());
+        env->raise("TypeError", "can't iterate from {}", m_begin.klass()->inspect_string());
 
     if (m_begin.is_string() && m_end.is_string())
         return iterate_over_string_range(env, func);
@@ -332,7 +332,7 @@ bool RangeObject::include(Env *env, Value arg) {
 
 Value RangeObject::bsearch(Env *env, Block *block) {
     if ((!m_begin.is_numeric() && !m_begin.is_nil()) || (!m_end.is_numeric() && !m_end.is_nil()))
-        env->raise("TypeError", "can't do binary search for {}", m_begin.klass()->inspect_str());
+        env->raise("TypeError", "can't do binary search for {}", m_begin.klass()->inspect_string());
 
     if (!block)
         return enum_for(env, "bsearch");
@@ -377,7 +377,7 @@ Value RangeObject::step(Env *env, Optional<Value> n_arg, Block *block) {
     if (!n.is_numeric() && !n.is_nil()) {
         static const auto coerce_sym = "coerce"_s;
         if (!n.respond_to(env, coerce_sym))
-            env->raise("TypeError", "no implicit conversion of {} into Integer", n.klass()->inspect_str());
+            env->raise("TypeError", "no implicit conversion of {} into Integer", n.klass()->inspect_string());
         n = n.send(env, coerce_sym, { Value::integer(0) }).as_array_or_raise(env)->last();
     }
 
@@ -411,7 +411,7 @@ Value RangeObject::step(Env *env, Optional<Value> n_arg, Block *block) {
         //   - It only appears for floats (not for rational for example)
         //   - Class names are written in lower case?
         if (n.is_float())
-            env->raise("TypeError", "no implicit conversion to float from {}", m_begin.klass()->inspect_str().lowercase());
+            env->raise("TypeError", "no implicit conversion to float from {}", m_begin.klass()->inspect_string().lowercase());
 
         auto step = n.to_int(env);
 

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -253,22 +253,8 @@ Value RangeObject::last(Env *env, Optional<Value> n) {
 }
 
 String RangeObject::dbg_inspect() const {
-    String str;
-    auto append = [&](Value v) {
-        if (v.is_integer()) {
-            str.append(v.integer().to_nat_int_t());
-        } else if (v.is_nil()) {
-            // do nothing
-        } else {
-            auto obj = v.object();
-            assert(obj);
-            str.append(obj->dbg_inspect());
-        }
-    };
-    append(m_begin);
-    str.append(m_exclude_end ? "..." : "..");
-    append(m_end);
-    return str;
+    auto dots = m_exclude_end ? "..." : "..";
+    return String::format("<RangeObject {h} {}{}{}>", this, m_begin.dbg_inspect(), dots, m_end.dbg_inspect());
 }
 
 Value RangeObject::to_s(Env *env) {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -252,9 +252,9 @@ Value RangeObject::last(Env *env, Optional<Value> n) {
     return to_a(env).as_array()->last(env, n);
 }
 
-String RangeObject::dbg_inspect() const {
+String RangeObject::dbg_inspect(int indent) const {
     auto dots = m_exclude_end ? "..." : "..";
-    return String::format("<RangeObject {h} {}{}{}>", this, m_begin.dbg_inspect(), dots, m_end.dbg_inspect());
+    return String::format("<RangeObject {h} {}{}{}>", this, m_begin.dbg_inspect(indent), dots, m_end.dbg_inspect());
 }
 
 Value RangeObject::to_s(Env *env) {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -36,7 +36,7 @@ Optional<Value> RangeObject::iterate_over_range(Env *env, Function &&func) {
 
     auto succ = "succ"_s;
     if (!m_begin.respond_to(env, succ))
-        env->raise("TypeError", "can't iterate from {}", m_begin.klass()->inspect_string());
+        env->raise("TypeError", "can't iterate from {}", m_begin.klass()->inspect_module());
 
     if (m_begin.is_string() && m_end.is_string())
         return iterate_over_string_range(env, func);
@@ -332,7 +332,7 @@ bool RangeObject::include(Env *env, Value arg) {
 
 Value RangeObject::bsearch(Env *env, Block *block) {
     if ((!m_begin.is_numeric() && !m_begin.is_nil()) || (!m_end.is_numeric() && !m_end.is_nil()))
-        env->raise("TypeError", "can't do binary search for {}", m_begin.klass()->inspect_string());
+        env->raise("TypeError", "can't do binary search for {}", m_begin.klass()->inspect_module());
 
     if (!block)
         return enum_for(env, "bsearch");
@@ -377,7 +377,7 @@ Value RangeObject::step(Env *env, Optional<Value> n_arg, Block *block) {
     if (!n.is_numeric() && !n.is_nil()) {
         static const auto coerce_sym = "coerce"_s;
         if (!n.respond_to(env, coerce_sym))
-            env->raise("TypeError", "no implicit conversion of {} into Integer", n.klass()->inspect_string());
+            env->raise("TypeError", "no implicit conversion of {} into Integer", n.klass()->inspect_module());
         n = n.send(env, coerce_sym, { Value::integer(0) }).as_array_or_raise(env)->last();
     }
 
@@ -411,7 +411,7 @@ Value RangeObject::step(Env *env, Optional<Value> n_arg, Block *block) {
         //   - It only appears for floats (not for rational for example)
         //   - Class names are written in lower case?
         if (n.is_float())
-            env->raise("TypeError", "no implicit conversion to float from {}", m_begin.klass()->inspect_string().lowercase());
+            env->raise("TypeError", "no implicit conversion to float from {}", m_begin.klass()->inspect_module().lowercase());
 
         auto step = n.to_int(env);
 

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -37,7 +37,7 @@ Value RationalObject::add(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "+"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
     }
 }
 
@@ -82,7 +82,7 @@ Value RationalObject::coerce(Env *env, Value other) {
         }
     }
 
-    env->raise("TypeError", "{} can't be coerced into {}", other.klass()->inspect_str(), klass()->inspect_str());
+    env->raise("TypeError", "{} can't be coerced into {}", other.klass()->inspect_string(), klass()->inspect_string());
 }
 
 Value RationalObject::denominator(Env *env) {
@@ -110,7 +110,7 @@ Value RationalObject::div(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "/"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
     }
 }
 
@@ -179,7 +179,7 @@ Value RationalObject::mul(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "*"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
     }
 }
 
@@ -203,7 +203,7 @@ Value RationalObject::pow(Env *env, Value other) {
             auto result = Natalie::coerce(env, other, this);
             return result.first.send(env, "**"_s, { result.second });
         } else {
-            env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_str());
+            env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
         }
     }
 
@@ -251,7 +251,7 @@ Value RationalObject::sub(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "-"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
     }
 }
 

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -37,7 +37,7 @@ Value RationalObject::add(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "+"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_module());
     }
 }
 
@@ -82,7 +82,7 @@ Value RationalObject::coerce(Env *env, Value other) {
         }
     }
 
-    env->raise("TypeError", "{} can't be coerced into {}", other.klass()->inspect_string(), klass()->inspect_string());
+    env->raise("TypeError", "{} can't be coerced into {}", other.klass()->inspect_module(), klass()->inspect_module());
 }
 
 Value RationalObject::denominator(Env *env) {
@@ -110,7 +110,7 @@ Value RationalObject::div(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "/"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_module());
     }
 }
 
@@ -179,7 +179,7 @@ Value RationalObject::mul(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "*"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_module());
     }
 }
 
@@ -203,7 +203,7 @@ Value RationalObject::pow(Env *env, Value other) {
             auto result = Natalie::coerce(env, other, this);
             return result.first.send(env, "**"_s, { result.second });
         } else {
-            env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
+            env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_module());
         }
     }
 
@@ -251,7 +251,7 @@ Value RationalObject::sub(Env *env, Value other) {
         auto result = Natalie::coerce(env, other, this);
         return result.first.send(env, "-"_s, { result.second });
     } else {
-        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Rational", other.klass()->inspect_module());
     }
 }
 

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -236,7 +236,7 @@ Value RegexpObject::initialize(Env *env, Value pattern, Optional<Value> opts_arg
                 }
             }
         } else {
-            env->verbose_warn("expected true or false as ignorecase: {}", opts.inspect_str(env));
+            env->verbose_warn("expected true or false as ignorecase: {}", opts.inspected(env));
             if (opts.is_truthy())
                 options = RegexOpts::IgnoreCase;
         }

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -692,7 +692,7 @@ Value RegexpObject::to_s(Env *env) const {
 }
 
 String RegexpObject::dbg_inspect() const {
-    return String::format("/{}/", m_pattern->string());
+    return String::format("<RegexpObject {h} regex=/{}/>", this, m_pattern->string());
 }
 
 }

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -691,7 +691,7 @@ Value RegexpObject::to_s(Env *env) const {
     return out;
 }
 
-String RegexpObject::dbg_inspect() const {
+String RegexpObject::dbg_inspect(int indent) const {
     return String::format("<RegexpObject {h} regex=/{}/>", this, m_pattern->string());
 }
 

--- a/src/rounding_mode.cpp
+++ b/src/rounding_mode.cpp
@@ -9,7 +9,7 @@ RoundingMode rounding_mode_from_value(Env *env, Optional<Value> value_arg, Round
     if (value.is_nil())
         return default_rounding_mode;
     if (!value.is_symbol())
-        env->raise("ArgumentError", "invalid rounding mode: {}", value.inspect_str(env));
+        env->raise("ArgumentError", "invalid rounding mode: {}", value.inspected(env));
 
     auto symbol = value.as_symbol();
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -612,7 +612,7 @@ StringObject *StringObject::inspect(Env *env) const {
 }
 
 String StringObject::dbg_inspect() const {
-    return String::format("\"{}\"", m_string);
+    return String::format("<StringObject {h} string=\"{}\">", this, m_string);
 }
 
 StringObject *StringObject::successive(Env *env) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -611,7 +611,7 @@ StringObject *StringObject::inspect(Env *env) const {
     return new StringObject { std::move(out) };
 }
 
-String StringObject::dbg_inspect() const {
+String StringObject::dbg_inspect(int indent) const {
     return String::format("<StringObject {h} string=\"{}\">", this, m_string);
 }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1422,7 +1422,7 @@ Value StringObject::encode_in_place(Env *env, Optional<Value> dst_encoding_arg, 
             else if (xml.value() == "text"_s)
                 options.xml_option = EncodeXmlOption::Text;
             else
-                env->raise("ArgumentError", "unexpected value for xml option: {}", xml.value().inspect_str(env));
+                env->raise("ArgumentError", "unexpected value for xml option: {}", xml.value().inspected(env));
         }
     }
 
@@ -1909,13 +1909,13 @@ Value StringObject::bytesplice(Env *env, Args &&args) {
 
         // Handle negative start index.
         if (index < -str_length)
-            env->raise("RangeError", "{} out of range", range->inspect_str(env));
+            env->raise("RangeError", "{} out of range", range->inspected(env));
         if (index < 0)
             index = str_length + index;
 
         // Handle index past end of string.
         if (index > str_length)
-            env->raise("RangeError", "{} out of range", range->inspect_str(env));
+            env->raise("RangeError", "{} out of range", range->inspected(env));
 
         // Handle negative end index.
         auto end = range->end().integer();
@@ -1963,7 +1963,7 @@ Value StringObject::bytesplice(Env *env, Args &&args) {
             auto str_actual_length = static_cast<nat_int_t>(str->length());
             str_range = args[2].as_range_or_raise(env);
             if (str_range->begin().integer() < -str_actual_length)
-                env->raise("RangeError", "{} out of range", str_range->inspect_str(env));
+                env->raise("RangeError", "{} out of range", str_range->inspected(env));
         }
 
     } else if (args.size() == 3 || args.size() == 5) {
@@ -2444,7 +2444,7 @@ Value StringObject::refeq(Env *env, Value arg1, Optional<Value> arg2, Optional<V
 
         // raises a RangeError if Range begin is greater than String size
         if (::abs(begin) >= (nat_int_t)chars->size())
-            env->raise("RangeError", "{} out of range", arg1.inspect_str(env));
+            env->raise("RangeError", "{} out of range", arg1.inspected(env));
 
         // process the begin later to eventually raise the error above
         begin = process_begin(begin);

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -979,7 +979,7 @@ Value StringObject::append_as_bytes(Env *env, Args &&args) {
             const auto c = static_cast<uint8_t>(arg.send(env, "&"_s, { Value::integer(0xFF) }).integer().to_nat_int_t());
             buf.append_char(c);
         } else {
-            env->raise("TypeError", "wrong argument type {} (expected String or Integer)", arg.klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected String or Integer)", arg.klass()->inspect_module());
         }
     }
     m_string.append(buf);
@@ -1950,7 +1950,7 @@ Value StringObject::bytesplice(Env *env, Args &&args) {
         // bytesplice(range, str, str_range)
 
         if (!args[0].is_range())
-            env->raise("TypeError", "wrong argument type {} (expected Range)", args[0].klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected Range)", args[0].klass()->inspect_module());
 
         auto range = args[0].as_range();
         std::tie(index, length) = index_and_length_from_range(m_string, range);
@@ -2530,7 +2530,7 @@ Value StringObject::sub(Env *env, Value find, Optional<Value> replacement_value,
         find = new RegexpObject { env, pattern, options };
     }
     if (!find.is_regexp())
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_module());
 
     MatchDataObject *match;
     StringObject *expanded_replacement;
@@ -2568,7 +2568,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
         find = new RegexpObject { env, pattern, options };
     }
     if (!find.is_regexp())
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_module());
 
     MatchDataObject *match = nullptr;
     StringObject *expanded_replacement = nullptr;
@@ -3078,7 +3078,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
     if (!splitter_arg || splitter_arg.value().is_nil()) {
         auto field_sep = env->global_get("$;"_s);
         if (!field_sep.is_nil()) {
-            env->warn("$; is set to non-nil value, but the output was {}", field_sep.klass()->inspect_string());
+            env->warn("$; is set to non-nil value, but the output was {}", field_sep.klass()->inspect_module());
             splitter_arg = field_sep;
         }
     }
@@ -3105,7 +3105,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
         if (!splitter.is_string() && splitter.respond_to(env, "to_str"_s))
             splitter = splitter.to_str(env);
         if (!splitter.is_string())
-            env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter.klass()->inspect_string());
+            env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter.klass()->inspect_module());
 
         StringObject *splitstr = splitter.as_string();
         splitstr->assert_valid_encoding(env);
@@ -4363,8 +4363,8 @@ Value StringObject::try_convert(Env *env, Value val) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        val.klass()->inspect_string(),
-        val.klass()->inspect_string(),
-        result.klass()->inspect_string());
+        val.klass()->inspect_module(),
+        val.klass()->inspect_module(),
+        result.klass()->inspect_module());
 }
 }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -979,7 +979,7 @@ Value StringObject::append_as_bytes(Env *env, Args &&args) {
             const auto c = static_cast<uint8_t>(arg.send(env, "&"_s, { Value::integer(0xFF) }).integer().to_nat_int_t());
             buf.append_char(c);
         } else {
-            env->raise("TypeError", "wrong argument type {} (expected String or Integer)", arg.klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected String or Integer)", arg.klass()->inspect_string());
         }
     }
     m_string.append(buf);
@@ -1950,7 +1950,7 @@ Value StringObject::bytesplice(Env *env, Args &&args) {
         // bytesplice(range, str, str_range)
 
         if (!args[0].is_range())
-            env->raise("TypeError", "wrong argument type {} (expected Range)", args[0].klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected Range)", args[0].klass()->inspect_string());
 
         auto range = args[0].as_range();
         std::tie(index, length) = index_and_length_from_range(m_string, range);
@@ -2530,7 +2530,7 @@ Value StringObject::sub(Env *env, Value find, Optional<Value> replacement_value,
         find = new RegexpObject { env, pattern, options };
     }
     if (!find.is_regexp())
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_string());
 
     MatchDataObject *match;
     StringObject *expanded_replacement;
@@ -2568,7 +2568,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
         find = new RegexpObject { env, pattern, options };
     }
     if (!find.is_regexp())
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_string());
 
     MatchDataObject *match = nullptr;
     StringObject *expanded_replacement = nullptr;
@@ -3078,7 +3078,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
     if (!splitter_arg || splitter_arg.value().is_nil()) {
         auto field_sep = env->global_get("$;"_s);
         if (!field_sep.is_nil()) {
-            env->warn("$; is set to non-nil value, but the output was {}", field_sep.klass()->inspect_str());
+            env->warn("$; is set to non-nil value, but the output was {}", field_sep.klass()->inspect_string());
             splitter_arg = field_sep;
         }
     }
@@ -3105,7 +3105,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
         if (!splitter.is_string() && splitter.respond_to(env, "to_str"_s))
             splitter = splitter.to_str(env);
         if (!splitter.is_string())
-            env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter.klass()->inspect_str());
+            env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter.klass()->inspect_string());
 
         StringObject *splitstr = splitter.as_string();
         splitstr->assert_valid_encoding(env);
@@ -4363,8 +4363,8 @@ Value StringObject::try_convert(Env *env, Value val) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        val.klass()->inspect_str(),
-        val.klass()->inspect_str(),
-        result.klass()->inspect_str());
+        val.klass()->inspect_string(),
+        val.klass()->inspect_string(),
+        result.klass()->inspect_string());
 }
 }

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -66,7 +66,7 @@ bool SymbolObject::should_be_quoted() const {
     return result < 0;
 }
 
-String SymbolObject::dbg_inspect() const {
+String SymbolObject::dbg_inspect(int indent) const {
     return String::format("<SymbolObject {h} name=\"{}\">", this, m_name);
 }
 

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -67,7 +67,7 @@ bool SymbolObject::should_be_quoted() const {
 }
 
 String SymbolObject::dbg_inspect() const {
-    return String::format(":{}", m_name);
+    return String::format("<SymbolObject {h} name=\"{}\">", this, m_name);
 }
 
 Value SymbolObject::eqtilde(Env *env, Value other) {

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -4,7 +4,7 @@ namespace Natalie {
 
 Value ThreadGroupObject::add(Env *env, Value value) {
     if (!value.is_thread())
-        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value.klass()->inspect_string());
     auto thread = value.as_thread();
 
     std::unique_lock lock { m_mutex };

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -4,7 +4,7 @@ namespace Natalie {
 
 Value ThreadGroupObject::add(Env *env, Value value) {
     if (!value.is_thread())
-        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", value.klass()->inspect_module());
     auto thread = value.as_thread();
 
     std::unique_lock lock { m_mutex };

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -144,7 +144,7 @@ static Value validate_key(Env *env, Value key) {
     if (key.is_string() || key.respond_to(env, "to_str"_s))
         key = key.to_str(env)->to_sym(env);
     if (!key.is_symbol())
-        env->raise("TypeError", "{} is not a symbol", key.inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol", key.inspected(env));
     return key;
 }
 

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -162,7 +162,7 @@ ThreadObject *ThreadObject::current() {
 
 Value ThreadObject::thread_kill(Env *env, Value thread) {
     if (!thread.is_thread())
-        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", thread.klass()->inspect_string());
+        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", thread.klass()->inspect_module());
 
     return thread.as_thread()->kill(env);
 }
@@ -265,7 +265,7 @@ Value ThreadObject::to_s(Env *env) {
 
     auto formatted = String::format(
         "#<{}:{}{} {}>",
-        m_klass->inspect_string(),
+        m_klass->inspect_module(),
         String::hex(Object::object_id(this), String::HexFormat::LowercaseAndPrefixed),
         location,
         status());

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -162,7 +162,7 @@ ThreadObject *ThreadObject::current() {
 
 Value ThreadObject::thread_kill(Env *env, Value thread) {
     if (!thread.is_thread())
-        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", thread.klass()->inspect_str());
+        env->raise("TypeError", "wrong argument type {} (expected VM/thread)", thread.klass()->inspect_string());
 
     return thread.as_thread()->kill(env);
 }
@@ -265,7 +265,7 @@ Value ThreadObject::to_s(Env *env) {
 
     auto formatted = String::format(
         "#<{}:{}{} {}>",
-        m_klass->inspect_str(),
+        m_klass->inspect_string(),
         String::hex(Object::object_id(this), String::HexFormat::LowercaseAndPrefixed),
         location,
         status());

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -99,7 +99,7 @@ TimeObject *TimeObject::utc(Env *env, Value year, Optional<Value> month, Optiona
         } else if (subsec.is_rational()) {
             result->m_subsec = subsec.as_rational()->div(env, Value::integer(1000000));
         } else {
-            env->raise("TypeError", "can't convert {} into an exact number", subsec.klass()->inspect_str());
+            env->raise("TypeError", "can't convert {} into an exact number", subsec.klass()->inspect_string());
         }
     }
     return result;
@@ -109,7 +109,7 @@ Value TimeObject::add(Env *env, Value other) {
     if (other.is_time()) {
         env->raise("TypeError", "time + time?");
     } else if (other.is_nil() || other.is_string() || !other.respond_to(env, "to_r"_s)) {
-        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_string());
     }
     RationalObject *rational = to_r(env).as_rational();
     rational = rational->add(env, other.send(env, "to_r"_s).as_rational()).as_rational();
@@ -208,7 +208,7 @@ Value TimeObject::minus(Env *env, Value other) {
         return to_r(env).as_rational()->sub(env, other.as_time()->to_r(env)).as_rational()->to_f(env);
     }
     if (other.is_nil() || other.is_string() || !other.respond_to(env, "to_r"_s)) {
-        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_string());
     }
     RationalObject *rational = to_r(env).as_rational()->sub(env, other.send(env, "to_r"_s)).as_rational();
     auto result = TimeObject::create(env, rational, m_mode);
@@ -432,7 +432,7 @@ RationalObject *TimeObject::convert_rational(Env *env, Value value) {
     } else if (value.respond_to(env, "to_int"_s)) {
         return RationalObject::create(env, value.to_int(env), Integer(1));
     } else {
-        env->raise("TypeError", "can't convert {} into an exact number", value.klass()->inspect_str());
+        env->raise("TypeError", "can't convert {} into an exact number", value.klass()->inspect_string());
     }
 }
 

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -99,7 +99,7 @@ TimeObject *TimeObject::utc(Env *env, Value year, Optional<Value> month, Optiona
         } else if (subsec.is_rational()) {
             result->m_subsec = subsec.as_rational()->div(env, Value::integer(1000000));
         } else {
-            env->raise("TypeError", "can't convert {} into an exact number", subsec.klass()->inspect_string());
+            env->raise("TypeError", "can't convert {} into an exact number", subsec.klass()->inspect_module());
         }
     }
     return result;
@@ -109,7 +109,7 @@ Value TimeObject::add(Env *env, Value other) {
     if (other.is_time()) {
         env->raise("TypeError", "time + time?");
     } else if (other.is_nil() || other.is_string() || !other.respond_to(env, "to_r"_s)) {
-        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_module());
     }
     RationalObject *rational = to_r(env).as_rational();
     rational = rational->add(env, other.send(env, "to_r"_s).as_rational()).as_rational();
@@ -208,7 +208,7 @@ Value TimeObject::minus(Env *env, Value other) {
         return to_r(env).as_rational()->sub(env, other.as_time()->to_r(env)).as_rational()->to_f(env);
     }
     if (other.is_nil() || other.is_string() || !other.respond_to(env, "to_r"_s)) {
-        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into an exact number", other.klass()->inspect_module());
     }
     RationalObject *rational = to_r(env).as_rational()->sub(env, other.send(env, "to_r"_s)).as_rational();
     auto result = TimeObject::create(env, rational, m_mode);
@@ -432,7 +432,7 @@ RationalObject *TimeObject::convert_rational(Env *env, Value value) {
     } else if (value.respond_to(env, "to_int"_s)) {
         return RationalObject::create(env, value.to_int(env), Integer(1));
     } else {
-        env->raise("TypeError", "can't convert {} into an exact number", value.klass()->inspect_string());
+        env->raise("TypeError", "can't convert {} into an exact number", value.klass()->inspect_module());
     }
 }
 

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -444,7 +444,7 @@ Value TimeObject::convert_unit(Env *env, Value value) {
     } else if (value == "nanosecond"_s || value == "nsec"_s) {
         return Value::integer(1000000000);
     } else {
-        env->raise("ArgumentError", "unexpected unit: {}", value.inspect_str(env));
+        env->raise("ArgumentError", "unexpected unit: {}", value.inspected(env));
     }
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -645,7 +645,7 @@ SymbolObject *Value::to_symbol(Env *env, Conversion conversion) {
     if (is_integer()) {
         if (conversion == Conversion::NullAllowed)
             return nullptr;
-        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol nor a string", inspected(env));
     }
 
     if (is_symbol())
@@ -655,10 +655,10 @@ SymbolObject *Value::to_symbol(Env *env, Conversion conversion) {
     else if (conversion == Conversion::NullAllowed)
         return nullptr;
     else
-        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
+        env->raise("TypeError", "{} is not a symbol nor a string", inspected(env));
 }
 
-String Value::inspect_str(Env *env) {
+String Value::inspected(Env *env) {
     if (!respond_to(env, "inspect"_s))
         return String::format("#<{}:{}>", klass()->inspect_string(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
     auto inspected = send(env, "inspect"_s);

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -107,9 +107,9 @@ StringObject *Value::to_str(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        klass()->inspect_str(),
-        klass()->inspect_str(),
-        result.klass()->inspect_str());
+        klass()->inspect_string(),
+        klass()->inspect_string(),
+        result.klass()->inspect_string());
 }
 
 // This is just like Value::to_str, but it raises more consistent error messages.
@@ -129,9 +129,9 @@ StringObject *Value::to_str2(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        klass()->inspect_str(),
-        klass()->inspect_str(),
-        result.klass()->inspect_str());
+        klass()->inspect_string(),
+        klass()->inspect_string(),
+        result.klass()->inspect_string());
 }
 
 Value Value::public_send(Env *env, SymbolObject *name, Args &&args, Block *block, Value sent_from) {
@@ -467,61 +467,61 @@ VoidPObject *Value::as_void_p() const {
 
 ArrayObject *Value::as_array_or_raise(Env *env) const {
     if (!is_array())
-        env->raise("TypeError", "{} can't be coerced into Array", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Array", klass()->inspect_string());
     return reinterpret_cast<ArrayObject *>(m_value);
 }
 
 ClassObject *Value::as_class_or_raise(Env *env) const {
     if (!is_class())
-        env->raise("TypeError", "{} can't be coerced into Class", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Class", klass()->inspect_string());
     return reinterpret_cast<ClassObject *>(m_value);
 }
 
 EncodingObject *Value::as_encoding_or_raise(Env *env) const {
     if (!is_encoding())
-        env->raise("TypeError", "{} can't be coerced into Encoding", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Encoding", klass()->inspect_string());
     return reinterpret_cast<EncodingObject *>(m_value);
 }
 
 ExceptionObject *Value::as_exception_or_raise(Env *env) const {
     if (!is_exception())
-        env->raise("TypeError", "{} can't be coerced into Exception", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Exception", klass()->inspect_string());
     return reinterpret_cast<ExceptionObject *>(m_value);
 }
 
 FloatObject *Value::as_float_or_raise(Env *env) const {
     if (!is_float())
-        env->raise("TypeError", "{} can't be coerced into Float", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Float", klass()->inspect_string());
     return reinterpret_cast<FloatObject *>(m_value);
 }
 
 HashObject *Value::as_hash_or_raise(Env *env) const {
     if (!is_hash())
-        env->raise("TypeError", "{} can't be coerced into Hash", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Hash", klass()->inspect_string());
     return reinterpret_cast<HashObject *>(m_value);
 }
 
 MatchDataObject *Value::as_match_data_or_raise(Env *env) const {
     if (!is_match_data())
-        env->raise("TypeError", "{} can't be coerced into MatchData", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into MatchData", klass()->inspect_string());
     return reinterpret_cast<MatchDataObject *>(m_value);
 }
 
 ModuleObject *Value::as_module_or_raise(Env *env) const {
     if (!is_module())
-        env->raise("TypeError", "{} can't be coerced into Module", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Module", klass()->inspect_string());
     return reinterpret_cast<ModuleObject *>(m_value);
 }
 
 RangeObject *Value::as_range_or_raise(Env *env) const {
     if (!is_range())
-        env->raise("TypeError", "{} can't be coerced into Range", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into Range", klass()->inspect_string());
     return reinterpret_cast<RangeObject *>(m_value);
 }
 
 StringObject *Value::as_string_or_raise(Env *env) const {
     if (!is_string())
-        env->raise("TypeError", "{} can't be coerced into String", klass()->inspect_str());
+        env->raise("TypeError", "{} can't be coerced into String", klass()->inspect_string());
     return reinterpret_cast<StringObject *>(m_value);
 }
 
@@ -529,7 +529,7 @@ ArrayObject *Value::to_ary(Env *env) {
     if (is_array())
         return as_array();
 
-    auto original_class = klass()->inspect_str();
+    auto original_class = klass()->inspect_string();
 
     auto to_ary = "to_ary"_s;
 
@@ -549,7 +549,7 @@ ArrayObject *Value::to_ary(Env *env) {
         "TypeError", "can't convert {} to Array ({}#to_ary gives {})",
         original_class,
         original_class,
-        val.klass()->inspect_str());
+        val.klass()->inspect_string());
 }
 
 IoObject *Value::to_io(Env *env) {
@@ -567,9 +567,9 @@ IoObject *Value::to_io(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to IO ({}#to_io gives {})",
-        klass()->inspect_str(),
-        klass()->inspect_str(),
-        result.klass()->inspect_str());
+        klass()->inspect_string(),
+        klass()->inspect_string(),
+        result.klass()->inspect_string());
 }
 
 Integer Value::to_int(Env *env) {
@@ -588,9 +588,9 @@ Integer Value::to_int(Env *env) {
     auto the_klass = klass();
     env->raise(
         "TypeError", "can't convert {} to Integer ({}#to_int gives {})",
-        the_klass->inspect_str(),
-        the_klass->inspect_str(),
-        result.klass()->inspect_str());
+        the_klass->inspect_string(),
+        the_klass->inspect_string(),
+        result.klass()->inspect_string());
 }
 
 FloatObject *Value::to_f(Env *env) {
@@ -610,7 +610,7 @@ HashObject *Value::to_hash(Env *env) {
     if (is_hash())
         return as_hash();
 
-    auto original_class = klass()->inspect_str();
+    auto original_class = klass()->inspect_string();
 
     auto to_hash = "to_hash"_s;
 
@@ -630,7 +630,7 @@ HashObject *Value::to_hash(Env *env) {
         "TypeError", "can't convert {} to Hash ({}#to_hash gives {})",
         original_class,
         original_class,
-        val.klass()->inspect_str());
+        val.klass()->inspect_string());
 }
 
 StringObject *Value::to_s(Env *env) {
@@ -660,7 +660,7 @@ SymbolObject *Value::to_symbol(Env *env, Conversion conversion) {
 
 String Value::inspect_str(Env *env) {
     if (!respond_to(env, "inspect"_s))
-        return String::format("#<{}:{}>", klass()->inspect_str(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
+        return String::format("#<{}:{}>", klass()->inspect_string(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
     auto inspected = send(env, "inspect"_s);
     if (!inspected.is_string())
         return ""; // TODO: what to do here?

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -107,9 +107,9 @@ StringObject *Value::to_str(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        klass()->inspect_string(),
-        klass()->inspect_string(),
-        result.klass()->inspect_string());
+        klass()->inspect_module(),
+        klass()->inspect_module(),
+        result.klass()->inspect_module());
 }
 
 // This is just like Value::to_str, but it raises more consistent error messages.
@@ -129,9 +129,9 @@ StringObject *Value::to_str2(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to String ({}#to_str gives {})",
-        klass()->inspect_string(),
-        klass()->inspect_string(),
-        result.klass()->inspect_string());
+        klass()->inspect_module(),
+        klass()->inspect_module(),
+        result.klass()->inspect_module());
 }
 
 Value Value::public_send(Env *env, SymbolObject *name, Args &&args, Block *block, Value sent_from) {
@@ -467,61 +467,61 @@ VoidPObject *Value::as_void_p() const {
 
 ArrayObject *Value::as_array_or_raise(Env *env) const {
     if (!is_array())
-        env->raise("TypeError", "{} can't be coerced into Array", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Array", klass()->inspect_module());
     return reinterpret_cast<ArrayObject *>(m_value);
 }
 
 ClassObject *Value::as_class_or_raise(Env *env) const {
     if (!is_class())
-        env->raise("TypeError", "{} can't be coerced into Class", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Class", klass()->inspect_module());
     return reinterpret_cast<ClassObject *>(m_value);
 }
 
 EncodingObject *Value::as_encoding_or_raise(Env *env) const {
     if (!is_encoding())
-        env->raise("TypeError", "{} can't be coerced into Encoding", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Encoding", klass()->inspect_module());
     return reinterpret_cast<EncodingObject *>(m_value);
 }
 
 ExceptionObject *Value::as_exception_or_raise(Env *env) const {
     if (!is_exception())
-        env->raise("TypeError", "{} can't be coerced into Exception", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Exception", klass()->inspect_module());
     return reinterpret_cast<ExceptionObject *>(m_value);
 }
 
 FloatObject *Value::as_float_or_raise(Env *env) const {
     if (!is_float())
-        env->raise("TypeError", "{} can't be coerced into Float", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Float", klass()->inspect_module());
     return reinterpret_cast<FloatObject *>(m_value);
 }
 
 HashObject *Value::as_hash_or_raise(Env *env) const {
     if (!is_hash())
-        env->raise("TypeError", "{} can't be coerced into Hash", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Hash", klass()->inspect_module());
     return reinterpret_cast<HashObject *>(m_value);
 }
 
 MatchDataObject *Value::as_match_data_or_raise(Env *env) const {
     if (!is_match_data())
-        env->raise("TypeError", "{} can't be coerced into MatchData", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into MatchData", klass()->inspect_module());
     return reinterpret_cast<MatchDataObject *>(m_value);
 }
 
 ModuleObject *Value::as_module_or_raise(Env *env) const {
     if (!is_module())
-        env->raise("TypeError", "{} can't be coerced into Module", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Module", klass()->inspect_module());
     return reinterpret_cast<ModuleObject *>(m_value);
 }
 
 RangeObject *Value::as_range_or_raise(Env *env) const {
     if (!is_range())
-        env->raise("TypeError", "{} can't be coerced into Range", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into Range", klass()->inspect_module());
     return reinterpret_cast<RangeObject *>(m_value);
 }
 
 StringObject *Value::as_string_or_raise(Env *env) const {
     if (!is_string())
-        env->raise("TypeError", "{} can't be coerced into String", klass()->inspect_string());
+        env->raise("TypeError", "{} can't be coerced into String", klass()->inspect_module());
     return reinterpret_cast<StringObject *>(m_value);
 }
 
@@ -529,7 +529,7 @@ ArrayObject *Value::to_ary(Env *env) {
     if (is_array())
         return as_array();
 
-    auto original_class = klass()->inspect_string();
+    auto original_class = klass()->inspect_module();
 
     auto to_ary = "to_ary"_s;
 
@@ -549,7 +549,7 @@ ArrayObject *Value::to_ary(Env *env) {
         "TypeError", "can't convert {} to Array ({}#to_ary gives {})",
         original_class,
         original_class,
-        val.klass()->inspect_string());
+        val.klass()->inspect_module());
 }
 
 IoObject *Value::to_io(Env *env) {
@@ -567,9 +567,9 @@ IoObject *Value::to_io(Env *env) {
 
     env->raise(
         "TypeError", "can't convert {} to IO ({}#to_io gives {})",
-        klass()->inspect_string(),
-        klass()->inspect_string(),
-        result.klass()->inspect_string());
+        klass()->inspect_module(),
+        klass()->inspect_module(),
+        result.klass()->inspect_module());
 }
 
 Integer Value::to_int(Env *env) {
@@ -588,9 +588,9 @@ Integer Value::to_int(Env *env) {
     auto the_klass = klass();
     env->raise(
         "TypeError", "can't convert {} to Integer ({}#to_int gives {})",
-        the_klass->inspect_string(),
-        the_klass->inspect_string(),
-        result.klass()->inspect_string());
+        the_klass->inspect_module(),
+        the_klass->inspect_module(),
+        result.klass()->inspect_module());
 }
 
 FloatObject *Value::to_f(Env *env) {
@@ -610,7 +610,7 @@ HashObject *Value::to_hash(Env *env) {
     if (is_hash())
         return as_hash();
 
-    auto original_class = klass()->inspect_string();
+    auto original_class = klass()->inspect_module();
 
     auto to_hash = "to_hash"_s;
 
@@ -630,7 +630,7 @@ HashObject *Value::to_hash(Env *env) {
         "TypeError", "can't convert {} to Hash ({}#to_hash gives {})",
         original_class,
         original_class,
-        val.klass()->inspect_string());
+        val.klass()->inspect_module());
 }
 
 StringObject *Value::to_s(Env *env) {
@@ -660,7 +660,7 @@ SymbolObject *Value::to_symbol(Env *env, Conversion conversion) {
 
 String Value::inspected(Env *env) {
     if (!respond_to(env, "inspect"_s))
-        return String::format("#<{}:{}>", klass()->inspect_string(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
+        return String::format("#<{}:{}>", klass()->inspect_module(), String::hex(object_id(), String::HexFormat::LowercaseAndPrefixed));
     auto inspected = send(env, "inspect"_s);
     if (!inspected.is_string())
         return ""; // TODO: what to do here?

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -667,7 +667,7 @@ String Value::inspect_str(Env *env) {
     return inspected.as_string()->string();
 }
 
-String Value::dbg_inspect() const {
+String Value::dbg_inspect(int indent) const {
     if (is_integer())
         return integer().to_string();
     if (is_nil())
@@ -676,7 +676,7 @@ String Value::dbg_inspect() const {
         return "true";
     if (is_false())
         return "false";
-    return object()->dbg_inspect();
+    return object()->dbg_inspect(indent);
 }
 
 #undef PROFILED_SEND

--- a/test/natalie/cli_test.rb
+++ b/test/natalie/cli_test.rb
@@ -39,8 +39,8 @@ end
 
 describe '--print-objects' do
   it 'prints objects allocated' do
-    out = ruby_exe('puts "hello world"', options: '--print-objects')
-    out.should =~ /<StringObject 0x[a-z0-9]+ str='hello world'>/
+    out = ruby_exe('puts "hello world"', args: '2>&1', options: '--print-objects')
+    out.should =~ /<StringObject 0x[a-z0-9]+ string="hello world">/
     out.should =~ /Total allocations: \d+/
   end
 end


### PR DESCRIPTION
I set out to print "large" objects after the self-hosted compiler runs, and I ended up cleaning up the various "inspect"-related functions to hopefully make things more clear. Here they are:

- `TM::String Object::inspected(Env *)` - Calls into Ruby land to `Kernel#inspect` or whatever is defined on the object and returns the result as a `TM::String`.
- `TM::String ModuleObject::inspect_module()` - Specifically for inspecting a module or class, since that is done frequently and is used in error messages a lot.
- `TM::String Cell::dbg_inspect()` - A useful representation for debugging the compiler, runtime, and especially the GC. Does not allocate with the GC. This one even indents hashes and arrays!
  ```
  <HashObject 0x5e84db6bafa0 size=4 {
    <SymbolObject 0x5e84db6b82a0 name="on_dollar"> => <SymbolObject 0x5e84db6cfea0 name="positional_argument_end">,
    <SymbolObject 0x5e84db6cf7a0 name="on_number"> => <SymbolObject 0x5e84db6cf820 name="width_or_positional_arg">,
    <SymbolObject 0x5e84db6cfc20 name="on_zero"> => <SymbolObject 0x5e84db6cf820 name="width_or_positional_arg">,
    <SymbolObject 0x5e84db6cfca0 name="return"> => <SymbolObject 0x5e84db6cd8a0 name="field">}>

  <ArrayObject 0x5e84db6fff20 size=2 data=[
    28,
    <StringObject 0x5e84db6ffea0 string="No space left on device">]>
  ```