### PR TITLE
Implement StringScanner#charpos

### DIFF
--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -15,6 +15,7 @@ class StringScanner
   end
 
   attr_reader :string, :matched, :pos
+  alias charpos pos
 
   def inspect
     if @pos >= @string.size

--- a/spec/library/stringscanner/charpos_spec.rb
+++ b/spec/library/stringscanner/charpos_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require 'strscan'
+
+describe "StringScanner#charpos" do
+  it "returns character index corresponding to the current position" do
+    s = StringScanner.new("abc")
+
+    s.scan_until(/b/)
+    s.charpos.should == 2
+  end
+
+  it "is multi-byte character sensitive" do
+    s = StringScanner.new("abcädeföghi")
+
+    s.scan_until(/ö/)
+    s.charpos.should == 8
+  end
+end


### PR DESCRIPTION
By aliasing it to #pos. This smells fishy, either it is an alias and it should use the shared spec for #pos, or it behaves diffently but the specs don't cover those differences.