### PR TITLE
Add Version constant to StringScanner

### DIFF
--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -1,4 +1,6 @@
 class StringScanner
+  Version = '3.1.3'
+
   class Error < StandardError
   end
 

--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StringScanner
   Version = '3.1.3'
 


### PR DESCRIPTION
The value is defined as the maximal value in the current upstream specs (Ruby 3.4.3).
This should resolve the crashes in the nightly spec runner and turn them into actual failed specs which we can fix.
