### PR TITLE
Optimize and cache string validity checks

### DIFF
--- a/include/natalie/encoding/ascii_8bit_encoding_object.hpp
+++ b/include/natalie/encoding/ascii_8bit_encoding_object.hpp
@@ -35,6 +35,8 @@ public:
     virtual bool is_ascii_compatible() const override { return true; };
 
     virtual bool is_single_byte_encoding() const override final { return true; }
+
+    virtual bool check_string_valid_in_encoding(const String &string) const override { return true; }
 };
 
 }

--- a/include/natalie/encoding/us_ascii_encoding_object.hpp
+++ b/include/natalie/encoding/us_ascii_encoding_object.hpp
@@ -35,6 +35,8 @@ public:
     virtual bool is_ascii_compatible() const override { return true; };
 
     virtual bool is_single_byte_encoding() const override final { return true; }
+
+    virtual bool check_string_valid_in_encoding(const String &string) const override;
 };
 
 }

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -78,6 +78,20 @@ public:
         return next_char(string, &index).first;
     }
 
+    // NOTE: This is a naiive and wasteful fallback; we should override this
+    // in each encoding where a more efficient approach is possible.
+    virtual bool check_string_valid_in_encoding(const String &string) const {
+        size_t index = 0;
+        for (;;) {
+            auto [valid, length, codepoint] = next_codepoint(string, &index);
+            if (!valid)
+                return false;
+            if (length == 0)
+                break;
+        }
+        return true;
+    }
+
     virtual StringView next_grapheme_cluster(const String &str, size_t *index) const {
         auto [_valid, view] = next_char(str, index);
         return view;

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -189,6 +189,10 @@ public:
         return valid;
     }
 
+    void force_validity(Validity validity) {
+        m_validity = validity;
+    }
+
     EncodingObject *encoding() const { return m_encoding.ptr(); }
     void set_encoding(EncodingObject *encoding) { m_encoding = encoding; }
     bool is_ascii_only() const;

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -99,7 +99,8 @@ public:
 
     StringObject(const StringObject &other)
         : Object { other }
-        , m_encoding { other.m_encoding } {
+        , m_encoding { other.m_encoding }
+        , m_validity { other.m_validity } {
         set_str(other.c_str(), other.length());
     }
 

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -545,7 +545,10 @@ private:
     StringObject *expand_backrefs(Env *, StringObject *, MatchDataObject *);
     void regexp_sub(Env *, TM::String &, StringObject *, RegexpObject *, Optional<Value>, MatchDataObject **, StringObject **, size_t = 0, Block *block = nullptr);
     nat_int_t unpack_offset(Env *, Optional<Value>) const;
-    bool check_valid_encoding() const;
+
+    bool check_valid_encoding() const {
+        return m_encoding->check_string_valid_in_encoding(m_string);
+    }
 
     using Object::Object;
 

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -189,6 +189,16 @@ public:
         return valid;
     }
 
+    void update_validity(StringObject *other) {
+        if (m_validity == Validity::Valid)
+            m_validity = other->valid_encoding() ? Validity::Valid : Validity::Invalid;
+        else
+            // NOTE: Here we assume that it's *possible* for two invalid strings
+            // to be combined in a way that produces a valid string.
+            // I'm not sure if that's really possible though!
+            m_validity = Validity::Unknown;
+    }
+
     void force_validity(Validity validity) {
         m_validity = validity;
     }

--- a/src/encoding/us_ascii_encoding_object.cpp
+++ b/src/encoding/us_ascii_encoding_object.cpp
@@ -1,3 +1,4 @@
+#include "natalie/encoding/us_ascii_encoding_object.hpp"
 #include "natalie.hpp"
 
 namespace Natalie {
@@ -53,6 +54,15 @@ nat_int_t UsAsciiEncodingObject::decode_codepoint(StringView &str) const {
     default:
         return -1;
     }
+}
+
+bool UsAsciiEncodingObject::check_string_valid_in_encoding(const String &string) const {
+    for (size_t i = 0; i < string.size(); i++) {
+        unsigned char codepoint = string[i];
+        if (!valid_codepoint(codepoint))
+            return false;
+    }
+    return true;
 }
 
 }

--- a/src/encoding/utf8_encoding_object.cpp
+++ b/src/encoding/utf8_encoding_object.cpp
@@ -295,4 +295,5 @@ nat_int_t Utf8EncodingObject::decode_codepoint(StringView &str) const {
         return -1;
     }
 }
+
 }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3879,18 +3879,6 @@ Value StringObject::reverse_in_place(Env *env) {
     return this;
 }
 
-bool StringObject::check_valid_encoding() const {
-    size_t index = 0;
-    std::pair<bool, StringView> pair;
-    do {
-        pair = m_encoding->next_char(m_string, &index);
-        if (!pair.first) {
-            return false;
-        }
-    } while (!pair.second.is_empty());
-    return true;
-}
-
 bool StringObject::is_ascii_only() const {
     if (!m_encoding->is_ascii_compatible())
         return false;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3048,7 +3048,9 @@ Value StringObject::split(Env *env, RegexpObject *splitter, int max_count) {
             }
             result = splitter->search(env, this, last_index, region, ONIG_OPTION_NONE);
         } while (result != ONIG_MISMATCH);
-        ary->push(new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding });
+        auto part = new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding };
+        part->force_validity(m_validity);
+        ary->push(part);
     }
     onig_region_free(region, true);
     return ary;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2323,6 +2323,13 @@ Value StringObject::ref_fast_range(Env *env, size_t begin, size_t end) const {
 }
 
 Value StringObject::ref_fast_range_endless(Env *env, size_t begin) const {
+    if (m_encoding->is_single_byte_encoding()) {
+        if (begin >= bytesize())
+            return Value::nil();
+        auto length = bytesize() - begin;
+        return new StringObject { m_string.substring(begin, length), m_encoding };
+    }
+
     size_t byte_index = 0;
     size_t char_index = 0;
     String result;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -194,8 +194,8 @@ bool Value::is_integer() const {
         return true;
     if (!is_pointer())
         return false;
-    auto ptr = reinterpret_cast<Object *>(m_value);
-    return ptr != 0x0 && reinterpret_cast<Object *>(ptr)->type() == ObjectType::BigInt;
+    auto ptr = pointer();
+    return ptr != 0x0 && ptr->type() == ObjectType::BigInt;
 }
 
 bool Value::is_frozen() const {


### PR DESCRIPTION
Checking whether a string is valid in its encoding can be pretty expensive; caching that validity result reduces how often we have to do it.

For this ruby code:

```ruby
s = 'x,' * 10_000
p s.encoding

def boo(arg)
end

100.times { boo s.split(',') }
```

...this produces a 1.28x speedup:

![Screenshot 2025-04-10 7 14 33 AM](https://github.com/user-attachments/assets/cee60aa7-22aa-43b2-93ae-8e17f270e522)

There's also an optimization for endless ranges on binary strings, which is how this rabbit trail started:

```ruby
s = 'x'.b * 10_000
p s.encoding

def boo(arg)
end

10_000.times { boo s[8000..] }
```

...this produces a 50x speedup:

![Screenshot 2025-04-10 7 18 41 AM](https://github.com/user-attachments/assets/6e466685-3de6-4f6a-a06f-9fcd15136342)
