### PR TITLE
Support buffer argument in UNIXSocket#recvfrom

### DIFF
--- a/spec/library/socket/unixsocket/recvfrom_spec.rb
+++ b/spec/library/socket/unixsocket/recvfrom_spec.rb
@@ -31,6 +31,29 @@ with_feature :unix_socket do
       sock.close
     end
 
+    it "allows an output buffer as third argument" do
+      buffer = +''
+
+      @client.send("foobar", 0)
+      sock = @server.accept
+      message, = sock.recvfrom(6, 0, buffer)
+      sock.close
+
+      message.should.equal?(buffer)
+      buffer.should == "foobar"
+    end
+
+    it "preserves the encoding of the given buffer" do
+      buffer = ''.encode(Encoding::ISO_8859_1)
+
+      @client.send("foobar", 0)
+      sock = @server.accept
+      sock.recvfrom(6, 0, buffer)
+      sock.close
+
+      buffer.encoding.should == Encoding::ISO_8859_1
+    end
+
     it "uses different message options" do
       @client.send("foobar", Socket::MSG_PEEK)
       sock = @server.accept


### PR DESCRIPTION
We still overwrite its internal buffer because we have no access to the inner TM::String, so it's not as efficient as the MRI implementation. It does save the encoding.