### PR TITLE
Fix partial argument extraction

### DIFF
--- a/lib/natalie/compiler/args.rb
+++ b/lib/natalie/compiler/args.rb
@@ -290,7 +290,7 @@ module Natalie
       def transform_keyword_rest_arg(arg)
         swap_keyword_arg_hash_with_args_array
         case arg
-        when Prism::NoKeywordsParameterNode
+        when Prism::NoKeywordsParameterNode, Prism::ForwardingParameterNode
           :noop
         when Prism::KeywordRestParameterNode
           if arg.name
@@ -365,6 +365,7 @@ module Natalie
 
       def maximum_arg_count
         return nil if @node.is_a?(Prism::ParametersNode) && @node.rest.is_a?(Prism::RestParameterNode)
+        return nil if @node.is_a?(Prism::ParametersNode) && @node.keyword_rest.is_a?(Prism::ForwardingParameterNode)
 
         args_to_array.count do |arg|
           %i[

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1277,7 +1277,8 @@ module Natalie
         instructions = []
 
         # special ... syntax
-        if node.is_a?(Prism::ParametersNode) && node.keyword_rest.is_a?(Prism::ForwardingParameterNode)
+        if node.is_a?(Prism::ParametersNode) && node.requireds.empty? &&
+             node.keyword_rest.is_a?(Prism::ForwardingParameterNode)
           # nothing to do
           return []
         end

--- a/spec/language/delegation_spec.rb
+++ b/spec/language/delegation_spec.rb
@@ -66,7 +66,7 @@ describe "delegation with def(x, ...)" do
       end
     RUBY
 
-    NATFIXME 'Partial delegation', exception: SpecFailedException do
+    NATFIXME 'Partial delegation', exception: ArgumentError do
       a.new.delegate(0, 1, b: 2).should == [[1], {b: 2}, nil]
     end
   end
@@ -79,7 +79,7 @@ describe "delegation with def(x, ...)" do
       end
     RUBY
 
-    NATFIXME 'Partial delegation', exception: SpecFailedException do
+    NATFIXME 'Partial delegation', exception: ArgumentError do
       a.new.delegate_block(0, 1, b: 2) { |x| x }.should == [{b: 2}, [1]]
     end
   end

--- a/test/natalie/argument_test.rb
+++ b/test/natalie/argument_test.rb
@@ -65,12 +65,20 @@ describe 'forward args' do
     a
   end
 
+  def forward_partial(a, b, ...)
+    [a, b]
+  end
+
   it 'passes all arguments as-is' do
     foo(1, b: 2, c: 3).should == [1, 2, 3]
   end
 
   it 'passes block arguments' do
     foo(1, b: 2) { 4 }.should == [1, 2, 4]
+  end
+
+  it 'can extract arguments from the list' do
+    forward_partial(1, 2, 3, 4).should == [1, 2]
   end
 end
 


### PR DESCRIPTION
This is probably not the official name, but it's related to code like this:
```ruby
def foo(a, ...) = a
```
This populates the named arguments.

The following behaviour still needs a follow-up:
```ruby
def foo(a, ...) = bar(...)
```
Currently we still forward the full original arguments.