### PR TITLE
Simplify subsecond algorithm in Time#inspect

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -177,6 +177,10 @@ public:
         m_string.set_str(str, length);
     }
 
+    void set_str(String &&str) {
+        m_string = std::move(str);
+    }
+
     bool is_chilled() const { return m_chilled != Chilled::None; }
     Chilled chilled() const { return m_chilled; }
     void set_chilled(Chilled chilled) { m_chilled = chilled; }

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -177,10 +177,9 @@ Value TimeObject::inspect(Env *env) {
         if (length > 9) {
             string->truncate(9);
         } else if (length < 9) {
-            nat_int_t n;
-            for (n = 9 - length - 1; n >= 0; n--) {
-                string->prepend_char(env, '0');
-            }
+            TM::String string_with_prefix(9 - length, '0');
+            string_with_prefix.append(string->string());
+            string->set_str(string_with_prefix.c_str(), string_with_prefix.size());
         }
         result->append_char('.');
         result->append(strip_zeroes(string));

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -179,7 +179,7 @@ Value TimeObject::inspect(Env *env) {
         } else if (length < 9) {
             TM::String string_with_prefix(9 - length, '0');
             string_with_prefix.append(string->string());
-            string->set_str(string_with_prefix.c_str(), string_with_prefix.size());
+            string->set_str(std::move(string_with_prefix));
         }
         result->append_char('.');
         result->append(strip_zeroes(string));


### PR DESCRIPTION
Instead of a loop, build the prefix zeroes string in a single statement. This removes the prepend_char call from the loop, which does move the strings memory in every iteration.
