### PR TITLE
Fix 'it warns when END is used in a method'

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -2292,9 +2292,13 @@ module Natalie
       end
 
       def transform_post_execution_node(node, used:)
-        instructions = [
-          DefineBlockInstruction.new(arity: 0),
-          transform_expression(node.statements, used: true),
+        instructions = [DefineBlockInstruction.new(arity: 0)]
+        if node.statements
+          instructions << transform_expression(node.statements, used: true)
+        else
+          instructions << PushNilInstruction.new
+        end
+        instructions.append(
           EndInstruction.new(:define_block),
           PushSelfInstruction.new,
           PushArgcInstruction.new(0),
@@ -2305,7 +2309,7 @@ module Natalie
             file: @file.path,
             line: node.location.start_line,
           ),
-        ]
+        )
         instructions << PopInstruction.new unless used
         instructions
       end

--- a/spec/language/END_spec.rb
+++ b/spec/language/END_spec.rb
@@ -15,13 +15,11 @@ describe "The END keyword" do
   end
 
   it "warns when END is used in a method" do
-    NATFIXME 'it warns when END is used in a method', exception: SpecFailedException do
-      ruby_exe(<<~ruby, args: "2>&1").should =~ /warning: END in method; use at_exit/
-        def foo
-          END { }
-        end
-      ruby
-    end
+    ruby_exe(<<~ruby, args: "2>&1").should =~ /warning: END in method; use at_exit/
+      def foo
+        END { }
+      end
+    ruby
   end
 
   context "END blocks and at_exit callbacks are mixed" do


### PR DESCRIPTION
Which is actually a fix for supporting END with an empty block.