### PR TITLE
Refresh specs after upstream updates

### DIFF
--- a/spec/language/fixtures/class_with_class_variable.rb
+++ b/spec/language/fixtures/class_with_class_variable.rb
@@ -1,0 +1,9 @@
+module StringSpecs
+  class ClassWithClassVariable
+    @@a = "xxx"
+
+    def foo
+      "#@@a"
+    end
+  end
+end

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -88,8 +88,8 @@ describe "Predefined global $~" do
     $~ = /foo/.match("foo")
     $~.should be_an_instance_of(MatchData)
 
-    -> { $~ = Object.new }.should raise_error(TypeError)
-    -> { $~ = 1 }.should raise_error(TypeError)
+    -> { $~ = Object.new }.should raise_error(TypeError, 'wrong argument type Object (expected MatchData)')
+    -> { $~ = 1 }.should raise_error(TypeError, 'wrong argument type Integer (expected MatchData)')
   end
 
   it "changes the value of derived capture globals when assigned" do
@@ -136,6 +136,19 @@ describe "Predefined global $&" do
     "abc".dup.force_encoding(Encoding::EUC_JP) =~ /b/
     $&.encoding.should equal(Encoding::EUC_JP)
   end
+
+  it "is read-only" do
+    -> {
+      eval %q{$& = ""}
+    }.should raise_error(SyntaxError, /Can't set variable \$&/)
+  end
+
+  it "is read-only when aliased" do
+    alias $predefined_spec_ampersand $&
+    -> {
+      $predefined_spec_ampersand = ""
+    }.should raise_error(NameError, '$predefined_spec_ampersand is a read-only variable')
+  end
 end
 
 describe "Predefined global $`" do
@@ -153,6 +166,19 @@ describe "Predefined global $`" do
   it "sets an empty result to the encoding of the source String" do
     "abc".dup.force_encoding(Encoding::ISO_8859_1) =~ /a/
     $`.encoding.should equal(Encoding::ISO_8859_1)
+  end
+
+  it "is read-only" do
+    -> {
+      eval %q{$` = ""}
+    }.should raise_error(SyntaxError, /Can't set variable \$`/)
+  end
+
+  it "is read-only when aliased" do
+    alias $predefined_spec_backquote $`
+    -> {
+      $predefined_spec_backquote = ""
+    }.should raise_error(NameError, '$predefined_spec_backquote is a read-only variable')
   end
 end
 
@@ -172,6 +198,19 @@ describe "Predefined global $'" do
     "abc".dup.force_encoding(Encoding::ISO_8859_1) =~ /c/
     $'.encoding.should equal(Encoding::ISO_8859_1)
   end
+
+  it "is read-only" do
+    -> {
+      eval %q{$' = ""}
+    }.should raise_error(SyntaxError, /Can't set variable \$'/)
+  end
+
+  it "is read-only when aliased" do
+    alias $predefined_spec_single_quote $'
+    -> {
+      $predefined_spec_single_quote = ""
+    }.should raise_error(NameError, '$predefined_spec_single_quote is a read-only variable')
+  end
 end
 
 describe "Predefined global $+" do
@@ -189,6 +228,19 @@ describe "Predefined global $+" do
   it "sets the encoding to the encoding of the source String" do
     "abc".dup.force_encoding(Encoding::EUC_JP) =~ /(b)/
     $+.encoding.should equal(Encoding::EUC_JP)
+  end
+
+  it "is read-only" do
+    -> {
+      eval %q{$+ = ""}
+    }.should raise_error(SyntaxError, /Can't set variable \$\+/)
+  end
+
+  it "is read-only when aliased" do
+    alias $predefined_spec_plus $+
+    -> {
+      $predefined_spec_plus = ""
+    }.should raise_error(NameError, '$predefined_spec_plus is a read-only variable')
   end
 end
 
@@ -229,7 +281,7 @@ describe "Predefined global $stdout" do
   end
 
   it "raises TypeError error if assigned to nil" do
-    -> { $stdout = nil }.should raise_error(TypeError)
+    -> { $stdout = nil }.should raise_error(TypeError, '$stdout must have write method, NilClass given')
   end
 
   it "raises TypeError error if assigned to object that doesn't respond to #write" do
@@ -251,6 +303,12 @@ describe "Predefined global $!" do
     end.resume
 
     $!.should == nil
+  end
+
+  it "is read-only" do
+    -> {
+      $! = []
+    }.should raise_error(NameError, '$! is a read-only variable')
   end
 
   # See http://jira.codehaus.org/browse/JRUBY-5550
@@ -520,6 +578,68 @@ describe "Predefined global $!" do
   end
 end
 
+describe "Predefined global $@" do
+  it "is Fiber-local" do
+    Fiber.new do
+      raise "hi"
+    rescue
+      Fiber.yield
+    end.resume
+
+    $@.should == nil
+  end
+
+  it "is set to a backtrace of a rescued exception" do
+    begin
+      raise
+    rescue
+      $@.should be_an_instance_of(Array)
+      $@.should == $!.backtrace
+    end
+  end
+
+  it "is cleared when an exception is rescued" do
+    begin
+      raise
+    rescue
+    end
+
+    $@.should == nil
+  end
+
+  it "is not set when there is no current exception" do
+    $@.should == nil
+  end
+
+  it "is set to a backtrace of a rescued exception" do
+    begin
+      raise
+    rescue
+      $@.should be_an_instance_of(Array)
+      $@.should == $!.backtrace
+    end
+  end
+
+  it "is not read-only" do
+    NATFIXME '$@ is not readonly', exception: NameError, message: '$@ is a read-only variable' do
+      begin
+        raise
+      rescue
+        $@ = []
+        $@.should == []
+      end
+    end
+  end
+
+  it "cannot be assigned when there is no a rescued exception" do
+    NATFIXME 'it cannot be assigned when there is no a rescued exception', exception: SpecFailedException, message: /should have raised ArgumentError,/ do
+      -> {
+        $@ = []
+      }.should raise_error(ArgumentError, '$! not set')
+    end
+  end
+end
+
 # Input/Output Variables
 # ---------------------------------------------------------------------------------------------------
 #
@@ -618,15 +738,21 @@ describe "Predefined global $/" do
     obj = mock("$/ value")
     obj.should_not_receive(:to_str)
 
-    -> { $/ = obj }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $/ = obj }.should raise_error(TypeError, 'value of $/ must be String')
+    end
   end
 
   it "raises a TypeError if assigned an Integer" do
-    -> { $/ = 1 }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $/ = 1 }.should raise_error(TypeError, 'value of $/ must be String')
+    end
   end
 
   it "raises a TypeError if assigned a boolean" do
-    -> { $/ = true }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $/ = true }.should raise_error(TypeError, 'value of $/ must be String')
+    end
   end
 end
 
@@ -695,15 +821,21 @@ describe "Predefined global $-0" do
     obj = mock("$-0 value")
     obj.should_not_receive(:to_str)
 
-    -> { $-0 = obj }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $-0 = obj }.should raise_error(TypeError, 'value of $-0 must be String')
+    end
   end
 
   it "raises a TypeError if assigned an Integer" do
-    -> { $-0 = 1 }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $-0 = 1 }.should raise_error(TypeError, 'value of $-0 must be String')
+    end
   end
 
   it "raises a TypeError if assigned a boolean" do
-    -> { $-0 = true }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $-0 = true }.should raise_error(TypeError, 'value of $-0 must be String')
+    end
   end
 end
 
@@ -737,12 +869,16 @@ describe "Predefined global $\\" do
     obj = mock("$\\ value")
     obj.should_not_receive(:to_str)
 
-    -> { $\ = obj }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $\ = obj }.should raise_error(TypeError, 'value of $\ must be String')
+    end
   end
 
   it "raises a TypeError if assigned not String" do
-    -> { $\ = 1 }.should raise_error(TypeError)
-    -> { $\ = true }.should raise_error(TypeError)
+    NATFIXME 'Include name of global in error message', exception: SpecFailedException, message: /but the message was/ do
+      -> { $\ = 1 }.should raise_error(TypeError, 'value of $\ must be String')
+      -> { $\ = true }.should raise_error(TypeError, 'value of $\ must be String')
+    end
   end
 end
 
@@ -757,7 +893,7 @@ describe "Predefined global $," do
 
   it "raises TypeError if assigned a non-String" do
     NATFIXME 'raises TypeError if assigned a non-String', exception: SpecFailedException do
-      -> { $, = Object.new }.should raise_error(TypeError)
+      -> { $, = Object.new }.should raise_error(TypeError, 'value of $, must be String')
     end
   end
 
@@ -957,15 +1093,15 @@ describe "Execution variable $:" do
     NATFIXME 'is read-only', exception: SpecFailedException do
       -> {
         $: = []
-      }.should raise_error(NameError)
+      }.should raise_error(NameError, '$: is a read-only variable')
 
       -> {
         $LOAD_PATH = []
-      }.should raise_error(NameError)
+      }.should raise_error(NameError, '$LOAD_PATH is a read-only variable')
 
       -> {
         $-I = []
-      }.should raise_error(NameError)
+      }.should raise_error(NameError, '$-I is a read-only variable')
     end
   end
 
@@ -990,11 +1126,11 @@ describe "Global variable $\"" do
   it "is read-only" do
     -> {
       $" = []
-    }.should raise_error(NameError)
+    }.should raise_error(NameError, '$" is a read-only variable')
 
     -> {
       $LOADED_FEATURES = []
-    }.should raise_error(NameError)
+    }.should raise_error(NameError, '$LOADED_FEATURES is a read-only variable')
   end
 end
 
@@ -1003,7 +1139,7 @@ describe "Global variable $<" do
     NATFIXME 'is read-only', exception: SpecFailedException do
       -> {
         $< = nil
-      }.should raise_error(NameError)
+      }.should raise_error(NameError, '$< is a read-only variable')
     end
   end
 end
@@ -1013,7 +1149,7 @@ describe "Global variable $FILENAME" do
     NATFIXME 'is read-only', exception: SpecFailedException do
       -> {
         $FILENAME = "-"
-      }.should raise_error(NameError)
+      }.should raise_error(NameError, '$FILENAME is a read-only variable')
     end
   end
 end
@@ -1022,7 +1158,7 @@ describe "Global variable $?" do
   it "is read-only" do
     -> {
       $? = nil
-    }.should raise_error(NameError)
+    }.should raise_error(NameError, '$? is a read-only variable')
   end
 
   # NATFIXME: Threads, and a very ugly error when running this
@@ -1035,7 +1171,7 @@ end
 describe "Global variable $-a" do
   it "is read-only" do
     NATFIXME 'is read-only', exception: SpecFailedException do
-      -> { $-a = true }.should raise_error(NameError)
+      -> { $-a = true }.should raise_error(NameError, '$-a is a read-only variable')
     end
   end
 end
@@ -1043,7 +1179,7 @@ end
 describe "Global variable $-l" do
   it "is read-only" do
     NATFIXME 'is read-only', exception: SpecFailedException do
-      -> { $-l = true }.should raise_error(NameError)
+      -> { $-l = true }.should raise_error(NameError, '$-l is a read-only variable')
     end
   end
 end
@@ -1051,7 +1187,7 @@ end
 describe "Global variable $-p" do
   it "is read-only" do
     NATFIXME 'is read-only', exception: SpecFailedException do
-      -> { $-p = true }.should raise_error(NameError)
+      -> { $-p = true }.should raise_error(NameError, '$-p is a read-only variable')
     end
   end
 end
@@ -1211,7 +1347,7 @@ describe "The predefined standard object nil" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("nil = true") }.should raise_error(SyntaxError)
+    -> { eval("nil = true") }.should raise_error(SyntaxError, /Can't assign to nil/)
   end
 end
 
@@ -1221,7 +1357,7 @@ describe "The predefined standard object true" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("true = false") }.should raise_error(SyntaxError)
+    -> { eval("true = false") }.should raise_error(SyntaxError, /Can't assign to true/)
   end
 end
 
@@ -1231,13 +1367,13 @@ describe "The predefined standard object false" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("false = nil") }.should raise_error(SyntaxError)
+    -> { eval("false = nil") }.should raise_error(SyntaxError, /Can't assign to false/)
   end
 end
 
 describe "The self pseudo-variable" do
   it "raises a SyntaxError if assigned to" do
-    -> { eval("self = 1") }.should raise_error(SyntaxError)
+    -> { eval("self = 1") }.should raise_error(SyntaxError, /Can't change the value of self/)
   end
 end
 
@@ -1435,7 +1571,7 @@ end
 describe "$LOAD_PATH.resolve_feature_path" do
   it "returns what will be loaded without actual loading, .rb file" do
     NATFIXME 'Implement $LOAD_PATH', exception: NoMethodError, message: /undefined method [`']resolve_feature_path' for nil/ do
-      extension, path = $LOAD_PATH.resolve_feature_path('set')
+      extension, path = $LOAD_PATH.resolve_feature_path('pp')
       extension.should == :rb
       path.should.end_with?('/pp.rb')
     end

--- a/spec/language/string_spec.rb
+++ b/spec/language/string_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding: binary -*-
 
 require_relative '../spec_helper'
+require_relative 'fixtures/class_with_class_variable'
 
 # TODO: rewrite these horrid specs. it "are..." seriously?!
 
@@ -25,6 +26,11 @@ describe "Ruby character strings" do
 
   it "interpolate global variables just with the # character" do
     "#$ip".should == 'xxx'
+  end
+
+  it "interpolate class variables just with the # character" do
+    object = StringSpecs::ClassWithClassVariable.new
+    object.foo.should == 'xxx'
   end
 
   it "allows underscore as part of a variable name in a simple interpolation" do
@@ -254,7 +260,7 @@ end
 
 describe "Ruby String interpolation" do
   it "permits an empty expression" do
-    s = "#{}"
+    s = "#{}" # rubocop:disable Lint/EmptyInterpolation
     s.should.empty?
     s.should_not.frozen?
   end
@@ -286,7 +292,7 @@ describe "Ruby String interpolation" do
 
   it "creates a non-frozen String" do
     code = <<~'RUBY'
-    "a#{6*7}c"
+      "a#{6*7}c"
     RUBY
     NATFIXME 'eval() only works on static strings', exception: TypeError, message: 'eval() only works on static strings' do
       eval(code).should_not.frozen?
@@ -295,8 +301,8 @@ describe "Ruby String interpolation" do
 
   it "creates a non-frozen String when # frozen-string-literal: true is used" do
     code = <<~'RUBY'
-    # frozen-string-literal: true
-    "a#{6*7}c"
+      # frozen-string-literal: true
+      "a#{6*7}c"
     RUBY
     NATFIXME 'eval() only works on static strings', exception: TypeError, message: 'eval() only works on static strings' do
       eval(code).should_not.frozen?

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -53,7 +53,7 @@ Value GlobalEnv::global_set(Env *env, SymbolObject *name, Optional<Value> val, b
     auto info = m_global_variables.get(name, env);
     if (info) {
         if (!readonly && info->is_readonly())
-            env->raise_name_error(name, "{} is a read only variable", name->string());
+            env->raise_name_error(name, "{} is a read-only variable", name->string());
         if (readonly)
             assert(info->is_readonly()); // changing a global to read-only is not anticipated.
         if (val)


### PR DESCRIPTION
And include a tiny error message fix for read-only globals, this was easier than adding NATFIXME blocks around all those failures.