### PR TITLE
Add fiddle to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'fiddle'
 gem 'minitest'
 gem 'minitest-reporters'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     ansi (1.5.0)
     builder (3.3.0)
     concurrent-ruby (1.2.2)
+    fiddle (1.1.6)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
       ansi
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   concurrent-ruby
+  fiddle
   minitest
   minitest-reporters
   rake


### PR DESCRIPTION
This is required to get the specs to work in Ruby 3.5.