### PR TITLE
Register $! and $@ as global variables on init

### DIFF
--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -85,13 +85,10 @@ Value GlobalEnv::global_alias(Env *env, SymbolObject *new_name, SymbolObject *ol
 ArrayObject *GlobalEnv::global_list(Env *env) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    auto result = new ArrayObject { m_global_variables.size() + 2 };
+    auto result = new ArrayObject { m_global_variables.size() };
     for (const auto &[key, _] : m_global_variables) {
         result->push(key);
     }
-    // $! and $@ are handled compile time in Natalie
-    result->push("$!"_s);
-    result->push("$@"_s);
     return result;
 }
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -477,6 +477,8 @@ Env *build_top_env() {
     env->global_set("$."_s, Value::integer(0));
     GlobalEnv::the()->global_set_write_hook(env, "$."_s, GlobalVariableAccessHooks::WriteHooks::to_int);
 
+    env->global_set("$!"_s, Value::nil(), true);
+    env->global_set("$@"_s, Value::nil(), true);
     GlobalEnv::the()->global_set_read_hook(env, "$!"_s, true, GlobalVariableAccessHooks::ReadHooks::last_exception);
     GlobalEnv::the()->global_set_read_hook(env, "$@"_s, true, GlobalVariableAccessHooks::ReadHooks::last_exception_backtrace);
 


### PR DESCRIPTION
The removes the exception for these methods from `Kernel#global_variables`, which also removes the outdated comment about them being handled compile time. We've replaced this with read hooks.

For now, still treat them as readonly, even though they can be written too (I'm not sure why you would want to do that, but who am I to judge). These changes are now easier to make.