### PR TITLE
fix compile issue on x86 MacOS

### DIFF
--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -960,7 +960,7 @@ void gc_signal_handler(int signal, siginfo_t *, void *ucontext) {
         memcpy(ctx, ucontext, sizeof(ucontext_t));
         thread->set_suspend_status(ThreadObject::SuspendStatus::Suspended);
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !defined(__APPLE__)
         thread->set_end_of_stack(reinterpret_cast<void *>(ctx->uc_mcontext.gregs[REG_RSP]));
 #endif
 


### PR DESCRIPTION
Fetch the thread context RSP register differently on x86_64 Apple devices.
This fixes a build issue where compilation fails with a

```
error: member reference type 'struct __darwin_mcontext64 *' is a pointer; did you mean to use '->'?
```

On such platforms, `ctx->uc_mcontext` is a pointer itself.
Thus the members of the struct being pointed to need to be accessed via the arrow operator.
Also, `gregs` is not a member of the struct so the registers are accessed via the `__ss` member.