### PR TITLE
Fix GC race condition again

### DIFF
--- a/.amazonq/rules/basic-rules.md
+++ b/.amazonq/rules/basic-rules.md
@@ -1,0 +1,8 @@
+Header files end in `.hpp` and C++ files end in `.cpp` in this codebase.
+Never alter files in the `build` directory. Those files are generated from other sources.
+Never write a script to make changes to the codebase. Make all changes carefully and manually.
+You can usually build the project using `rake build`, but if you make changes to the compiler, you may need to run `rake clean build`.
+You can do a quick smoke-test by running `bin/natalie examples/hello.rb` or `bin/natalie examples/boardslam.rb 5 3 1`. Those are good tests.
+Of course, running an actual test like `bin/natalie spec/core/float/to_s_spec.rb` (or similar) is probably better.
+You should run `rake clean test` before committing to make sure the entire test suite passes.
+And lastly, please run `rake format` before committing to make sure all code is formatted correctly.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,3 +111,11 @@ jobs:
           SPEC_TIMEOUT: 480
           SOME_TESTS: true
         run: rake docker_test_asan
+  gc_stress_test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Run stress test
+        run: rake docker_gc_stress_test

--- a/Rakefile
+++ b/Rakefile
@@ -333,6 +333,13 @@ task :docker_test_perf do
        "natalie_clang_#{ruby_version_string} test_perf"
 end
 
+task docker_gc_stress_test: :docker_build_clang do
+  sh "docker run #{docker_run_flags} " \
+       '--rm ' \
+       '--entrypoint bash ' \
+       "natalie_clang_#{ruby_version_string} -c 'bin/natalie test/gc_stress_test.rb; status=$?; echo; echo $status; exit $status'"
+end
+
 task docker_tidy: :docker_build_clang do
   sh "docker run #{docker_run_flags} --rm --entrypoint rake natalie_clang_#{ruby_version_string} tidy"
 end

--- a/bin/natalie
+++ b/bin/natalie
@@ -196,7 +196,8 @@ class Runner
     case options[:debug]
     when 'gdb', 'lldb', 'strace'
       compiler.compile
-      exec(options[:debug], out.path)
+      flags = options[:debug] == 'gdb' ? %w[-x test/gdb-signals.gdb] : []
+      exec(options[:debug], *flags, out.path)
     when 'callgrind'
       callgrind_out = Tempfile.create('callgrind.out')
       callgrind_out.close

--- a/examples/gtk3.rb
+++ b/examples/gtk3.rb
@@ -102,7 +102,7 @@ module Gtk3
       arg_spread(env, args, "i", &type);
       GtkWidget *gtk_window = gtk_window_new((GtkWindowType)type);
       ClassObject *Window = self->const_fetch("Window"_s).as_class();
-      Object *window_wrapper = new Object { Window };
+      Object *window_wrapper = Object::create(Window);
       Object *ptr = new VoidPObject { gtk_window };
       window_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return window_wrapper;
@@ -131,7 +131,7 @@ module Gtk3
       arg_spread(env, args, "ii", &orientation, &spacing);
       GtkWidget *gtk_box = gtk_box_new((GtkOrientation)orientation, spacing);
       ClassObject *Box = self->const_fetch("Box"_s).as_class();
-      Object *box_wrapper = new Object { Box };
+      Object *box_wrapper = Object::create(Box);
       Object *ptr = new VoidPObject { gtk_box };
       box_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return box_wrapper;
@@ -151,7 +151,7 @@ module Gtk3
       arg_spread(env, args, "s", &filename);
       GtkWidget *gtk_image = gtk_image_new_from_file(filename);
       ClassObject *Image = self->const_fetch("Image"_s).as_class();
-      Object *image_wrapper = new Object { Image };
+      Object *image_wrapper = Object::create(Image);
       Object *ptr = new VoidPObject { gtk_image };
       image_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return image_wrapper;
@@ -195,7 +195,7 @@ module Gtk3
           gtk_label = gtk_label_new(text);
       }
       ClassObject *Label = self->const_fetch("Label"_s).as_class();
-      Object *label_wrapper = new Object { Label };
+      Object *label_wrapper = Object::create(Label);
       Object *ptr = new VoidPObject { gtk_label };
       label_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return label_wrapper;
@@ -216,7 +216,7 @@ module Gtk3
       arg_spread(env, args, "s", &label);
       GtkWidget *gtk_button = gtk_button_new_with_label(label);
       ClassObject *Button = self->const_fetch("Button"_s).as_class();
-      Object *button_wrapper = new Object { Button };
+      Object *button_wrapper = Object::create(Button);
       Object *ptr = new VoidPObject { gtk_button };
       button_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return button_wrapper;

--- a/examples/gtk3.rb
+++ b/examples/gtk3.rb
@@ -103,7 +103,7 @@ module Gtk3
       GtkWidget *gtk_window = gtk_window_new((GtkWindowType)type);
       ClassObject *Window = self->const_fetch("Window"_s).as_class();
       Object *window_wrapper = Object::create(Window);
-      Object *ptr = new VoidPObject { gtk_window };
+      Object *ptr = VoidPObject::create(gtk_window);
       window_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return window_wrapper;
     END
@@ -132,7 +132,7 @@ module Gtk3
       GtkWidget *gtk_box = gtk_box_new((GtkOrientation)orientation, spacing);
       ClassObject *Box = self->const_fetch("Box"_s).as_class();
       Object *box_wrapper = Object::create(Box);
-      Object *ptr = new VoidPObject { gtk_box };
+      Object *ptr = VoidPObject::create(gtk_box);
       box_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return box_wrapper;
     END
@@ -152,7 +152,7 @@ module Gtk3
       GtkWidget *gtk_image = gtk_image_new_from_file(filename);
       ClassObject *Image = self->const_fetch("Image"_s).as_class();
       Object *image_wrapper = Object::create(Image);
-      Object *ptr = new VoidPObject { gtk_image };
+      Object *ptr = VoidPObject::create(gtk_image);
       image_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return image_wrapper;
     END
@@ -196,7 +196,7 @@ module Gtk3
       }
       ClassObject *Label = self->const_fetch("Label"_s).as_class();
       Object *label_wrapper = Object::create(Label);
-      Object *ptr = new VoidPObject { gtk_label };
+      Object *ptr = VoidPObject::create(gtk_label);
       label_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return label_wrapper;
     END
@@ -217,7 +217,7 @@ module Gtk3
       GtkWidget *gtk_button = gtk_button_new_with_label(label);
       ClassObject *Button = self->const_fetch("Button"_s).as_class();
       Object *button_wrapper = Object::create(Button);
-      Object *ptr = new VoidPObject { gtk_button };
+      Object *ptr = VoidPObject::create(gtk_button);
       button_wrapper->ivar_set(env, "@_ptr"_s, ptr);
       return button_wrapper;
     END

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -16,51 +16,45 @@ using namespace TM;
 
 class ArrayObject : public Object {
 public:
-    ArrayObject()
-        : Object { Object::Type::Array, GlobalEnv::the()->Array() } { }
-
-    ArrayObject(ClassObject *klass)
-        : Object { Object::Type::Array, klass } { }
-
-    ArrayObject(size_t initial_capacity)
-        : ArrayObject {} {
-        m_vector.set_capacity(initial_capacity);
+    static ArrayObject *create() {
+        return new ArrayObject;
     }
 
-    ArrayObject(std::initializer_list<Value> list);
-
-    ArrayObject(const ArrayObject &other)
-        : Object { other }
-        , m_vector { other.m_vector } { }
-
-    ArrayObject &operator=(ArrayObject &&other) {
-        Object::operator=(std::move(other));
-        m_vector = std::move(other.m_vector);
-        return *this;
+    static ArrayObject *create(ClassObject *klass) {
+        return new ArrayObject(klass);
     }
 
-    ArrayObject(size_t argc, const Value *args)
-        : ArrayObject { argc, args, GlobalEnv::the()->Array() } { }
-
-    ArrayObject(size_t argc, const Value *args, ClassObject *klass)
-        : Object { Object::Type::Array, klass } {
-        m_vector.set_capacity(argc);
-        for (size_t i = 0; i < argc; i++) {
-            push(args[i]);
-        }
+    static ArrayObject *create(size_t initial_capacity) {
+        return new ArrayObject(initial_capacity);
     }
 
-    ArrayObject(const Vector<Value> &other)
-        : Object { Object::Type::Array, GlobalEnv::the()->Array() }
-        , m_vector { other } { }
+    static ArrayObject *create(std::initializer_list<Value> list) {
+        return new ArrayObject(list);
+    }
 
-    ArrayObject(Vector<Value> &&other)
-        : Object { Object::Type::Array, GlobalEnv::the()->Array() }
-        , m_vector { std::move(other) } { }
+    static ArrayObject *create(const ArrayObject &other) {
+        return new ArrayObject(other);
+    }
+
+    static ArrayObject *create(size_t argc, const Value *args) {
+        return new ArrayObject(argc, args);
+    }
+
+    static ArrayObject *create(size_t argc, const Value *args, ClassObject *klass) {
+        return new ArrayObject(argc, args, klass);
+    }
+
+    static ArrayObject *create(const Vector<Value> &other) {
+        return new ArrayObject(other);
+    }
+
+    static ArrayObject *create(Vector<Value> &&other) {
+        return new ArrayObject(std::move(other));
+    }
 
     // Array[]
     static Value square_new(Env *env, ClassObject *klass, Args &&args) {
-        return new ArrayObject { args.size(), args.data(), klass };
+        return ArrayObject::create(args.size(), args.data(), klass);
     }
 
     static Value size_fn(Env *, Value self, Args &&, Block *) {
@@ -221,6 +215,48 @@ public:
     }
 
 private:
+    ArrayObject()
+        : Object { Object::Type::Array, GlobalEnv::the()->Array() } { }
+
+    ArrayObject(ClassObject *klass)
+        : Object { Object::Type::Array, klass } { }
+
+    ArrayObject(size_t initial_capacity)
+        : ArrayObject {} {
+        m_vector.set_capacity(initial_capacity);
+    }
+
+    ArrayObject(std::initializer_list<Value> list);
+
+    ArrayObject(const ArrayObject &other)
+        : Object { other }
+        , m_vector { other.m_vector } { }
+
+    ArrayObject &operator=(ArrayObject &&other) {
+        Object::operator=(std::move(other));
+        m_vector = std::move(other.m_vector);
+        return *this;
+    }
+
+    ArrayObject(size_t argc, const Value *args)
+        : ArrayObject { argc, args, GlobalEnv::the()->Array() } { }
+
+    ArrayObject(size_t argc, const Value *args, ClassObject *klass)
+        : Object { Object::Type::Array, klass } {
+        m_vector.set_capacity(argc);
+        for (size_t i = 0; i < argc; i++) {
+            push(args[i]);
+        }
+    }
+
+    ArrayObject(const Vector<Value> &other)
+        : Object { Object::Type::Array, GlobalEnv::the()->Array() }
+        , m_vector { other } { }
+
+    ArrayObject(Vector<Value> &&other)
+        : Object { Object::Type::Array, GlobalEnv::the()->Array() }
+        , m_vector { std::move(other) } { }
+
     Vector<Value> m_vector {};
 
     nat_int_t _resolve_index(nat_int_t) const;

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -17,38 +17,47 @@ using namespace TM;
 class ArrayObject : public Object {
 public:
     static ArrayObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject;
     }
 
     static ArrayObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(klass);
     }
 
     static ArrayObject *create(size_t initial_capacity) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(initial_capacity);
     }
 
     static ArrayObject *create(std::initializer_list<Value> list) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(list);
     }
 
     static ArrayObject *create(const ArrayObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(other);
     }
 
     static ArrayObject *create(size_t argc, const Value *args) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(argc, args);
     }
 
     static ArrayObject *create(size_t argc, const Value *args, ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(argc, args, klass);
     }
 
     static ArrayObject *create(const Vector<Value> &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(other);
     }
 
     static ArrayObject *create(Vector<Value> &&other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ArrayObject(std::move(other));
     }
 

--- a/include/natalie/array_packer/float_handler.hpp
+++ b/include/natalie/array_packer/float_handler.hpp
@@ -17,7 +17,6 @@ namespace ArrayPacker {
         String pack(Env *env);
 
         virtual void visit_children(Visitor &visitor) const override {
-            Cell::visit_children(visitor);
             visitor.visit(m_source);
         }
 

--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -17,7 +17,6 @@ namespace ArrayPacker {
         String pack(Env *env);
 
         virtual void visit_children(Visitor &visitor) const override {
-            Cell::visit_children(visitor);
             visitor.visit(m_source);
         }
 

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -25,7 +25,6 @@ namespace ArrayPacker {
         StringObject *pack(Env *env, StringObject *buffer);
 
         virtual void visit_children(Visitor &visitor) const override {
-            Cell::visit_children(visitor);
             visitor.visit(m_source);
             visitor.visit(m_encoding);
         }

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -20,7 +20,6 @@ namespace ArrayPacker {
         using PackHandlerFn = void (StringHandler::*)();
 
         virtual void visit_children(Visitor &visitor) const override {
-            Cell::visit_children(visitor);
             visitor.visit(m_string_object);
         }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -49,7 +49,6 @@ public:
     void copy_fn_pointer_to_method(Method *);
 
     virtual void visit_children(Visitor &visitor) const override final {
-        Cell::visit_children(visitor);
         visitor.visit(m_env);
         visitor.visit(m_calling_env);
         visitor.visit(m_self);

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -18,10 +18,12 @@ public:
     };
 
     static Block *create(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Block(env, self, fn, arity, type);
     }
 
     static Block *create(TM::OwnedPtr<Env> &&env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Block(std::move(env), self, fn, arity, type);
     }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -62,7 +62,7 @@ private:
     Block(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
         : m_fn { fn }
         , m_arity { arity }
-        , m_env { new Env(env) }
+        , m_env { Env::create(env) }
         , m_self { self }
         , m_type { type } { }
 

--- a/include/natalie/block.hpp
+++ b/include/natalie/block.hpp
@@ -17,20 +17,13 @@ public:
         Method
     };
 
-    Block(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
-        : m_fn { fn }
-        , m_arity { arity }
-        , m_env { new Env(env) }
-        , m_self { self }
-        , m_type { type } { }
+    static Block *create(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc) {
+        return new Block(env, self, fn, arity, type);
+    }
 
-    // Keep the TM:: namespace, ffi-clang (used in gc_lint) gets confused otherwise
-    Block(TM::OwnedPtr<Env> &&env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
-        : m_fn { fn }
-        , m_arity { arity }
-        , m_env { env.release() }
-        , m_self { self }
-        , m_type { type } { }
+    static Block *create(TM::OwnedPtr<Env> &&env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc) {
+        return new Block(std::move(env), self, fn, arity, type);
+    }
 
     Value run(Env *env, Args &&args = {}, Block *block = nullptr);
 
@@ -65,6 +58,20 @@ public:
     }
 
 private:
+    Block(Env &env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
+        : m_fn { fn }
+        , m_arity { arity }
+        , m_env { new Env(env) }
+        , m_self { self }
+        , m_type { type } { }
+
+    Block(OwnedPtr<Env> &&env, Value self, MethodFnPtr fn, int arity, BlockType type = BlockType::Proc)
+        : m_fn { fn }
+        , m_arity { arity }
+        , m_env { env.release() }
+        , m_self { self }
+        , m_type { type } { }
+
     MethodFnPtr m_fn;
     int m_arity { 0 };
     Env *m_env { nullptr };

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -14,17 +14,17 @@ namespace Natalie {
 
 class ClassObject : public ModuleObject {
 public:
-    ClassObject()
-        : ClassObject { GlobalEnv::the()->Class() } { }
+    static ClassObject *create() {
+        return new ClassObject();
+    }
 
-    ClassObject(ClassObject *klass)
-        : ModuleObject { Object::Type::Class, klass } { }
+    static ClassObject *create(ClassObject *klass) {
+        return new ClassObject(klass);
+    }
 
-    ClassObject(const ClassObject &other)
-        : ModuleObject { other }
-        , m_object_type { other.m_object_type }
-        , m_is_singleton { other.m_is_singleton }
-        , m_is_initialized { other.m_is_initialized } { }
+    static ClassObject *create(const ClassObject &other) {
+        return new ClassObject(other);
+    }
 
     ClassObject *superclass(Env *env) override {
         if (!m_is_initialized)
@@ -64,6 +64,19 @@ public:
     virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<ClassObject {h} name=\"{}\">", this, m_name.value_or("none"));
     }
+
+protected:
+    ClassObject()
+        : ClassObject { GlobalEnv::the()->Class() } { }
+
+    ClassObject(ClassObject *klass)
+        : ModuleObject { Object::Type::Class, klass } { }
+
+    ClassObject(const ClassObject &other)
+        : ModuleObject { other }
+        , m_object_type { other.m_object_type }
+        , m_is_singleton { other.m_is_singleton }
+        , m_is_initialized { other.m_is_initialized } { }
 
 private:
     Type m_object_type { Type::Object };

--- a/include/natalie/complex_object.hpp
+++ b/include/natalie/complex_object.hpp
@@ -12,6 +12,37 @@ namespace Natalie {
 class ComplexObject : public Object {
 
 public:
+    static ComplexObject *create() {
+        return new ComplexObject();
+    }
+
+    static ComplexObject *create(ClassObject *klass) {
+        return new ComplexObject(klass);
+    }
+
+    static ComplexObject *create(Value real) {
+        return new ComplexObject(real);
+    }
+
+    static ComplexObject *create(Value real, Value imaginary) {
+        return new ComplexObject(real, imaginary);
+    }
+
+    static ComplexObject *create(const ComplexObject &other) {
+        return new ComplexObject(other);
+    }
+
+    Value imaginary() { return m_imaginary; }
+    Value inspect(Env *);
+    Value real() { return m_real; }
+
+    virtual void visit_children(Visitor &visitor) const override {
+        Object::visit_children(visitor);
+        visitor.visit(m_real);
+        visitor.visit(m_imaginary);
+    }
+
+protected:
     ComplexObject()
         : Object { Object::Type::Complex, GlobalEnv::the()->Object()->const_fetch("Complex"_s).as_class() } {
         freeze();
@@ -36,14 +67,11 @@ public:
         freeze();
     }
 
-    Value imaginary() { return m_imaginary; }
-    Value inspect(Env *);
-    Value real() { return m_real; }
-
-    virtual void visit_children(Visitor &visitor) const override {
-        Object::visit_children(visitor);
-        visitor.visit(m_real);
-        visitor.visit(m_imaginary);
+    ComplexObject(const ComplexObject &other)
+        : Object { other }
+        , m_real { other.m_real }
+        , m_imaginary { other.m_imaginary } {
+        freeze();
     }
 
 private:

--- a/include/natalie/dir_object.hpp
+++ b/include/natalie/dir_object.hpp
@@ -19,11 +19,17 @@ namespace Natalie {
 class DirObject : public Object {
 
 public:
-    DirObject()
-        : Object { Object::Type::Dir, GlobalEnv::the()->Object()->const_fetch("Dir"_s).as_class() } { }
+    static DirObject *create() {
+        return new DirObject();
+    }
 
-    DirObject(ClassObject *klass)
-        : Object { Object::Type::Dir, klass } { }
+    static DirObject *create(ClassObject *klass) {
+        return new DirObject(klass);
+    }
+
+    static DirObject *create(const DirObject &other) {
+        return new DirObject(other);
+    }
 
     virtual ~DirObject();
 
@@ -69,6 +75,18 @@ public:
     static Value foreach (Env *env, Value path, Optional<Value> encoding, Block * block);
 
 private:
+    DirObject()
+        : Object { Object::Type::Dir, GlobalEnv::the()->Object()->const_fetch("Dir"_s).as_class() } { }
+
+    DirObject(ClassObject *klass)
+        : Object { Object::Type::Dir, klass } { }
+
+    DirObject(const DirObject &other)
+        : Object { other }
+        , m_dir { other.m_dir }
+        , m_path { other.m_path }
+        , m_encoding { other.m_encoding } { }
+
     DIR *m_dir { nullptr };
     StringObject *m_path { nullptr };
     EncodingObject *m_encoding { nullptr };

--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -18,6 +18,21 @@ extern thread_local ExceptionObject *tl_current_exception;
 
 class Env : public Cell {
 public:
+    static Env *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        return new Env;
+    }
+
+    static Env *create(Env *outer) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        return new Env { outer };
+    }
+
+    static Env *create(const Env &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+        return new Env { other };
+    }
+
     Env() { }
 
     Env(Env *outer)

--- a/include/natalie/exception_object.hpp
+++ b/include/natalie/exception_object.hpp
@@ -13,20 +13,20 @@ namespace Natalie {
 
 class ExceptionObject : public Object {
 public:
-    ExceptionObject()
-        : Object { Object::Type::Exception, GlobalEnv::the()->Object()->const_fetch("Exception"_s).as_class() } { }
+    static ExceptionObject *create() {
+        return new ExceptionObject();
+    }
 
-    ExceptionObject(ClassObject *klass)
-        : Object { Object::Type::Exception, klass } { }
+    static ExceptionObject *create(ClassObject *klass) {
+        return new ExceptionObject(klass);
+    }
 
-    ExceptionObject(ClassObject *klass, Value message)
-        : Object { Object::Type::Exception, klass }
-        , m_message { message } { }
+    static ExceptionObject *create(ClassObject *klass, Value message) {
+        return new ExceptionObject(klass, message);
+    }
 
-    ExceptionObject(Env *env, ExceptionObject &other)
-        : Object { other } {
-        m_message = other.m_message;
-        m_backtrace = other.m_backtrace;
+    static ExceptionObject *create(const ExceptionObject &other) {
+        return new ExceptionObject(other);
     }
 
     static ExceptionObject *create_for_raise(Env *env, Args &&args, ExceptionObject *current_exception, bool accept_cause);
@@ -68,6 +68,24 @@ public:
     void set_break_point(nat_int_t break_point) { m_break_point = break_point; }
 
 private:
+    ExceptionObject()
+        : Object { Object::Type::Exception, GlobalEnv::the()->Object()->const_fetch("Exception"_s).as_class() } { }
+
+    ExceptionObject(ClassObject *klass)
+        : Object { Object::Type::Exception, klass } { }
+
+    ExceptionObject(ClassObject *klass, Value message)
+        : Object { Object::Type::Exception, klass }
+        , m_message { message } { }
+
+    ExceptionObject(const ExceptionObject &other)
+        : Object { other }
+        , m_message { other.m_message }
+        , m_backtrace { other.m_backtrace }
+        , m_backtrace_value { other.m_backtrace_value }
+        , m_backtrace_locations { other.m_backtrace_locations }
+        , m_cause { other.m_cause } { }
+
     ArrayObject *generate_backtrace();
 
     Value m_message { Value::nil() };

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -39,11 +39,13 @@ public:
         Terminated,
     };
 
-    FiberObject()
-        : Object { Object::Type::Fiber, GlobalEnv::the()->Object()->const_fetch("Fiber"_s).as_class() } { }
+    static FiberObject *create() {
+        return new FiberObject();
+    }
 
-    FiberObject(ClassObject *klass)
-        : Object { Object::Type::Fiber, klass } { }
+    static FiberObject *create(ClassObject *klass) {
+        return new FiberObject(klass);
+    }
 
     ~FiberObject() {
         if (!m_coroutine) {
@@ -147,6 +149,12 @@ public:
 #endif
 
 private:
+    FiberObject()
+        : Object { Object::Type::Fiber, GlobalEnv::the()->Object()->const_fetch("Fiber"_s).as_class() } { }
+
+    FiberObject(ClassObject *klass)
+        : Object { Object::Type::Fiber, klass } { }
+
     friend Args;
     friend ThreadObject;
 

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -5,22 +5,21 @@
 #include <sys/stat.h>
 
 #include "natalie/forward.hpp"
-#include "natalie/integer_methods.hpp"
 #include "natalie/io_object.hpp"
-#include "natalie/regexp_object.hpp"
 #include "natalie/string_object.hpp"
 #include "natalie/symbol_object.hpp"
-#include "tm/defer.hpp"
 
 namespace Natalie {
 
 class FileObject : public IoObject {
 public:
-    FileObject()
-        : FileObject { GlobalEnv::the()->Object()->const_fetch("File"_s).as_class() } { }
+    static FileObject *create() {
+        return new FileObject();
+    }
 
-    FileObject(ClassObject *klass)
-        : IoObject { Object::Type::File, klass } { }
+    static FileObject *create(ClassObject *klass) {
+        return new FileObject(klass);
+    }
 
     Value initialize(Env *, Args &&, Block *);
 
@@ -103,6 +102,13 @@ public:
     }
 
     IoObject *as_io() { return static_cast<IoObject *>(this); }
+
+private:
+    FileObject()
+        : FileObject { GlobalEnv::the()->Object()->const_fetch("File"_s).as_class() } { }
+
+    FileObject(ClassObject *klass)
+        : IoObject { Object::Type::File, klass } { }
 };
 
 }

--- a/include/natalie/file_object.hpp
+++ b/include/natalie/file_object.hpp
@@ -14,10 +14,12 @@ namespace Natalie {
 class FileObject : public IoObject {
 public:
     static FileObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FileObject();
     }
 
     static FileObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FileObject(klass);
     }
 

--- a/include/natalie/file_stat_object.hpp
+++ b/include/natalie/file_stat_object.hpp
@@ -23,16 +23,20 @@ namespace Natalie {
 
 class FileStatObject : public Object {
 public:
-    FileStatObject()
-        : Object { Object::Type::FileStat,
-            GlobalEnv::the()->Object()->const_fetch("File"_s).as_class()->const_fetch("Stat"_s).as_class() } { }
-    FileStatObject(ClassObject *klass)
-        : Object { Object::Type::FileStat, klass } { }
+    static FileStatObject *create() {
+        return new FileStatObject();
+    }
 
-    FileStatObject(struct stat status)
-        : Object { Object::Type::FileStat,
-            GlobalEnv::the()->Object()->const_fetch("File"_s).as_class()->const_fetch("Stat"_s).as_class() } {
-        fstatus = status;
+    static FileStatObject *create(ClassObject *klass) {
+        return new FileStatObject(klass);
+    }
+
+    static FileStatObject *create(struct stat status) {
+        return new FileStatObject(status);
+    }
+
+    static FileStatObject *create(const FileStatObject &other) {
+        return new FileStatObject(other);
     }
 
     Value initialize(Env *, Value);
@@ -74,6 +78,23 @@ public:
     Value gid() const;
 
 private:
+    FileStatObject()
+        : Object { Object::Type::FileStat,
+            GlobalEnv::the()->Object()->const_fetch("File"_s).as_class()->const_fetch("Stat"_s).as_class() } { }
+
+    FileStatObject(ClassObject *klass)
+        : Object { Object::Type::FileStat, klass } { }
+
+    FileStatObject(struct stat status)
+        : Object { Object::Type::FileStat,
+            GlobalEnv::the()->Object()->const_fetch("File"_s).as_class()->const_fetch("Stat"_s).as_class() } {
+        fstatus = status;
+    }
+
+    FileStatObject(const FileStatObject &other)
+        : Object { other }
+        , fstatus { other.fstatus } { }
+
     struct stat fstatus;
 };
 

--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -16,39 +16,49 @@ namespace Natalie {
 class FloatObject : public Object {
 public:
     static FloatObject *nan() {
-        if (!s_nan)
+        if (!s_nan) {
+            std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
             s_nan = new FloatObject { 0.0 / 0.0 };
+        }
         return s_nan;
     }
     static FloatObject *create(double number) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { number };
     }
 
     static FloatObject *create(nat_int_t number) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { number };
     }
 
     static FloatObject *create(const FloatObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { other };
     }
 
     static FloatObject *positive_infinity(Env *env) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { std::numeric_limits<double>::infinity() };
     }
 
     static FloatObject *negative_infinity(Env *env) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { -std::numeric_limits<double>::infinity() };
     }
 
     static FloatObject *max(Env *env) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { DBL_MAX };
     }
 
     static FloatObject *neg_max(Env *env) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { -DBL_MAX };
     }
 
     static FloatObject *min(Env *env) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new FloatObject { DBL_MIN };
     }
 

--- a/include/natalie/float_object.hpp
+++ b/include/natalie/float_object.hpp
@@ -7,7 +7,6 @@
 #include "natalie/class_object.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
-#include "natalie/integer_methods.hpp"
 #include "natalie/macros.hpp"
 #include "natalie/object.hpp"
 #include "natalie/symbol_object.hpp"
@@ -16,22 +15,21 @@ namespace Natalie {
 
 class FloatObject : public Object {
 public:
-    FloatObject(double number)
-        : Object { Object::Type::Float, GlobalEnv::the()->Float() }
-        , m_double { number } { }
-
-    FloatObject(nat_int_t number)
-        : Object { Object::Type::Float, GlobalEnv::the()->Float() }
-        , m_double { static_cast<double>(number) } { }
-
-    FloatObject(const FloatObject &other)
-        : Object { Object::Type::Float, other.klass() }
-        , m_double { other.m_double } { }
-
     static FloatObject *nan() {
         if (!s_nan)
             s_nan = new FloatObject { 0.0 / 0.0 };
         return s_nan;
+    }
+    static FloatObject *create(double number) {
+        return new FloatObject { number };
+    }
+
+    static FloatObject *create(nat_int_t number) {
+        return new FloatObject { number };
+    }
+
+    static FloatObject *create(const FloatObject &other) {
+        return new FloatObject { other };
     }
 
     static FloatObject *positive_infinity(Env *env) {
@@ -141,26 +139,26 @@ public:
     bool gte(Env *, Value);
 
     Value uminus() const {
-        return new FloatObject { -m_double };
+        return FloatObject::create(-m_double);
     }
 
     Value uplus() const {
-        return new FloatObject { m_double };
+        return FloatObject::create(m_double);
     }
 
     static void build_constants(Env *env, ClassObject *klass) {
-        klass->const_set("DIG"_s, new FloatObject { double { DBL_DIG } });
-        klass->const_set("EPSILON"_s, new FloatObject { std::numeric_limits<double>::epsilon() });
+        klass->const_set("DIG"_s, FloatObject::create(double { DBL_DIG }));
+        klass->const_set("EPSILON"_s, FloatObject::create(std::numeric_limits<double>::epsilon()));
         klass->const_set("INFINITY"_s, FloatObject::positive_infinity(env));
-        klass->const_set("MANT_DIG"_s, new FloatObject { double { DBL_MANT_DIG } });
+        klass->const_set("MANT_DIG"_s, FloatObject::create(double { DBL_MANT_DIG }));
         klass->const_set("MAX"_s, FloatObject::max(env));
-        klass->const_set("MAX_10_EXP"_s, new FloatObject { double { DBL_MAX_10_EXP } });
-        klass->const_set("MAX_EXP"_s, new FloatObject { double { DBL_MAX_EXP } });
+        klass->const_set("MAX_10_EXP"_s, FloatObject::create(double { DBL_MAX_10_EXP }));
+        klass->const_set("MAX_EXP"_s, FloatObject::create(double { DBL_MAX_EXP }));
         klass->const_set("MIN"_s, FloatObject::min(env));
-        klass->const_set("MIN_10_EXP"_s, new FloatObject { double { DBL_MIN_10_EXP } });
-        klass->const_set("MIN_EXP"_s, new FloatObject { double { DBL_MIN_EXP } });
+        klass->const_set("MIN_10_EXP"_s, FloatObject::create(double { DBL_MIN_10_EXP }));
+        klass->const_set("MIN_EXP"_s, FloatObject::create(double { DBL_MIN_EXP }));
         klass->const_set("NAN"_s, FloatObject::nan());
-        klass->const_set("RADIX"_s, new FloatObject { double { std::numeric_limits<double>::radix } });
+        klass->const_set("RADIX"_s, FloatObject::create(double { std::numeric_limits<double>::radix }));
     }
 
     virtual TM::String dbg_inspect(int indent = 0) const override {
@@ -168,6 +166,18 @@ public:
     }
 
 private:
+    FloatObject(double number)
+        : Object { Object::Type::Float, GlobalEnv::the()->Float() }
+        , m_double { number } { }
+
+    FloatObject(nat_int_t number)
+        : Object { Object::Type::Float, GlobalEnv::the()->Float() }
+        , m_double { static_cast<double>(number) } { }
+
+    FloatObject(const FloatObject &other)
+        : Object { Object::Type::Float, other.klass() }
+        , m_double { other.m_double } { }
+
     inline static FloatObject *s_nan { nullptr };
 
     double m_double { 0.0 };

--- a/include/natalie/gc/cell.hpp
+++ b/include/natalie/gc/cell.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <assert.h>
+#include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,13 +14,6 @@ namespace Natalie {
 
 class Cell {
 public:
-    enum class Status {
-        Unused, // in the free list, not yet allocated
-        Unmarked, // allocated, not yet marked (maybe unreachable)
-        Marked, // allocated, reachable
-        MarkedAndVisited, // allocated, reachable, and visited already
-    };
-
     Cell() { }
     virtual ~Cell() { }
 
@@ -34,7 +28,6 @@ public:
     };
 
     virtual void visit_children(Visitor &) const {
-        m_status = Status::MarkedAndVisited;
     }
 
     virtual TM::String dbg_inspect(int indent = 0) const {
@@ -50,39 +43,19 @@ public:
     }
 
     bool is_marked() const {
-        return m_status == Status::Marked || m_status == Status::MarkedAndVisited;
-    }
-
-    bool is_visited() const {
-        return m_status == Status::MarkedAndVisited;
+        return m_marked;
     }
 
     void mark() const {
-        m_status = Status::Marked;
+        m_marked = true;
     }
 
     void unmark() const {
-        m_status = Status::Unmarked;
+        m_marked = false;
     }
 
 private:
-    // The reason that Cells are "Marked" by default is because of an insidious race condition
-    // in multi-threaded code that goes something like this:
-    //
-    // 1. Thread A allocates a new Cell, let's pretend it's a StringObject "Jimmy".
-    //    A new Cell is allocated, but before the object initialization is complete...
-    // 2. Thread Main pauses the world and starts marking reachable Cells.
-    // 3. Thread Main does indeed see that "Jimmy" is reachable, and marks him.
-    // 4. Thread Main wakes up the world.
-    // 5. Thread A finishes initializing "Jimmy" and default initializes the `m_status` value.
-    // 6. Thread Main sweeps unmarked cells.
-    //
-    // If the default was "Unmarked", then Thread Main would sweep the brand new object
-    // that is indeed reachable and was just marked. :-/
-    //
-    // The downside to this is that every Cell will live through at least one GC cycle.
-    // We may come up with another solution down the road...
-    mutable Status m_status { Status::Marked };
+    mutable bool m_marked { false };
 };
 
 }

--- a/include/natalie/gc/marking_visitor.hpp
+++ b/include/natalie/gc/marking_visitor.hpp
@@ -11,7 +11,7 @@ public:
     virtual void visit(Value val) override final;
 
     virtual void visit(const Cell *cell) override final {
-        if (!cell || cell->is_visited()) return;
+        if (!cell || cell->is_marked()) return;
         m_stack.push(cell);
     }
 

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -49,54 +49,24 @@ namespace Natalie {
 
 class HashObject : public Object {
 public:
-    HashObject()
-        : HashObject { GlobalEnv::the()->Hash() } { }
-
-    HashObject(Env *env, std::initializer_list<Value> items)
-        : HashObject {} {
-        assert(items.size() % 2 == 0);
-        for (auto it = items.begin(); it != items.end(); it++) {
-            auto key = *it;
-            it++;
-            auto value = *it;
-            put(env, key, value);
-        }
+    static HashObject *create() {
+        return new HashObject();
     }
 
-    HashObject(Env *env, size_t argc, Value *items)
-        : HashObject {} {
-        assert(argc % 2 == 0);
-        for (size_t i = 0; i < argc; i += 2) {
-            auto key = items[i];
-            auto value = items[i + 1];
-            put(env, key, value);
-        }
+    static HashObject *create(ClassObject *klass) {
+        return new HashObject(klass);
     }
 
-    HashObject(ClassObject *klass)
-        : Object { Object::Type::Hash, klass }
-        , m_default_value { Value::nil() } { }
-
-    HashObject(Env *env, const HashObject &other)
-        : Object { other }
-        , m_is_comparing_by_identity { other.m_is_comparing_by_identity }
-        , m_default_value { other.m_default_value }
-        , m_default_proc { other.m_default_proc } {
-        for (auto node : other) {
-            put(env, node.key, node.val);
-        }
+    static HashObject *create(Env *env, std::initializer_list<Value> items) {
+        return new HashObject(env, items);
     }
 
-    HashObject &operator=(HashObject &&other) {
-        Object::operator=(std::move(other));
-        m_hashmap.clear();
-        m_hashmap = std::move(other.m_hashmap);
-        m_key_list = other.m_key_list;
-        m_is_comparing_by_identity = other.m_is_comparing_by_identity;
-        m_default_value = other.m_default_value;
-        m_default_proc = other.m_default_proc;
-        other.m_key_list = nullptr;
-        return *this;
+    static HashObject *create(Env *env, size_t argc, Value *items) {
+        return new HashObject(env, argc, items);
+    }
+
+    static HashObject *create(Env *env, const HashObject &other) {
+        return new HashObject(env, other);
     }
 
     static Value square_new(Env *, ClassObject *klass, Args &&args);
@@ -228,6 +198,56 @@ public:
     }
 
 private:
+    HashObject()
+        : HashObject { GlobalEnv::the()->Hash() } { }
+
+    HashObject(Env *env, std::initializer_list<Value> items)
+        : HashObject {} {
+        assert(items.size() % 2 == 0);
+        for (auto it = items.begin(); it != items.end(); it++) {
+            auto key = *it;
+            it++;
+            auto value = *it;
+            put(env, key, value);
+        }
+    }
+
+    HashObject(Env *env, size_t argc, Value *items)
+        : HashObject {} {
+        assert(argc % 2 == 0);
+        for (size_t i = 0; i < argc; i += 2) {
+            auto key = items[i];
+            auto value = items[i + 1];
+            put(env, key, value);
+        }
+    }
+
+    HashObject(ClassObject *klass)
+        : Object { Object::Type::Hash, klass }
+        , m_default_value { Value::nil() } { }
+
+    HashObject(Env *env, const HashObject &other)
+        : Object { other }
+        , m_is_comparing_by_identity { other.m_is_comparing_by_identity }
+        , m_default_value { other.m_default_value }
+        , m_default_proc { other.m_default_proc } {
+        for (auto node : other) {
+            put(env, node.key, node.val);
+        }
+    }
+
+    HashObject &operator=(HashObject &&other) {
+        Object::operator=(std::move(other));
+        m_hashmap.clear();
+        m_hashmap = std::move(other.m_hashmap);
+        m_key_list = other.m_key_list;
+        m_is_comparing_by_identity = other.m_is_comparing_by_identity;
+        m_default_value = other.m_default_value;
+        m_default_proc = other.m_default_proc;
+        other.m_key_list = nullptr;
+        return *this;
+    }
+
     void key_list_remove_node(HashKey *);
     HashKey *key_list_append(Env *, Value, nat_int_t, Value);
     nat_int_t generate_key_hash(Env *, Value) const;

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -25,7 +25,6 @@ struct HashKey : public Cell {
     bool removed { false };
 
     virtual void visit_children(Visitor &visitor) const override final {
-        Cell::visit_children(visitor);
         visitor.visit(prev);
         visitor.visit(next);
         visitor.visit(key);

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <assert.h>
-#include <mutex>
 
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"
@@ -13,6 +12,10 @@
 namespace Natalie {
 
 struct HashKey : public Cell {
+    static HashKey *create(Value key, Value val, size_t hash) {
+        return new HashKey { key, val, hash };
+    }
+
     HashKey *prev { nullptr };
     HashKey *next { nullptr };
     Value key;
@@ -31,6 +34,13 @@ struct HashKey : public Cell {
     virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<HashKey {h} key={} val={}>", this, key.dbg_inspect(), val.dbg_inspect());
     }
+
+    HashKey() { }
+
+    HashKey(Value key, Value val, size_t hash)
+        : key { key }
+        , val { val }
+        , hash { hash } { }
 };
 
 }

--- a/include/natalie/hash_object.hpp
+++ b/include/natalie/hash_object.hpp
@@ -13,6 +13,7 @@ namespace Natalie {
 
 struct HashKey : public Cell {
     static HashKey *create(Value key, Value val, size_t hash) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashKey { key, val, hash };
     }
 
@@ -60,22 +61,27 @@ namespace Natalie {
 class HashObject : public Object {
 public:
     static HashObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashObject();
     }
 
     static HashObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashObject(klass);
     }
 
     static HashObject *create(Env *env, std::initializer_list<Value> items) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashObject(env, items);
     }
 
     static HashObject *create(Env *env, size_t argc, Value *items) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashObject(env, argc, items);
     }
 
     static HashObject *create(Env *env, const HashObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new HashObject(env, other);
     }
 

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -125,7 +125,7 @@ public:
 
     Value get_path() const;
     void set_path(StringObject *path) { m_path = path; }
-    void set_path(String path) { m_path = new StringObject { path }; }
+    void set_path(String path) { m_path = StringObject::create(path); }
 
     Value external_encoding() const {
         if (!m_external_encoding)

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -17,19 +17,20 @@ namespace Natalie {
 
 class IoObject : public Object {
 public:
-    IoObject()
-        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() } { }
+    static IoObject *create() {
+        return new IoObject();
+    }
 
-    IoObject(ClassObject *klass)
-        : Object { Object::Type::Io, klass } { }
+    static IoObject *create(ClassObject *klass) {
+        return new IoObject(klass);
+    }
 
-    IoObject(Type type, ClassObject *klass)
-        : Object { type, klass } { }
+    static IoObject *create(Type type, ClassObject *klass) {
+        return new IoObject(type, klass);
+    }
 
-    IoObject(int fileno)
-        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() }
-        , m_sync { fileno == STDERR_FILENO } {
-        set_fileno(fileno);
+    static IoObject *create(int fileno) {
+        return new IoObject(fileno);
     }
 
     virtual ~IoObject() override {
@@ -145,6 +146,21 @@ public:
     }
 
 protected:
+    IoObject()
+        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() } { }
+
+    IoObject(ClassObject *klass)
+        : Object { Object::Type::Io, klass } { }
+
+    IoObject(Type type, ClassObject *klass)
+        : Object { type, klass } { }
+
+    IoObject(int fileno)
+        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() }
+        , m_sync { fileno == STDERR_FILENO } {
+        set_fileno(fileno);
+    }
+
     void raise_if_closed(Env *) const;
     int write(Env *, Value);
 

--- a/include/natalie/managed_vector.hpp
+++ b/include/natalie/managed_vector.hpp
@@ -18,7 +18,6 @@ public:
     virtual ~ManagedVector() { }
 
     virtual void visit_children(Visitor &visitor) const override final {
-        Cell::visit_children(visitor);
         for (auto it = TM::Vector<T>::begin(); it != TM::Vector<T>::end(); ++it) {
             visitor.visit(*it);
         }

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -14,17 +14,21 @@ namespace Natalie {
 
 class MatchDataObject : public Object {
 public:
-    MatchDataObject()
-        : Object { Object::Type::MatchData, GlobalEnv::the()->Object()->const_fetch("MatchData"_s).as_class() } { }
+    static MatchDataObject *create() {
+        return new MatchDataObject {};
+    }
 
-    MatchDataObject(ClassObject *klass)
-        : Object { Object::Type::MatchData, klass } { }
+    static MatchDataObject *create(ClassObject *klass) {
+        return new MatchDataObject { klass };
+    }
 
-    MatchDataObject(OnigRegion *region, const StringObject *string, RegexpObject *regexp)
-        : Object { Object::Type::MatchData, GlobalEnv::the()->Object()->const_fetch("MatchData"_s).as_class() }
-        , m_region { region }
-        , m_string { StringObject::create(*string) }
-        , m_regexp { regexp } { }
+    static MatchDataObject *create(OnigRegion *region, const StringObject *string, RegexpObject *regexp) {
+        return new MatchDataObject { region, string, regexp };
+    }
+
+    static MatchDataObject *create(const MatchDataObject &other) {
+        return new MatchDataObject { other };
+    }
 
     virtual ~MatchDataObject() override {
         onig_region_free(m_region, true);
@@ -83,6 +87,26 @@ public:
     }
 
 private:
+    MatchDataObject()
+        : Object { Object::Type::MatchData, GlobalEnv::the()->Object()->const_fetch("MatchData"_s).as_class() } { }
+
+    MatchDataObject(ClassObject *klass)
+        : Object { Object::Type::MatchData, klass } { }
+
+    MatchDataObject(OnigRegion *region, const StringObject *string, RegexpObject *regexp)
+        : Object { Object::Type::MatchData, GlobalEnv::the()->Object()->const_fetch("MatchData"_s).as_class() }
+        , m_region { region }
+        , m_string { StringObject::create(*string) }
+        , m_regexp { regexp } { }
+
+    MatchDataObject(const MatchDataObject &other)
+        : Object { other }
+        , m_region { other.m_region }
+        , m_string { other.m_string }
+        , m_regexp { other.m_regexp } {
+        onig_region_copy(m_region, other.m_region);
+    }
+
     OnigRegion *m_region { nullptr };
     StringObject *m_string { nullptr };
     RegexpObject *m_regexp { nullptr };

--- a/include/natalie/match_data_object.hpp
+++ b/include/natalie/match_data_object.hpp
@@ -23,7 +23,7 @@ public:
     MatchDataObject(OnigRegion *region, const StringObject *string, RegexpObject *regexp)
         : Object { Object::Type::MatchData, GlobalEnv::the()->Object()->const_fetch("MatchData"_s).as_class() }
         , m_region { region }
-        , m_string { new StringObject(*string) }
+        , m_string { StringObject::create(*string) }
         , m_regexp { regexp } { }
 
     virtual ~MatchDataObject() override {

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -25,7 +25,7 @@ public:
         : m_name { std::move(name) }
         , m_owner { owner }
         , m_arity { block->arity() }
-        , m_env { new Env(*block->env()) } {
+        , m_env { Env::create(*block->env()) } {
         assert(m_env);
         block->copy_fn_pointer_to_method(this);
 

--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -79,7 +79,6 @@ public:
     const Optional<size_t> &get_line() const { return m_line; }
 
     virtual void visit_children(Visitor &visitor) const override final {
-        Cell::visit_children(visitor);
         visitor.visit(m_owner);
         visitor.visit(m_env);
         if (m_self)

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -32,7 +32,7 @@ public:
     }
 
     virtual ProcObject *to_proc(Env *env) override {
-        auto block = new Block { *env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method };
+        auto block = Block::create(*env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method);
         return new ProcObject { block };
     }
 

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -6,13 +6,12 @@ namespace Natalie {
 
 class MethodObject : public AbstractMethodObject {
 public:
-    MethodObject(Value object, Method *method)
-        : AbstractMethodObject { Object::Type::Method, GlobalEnv::the()->Object()->const_fetch("Method"_s).as_class(), method }
-        , m_object { object } { }
+    static MethodObject *create(Value object, Method *method) {
+        return new MethodObject { object, method };
+    }
 
-    MethodObject(Value object, Method *method, SymbolObject *method_missing_name)
-        : MethodObject { object, method } {
-        m_method_missing_name = method_missing_name;
+    static MethodObject *create(Value object, Method *method, SymbolObject *method_missing_name) {
+        return new MethodObject { object, method, method_missing_name };
     }
 
     Value unbind(Env *);
@@ -54,6 +53,15 @@ public:
     }
 
 private:
+    MethodObject(Value object, Method *method)
+        : AbstractMethodObject { Object::Type::Method, GlobalEnv::the()->Object()->const_fetch("Method"_s).as_class(), method }
+        , m_object { object } { }
+
+    MethodObject(Value object, Method *method, SymbolObject *method_missing_name)
+        : MethodObject { object, method } {
+        m_method_missing_name = method_missing_name;
+    }
+
     Value m_object;
     SymbolObject *m_method_missing_name { nullptr };
 };

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -32,7 +32,7 @@ public:
 
     virtual ProcObject *to_proc(Env *env) override {
         auto block = Block::create(*env, m_object, m_method->fn(), m_method->arity(), Block::BlockType::Method);
-        return new ProcObject { block };
+        return ProcObject::create(block);
     }
 
     Value call(Env *env, Args &&args, Block *block) {

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -20,23 +20,24 @@ using namespace TM;
 
 class ModuleObject : public Object {
 public:
-    ModuleObject();
-    ModuleObject(const char *);
-    ModuleObject(Type, ClassObject *);
+    static ModuleObject *create() {
+        return new ModuleObject();
+    }
 
-    ModuleObject(ClassObject *klass)
-        : ModuleObject { Type::Module, klass } { }
+    static ModuleObject *create(const char *name) {
+        return new ModuleObject(name);
+    }
 
-    ModuleObject(const ModuleObject &other)
-        : Object { other.type(), other.klass() }
-        , m_constants { other.m_constants }
-        , m_superclass { other.m_superclass }
-        , m_owner { other.m_owner }
-        , m_methods { other.m_methods }
-        , m_class_vars { other.m_class_vars } {
-        for (ModuleObject *module : const_cast<ModuleObject &>(other).m_included_modules) {
-            m_included_modules.push(module);
-        }
+    static ModuleObject *create(Type type, ClassObject *klass) {
+        return new ModuleObject(type, klass);
+    }
+
+    static ModuleObject *create(ClassObject *klass) {
+        return new ModuleObject(klass);
+    }
+
+    static ModuleObject *create(const ModuleObject &other) {
+        return new ModuleObject(other);
     }
 
     Object &operator=(Object &&other) = delete;
@@ -186,6 +187,25 @@ private:
     void cache_method(SymbolObject *, MethodInfo, Env *);
 
 protected:
+    ModuleObject();
+    ModuleObject(const char *);
+    ModuleObject(Type, ClassObject *);
+
+    ModuleObject(ClassObject *klass)
+        : ModuleObject { Type::Module, klass } { }
+
+    ModuleObject(const ModuleObject &other)
+        : Object { other.type(), other.klass() }
+        , m_constants { other.m_constants }
+        , m_superclass { other.m_superclass }
+        , m_owner { other.m_owner }
+        , m_methods { other.m_methods }
+        , m_class_vars { other.m_class_vars } {
+        for (ModuleObject *module : const_cast<ModuleObject &>(other).m_included_modules) {
+            m_included_modules.push(module);
+        }
+    }
+
     Constant *find_constant(Env *, SymbolObject *, ModuleObject **, ConstLookupSearchMode = ConstLookupSearchMode::Strict);
 
     TM::Hashmap<SymbolObject *, Constant *> m_constants {};

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -21,22 +21,27 @@ using namespace TM;
 class ModuleObject : public Object {
 public:
     static ModuleObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ModuleObject();
     }
 
     static ModuleObject *create(const char *name) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ModuleObject(name);
     }
 
     static ModuleObject *create(Type type, ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ModuleObject(type, klass);
     }
 
     static ModuleObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ModuleObject(klass);
     }
 
     static ModuleObject *create(const ModuleObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ModuleObject(other);
     }
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -36,22 +36,27 @@ public:
     };
 
     static Object *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Object();
     }
 
     static Object *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Object(klass);
     }
 
     static Object *create(Type type) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Object(type);
     }
 
     static Object *create(Type type, ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Object(type, klass);
     }
 
     static Object *create(const Object &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new Object(other);
     }
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -35,24 +35,25 @@ public:
         ConstMissing,
     };
 
-    Object()
-        : m_klass { GlobalEnv::the()->Object() } { }
-
-    Object(ClassObject *klass)
-        : m_klass { klass } {
-        assert(klass);
+    static Object *create() {
+        return new Object();
     }
 
-    Object(Type type)
-        : m_type { type } { }
-
-    Object(Type type, ClassObject *klass)
-        : m_klass { klass }
-        , m_type { type } {
-        assert(klass);
+    static Object *create(ClassObject *klass) {
+        return new Object(klass);
     }
 
-    Object(const Object &);
+    static Object *create(Type type) {
+        return new Object(type);
+    }
+
+    static Object *create(Type type, ClassObject *klass) {
+        return new Object(type, klass);
+    }
+
+    static Object *create(const Object &other) {
+        return new Object(other);
+    }
 
     Object &operator=(const Object &) = delete;
 
@@ -199,6 +200,25 @@ public:
     virtual String dbg_inspect(int indent = 0) const override;
 
 protected:
+    Object()
+        : m_klass { GlobalEnv::the()->Object() } { }
+
+    Object(ClassObject *klass)
+        : m_klass { klass } {
+        assert(klass);
+    }
+
+    Object(Type type)
+        : m_type { type } { }
+
+    Object(Type type, ClassObject *klass)
+        : m_klass { klass }
+        , m_type { type } {
+        assert(klass);
+    }
+
+    Object(const Object &);
+
     ClassObject *m_klass { nullptr };
 
 private:

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -18,14 +18,17 @@ public:
     }
 
     static ProcObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ProcObject(klass);
     }
 
     static ProcObject *create(Block *block, nat_int_t break_point = 0) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ProcObject(block, break_point);
     }
 
     static ProcObject *create(const ProcObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new ProcObject(other);
     }
 

--- a/include/natalie/proc_object.hpp
+++ b/include/natalie/proc_object.hpp
@@ -13,29 +13,27 @@ namespace Natalie {
 
 class ProcObject : public Object {
 public:
-    ProcObject()
-        : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s).as_class() } { }
-
-    ProcObject(ClassObject *klass)
-        : Object { Object::Type::Proc, klass } { }
-
-    ProcObject(Block *block, nat_int_t break_point = 0)
-        : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s).as_class() }
-        , m_block { block }
-        , m_break_point { break_point } {
-        assert(m_block);
+    static ProcObject *create() {
+        return new ProcObject();
     }
 
-    ProcObject(const ProcObject &other)
-        : Object { other }
-        , m_block { other.m_block }
-        , m_break_point { other.m_break_point } { }
+    static ProcObject *create(ClassObject *klass) {
+        return new ProcObject(klass);
+    }
+
+    static ProcObject *create(Block *block, nat_int_t break_point = 0) {
+        return new ProcObject(block, break_point);
+    }
+
+    static ProcObject *create(const ProcObject &other) {
+        return new ProcObject(other);
+    }
 
     static Value from_block_maybe(Block *block) {
         if (!block) {
             return Value::nil();
         }
-        return new ProcObject { block };
+        return ProcObject::create(block);
     }
 
     Value initialize(Env *, Block *);
@@ -69,6 +67,24 @@ public:
     }
 
 private:
+    ProcObject()
+        : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s).as_class() } { }
+
+    ProcObject(ClassObject *klass)
+        : Object { Object::Type::Proc, klass } { }
+
+    ProcObject(Block *block, nat_int_t break_point = 0)
+        : Object { Object::Type::Proc, GlobalEnv::the()->Object()->const_fetch("Proc"_s).as_class() }
+        , m_block { block }
+        , m_break_point { break_point } {
+        assert(m_block);
+    }
+
+    ProcObject(const ProcObject &other)
+        : Object { other }
+        , m_block { other.m_block }
+        , m_break_point { other.m_break_point } { }
+
     Block *m_block { nullptr };
     nat_int_t m_break_point { 0 };
 };

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -106,7 +106,7 @@ public:
         if (result < 0) env->raise_errno();
         auto curlim = Value::integer((nat_int_t)(rlim.rlim_cur));
         auto maxlim = Value::integer((nat_int_t)(rlim.rlim_max));
-        return new ArrayObject { curlim, maxlim };
+        return ArrayObject::create({ curlim, maxlim });
     }
 
     static int getsid(Env *env, Optional<Value> pid = {}) {

--- a/include/natalie/process_module.hpp
+++ b/include/natalie/process_module.hpp
@@ -176,7 +176,7 @@ private:
         }
         if (rlimit_symbol) {
             Value(rlimit_symbol).assert_type(env, Object::Type::Symbol, "Symbol");
-            StringObject *rlimit_str = new StringObject { "RLIMIT_" };
+            StringObject *rlimit_str = StringObject::create("RLIMIT_");
             rlimit_str->append(rlimit_symbol->string());
             rlimit_symbol = rlimit_str->to_symbol(env);
             auto ProcessMod = GlobalEnv::the()->Object()->const_fetch("Process"_s).as_module();

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -19,14 +19,17 @@ using namespace TM;
 class RandomObject : public Object {
 public:
     static RandomObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new RandomObject();
     }
 
     static RandomObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new RandomObject(klass);
     }
 
     static RandomObject *create(const RandomObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new RandomObject(other);
     }
 

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <utility>
-
 #include "natalie/class_object.hpp"
 #include "natalie/float_object.hpp"
 #include "natalie/forward.hpp"
@@ -58,7 +56,7 @@ public:
         if (integer.is_negative())
             env->raise("ArgumentError", "negative string size (or size too big)");
         if (integer.is_zero())
-            return new StringObject { "", Encoding::ASCII_8BIT };
+            return StringObject::create("", Encoding::ASCII_8BIT);
 
         size_t length = (size_t)integer.to_nat_int_t();
         char buffer[length];
@@ -69,7 +67,7 @@ public:
 #else
         arc4random_buf(buffer, length);
 #endif
-        return new StringObject { buffer, length, Encoding::ASCII_8BIT };
+        return StringObject::create(buffer, length, Encoding::ASCII_8BIT);
     }
 
 private:

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -18,11 +18,17 @@ using namespace TM;
 
 class RandomObject : public Object {
 public:
-    RandomObject(ClassObject *klass)
-        : Object { Object::Type::Random, klass } { }
+    static RandomObject *create() {
+        return new RandomObject();
+    }
 
-    RandomObject()
-        : Object { Object::Type::Random, GlobalEnv::the()->Random() } { }
+    static RandomObject *create(ClassObject *klass) {
+        return new RandomObject(klass);
+    }
+
+    static RandomObject *create(const RandomObject &other) {
+        return new RandomObject(other);
+    }
 
     ~RandomObject() { delete m_generator; }
 
@@ -71,6 +77,17 @@ public:
     }
 
 private:
+    RandomObject()
+        : Object { Object::Type::Random, GlobalEnv::the()->Random() } { }
+
+    RandomObject(ClassObject *klass)
+        : Object { Object::Type::Random, klass } { }
+
+    RandomObject(const RandomObject &other)
+        : Object { other }
+        , m_seed { other.m_seed }
+        , m_generator { new std::mt19937(*other.m_generator) } { }
+
     nat_int_t m_seed;
     std::mt19937 *m_generator { nullptr };
 

--- a/include/natalie/random_object.hpp
+++ b/include/natalie/random_object.hpp
@@ -77,7 +77,7 @@ private:
     Value generate_random(double min, double max) {
         assert(m_generator);
         std::uniform_real_distribution<double> random_number(min, max);
-        return new FloatObject { random_number(*m_generator) };
+        return FloatObject::create(random_number(*m_generator));
     }
 
     Value generate_random(nat_int_t min, nat_int_t max) {

--- a/include/natalie/range_object.hpp
+++ b/include/natalie/range_object.hpp
@@ -13,11 +13,17 @@ namespace Natalie {
 
 class RangeObject : public Object {
 public:
-    RangeObject()
-        : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s).as_class() } { }
+    static RangeObject *create() {
+        return new RangeObject();
+    }
 
-    RangeObject(ClassObject *klass)
-        : Object { Object::Type::Range, klass } { }
+    static RangeObject *create(ClassObject *klass) {
+        return new RangeObject(klass);
+    }
+
+    static RangeObject *create(const RangeObject &other) {
+        return new RangeObject(other);
+    }
 
     static RangeObject *create(Env *, Value, Value, bool);
 
@@ -52,6 +58,18 @@ public:
     virtual String dbg_inspect(int indent = 0) const override;
 
 private:
+    RangeObject()
+        : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s).as_class() } { }
+
+    RangeObject(ClassObject *klass)
+        : Object { Object::Type::Range, klass } { }
+
+    RangeObject(const RangeObject &other)
+        : Object { other }
+        , m_begin { other.m_begin }
+        , m_end { other.m_end }
+        , m_exclude_end { other.m_exclude_end } { }
+
     RangeObject(Value begin, Value end, bool exclude_end)
         : Object { Object::Type::Range, GlobalEnv::the()->Object()->const_fetch("Range"_s).as_class() }
         , m_begin { begin }

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -1,25 +1,18 @@
 #pragma once
 
 #include "natalie/forward.hpp"
-#include "natalie/integer_methods.hpp"
 #include "natalie/object.hpp"
 
 namespace Natalie {
 
 class RationalObject : public Object {
 public:
-    RationalObject(Value numerator, Value denominator)
-        : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s).as_class() }
-        , m_numerator { numerator.integer() }
-        , m_denominator { denominator.integer() } {
-        freeze();
+    static RationalObject *create(Value numerator, Value denominator) {
+        return new RationalObject { numerator, denominator };
     }
 
-    RationalObject(const RationalObject &other)
-        : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s).as_class() }
-        , m_numerator { other.m_numerator }
-        , m_denominator { other.m_denominator } {
-        freeze();
+    static RationalObject *create(const RationalObject &other) {
+        return new RationalObject { other };
     }
 
     static RationalObject *create(Env *env, Integer numerator, Integer denominator);
@@ -59,6 +52,20 @@ public:
     }
 
 private:
+    RationalObject(Value numerator, Value denominator)
+        : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s).as_class() }
+        , m_numerator { numerator.integer() }
+        , m_denominator { denominator.integer() } {
+        freeze();
+    }
+
+    RationalObject(const RationalObject &other)
+        : Object { Object::Type::Rational, GlobalEnv::the()->Object()->const_fetch("Rational"_s).as_class() }
+        , m_numerator { other.m_numerator }
+        , m_denominator { other.m_denominator } {
+        freeze();
+    }
+
     Integer m_numerator;
     Integer m_denominator;
 };

--- a/include/natalie/rational_object.hpp
+++ b/include/natalie/rational_object.hpp
@@ -8,10 +8,12 @@ namespace Natalie {
 class RationalObject : public Object {
 public:
     static RationalObject *create(Value numerator, Value denominator) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new RationalObject { numerator, denominator };
     }
 
     static RationalObject *create(const RationalObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new RationalObject { other };
     }
 

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -33,25 +33,24 @@ enum RegexOpts {
 
 class RegexpObject : public Object {
 public:
-    RegexpObject()
-        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } { }
-
-    RegexpObject(ClassObject *klass)
-        : Object { Object::Type::Regexp, klass } { }
-
-    RegexpObject(Env *env, const RegexpObject &other)
-        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
-        initialize_internal(env, other.m_pattern, other.m_options);
+    static RegexpObject *create() {
+        return new RegexpObject();
     }
 
-    RegexpObject(Env *env, const StringObject *pattern, int options = 0, EncodingObject *encoding = nullptr)
-        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
-        initialize_internal(env, pattern, options, encoding);
+    static RegexpObject *create(ClassObject *klass) {
+        return new RegexpObject(klass);
     }
 
-    RegexpObject(Env *env, const String pattern, int options = 0, EncodingObject *encoding = nullptr)
-        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
-        initialize_internal(env, StringObject::create(pattern), options, encoding);
+    static RegexpObject *create(Env *env, const RegexpObject &other) {
+        return new RegexpObject(env, other);
+    }
+
+    static RegexpObject *create(Env *env, const StringObject *pattern, int options = 0, EncodingObject *encoding = nullptr) {
+        return new RegexpObject(env, pattern, options, encoding);
+    }
+
+    static RegexpObject *create(Env *env, const String pattern, int options = 0, EncodingObject *encoding = nullptr) {
+        return new RegexpObject(env, pattern, options, encoding);
     }
 
     virtual ~RegexpObject() {
@@ -198,6 +197,27 @@ public:
     }
 
 private:
+    RegexpObject()
+        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } { }
+
+    RegexpObject(ClassObject *klass)
+        : Object { Object::Type::Regexp, klass } { }
+
+    RegexpObject(Env *env, const RegexpObject &other)
+        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
+        initialize_internal(env, other.m_pattern, other.m_options);
+    }
+
+    RegexpObject(Env *env, const StringObject *pattern, int options = 0, EncodingObject *encoding = nullptr)
+        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
+        initialize_internal(env, pattern, options, encoding);
+    }
+
+    RegexpObject(Env *env, const String pattern, int options = 0, EncodingObject *encoding = nullptr)
+        : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
+        initialize_internal(env, StringObject::create(pattern), options, encoding);
+    }
+
     friend MatchDataObject;
 
     regex_t *m_regex { nullptr };

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -5,7 +5,6 @@
 #include "natalie/class_object.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
-#include "natalie/integer_methods.hpp"
 #include "natalie/macros.hpp"
 #include "natalie/object.hpp"
 #include "natalie/string_object.hpp"
@@ -52,7 +51,7 @@ public:
 
     RegexpObject(Env *env, const String pattern, int options = 0, EncodingObject *encoding = nullptr)
         : Object { Object::Type::Regexp, GlobalEnv::the()->Regexp() } {
-        initialize_internal(env, new StringObject(pattern), options, encoding);
+        initialize_internal(env, StringObject::create(pattern), options, encoding);
     }
 
     virtual ~RegexpObject() {

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -274,9 +274,9 @@ public:
     Value byteindex(Env *, Value, Optional<Value> = {}) const;
     Value byterindex(Env *, Value, Optional<Value> = {}) const;
 
-    Value index(Env *, Value, Optional<Value>);
-    Value index(Env *, Value, size_t start);
-    nat_int_t index_int(Env *, Value, size_t byte_start);
+    Value index(Env *, Value, Optional<Value>) const;
+    Value index(Env *, Value, size_t start) const;
+    nat_int_t index_int(Env *, Value, size_t byte_start) const;
 
     Value rindex(Env *, Value, Optional<Value> = {}) const;
     Value rindex(Env *, Value, size_t) const;

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -40,70 +40,87 @@ public:
     };
 
     static StringObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(klass);
     }
 
     static StringObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject();
     }
 
     static StringObject *create(NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(encoding);
     }
 
     static StringObject *create(const char *str) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str);
     }
 
     static StringObject *create(const char *str, NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, encoding);
     }
 
     static StringObject *create(const char *str, Encoding encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, encoding);
     }
 
     static StringObject *create(const char *str, size_t length) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, length);
     }
 
     static StringObject *create(const char *str, size_t length, NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, length, encoding);
     }
 
     static StringObject *create(const char *str, size_t length, Encoding encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, length, encoding);
     }
 
     static StringObject *create(const StringObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(other);
     }
 
     static StringObject *create(const String &str) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str);
     }
 
     static StringObject *create(String &&str) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(std::move(str));
     }
 
     static StringObject *create(const String &str, NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, encoding);
     }
 
     static StringObject *create(String &&str, NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(std::move(str), encoding);
     }
 
     static StringObject *create(const String &str, Encoding encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, encoding);
     }
 
     static StringObject *create(String &&str, Encoding encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(std::move(str), encoding);
     }
 
     static StringObject *create(const StringView &str, NonNullPtr<EncodingObject> encoding) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new StringObject(str, encoding);
     }
 

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -437,7 +437,7 @@ public:
 
     template <typename... Args>
     static StringObject *format(const char *fmt, Args... args) {
-        auto out = new StringObject;
+        auto out = StringObject::create();
         format(out, fmt, args...);
         return out;
     }

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -39,118 +39,72 @@ public:
         Invalid,
     };
 
-    StringObject(ClassObject *klass)
-        : Object { Object::Type::String, klass }
-        , m_encoding { EncodingObject::get(Encoding::ASCII_8BIT) } {
-        assert(m_encoding);
+    static StringObject *create(ClassObject *klass) {
+        return new StringObject(klass);
     }
 
-    StringObject()
-        : StringObject { "" } { }
-
-    StringObject(NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        set_str("", 0);
+    static StringObject *create() {
+        return new StringObject();
     }
 
-    StringObject(const char *str)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
-        assert(m_encoding);
-        set_str(str);
+    static StringObject *create(NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(encoding);
     }
 
-    StringObject(const char *str, NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        set_str(str);
+    static StringObject *create(const char *str) {
+        return new StringObject(str);
     }
 
-    StringObject(const char *str, Encoding encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(encoding) } {
-        assert(m_encoding);
-        set_str(str);
+    static StringObject *create(const char *str, NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(str, encoding);
     }
 
-    StringObject(const char *str, size_t length)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
-        assert(m_encoding);
-        set_str(str, length);
+    static StringObject *create(const char *str, Encoding encoding) {
+        return new StringObject(str, encoding);
     }
 
-    StringObject(const char *str, size_t length, NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        set_str(str, length);
+    static StringObject *create(const char *str, size_t length) {
+        return new StringObject(str, length);
     }
 
-    StringObject(const char *str, size_t length, Encoding encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(encoding) } {
-        assert(m_encoding);
-        set_str(str, length);
+    static StringObject *create(const char *str, size_t length, NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(str, length, encoding);
     }
 
-    StringObject(const StringObject &other)
-        : Object { other }
-        , m_encoding { other.m_encoding }
-        , m_validity { other.m_validity } {
-        set_str(other.c_str(), other.length());
+    static StringObject *create(const char *str, size_t length, Encoding encoding) {
+        return new StringObject(str, length, encoding);
     }
 
-    StringObject(const String &str)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
-        assert(m_encoding);
-        m_string = str;
+    static StringObject *create(const StringObject &other) {
+        return new StringObject(other);
     }
 
-    StringObject(String &&str)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
-        assert(m_encoding);
-        m_string = std::move(str);
+    static StringObject *create(const String &str) {
+        return new StringObject(str);
     }
 
-    StringObject(const String &str, NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        m_string = str;
+    static StringObject *create(String &&str) {
+        return new StringObject(std::move(str));
     }
 
-    StringObject(String &&str, NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        m_string = std::move(str);
+    static StringObject *create(const String &str, NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(str, encoding);
     }
 
-    StringObject(const String &str, Encoding encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(encoding) } {
-        assert(m_encoding);
-        m_string = str;
+    static StringObject *create(String &&str, NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(std::move(str), encoding);
     }
 
-    StringObject(String &&str, Encoding encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { EncodingObject::get(encoding) } {
-        assert(m_encoding);
-        m_string = std::move(str);
+    static StringObject *create(const String &str, Encoding encoding) {
+        return new StringObject(str, encoding);
     }
 
-    StringObject(const StringView &str, NonNullPtr<EncodingObject> encoding)
-        : Object { Object::Type::String, GlobalEnv::the()->String() }
-        , m_encoding { encoding } {
-        assert(m_encoding);
-        m_string = str.clone();
+    static StringObject *create(String &&str, Encoding encoding) {
+        return new StringObject(std::move(str), encoding);
+    }
+
+    static StringObject *create(const StringView &str, NonNullPtr<EncodingObject> encoding) {
+        return new StringObject(str, encoding);
     }
 
     const String &string() const { return m_string; }
@@ -557,6 +511,120 @@ public:
     }
 
 private:
+    StringObject(ClassObject *klass)
+        : Object { Object::Type::String, klass }
+        , m_encoding { EncodingObject::get(Encoding::ASCII_8BIT) } {
+        assert(m_encoding);
+    }
+
+    StringObject()
+        : StringObject { "" } { }
+
+    StringObject(NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        set_str("", 0);
+    }
+
+    StringObject(const char *str)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
+        assert(m_encoding);
+        set_str(str);
+    }
+
+    StringObject(const char *str, NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        set_str(str);
+    }
+
+    StringObject(const char *str, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
+        assert(m_encoding);
+        set_str(str);
+    }
+
+    StringObject(const char *str, size_t length)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
+        assert(m_encoding);
+        set_str(str, length);
+    }
+
+    StringObject(const char *str, size_t length, NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        set_str(str, length);
+    }
+
+    StringObject(const char *str, size_t length, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
+        assert(m_encoding);
+        set_str(str, length);
+    }
+
+    StringObject(const StringObject &other)
+        : Object { other }
+        , m_encoding { other.m_encoding }
+        , m_validity { other.m_validity } {
+        set_str(other.c_str(), other.length());
+    }
+
+    StringObject(const String &str)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
+        assert(m_encoding);
+        m_string = str;
+    }
+
+    StringObject(String &&str)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(Encoding::UTF_8) } {
+        assert(m_encoding);
+        m_string = std::move(str);
+    }
+
+    StringObject(const String &str, NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        m_string = str;
+    }
+
+    StringObject(String &&str, NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        m_string = std::move(str);
+    }
+
+    StringObject(const String &str, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
+        assert(m_encoding);
+        m_string = str;
+    }
+
+    StringObject(String &&str, Encoding encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { EncodingObject::get(encoding) } {
+        assert(m_encoding);
+        m_string = std::move(str);
+    }
+
+    StringObject(const StringView &str, NonNullPtr<EncodingObject> encoding)
+        : Object { Object::Type::String, GlobalEnv::the()->String() }
+        , m_encoding { encoding } {
+        assert(m_encoding);
+        m_string = str.clone();
+    }
+
     StringObject *expand_backrefs(Env *, StringObject *, MatchDataObject *);
     void regexp_sub(Env *, TM::String &, StringObject *, RegexpObject *, Optional<Value>, MatchDataObject **, StringObject **, size_t = 0, Block *block = nullptr);
     nat_int_t unpack_offset(Env *, Optional<Value>) const;

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -202,7 +202,7 @@ private:
             m_unpacked_value = value;
         } else {
             if (!m_unpacked_array) {
-                m_unpacked_array = new ArrayObject {};
+                m_unpacked_array = ArrayObject::create();
                 m_unpacked_array->push(m_unpacked_value.value());
             }
             m_unpacked_array->push(value);
@@ -213,8 +213,8 @@ private:
         if (m_unpacked_array)
             return m_unpacked_array;
         else if (m_unpacked_value)
-            return new ArrayObject { m_unpacked_value.value() };
-        return new ArrayObject {};
+            return ArrayObject::create({ m_unpacked_value.value() });
+        return ArrayObject::create();
     }
 
     const StringObject *m_source;

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -74,7 +74,7 @@ private:
                 }
                 m_index += sizeof(T);
                 double double_val = double(*(T *)out.c_str());
-                auto fltobj = new FloatObject { double_val };
+                auto fltobj = FloatObject::create(double_val);
                 append(fltobj);
             }
             consumed++;

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -22,7 +22,6 @@ public:
     Value unpack1(Env *env);
 
     virtual void visit_children(Visitor &visitor) const override {
-        Cell::visit_children(visitor);
         visitor.visit(m_source);
         if (m_unpacked_value)
             visitor.visit(m_unpacked_value.value());

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -18,11 +18,6 @@ public:
     static SymbolObject *intern(const char *, size_t, EncodingObject * = nullptr);
     static SymbolObject *intern(const String &, EncodingObject * = nullptr);
 
-    static SymbolObject *intern_with_lock(const String &name, EncodingObject *encoding = nullptr) {
-        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
-        return intern(name, encoding);
-    }
-
     static ArrayObject *all_symbols(Env *);
     StringObject *to_s(Env *);
     SymbolObject *to_sym(Env *env) { return this; }
@@ -126,7 +121,7 @@ private:
 };
 
 [[nodiscard]] __attribute__((always_inline)) inline SymbolObject *operator"" _s(const char *cstring, size_t) {
-    return SymbolObject::intern_with_lock(cstring);
+    return SymbolObject::intern(cstring);
 }
 
 }

--- a/include/natalie/thread/backtrace/location_object.hpp
+++ b/include/natalie/thread/backtrace/location_object.hpp
@@ -3,7 +3,6 @@
 #include "natalie/forward.hpp"
 #include "natalie/object.hpp"
 #include "natalie/symbol_object.hpp"
-#include "natalie/thread_object.hpp"
 
 namespace Natalie {
 
@@ -17,8 +16,8 @@ public:
 
     LocationObject(const String &source_location, const String &file, const size_t line)
         : Object { Object::Type::ThreadBacktraceLocation, GlobalEnv::the()->Object()->const_fetch("Thread"_s).as_class()->const_fetch("Backtrace"_s).as_module()->const_fetch("Location"_s).as_class() }
-        , m_source_location { new StringObject { source_location } }
-        , m_file { new StringObject { file } }
+        , m_source_location { StringObject::create(source_location) }
+        , m_file { StringObject::create(file) }
         , m_line { Value::integer(line) } { }
 
     Value absolute_path(Env *) const;

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -93,7 +93,7 @@ public:
     void set_exception(ExceptionObject *exception) { m_exception = exception; }
     ExceptionObject *exception() { return m_exception; }
 
-    ArrayObject *args() { return new ArrayObject(m_args.size(), m_args.data()); }
+    ArrayObject *args() { return ArrayObject::create(m_args.size(), m_args.data()); }
     Block *block() { return m_block; }
 
     bool is_alive() const {

--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -47,14 +47,17 @@ public:
         Suspended,
     };
 
-    ThreadObject()
-        : Object { Object::Type::Thread, GlobalEnv::the()->Object()->const_fetch("Thread"_s).as_class() } { }
+    static ThreadObject *create() {
+        return new ThreadObject;
+    }
 
-    ThreadObject(ClassObject *klass)
-        : Object { Object::Type::Thread, klass } { }
+    static ThreadObject *create(ClassObject *klass) {
+        return new ThreadObject(klass);
+    }
 
-    ThreadObject(ClassObject *klass, Block *block)
-        : Object { Object::Type::Thread, klass } { }
+    static ThreadObject *create(ClassObject *klass, Block *block) {
+        return new ThreadObject(klass, block);
+    }
 
     virtual ~ThreadObject() {
         free(m_context);
@@ -266,6 +269,15 @@ public:
     static void wake_up_the_world();
 
 private:
+    ThreadObject()
+        : Object { Object::Type::Thread, GlobalEnv::the()->Object()->const_fetch("Thread"_s).as_class() } { }
+
+    ThreadObject(ClassObject *klass)
+        : Object { Object::Type::Thread, klass } { }
+
+    ThreadObject(ClassObject *klass, Block *block)
+        : Object { Object::Type::Thread, klass } { }
+
     void wait_until_running() const;
 
     void visit_children_from_stack(Visitor &) const;

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -18,14 +18,17 @@ public:
     };
 
     static TimeObject *create() {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new TimeObject;
     }
 
     static TimeObject *create(ClassObject *klass) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new TimeObject { klass };
     }
 
     static TimeObject *create(const TimeObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new TimeObject { other };
     }
 

--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -17,22 +17,16 @@ public:
         UTC
     };
 
-    TimeObject()
-        : Object { Object::Type::Time, GlobalEnv::the()->Time() } { }
+    static TimeObject *create() {
+        return new TimeObject;
+    }
 
-    TimeObject(ClassObject *klass)
-        : Object { Object::Type::Time, klass } { }
+    static TimeObject *create(ClassObject *klass) {
+        return new TimeObject { klass };
+    }
 
-    TimeObject(const TimeObject &other)
-        : Object { other }
-        , m_integer { other.m_integer }
-        , m_mode { other.m_mode }
-        , m_subsec { other.m_subsec }
-        , m_time { other.m_time } {
-        if (other.m_zone) {
-            m_zone = strdup(other.m_zone);
-            m_time.tm_zone = m_zone;
-        }
+    static TimeObject *create(const TimeObject &other) {
+        return new TimeObject { other };
     }
 
     ~TimeObject() {
@@ -89,6 +83,24 @@ public:
     }
 
 private:
+    TimeObject()
+        : Object { Object::Type::Time, GlobalEnv::the()->Time() } { }
+
+    TimeObject(ClassObject *klass)
+        : Object { Object::Type::Time, klass } { }
+
+    TimeObject(const TimeObject &other)
+        : Object { other }
+        , m_integer { other.m_integer }
+        , m_mode { other.m_mode }
+        , m_subsec { other.m_subsec }
+        , m_time { other.m_time } {
+        if (other.m_zone) {
+            m_zone = strdup(other.m_zone);
+            m_time.tm_zone = m_zone;
+        }
+    }
+
     static RationalObject *convert_rational(Env *, Value);
     static Value convert_unit(Env *, Value);
     static TimeObject *create(Env *, ClassObject *, RationalObject *, Mode);

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -8,10 +8,12 @@ namespace Natalie {
 class UnboundMethodObject : public AbstractMethodObject {
 public:
     static UnboundMethodObject *create(ModuleObject *module_or_class, Method *method) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new UnboundMethodObject { module_or_class, method };
     }
 
     static UnboundMethodObject *create(const UnboundMethodObject &other) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new UnboundMethodObject { other };
     }
 

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -17,7 +17,7 @@ public:
 
     Value bind(Env *env, Value obj) {
         if (owner()->type() != Type::Class || obj.is_a(env, owner())) {
-            return new MethodObject { obj, m_method };
+            return MethodObject::create(obj, m_method);
         } else {
             env->raise("TypeError", "bind argument must be an instance of {}", owner()->inspect_module());
         }

--- a/include/natalie/unbound_method_object.hpp
+++ b/include/natalie/unbound_method_object.hpp
@@ -7,13 +7,13 @@ namespace Natalie {
 
 class UnboundMethodObject : public AbstractMethodObject {
 public:
-    UnboundMethodObject(ModuleObject *module_or_class, Method *method)
-        : AbstractMethodObject { Object::Type::UnboundMethod, GlobalEnv::the()->Object()->const_fetch("UnboundMethod"_s).as_class(), method }
-        , m_module_or_class { module_or_class } { }
+    static UnboundMethodObject *create(ModuleObject *module_or_class, Method *method) {
+        return new UnboundMethodObject { module_or_class, method };
+    }
 
-    UnboundMethodObject(const UnboundMethodObject &other)
-        : AbstractMethodObject { Object::Type::UnboundMethod, GlobalEnv::the()->Object()->const_fetch("UnboundMethod"_s).as_class(), other.m_method }
-        , m_module_or_class { other.m_module_or_class } { }
+    static UnboundMethodObject *create(const UnboundMethodObject &other) {
+        return new UnboundMethodObject { other };
+    }
 
     Value bind(Env *env, Value obj) {
         if (owner()->type() != Type::Class || obj.is_a(env, owner())) {
@@ -61,6 +61,14 @@ public:
     }
 
 private:
+    UnboundMethodObject(ModuleObject *module_or_class, Method *method)
+        : AbstractMethodObject { Object::Type::UnboundMethod, GlobalEnv::the()->Object()->const_fetch("UnboundMethod"_s).as_class(), method }
+        , m_module_or_class { module_or_class } { }
+
+    UnboundMethodObject(const UnboundMethodObject &other)
+        : AbstractMethodObject { Object::Type::UnboundMethod, GlobalEnv::the()->Object()->const_fetch("UnboundMethod"_s).as_class(), other.m_method }
+        , m_module_or_class { other.m_module_or_class } { }
+
     ModuleObject *m_module_or_class { nullptr };
 };
 

--- a/include/natalie/void_p_object.hpp
+++ b/include/natalie/void_p_object.hpp
@@ -13,10 +13,12 @@ namespace Natalie {
 class VoidPObject : public Object {
 public:
     static VoidPObject *create(void *ptr) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new VoidPObject { ptr };
     }
 
     static VoidPObject *create(void *ptr, std::function<void(VoidPObject *)> cleanup_fn) {
+        std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
         return new VoidPObject { ptr, cleanup_fn };
     }
 

--- a/include/natalie/void_p_object.hpp
+++ b/include/natalie/void_p_object.hpp
@@ -3,8 +3,6 @@
 #include <assert.h>
 #include <functional>
 
-#include "natalie/class_object.hpp"
-#include "natalie/encoding_object.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/macros.hpp"
@@ -14,16 +12,15 @@ namespace Natalie {
 
 class VoidPObject : public Object {
 public:
+    static VoidPObject *create(void *ptr) {
+        return new VoidPObject { ptr };
+    }
+
+    static VoidPObject *create(void *ptr, std::function<void(VoidPObject *)> cleanup_fn) {
+        return new VoidPObject { ptr, cleanup_fn };
+    }
+
     using CleanupFnPtr = std::function<void(VoidPObject *)>;
-
-    VoidPObject(void *ptr)
-        : Object { Object::Type::VoidP, GlobalEnv::the()->Object() }
-        , m_void_ptr { ptr } { }
-
-    VoidPObject(void *ptr, CleanupFnPtr cleanup_fn)
-        : Object { Object::Type::VoidP, GlobalEnv::the()->Object() }
-        , m_void_ptr { ptr }
-        , m_cleanup_fn { cleanup_fn } { }
 
     virtual ~VoidPObject() override {
         // FIXME: Allocating an object here can cause the GC to deadlock,
@@ -40,6 +37,15 @@ public:
     Optional<CleanupFnPtr> cleanup_fn() { return m_cleanup_fn; }
 
 private:
+    VoidPObject(void *ptr)
+        : Object { Object::Type::VoidP, GlobalEnv::the()->Object() }
+        , m_void_ptr { ptr } { }
+
+    VoidPObject(void *ptr, CleanupFnPtr cleanup_fn)
+        : Object { Object::Type::VoidP, GlobalEnv::the()->Object() }
+        , m_void_ptr { ptr }
+        , m_cleanup_fn { cleanup_fn } { }
+
     void *m_void_ptr { nullptr };
     Optional<CleanupFnPtr> m_cleanup_fn;
 };

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -346,7 +346,7 @@ class Date
       int maxsize = 32;
       char buffer[maxsize];
       auto length = ::strftime(buffer, maxsize, format_var.as_string()->c_str(), &time);
-      return new StringObject { buffer, length, Encoding::US_ASCII };
+      return StringObject::create(buffer, length, Encoding::US_ASCII);
     END
   end
 

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -14,13 +14,13 @@ Value group_to_struct(Env *env, Value self, struct group *grp) {
     auto grpstruct = etc_group.send(env, "new"_s, {});
     // It is possible more fields could be set, but these
     // are the ones required by POSIX
-    grpstruct.send(env, "name="_s, { new StringObject { grp->gr_name } });
-    grpstruct.send(env, "passwd="_s, { new StringObject { grp->gr_passwd } });
+    grpstruct.send(env, "name="_s, { StringObject::create(grp->gr_name) });
+    grpstruct.send(env, "passwd="_s, { StringObject::create(grp->gr_passwd) });
     grpstruct.send(env, "gid="_s, { Value::integer(grp->gr_gid) });
     auto mem_ary = new ArrayObject {};
     char **memptr = grp->gr_mem;
     for (char *member_name = *memptr; member_name; member_name = *++memptr) {
-        auto memstr = new StringObject { member_name };
+        auto memstr = StringObject::create(member_name);
         mem_ary->push(Value(memstr));
     }
     grpstruct.send(env, "mem="_s, { mem_ary });
@@ -32,13 +32,13 @@ Value passwd_to_struct(Env *env, Value self, struct passwd *pwd) {
     auto pwdstruct = etc_passwd.send(env, "new"_s, {});
     // It is possible more fields could be set, but these
     // are the ones required by POSIX
-    pwdstruct.send(env, "name="_s, { new StringObject { pwd->pw_name } });
+    pwdstruct.send(env, "name="_s, { StringObject::create(pwd->pw_name) });
     pwdstruct.send(env, "uid="_s, { Value::integer(pwd->pw_uid) });
     pwdstruct.send(env, "gid="_s, { Value::integer(pwd->pw_gid) });
-    pwdstruct.send(env, "dir="_s, { new StringObject { pwd->pw_dir } });
-    pwdstruct.send(env, "gecos="_s, { new StringObject { pwd->pw_gecos } });
-    pwdstruct.send(env, "passwd="_s, { new StringObject { pwd->pw_passwd } });
-    pwdstruct.send(env, "shell="_s, { new StringObject { pwd->pw_shell } });
+    pwdstruct.send(env, "dir="_s, { StringObject::create(pwd->pw_dir) });
+    pwdstruct.send(env, "gecos="_s, { StringObject::create(pwd->pw_gecos) });
+    pwdstruct.send(env, "passwd="_s, { StringObject::create(pwd->pw_passwd) });
+    pwdstruct.send(env, "shell="_s, { StringObject::create(pwd->pw_shell) });
     return pwdstruct;
 }
 
@@ -58,7 +58,7 @@ Value Etc_confstr(Env *env, Value self, Args &&args, Block *) {
     TM::String buf(size - 1, '\0');
     if (!::confstr(name, &buf[0], size))
         env->raise_errno();
-    return new StringObject { std::move(buf) };
+    return StringObject::create(std::move(buf));
 }
 
 Value Etc_endgrent(Env *env, Value self, Args &&args, Block *_block) {
@@ -109,7 +109,7 @@ Value Etc_getlogin(Env *env, Value self, Args &&args, Block *_block) {
     char *login = ::getlogin();
     if (!login) login = ::getenv("USER");
     if (!login) return Value::nil();
-    return new StringObject { login, EncodingObject::locale() };
+    return StringObject::create(login, EncodingObject::locale());
 }
 
 Value Etc_getpwent(Env *env, Value self, Args &&args, Block *_block) {
@@ -181,9 +181,9 @@ Value Etc_systmpdir(Env *env, Value, Args &&args, Block *) {
     // https://forums.developer.apple.com/forums/thread/71382
     char buf[PATH_MAX + 1];
     const auto len = confstr(_CS_DARWIN_USER_TEMP_DIR, buf, PATH_MAX);
-    return new StringObject { buf, len, Encoding::ASCII_8BIT };
+    return StringObject::create(buf, len, Encoding::ASCII_8BIT);
 #else
-    return new StringObject { "/tmp", Encoding::ASCII_8BIT };
+    return StringObject::create("/tmp", Encoding::ASCII_8BIT);
 #endif
 }
 
@@ -195,10 +195,10 @@ Value Etc_uname(Env *env, Value, Args &&args, Block *) {
         env->raise_errno();
 
     auto result = new HashObject;
-    result->put(env, SymbolObject::intern("sysname"), new StringObject { buf.sysname });
-    result->put(env, SymbolObject::intern("nodename"), new StringObject { buf.nodename });
-    result->put(env, SymbolObject::intern("release"), new StringObject { buf.release });
-    result->put(env, SymbolObject::intern("version"), new StringObject { buf.version });
-    result->put(env, SymbolObject::intern("machine"), new StringObject { buf.machine });
+    result->put(env, SymbolObject::intern("sysname"), StringObject::create(buf.sysname));
+    result->put(env, SymbolObject::intern("nodename"), StringObject::create(buf.nodename));
+    result->put(env, SymbolObject::intern("release"), StringObject::create(buf.release));
+    result->put(env, SymbolObject::intern("version"), StringObject::create(buf.version));
+    result->put(env, SymbolObject::intern("machine"), StringObject::create(buf.machine));
     return result;
 }

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -17,7 +17,7 @@ Value group_to_struct(Env *env, Value self, struct group *grp) {
     grpstruct.send(env, "name="_s, { StringObject::create(grp->gr_name) });
     grpstruct.send(env, "passwd="_s, { StringObject::create(grp->gr_passwd) });
     grpstruct.send(env, "gid="_s, { Value::integer(grp->gr_gid) });
-    auto mem_ary = new ArrayObject {};
+    auto mem_ary = ArrayObject::create();
     char **memptr = grp->gr_mem;
     for (char *member_name = *memptr; member_name; member_name = *++memptr) {
         auto memstr = StringObject::create(member_name);

--- a/lib/etc.cpp
+++ b/lib/etc.cpp
@@ -194,7 +194,7 @@ Value Etc_uname(Env *env, Value, Args &&args, Block *) {
     if (uname(&buf) < 0)
         env->raise_errno();
 
-    auto result = new HashObject;
+    auto result = HashObject::create();
     result->put(env, SymbolObject::intern("sysname"), StringObject::create(buf.sysname));
     result->put(env, SymbolObject::intern("nodename"), StringObject::create(buf.nodename));
     result->put(env, SymbolObject::intern("release"), StringObject::create(buf.release));

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -390,7 +390,7 @@ Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     if (status != FFI_OK)
         env->raise("LoadError", "There was an error preparing the FFI call data structure: {}", (int)status);
 
-    OwnedPtr<Env> block_env { new Env {} };
+    OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("cif", 0, true, VoidPObject::create(cif, [](auto p) { delete (ffi_cif *)p->void_ptr(); }));
     block_env->var_set("arg_types", 1, true, arg_types_array);
     block_env->var_set("return_type", 2, true, return_type);

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -105,7 +105,7 @@ Value FFI_Library_ffi_lib(Env *env, Value self, Args &&args, Block *) {
     auto handle_ptr = new VoidPObject { handle, [](auto p) { dlclose(p->void_ptr()); } };
     auto libs = self->ivar_get(env, "@ffi_libs"_s);
     if (libs.is_nil())
-        libs = self->ivar_set(env, "@ffi_libs"_s, new ArrayObject);
+        libs = self->ivar_set(env, "@ffi_libs"_s, ArrayObject::create());
     auto DynamicLibrary = fetch_nested_const({ "FFI"_s, "DynamicLibrary"_s });
     auto lib = DynamicLibrary.send(env, "new"_s, { name, handle_ptr });
     libs.as_array()->push(lib);

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -397,7 +397,7 @@ Value FFI_Library_attach_function(Env *env, Value self, Args &&args, Block *) {
     block_env->var_set("return_type", 2, true, return_type);
     block_env->var_set("ffi_args", 3, true, ffi_args_obj);
     block_env->var_set("fn", 4, true, new VoidPObject { fn });
-    Block *block = new Block { std::move(block_env), self, FFI_Library_fn_call_block, 0 };
+    Block *block = Block::create(std::move(block_env), self, FFI_Library_fn_call_block, 0);
     Object::define_singleton_method(env, self, name, block);
 
     return Value::nil();

--- a/lib/ffi.cpp
+++ b/lib/ffi.cpp
@@ -302,7 +302,7 @@ static Value FFI_Library_fn_call_block(Env *env, Value self, Args &&args, Block 
     } else if (return_type == char_sym) {
         return Value::integer(result);
     } else if (return_type == double_sym) {
-        return new FloatObject { *reinterpret_cast<double *>(&result) };
+        return FloatObject::create(*reinterpret_cast<double *>(&result));
     } else if (return_type == int_sym || return_type == uint_sym || return_type == ulong_sym) {
         return Value::integer(result);
     } else if (return_type == pointer_sym) {

--- a/lib/ffi.rb
+++ b/lib/ffi.rb
@@ -114,7 +114,7 @@ module FFI
 
     def self.new_env
       __inline__ <<~END
-        auto e = new Env { env->caller() };
+        auto e = Env::create(env->caller());
         return self.send(env, "new"_s, { Value::integer((uintptr_t)e) });
       END
     end

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -22,7 +22,7 @@ class Fiddle
           auto dl_error = self.klass()->const_find(env, "DLError"_s, Object::ConstLookupSearchMode::NotStrict).value().as_class();
           env->raise(dl_error, "{}", dlerror());
       }
-      auto handle_ptr = new VoidPObject { handle };
+      auto handle_ptr = VoidPObject::create(handle);
       self->ivar_set(env, "@ptr"_s, handle_ptr);
       return self;
     END
@@ -92,7 +92,7 @@ class Fiddle
       auto result = fn();
       auto pointer_class = self.klass()->const_find(env, "Pointer"_s, Object::ConstLookupSearchMode::NotStrict).value().as_class();
       auto pointer_obj = Object::create(Object::Type::Object, pointer_class);
-      auto pointer_ptr = new VoidPObject { result };
+      auto pointer_ptr = VoidPObject::create(result);
       pointer_obj->ivar_set(env, "@ptr"_s, pointer_ptr);
       return pointer_obj;
     END
@@ -110,7 +110,7 @@ class Fiddle
           p1_ptr = (void*)(p1.object());
       auto result = fn(p1_ptr);
       auto pointer_obj = Object::create(Object::Type::Object, pointer_class);
-      auto pointer_ptr = new VoidPObject { result };
+      auto pointer_ptr = VoidPObject::create(result);
       pointer_obj->ivar_set(env, "@ptr"_s, pointer_ptr);
       return pointer_obj;
     END

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -91,7 +91,7 @@ class Fiddle
       auto fn = (void* (*)())symbol;
       auto result = fn();
       auto pointer_class = self.klass()->const_find(env, "Pointer"_s, Object::ConstLookupSearchMode::NotStrict).value().as_class();
-      auto pointer_obj = new Object { Object::Type::Object, pointer_class };
+      auto pointer_obj = Object::create(Object::Type::Object, pointer_class);
       auto pointer_ptr = new VoidPObject { result };
       pointer_obj->ivar_set(env, "@ptr"_s, pointer_ptr);
       return pointer_obj;
@@ -109,7 +109,7 @@ class Fiddle
       else
           p1_ptr = (void*)(p1.object());
       auto result = fn(p1_ptr);
-      auto pointer_obj = new Object { Object::Type::Object, pointer_class };
+      auto pointer_obj = Object::create(Object::Type::Object, pointer_class);
       auto pointer_ptr = new VoidPObject { result };
       pointer_obj->ivar_set(env, "@ptr"_s, pointer_ptr);
       return pointer_obj;

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -44,8 +44,8 @@ class Fiddle
       ptr_obj.assert_type(env, Object::Type::VoidP, "VoidP");
       auto ptr = (const char *)ptr_obj.as_void_p()->void_ptr();
       if (!len.is_nil())
-        return new StringObject { ptr, (size_t)len.integer().to_nat_int_t() };
-      return new StringObject { ptr };
+        return StringObject::create(ptr, (size_t)len.integer().to_nat_int_t());
+      return StringObject::create(ptr);
     END
   end
 

--- a/lib/linenoise.cpp
+++ b/lib/linenoise.cpp
@@ -25,7 +25,7 @@ Value Linenoise_get_history(Env *env, Value self, Args &&args, Block *) {
     char **history = nullptr;
     int history_len = linenoiseHistoryGet(&history);
 
-    auto ary = new ArrayObject {};
+    auto ary = ArrayObject::create();
     if (history) {
         for (int i = 0; i < history_len; i++)
             ary->push(StringObject::create(history[i]));

--- a/lib/linenoise.cpp
+++ b/lib/linenoise.cpp
@@ -179,7 +179,7 @@ Value Linenoise_set_multi_line(Env *env, Value self, Args &&args, Block *) {
 }
 
 Value init_linenoise(Env *env, Value self) {
-    auto Linenoise = new ModuleObject { "Linenoise" };
+    auto Linenoise = ModuleObject::create("Linenoise");
     GlobalEnv::the()->Object()->const_set("Linenoise"_s, Linenoise);
 
     Object::define_singleton_method(env, Linenoise, "add_history"_s, Linenoise_add_history, 1);

--- a/lib/linenoise.cpp
+++ b/lib/linenoise.cpp
@@ -28,7 +28,7 @@ Value Linenoise_get_history(Env *env, Value self, Args &&args, Block *) {
     auto ary = new ArrayObject {};
     if (history) {
         for (int i = 0; i < history_len; i++)
-            ary->push(new StringObject { history[i] });
+            ary->push(StringObject::create(history[i]));
     }
 
     return ary;
@@ -58,7 +58,7 @@ Value Linenoise_readline(Env *env, Value self, Args &&args, Block *) {
     if (!line)
         return Value::nil();
 
-    return new StringObject { line };
+    return StringObject::create(line);
 }
 
 Value Linenoise_save_history(Env *env, Value self, Args &&args, Block *) {
@@ -73,7 +73,7 @@ Value Linenoise_save_history(Env *env, Value self, Args &&args, Block *) {
 static void completion_callback(const char *edit_buffer, linenoiseCompletions *completions) {
     Env e {};
     auto proc = GlobalEnv::the()->Object()->const_fetch("Linenoise"_s).as_module()->ivar_get(&e, "@completion_callback"_s).as_proc();
-    auto edit_buffer_string = new StringObject { edit_buffer };
+    auto edit_buffer_string = StringObject::create(edit_buffer);
     auto env = proc->env();
     auto ary = proc->send(env, "call"_s, { edit_buffer_string }).as_array_or_raise(env);
     for (auto &completion : *ary)
@@ -99,7 +99,7 @@ static void free_hints_callback(void *hint) {
 static char *hints_callback(const char *buf, int *color, int *bold) {
     Env e {};
     auto proc = GlobalEnv::the()->Object()->const_fetch("Linenoise"_s).as_module()->ivar_get(&e, "@hints_callback"_s).as_proc();
-    auto buf_string = new StringObject { buf };
+    auto buf_string = StringObject::create(buf);
     auto env = proc->env();
 
     auto ret = proc->send(env, "call"_s, { buf_string });
@@ -133,7 +133,7 @@ Value Linenoise_set_hints_callback(Env *env, Value self, Args &&args, Block *) {
 static const char *highlight_callback(const char *edit_buffer, int *length) {
     Env e {};
     auto proc = GlobalEnv::the()->Object()->const_fetch("Linenoise"_s).as_module()->ivar_get(&e, "@highlight_callback"_s).as_proc();
-    auto edit_buffer_string = new StringObject { edit_buffer };
+    auto edit_buffer_string = StringObject::create(edit_buffer);
     auto env = proc->env();
     auto string = proc->send(env, "call"_s, { edit_buffer_string }).as_string_or_raise(env);
     *length = string->length();

--- a/lib/natalie/compiler/backends/cpp_backend/out_file.rb
+++ b/lib/natalie/compiler/backends/cpp_backend/out_file.rb
@@ -261,9 +261,9 @@ module Natalie
               encoding_object = "EncodingObject::get(Encoding::#{enum})"
               new_string =
                 if str.empty?
-                  "#{interned_strings_var_name}[#{index}] = new StringObject(#{encoding_object});"
+                  "#{interned_strings_var_name}[#{index}] = StringObject::create(#{encoding_object});"
                 else
-                  "#{interned_strings_var_name}[#{index}] = new StringObject(#{string_to_cpp(str)}, #{str.bytesize}, #{encoding_object});"
+                  "#{interned_strings_var_name}[#{index}] = StringObject::create(#{string_to_cpp(str)}, #{str.bytesize}, #{encoding_object});"
                 end
               [new_string, "#{interned_strings_var_name}[#{index}]->freeze();"]
             end
@@ -272,7 +272,7 @@ module Natalie
         def init_dollar_zero_global
           return unless @type == :main
 
-          "env->global_set(\"$0\"_s, new StringObject { #{@backend.compiler_context[:source_path].inspect} });"
+          "env->global_set(\"$0\"_s, StringObject::create(#{@backend.compiler_context[:source_path].inspect}));"
         end
 
         def symbols_var_name

--- a/lib/natalie/compiler/instructions/autoload_const_instruction.rb
+++ b/lib/natalie/compiler/instructions/autoload_const_instruction.rb
@@ -27,7 +27,7 @@ module Natalie
           transform.top(fn, fn_code)
         end
         transform.exec(
-          "Object::const_set(env, self, #{transform.intern(@name)}, #{fn}, new StringObject(#{@path.inspect}))",
+          "Object::const_set(env, self, #{transform.intern(@name)}, #{fn}, StringObject::create(#{@path.inspect}))",
         )
         transform.push_nil
       end

--- a/lib/natalie/compiler/instructions/compile_time_warn.rb
+++ b/lib/natalie/compiler/instructions/compile_time_warn.rb
@@ -27,7 +27,7 @@ module Natalie
           transform.exec '      return false'
           transform.exec '    }'
         end
-        transform.exec "    self.send(env, \"warn\"_s, { new StringObject { #{string_to_cpp(message)} } })"
+        transform.exec "    self.send(env, \"warn\"_s, { StringObject::create(#{string_to_cpp(message)}) })"
         transform.exec '    return true'
         transform.exec '}()'
       end

--- a/lib/natalie/compiler/instructions/create_array_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_array_instruction.rb
@@ -14,12 +14,12 @@ module Natalie
       def generate(transform)
         items = []
         if @count.zero?
-          transform.exec_and_push(:array, 'Value(new ArrayObject)')
+          transform.exec_and_push(:array, 'Value(ArrayObject::create())')
         else
           @count.times { items.unshift(transform.pop) }
           items_temp = transform.temp('items')
           transform.exec("Value #{items_temp}[] = { #{items.join(', ')} };")
-          transform.exec_and_push(:array, "Value(new ArrayObject(#{@count}, #{items_temp}))")
+          transform.exec_and_push(:array, "Value(ArrayObject::create(#{@count}, #{items_temp}))")
         end
       end
 

--- a/lib/natalie/compiler/instructions/create_complex_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_complex_instruction.rb
@@ -9,7 +9,7 @@ module Natalie
 
       def generate(transform)
         imaginary = transform.pop
-        transform.exec_and_push(:complex, "Value(new ComplexObject(Value::integer(0), #{imaginary}))")
+        transform.exec_and_push(:complex, "Value(ComplexObject::create(Value::integer(0), #{imaginary}))")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/create_hash_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_hash_instruction.rb
@@ -21,7 +21,7 @@ module Natalie
         end
         items_temp = transform.temp('items')
         transform.exec("Value #{items_temp}[] = { #{items.join(', ')} };")
-        transform.exec_and_push(:hash, "Value(new HashObject(env, #{items.size}, #{items_temp}))")
+        transform.exec_and_push(:hash, "Value(HashObject::create(env, #{items.size}, #{items_temp}))")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/create_lambda_instruction.rb
+++ b/lib/natalie/compiler/instructions/create_lambda_instruction.rb
@@ -32,7 +32,7 @@ module Natalie
           [
             "auto #{block_temp} = #{block}",
             "#{block_temp}->set_type(Block::BlockType::Lambda)",
-            "Value(new ProcObject(#{block_temp}, #{@break_point || 0}))",
+            "Value(ProcObject::create(#{block_temp}, #{@break_point || 0}))",
           ],
         )
       end

--- a/lib/natalie/compiler/instructions/define_block_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_block_instruction.rb
@@ -27,7 +27,7 @@ module Natalie
           body << '}'
           transform.top(fn, body)
         end
-        transform.push("(new Block(*env, self, #{fn}, #{@arity}))")
+        transform.push("Block::create(*env, self, #{fn}, #{@arity})")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/define_module_instruction.rb
+++ b/lib/natalie/compiler/instructions/define_module_instruction.rb
@@ -59,7 +59,7 @@ module Natalie
         code << "    env->raise(\"TypeError\", \"#{@name} is not a module\");"
         code << '  }'
         code << '} else {'
-        code << "  #{mod} = new ModuleObject(#{@name.to_s.inspect})"
+        code << "  #{mod} = ModuleObject::create(#{@name.to_s.inspect})"
         code << "  Object::const_set(env, #{namespace}, #{transform.intern(@name)}, #{mod})"
         code << '}'
         code << "#{mod}.as_module()->eval_body(env, #{fn})"

--- a/lib/natalie/compiler/instructions/global_variable_defined_instruction.rb
+++ b/lib/natalie/compiler/instructions/global_variable_defined_instruction.rb
@@ -14,7 +14,7 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec("if (!env->global_defined(#{transform.intern(@name)})) throw new ExceptionObject")
+        transform.exec("if (!env->global_defined(#{transform.intern(@name)})) throw ExceptionObject::create()")
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
+++ b/lib/natalie/compiler/instructions/inline_cpp_instruction.rb
@@ -86,7 +86,7 @@ module Natalie
           lambda do |value, type|
             case type
             when 'double'
-              "Value(new FloatObject { #{value} })"
+              "Value(FloatObject::create(#{value}))"
             when 'Value'
               value
             else

--- a/lib/natalie/compiler/instructions/instance_variable_defined_instruction.rb
+++ b/lib/natalie/compiler/instructions/instance_variable_defined_instruction.rb
@@ -14,7 +14,9 @@ module Natalie
       end
 
       def generate(transform)
-        transform.exec("if (!Object::ivar_defined(env, self, #{transform.intern(@name)})) throw new ExceptionObject")
+        transform.exec(
+          "if (!Object::ivar_defined(env, self, #{transform.intern(@name)})) throw ExceptionObject::create()",
+        )
       end
 
       def execute(vm)

--- a/lib/natalie/compiler/instructions/is_defined_instruction.rb
+++ b/lib/natalie/compiler/instructions/is_defined_instruction.rb
@@ -23,7 +23,7 @@ module Natalie
         transform.with_same_scope(body) do |t|
           code << 'try {'
           code << t.transform
-          code << "#{result} = new StringObject(#{@type.inspect})"
+          code << "#{result} = StringObject::create(#{@type.inspect})"
           code << "#{result}->freeze()"
           code << '} catch (ExceptionObject *) {'
           code << "#{result} = Value::nil()"

--- a/lib/natalie/compiler/instructions/method_defined_instruction.rb
+++ b/lib/natalie/compiler/instructions/method_defined_instruction.rb
@@ -31,7 +31,7 @@ module Natalie
         # we have to include all methods in this case
         include_all = receiver == 'self'
         transform.exec(
-          "if (!#{receiver}.respond_to(env, #{transform.intern(@message)}, #{include_all})) throw new ExceptionObject",
+          "if (!#{receiver}.respond_to(env, #{transform.intern(@message)}, #{include_all})) throw ExceptionObject::create()",
         )
         transform.push_nil
       end

--- a/lib/natalie/compiler/instructions/pop_keyword_args_instruction.rb
+++ b/lib/natalie/compiler/instructions/pop_keyword_args_instruction.rb
@@ -10,7 +10,7 @@ module Natalie
       def generate(transform)
         transform.exec_and_push(
           :keyword_args_hash,
-          'args.has_keyword_hash() ? args.pop_keyword_hash() : new HashObject',
+          'args.has_keyword_hash() ? args.pop_keyword_hash() : HashObject::create()',
         )
       end
 

--- a/lib/natalie/compiler/instructions/push_float_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_float_instruction.rb
@@ -21,7 +21,7 @@ module Natalie
             transform.push('Value(FloatObject::negative_infinity(env))')
           end
         else
-          transform.push("Value(new FloatObject(#{@float}))")
+          transform.push("Value(FloatObject::create(#{@float}))")
         end
       end
 

--- a/lib/natalie/compiler/instructions/push_string_instruction.rb
+++ b/lib/natalie/compiler/instructions/push_string_instruction.rb
@@ -37,11 +37,11 @@ module Natalie
           encoding_object = "EncodingObject::get(Encoding::#{enum})"
           name =
             if @string.empty?
-              transform.exec_and_push(:string, "Value(new StringObject(#{encoding_object}))")
+              transform.exec_and_push(:string, "Value(StringObject::create(#{encoding_object}))")
             else
               transform.exec_and_push(
                 :string,
-                "Value(new StringObject(#{string_to_cpp(@string)}, (size_t)#{@bytesize}, #{encoding_object}))",
+                "Value(StringObject::create(#{string_to_cpp(@string)}, (size_t)#{@bytesize}, #{encoding_object}))",
               )
             end
           transform.exec("#{name}.as_string()->set_chilled(StringObject::Chilled::String)") if chilled?

--- a/lib/natalie/compiler/instructions/string_to_regexp_instruction.rb
+++ b/lib/natalie/compiler/instructions/string_to_regexp_instruction.rb
@@ -23,12 +23,12 @@ module Natalie
         if @once
           transform.exec_and_push(
             :regexp,
-            "Value([&]() { static auto result = new RegexpObject(env, #{string}.as_string()->string(), #{@options}, #{encoding}); return result; }())",
+            "Value([&]() { static auto result = RegexpObject::create(env, #{string}.as_string()->string(), #{@options}, #{encoding}); return result; }())",
           )
         else
           transform.exec_and_push(
             :regexp,
-            "Value(new RegexpObject(env, #{string}.as_string()->string(), #{@options}, #{encoding}))",
+            "Value(RegexpObject::create(env, #{string}.as_string()->string(), #{@options}, #{encoding}))",
           )
         end
       end

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -255,7 +255,7 @@ Value OpenSSL_Cipher_update(Env *env, Value self, Args &&args, Block *) {
 }
 
 Value OpenSSL_Cipher_ciphers(Env *env, Value self, Args &&args, Block *) {
-    auto result = new ArrayObject {};
+    auto result = ArrayObject::create();
     OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_CIPHER_METH, OpenSSL_Cipher_ciphers_add_cipher, result);
     return result;
 }
@@ -1246,10 +1246,10 @@ Value OpenSSL_X509_Name_to_a(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
     auto name = static_cast<X509_NAME *>(self->ivar_get(env, "@name"_s).as_void_p()->void_ptr());
     const size_t size = X509_NAME_entry_count(name);
-    auto result = new ArrayObject { size };
+    auto result = ArrayObject::create(size);
     for (size_t i = 0; i < size; i++) {
         X509_NAME_ENTRY *name_entry = X509_NAME_get_entry(name, i);
-        auto entry_result = new ArrayObject { 3 };
+        auto entry_result = ArrayObject::create(3);
 
         ASN1_OBJECT *obj = X509_NAME_ENTRY_get_object(name_entry);
         if (!obj)

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -99,7 +99,7 @@ static Value OpenSSL_BN_new(Env *env, const ASN1_INTEGER *asn1) {
         OpenSSL_raise_error(env, "ASN1_INTEGER_to_BN");
     auto BN = fetch_nested_const({ "OpenSSL"_s, "BN"_s }).as_class();
     auto bn = Object::allocate(env, BN, {}, nullptr);
-    bn->ivar_set(env, "@bn"_s, new VoidPObject { value, OpenSSL_BN_cleanup });
+    bn->ivar_set(env, "@bn"_s, VoidPObject::create(value, OpenSSL_BN_cleanup));
     return bn;
 }
 
@@ -114,7 +114,7 @@ static Value OpenSSL_PKey_new(Env *env, EVP_PKEY *value) {
     if (!klass)
         env->raise("NotImplementedError", "No support for used key type");
     auto pkey = Object::allocate(env, klass, {}, nullptr);
-    pkey->ivar_set(env, "@pkey"_s, new VoidPObject { copy, OpenSSL_PKEY_cleanup });
+    pkey->ivar_set(env, "@pkey"_s, VoidPObject::create(copy, OpenSSL_PKEY_cleanup));
     return pkey;
 }
 
@@ -124,7 +124,7 @@ static Value OpenSSL_X509_Name_new(Env *env, const X509_NAME *value) {
         OpenSSL_raise_error(env, "X509_NAME_dup");
     auto Name = fetch_nested_const({ "OpenSSL"_s, "X509"_s, "Name"_s }).as_class();
     auto name = Object::allocate(env, Name, {}, nullptr);
-    name->ivar_set(env, "@name"_s, new VoidPObject { copy, OpenSSL_X509_NAME_cleanup });
+    name->ivar_set(env, "@name"_s, VoidPObject::create(copy, OpenSSL_X509_NAME_cleanup));
     return name;
 }
 
@@ -158,7 +158,7 @@ Value OpenSSL_Cipher_initialize(Env *env, Value self, Args &&args, Block *) {
         EVP_CIPHER_CTX_free(ctx);
         OpenSSL_Cipher_raise_error(env, "EVP_EncryptInit_ex");
     }
-    self->ivar_set(env, "@ctx"_s, new VoidPObject { ctx, OpenSSL_CIPHER_CTX_cleanup });
+    self->ivar_set(env, "@ctx"_s, VoidPObject::create(ctx, OpenSSL_CIPHER_CTX_cleanup));
 
     return self;
 }
@@ -290,7 +290,7 @@ Value OpenSSL_Digest_initialize(Env *env, Value self, Args &&args, Block *) {
         OpenSSL_raise_error(env, "EVP_DigestInit_ex");
 
     self->ivar_set(env, "@name"_s, name.as_string()->upcase(env));
-    self->ivar_set(env, "@mdctx"_s, new VoidPObject { mdctx, OpenSSL_MD_CTX_cleanup });
+    self->ivar_set(env, "@mdctx"_s, VoidPObject::create(mdctx, OpenSSL_MD_CTX_cleanup));
 
     if (args.size() == 2)
         OpenSSL_Digest_update(env, self, { args[1] }, nullptr);
@@ -373,7 +373,7 @@ Value OpenSSL_SSL_SSLContext_initialize(Env *env, Value self, Args &&args, Block
     SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION | SSL_OP_ENABLE_MIDDLEBOX_COMPAT);
     if (!ctx)
         OpenSSL_SSL_raise_error(env, "SSL_CTX_new");
-    self->ivar_set(env, "@ctx"_s, new VoidPObject { ctx, OpenSSL_SSL_CTX_cleanup });
+    self->ivar_set(env, "@ctx"_s, VoidPObject::create(ctx, OpenSSL_SSL_CTX_cleanup));
     self->ivar_set(env, "@verify_hostname"_s, Value::False());
     self->ivar_set(env, "@verify_mode"_s, Value::integer(0));
     return self;
@@ -534,7 +534,7 @@ Value OpenSSL_SSL_SSLSocket_initialize(Env *env, Value self, Args &&args, Block 
         OpenSSL_SSL_raise_error(env, "SSL_new");
     self->ivar_set(env, "@context"_s, context);
     self->ivar_set(env, "@io"_s, io);
-    self->ivar_set(env, "@ssl"_s, new VoidPObject { ssl, OpenSSL_SSL_cleanup });
+    self->ivar_set(env, "@ssl"_s, VoidPObject::create(ssl, OpenSSL_SSL_cleanup));
     return self;
 }
 
@@ -651,7 +651,7 @@ Value OpenSSL_PKey_RSA_initialize(Env *env, Value self, Args &&args, Block *) {
             OpenSSL_raise_error(env, "EVP_PKEY_new");
     }
 
-    self->ivar_set(env, "@pkey"_s, new VoidPObject { pkey, OpenSSL_PKEY_cleanup });
+    self->ivar_set(env, "@pkey"_s, VoidPObject::create(pkey, OpenSSL_PKEY_cleanup));
     return self;
 }
 
@@ -718,7 +718,7 @@ Value OpenSSL_X509_Certificate_initialize(Env *env, Value self, Args &&args, Blo
     X509 *x509 = X509_new();
     if (!x509)
         OpenSSL_raise_error(env, "X509_new");
-    self->ivar_set(env, "@x509"_s, new VoidPObject { x509, OpenSSL_X509_cleanup });
+    self->ivar_set(env, "@x509"_s, VoidPObject::create(x509, OpenSSL_X509_cleanup));
 
     self.send(env, "serial="_s, { Value::integer(0) });
 
@@ -1130,7 +1130,7 @@ Value OpenSSL_BN_initialize(Env *env, Value self, Args &&args, Block *) {
     auto bn = BN_secure_new();
     if (!bn)
         OpenSSL_raise_error(env, "BN_secure_new");
-    self->ivar_set(env, "@bn"_s, new VoidPObject { bn, OpenSSL_BN_cleanup });
+    self->ivar_set(env, "@bn"_s, VoidPObject::create(bn, OpenSSL_BN_cleanup));
 
     auto arg = args.at(0, Value::nil());
     if (arg.is_a(env, self.klass())) {
@@ -1225,7 +1225,7 @@ Value OpenSSL_X509_Name_initialize(Env *env, Value self, Args &&args, Block *) {
     X509_NAME *name = X509_NAME_new();
     if (!name)
         OpenSSL_X509_Name_raise_error(env, "X509_NAME_new");
-    self->ivar_set(env, "@name"_s, new VoidPObject { name, OpenSSL_X509_NAME_cleanup });
+    self->ivar_set(env, "@name"_s, VoidPObject::create(name, OpenSSL_X509_NAME_cleanup));
     if (args.size() > 0) {
         HashObject *lookup = self.klass()->const_fetch("OBJECT_TYPE_TEMPLATE"_s).as_hash();
         if (args.size() >= 2 && !args.at(1).is_nil())
@@ -1315,7 +1315,7 @@ Value OpenSSL_X509_Store_initialize(Env *env, Value self, Args &&args, Block *) 
     X509_STORE *store = X509_STORE_new();
     if (!store)
         OpenSSL_X509_Store_raise_error(env, "X509_STORE_new");
-    self->ivar_set(env, "@store"_s, new VoidPObject { store, OpenSSL_X509_STORE_cleanup });
+    self->ivar_set(env, "@store"_s, VoidPObject::create(store, OpenSSL_X509_STORE_cleanup));
     return self;
 }
 

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -1050,7 +1050,7 @@ Value init_openssl(Env *env, Value self) {
     if (lookup_OpenSSL) {
         OpenSSL = lookup_OpenSSL.value().as_module();
     } else {
-        OpenSSL = new ModuleObject { "OpenSSL" };
+        OpenSSL = ModuleObject::create("OpenSSL");
         GlobalEnv::the()->Object()->const_set("OpenSSL"_s, OpenSSL);
     }
 
@@ -1117,7 +1117,7 @@ Value init_openssl(Env *env, Value self) {
     if (lookup_KDF) {
         KDF = lookup_KDF.value();
     } else {
-        KDF = new ModuleObject { "KDF" };
+        KDF = ModuleObject::create("KDF");
         OpenSSL->const_set("KDF"_s, KDF);
     }
     Object::define_singleton_method(env, KDF, "pbkdf2_hmac"_s, OpenSSL_KDF_pbkdf2_hmac, -1);

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -142,7 +142,7 @@ Value OpenSSL_fixed_length_secure_compare(Env *env, Value self, Args &&args, Blo
 
 static void OpenSSL_Cipher_ciphers_add_cipher(const OBJ_NAME *cipher_meth, void *arg) {
     auto result = static_cast<ArrayObject *>(arg);
-    result->push(new StringObject { cipher_meth->name });
+    result->push(StringObject::create(cipher_meth->name));
 }
 
 Value OpenSSL_Cipher_initialize(Env *env, Value self, Args &&args, Block *) {
@@ -196,7 +196,7 @@ Value OpenSSL_Cipher_final(Env *env, Value self, Args &&args, Block *) {
     if (!EVP_CipherFinal_ex(ctx, reinterpret_cast<unsigned char *>(&buf[0]), &size))
         OpenSSL_Cipher_raise_error(env, "EVP_CipherFinal_ex");
     buf.truncate(size);
-    return new StringObject { std::move(buf), Encoding::ASCII_8BIT };
+    return StringObject::create(std::move(buf), Encoding::ASCII_8BIT);
 }
 
 Value OpenSSL_Cipher_iv_set(Env *env, Value self, Args &&args, Block *) {
@@ -251,7 +251,7 @@ Value OpenSSL_Cipher_update(Env *env, Value self, Args &&args, Block *) {
     if (!EVP_CipherUpdate(ctx, reinterpret_cast<unsigned char *>(&buf[0]), &size, reinterpret_cast<const unsigned char *>(data->c_str()), data->bytesize()))
         OpenSSL_Cipher_raise_error(env, "EVP_CipherUpdate");
     buf.truncate(size);
-    return new StringObject { std::move(buf), Encoding::ASCII_8BIT };
+    return StringObject::create(std::move(buf), Encoding::ASCII_8BIT);
 }
 
 Value OpenSSL_Cipher_ciphers(Env *env, Value self, Args &&args, Block *) {
@@ -342,7 +342,7 @@ Value OpenSSL_Digest_digest(Env *env, Value self, Args &&args, Block *) {
     if (args.size() == 1)
         OpenSSL_Digest_reset(env, self, {}, nullptr);
 
-    return new StringObject { reinterpret_cast<const char *>(buf), md_len, Encoding::ASCII_8BIT };
+    return StringObject::create(reinterpret_cast<const char *>(buf), md_len, Encoding::ASCII_8BIT);
 }
 
 Value OpenSSL_Digest_digest_length(Env *env, Value self, Args &&args, Block *) {
@@ -364,7 +364,7 @@ Value OpenSSL_HMAC_digest(Env *env, Value self, Args &&args, Block *) {
     auto res = HMAC(evp_md, key->c_str(), key->bytesize(), reinterpret_cast<const unsigned char *>(data->c_str()), data->bytesize(), md, &md_len);
     if (!res)
         OpenSSL_raise_error(env, "HMAC");
-    return new StringObject { reinterpret_cast<const char *>(md), md_len };
+    return StringObject::create(reinterpret_cast<const char *>(md), md_len);
 }
 
 Value OpenSSL_SSL_SSLContext_initialize(Env *env, Value self, Args &&args, Block *) {
@@ -602,7 +602,7 @@ Value OpenSSL_SSL_SSLSocket_read(Env *env, Value self, Args &&args, Block *) {
     TM::String buf(buf_size, '\0');
     StringObject *result;
     if (args.at(1, Value::nil()).is_nil()) {
-        result = new StringObject {};
+        result = StringObject::create();
     } else {
         result = args[1].to_str(env);
         result->clear(env);
@@ -676,7 +676,7 @@ Value OpenSSL_PKey_RSA_export(Env *env, Value self, Args &&args, Block *) {
     auto size = BIO_get_mem_data(bio, &data);
     if (size <= 0)
         OpenSSL_raise_error(env, "BIO_get_mem_data");
-    return new StringObject { data, static_cast<size_t>(size) };
+    return StringObject::create(data, static_cast<size_t>(size));
 }
 
 Value OpenSSL_PKey_RSA_is_private(Env *env, Value self, Args &&args, Block *) {
@@ -707,7 +707,7 @@ Value OpenSSL_PKey_RSA_public_key(Env *env, Value self, Args &&args, Block *) {
     const auto size = BIO_get_mem_data(bio, &data);
     if (size <= 0)
         OpenSSL_raise_error(env, "BIO_get_mem_data");
-    auto pem = new StringObject { data, static_cast<size_t>(size) };
+    auto pem = StringObject::create(data, static_cast<size_t>(size));
     return Object::_new(env, self.klass(), { pem }, nullptr);
 }
 
@@ -993,7 +993,7 @@ Value OpenSSL_KDF_pbkdf2_hmac(Env *env, Value self, Args &&args, Block *) {
         OpenSSL_raise_error(env, "PKCS5_PBKDF2_HMAC", KDFError.as_class());
     }
 
-    return new StringObject { reinterpret_cast<char *>(out), out_size, Encoding::ASCII_8BIT };
+    return StringObject::create(reinterpret_cast<char *>(out), out_size, Encoding::ASCII_8BIT);
 }
 
 Value OpenSSL_KDF_scrypt(Env *env, Value self, Args &&args, Block *) {
@@ -1039,7 +1039,7 @@ Value OpenSSL_KDF_scrypt(Env *env, Value self, Args &&args, Block *) {
         OpenSSL_raise_error(env, "EVP_PBE_scrypt", KDFError.as_class());
     }
 
-    return new StringObject { reinterpret_cast<const char *>(out), outlen };
+    return StringObject::create(reinterpret_cast<const char *>(out), outlen);
 }
 
 Value init_openssl(Env *env, Value self) {
@@ -1058,12 +1058,11 @@ Value init_openssl(Env *env, Value self) {
     const auto openssl_version_major = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 28) & 0xFF);
     const auto openssl_version_minor = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 20) & 0xFF);
     const auto openssl_version_patchlevel = static_cast<nat_int_t>((OPENSSL_VERSION_NUMBER >> 12) & 0xFF);
-    StringObject *VERSION = new StringObject {
-        TM::String::format("{}.{}.{}", openssl_version_major, openssl_version_minor, openssl_version_patchlevel)
-    };
+    StringObject *VERSION = StringObject::create(
+        TM::String::format("{}.{}.{}", openssl_version_major, openssl_version_minor, openssl_version_patchlevel));
     OpenSSL->const_set("VERSION"_s, VERSION);
 
-    OpenSSL->const_set("OPENSSL_VERSION"_s, new StringObject { OPENSSL_VERSION_TEXT });
+    OpenSSL->const_set("OPENSSL_VERSION"_s, StringObject::create(OPENSSL_VERSION_TEXT));
     OpenSSL->const_set("OPENSSL_VERSION_NUMBER"_s, Value::integer(OPENSSL_VERSION_NUMBER));
     Object::define_singleton_method(env, OpenSSL, "fixed_length_secure_compare"_s, OpenSSL_fixed_length_secure_compare, 2);
 
@@ -1195,7 +1194,7 @@ Value OpenSSL_Random_random_bytes(Env *env, Value self, Args &&args, Block *) {
     if (RAND_bytes(buf, num) != 1)
         OpenSSL_raise_error(env, "RAND_bytes");
 
-    return new StringObject { reinterpret_cast<char *>(buf), static_cast<size_t>(num), Encoding::ASCII_8BIT };
+    return StringObject::create(reinterpret_cast<char *>(buf), static_cast<size_t>(num), Encoding::ASCII_8BIT);
 }
 
 Value OpenSSL_X509_Name_add_entry(Env *env, Value self, Args &&args, Block *) {
@@ -1261,12 +1260,12 @@ Value OpenSSL_X509_Name_to_a(Env *env, Value self, Args &&args, Block *) {
         const char *sn = OBJ_nid2sn(nid);
         if (!sn)
             OpenSSL_X509_Name_raise_error(env, "OBJ_nid2sn");
-        entry_result->push(new StringObject { sn });
+        entry_result->push(StringObject::create(sn));
 
         ASN1_STRING *data = X509_NAME_ENTRY_get_data(name_entry);
         if (!data)
             OpenSSL_X509_Name_raise_error(env, "X509_NAME_ENTRY_get_data");
-        entry_result->push(new StringObject { reinterpret_cast<const char *>(ASN1_STRING_get0_data(data)), static_cast<size_t>(ASN1_STRING_length(data)) });
+        entry_result->push(StringObject::create(reinterpret_cast<const char *>(ASN1_STRING_get0_data(data)), static_cast<size_t>(ASN1_STRING_length(data))));
 
         entry_result->push(Value::integer(ASN1_STRING_type(data)));
 
@@ -1283,7 +1282,7 @@ Value OpenSSL_X509_Name_to_s(Env *env, Value self, Args &&args, Block *) {
         char *str = X509_NAME_oneline(name, nullptr, 0);
         if (!str)
             OpenSSL_X509_Name_raise_error(env, "X509_NAME_oneline");
-        auto result = new StringObject { str };
+        auto result = StringObject::create(str);
         free(str);
         return result;
     }
@@ -1298,7 +1297,7 @@ Value OpenSSL_X509_Name_to_s(Env *env, Value self, Args &&args, Block *) {
     auto size = BIO_get_mem_data(bio, &mem);
     if (size < 0)
         OpenSSL_X509_Name_raise_error(env, "BIO_get_mem_data");
-    return new StringObject { mem, static_cast<size_t>(size) };
+    return StringObject::create(mem, static_cast<size_t>(size));
 }
 
 Value OpenSSL_X509_Name_cmp(Env *env, Value self, Args &&args, Block *) {
@@ -1364,6 +1363,6 @@ Value OpenSSL_X509_Store_verify(Env *env, Value self, Args &&args, Block *) {
     const auto verify = X509_verify_cert(ctx) != 0;
     const auto error = X509_STORE_CTX_get_error(ctx);
     self->ivar_set(env, "@error"_s, Value::integer(error));
-    self->ivar_set(env, "@error_string"_s, new StringObject { X509_verify_cert_error_string(error), Encoding::ASCII_8BIT });
+    self->ivar_set(env, "@error_string"_s, StringObject::create(X509_verify_cert_error_string(error), Encoding::ASCII_8BIT));
     return bool_object(verify);
 }

--- a/lib/openssl.cpp
+++ b/lib/openssl.cpp
@@ -764,7 +764,7 @@ Value OpenSSL_X509_Certificate_not_after(Env *env, Value self, Args &&args, Bloc
 
     auto Time = find_top_level_const(env, "Time"_s).as_class();
     time_t time_since_epoch = mktime(&tm);
-    auto kwargs = new HashObject { env, { "in"_s, Value::integer(0) } };
+    auto kwargs = HashObject::create(env, { "in"_s, Value::integer(0) });
     return Time->send(env, "at"_s, Args { { Value::integer(time_since_epoch), kwargs }, true });
 }
 
@@ -802,7 +802,7 @@ Value OpenSSL_X509_Certificate_not_before(Env *env, Value self, Args &&args, Blo
 
     auto Time = find_top_level_const(env, "Time"_s).as_class();
     time_t time_since_epoch = mktime(&tm);
-    auto kwargs = new HashObject { env, { "in"_s, Value::integer(0) } };
+    auto kwargs = HashObject::create(env, { "in"_s, Value::integer(0) });
     return Time->send(env, "at"_s, Args { { Value::integer(time_since_epoch), kwargs }, true });
 }
 
@@ -964,7 +964,7 @@ Value OpenSSL_KDF_pbkdf2_hmac(Env *env, Value self, Args &&args, Block *) {
     auto kwargs = args.pop_keyword_hash();
     args.ensure_argc_is(env, 1);
     auto pass = args.at(0).to_str(env);
-    if (!kwargs) kwargs = new HashObject {};
+    if (!kwargs) kwargs = HashObject::create();
     env->ensure_no_missing_keywords(kwargs, { "salt", "iterations", "length", "hash" });
     auto salt = kwargs->remove(env, "salt"_s).value().to_str(env);
     auto iterations = kwargs->remove(env, "iterations"_s).value().to_int(env);

--- a/lib/rbconfig/sizeof.rb
+++ b/lib/rbconfig/sizeof.rb
@@ -7,23 +7,23 @@ module RbConfig
 
   __inline__ <<~CPP
     auto SIZEOF = self.as_module()->const_fetch("SIZEOF"_s).as_hash();
-    SIZEOF->put(env, new StringObject { "double" }, Value::integer(sizeof(double)));
-    SIZEOF->put(env, new StringObject { "float" }, Value::integer(sizeof(float)));
-    SIZEOF->put(env, new StringObject { "int" }, Value::integer(sizeof(int)));
-    SIZEOF->put(env, new StringObject { "long" }, Value::integer(sizeof(long)));
-    SIZEOF->put(env, new StringObject { "short" }, Value::integer(sizeof(short)));
-    SIZEOF->put(env, new StringObject { "void*" }, Value::integer(sizeof(void *)));
+    SIZEOF->put(env, StringObject::create("double"), Value::integer(sizeof(double)));
+    SIZEOF->put(env, StringObject::create("float"), Value::integer(sizeof(float)));
+    SIZEOF->put(env, StringObject::create("int"), Value::integer(sizeof(int)));
+    SIZEOF->put(env, StringObject::create("long"), Value::integer(sizeof(long)));
+    SIZEOF->put(env, StringObject::create("short"), Value::integer(sizeof(short)));
+    SIZEOF->put(env, StringObject::create("void*"), Value::integer(sizeof(void *)));
 
     auto LIMITS = self.as_module()->const_fetch("LIMITS"_s).as_hash();
-    LIMITS->put(env, new StringObject { "CHAR_MIN" }, Value::integer(std::numeric_limits<char>::min()));
-    LIMITS->put(env, new StringObject { "CHAR_MAX" }, Value::integer(std::numeric_limits<char>::max()));
-    LIMITS->put(env, new StringObject { "SHRT_MIN" }, Value::integer(std::numeric_limits<short>::min()));
-    LIMITS->put(env, new StringObject { "SHRT_MAX" }, Value::integer(std::numeric_limits<short>::max()));
-    LIMITS->put(env, new StringObject { "INT_MIN" }, Value::integer(std::numeric_limits<int>::min()));
-    LIMITS->put(env, new StringObject { "INT_MAX" }, Value::integer(std::numeric_limits<int>::max()));
-    LIMITS->put(env, new StringObject { "LONG_MIN" }, Value::integer(std::numeric_limits<long>::min()));
-    LIMITS->put(env, new StringObject { "LONG_MAX" }, Value::integer(std::numeric_limits<long>::max()));
-    LIMITS->put(env, new StringObject { "FIXNUM_MIN" }, Value::integer(std::numeric_limits<long>::min() >> 1));
-    LIMITS->put(env, new StringObject { "FIXNUM_MAX" }, Value::integer(std::numeric_limits<long>::max() >> 1));
+    LIMITS->put(env, StringObject::create("CHAR_MIN"), Value::integer(std::numeric_limits<char>::min()));
+    LIMITS->put(env, StringObject::create("CHAR_MAX"), Value::integer(std::numeric_limits<char>::max()));
+    LIMITS->put(env, StringObject::create("SHRT_MIN"), Value::integer(std::numeric_limits<short>::min()));
+    LIMITS->put(env, StringObject::create("SHRT_MAX"), Value::integer(std::numeric_limits<short>::max()));
+    LIMITS->put(env, StringObject::create("INT_MIN"), Value::integer(std::numeric_limits<int>::min()));
+    LIMITS->put(env, StringObject::create("INT_MAX"), Value::integer(std::numeric_limits<int>::max()));
+    LIMITS->put(env, StringObject::create("LONG_MIN"), Value::integer(std::numeric_limits<long>::min()));
+    LIMITS->put(env, StringObject::create("LONG_MAX"), Value::integer(std::numeric_limits<long>::max()));
+    LIMITS->put(env, StringObject::create("FIXNUM_MIN"), Value::integer(std::numeric_limits<long>::min() >> 1));
+    LIMITS->put(env, StringObject::create("FIXNUM_MAX"), Value::integer(std::numeric_limits<long>::max() >> 1));
   CPP
 end

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -12,7 +12,7 @@ module Readline
 
       std::string line;
       std::getline(std::cin, line);
-      return new StringObject { line.c_str() };
+      return StringObject::create(line.c_str());
     END
   end
 end

--- a/lib/securerandom.cpp
+++ b/lib/securerandom.cpp
@@ -6,7 +6,7 @@ using namespace Natalie;
 static Value generate_random(double min, double max) {
     std::random_device rd;
     std::uniform_real_distribution<double> random_number(min, max);
-    return new FloatObject { random_number(rd) };
+    return FloatObject::create(random_number(rd));
 }
 
 static Value generate_random(nat_int_t min, nat_int_t max) {

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1643,7 +1643,7 @@ Value TCPSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
     self.as_io()->set_nonblock(env, true);
     Args new_args = { sockaddr };
     if (connect_timeout) {
-        auto new_kwargs = new HashObject { env, { "connect_timeout"_s, *connect_timeout } };
+        auto new_kwargs = HashObject::create(env, { "connect_timeout"_s, *connect_timeout });
         Socket_connect(env, self, Args({ sockaddr, new_kwargs }, true), nullptr);
     } else {
         Socket_connect(env, self, { sockaddr }, nullptr);
@@ -1921,7 +1921,7 @@ Value UNIXServer_initialize(Env *env, Value self, Args &&args, Block *block) {
     if (fd == -1)
         env->raise_errno();
 
-    auto kwargs = new HashObject { env, { "path"_s, path } };
+    auto kwargs = HashObject::create(env, { "path"_s, path });
     self.as_io()->initialize(env, Args({ Value::integer(fd), kwargs }, true), block);
     self.as_io()->binmode(env);
     self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s).send(env, "do_not_reverse_lookup"_s));

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -152,7 +152,7 @@ static Value Server_accept(Env *env, Value self, SymbolObject *klass, sockaddr_s
         return fd;
 
     auto Socket = find_top_level_const(env, klass).as_class_or_raise(env);
-    auto socket = new IoObject { Socket };
+    auto socket = IoObject::create(Socket);
     socket->set_fileno(IntegerMethods::convert_to_native_type<int>(env, fd));
     socket->set_close_on_exec(env, Value::True());
     socket->set_nonblock(env, true);

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -13,10 +13,10 @@ Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_between(env, 0, 2);
     auto basename = args.at(0, Value::nil());
     auto tmpdir = args.at(1, Value::nil());
-    auto suffix = new StringObject { "" };
+    auto suffix = StringObject::create("");
 
     if (basename.is_nil()) {
-        basename = new StringObject { "" };
+        basename = StringObject::create("");
     } else if (!basename.is_string() && basename.respond_to(env, "to_str"_s)) {
         basename = basename.to_str(env);
     } else if (basename.is_array()) {

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -9,7 +9,7 @@ Value init_tempfile(Env *env, Value self) {
 Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
     auto kwargs = args.pop_keyword_hash();
     if (!kwargs)
-        kwargs = new HashObject {};
+        kwargs = HashObject::create();
     args.ensure_argc_between(env, 0, 2);
     auto basename = args.at(0, Value::nil());
     auto tmpdir = args.at(1, Value::nil());

--- a/lib/tempfile.cpp
+++ b/lib/tempfile.cpp
@@ -40,7 +40,7 @@ Value Tempfile_initialize(Env *env, Value self, Args &&args, Block *) {
     if (fileno == -1)
         env->raise_errno();
 
-    auto file = new FileObject {};
+    auto file = FileObject::create();
     file->initialize(env, Args({ Value::integer(fileno), kwargs }, true), nullptr);
     file->set_path(path);
 

--- a/lib/tmpdir.cpp
+++ b/lib/tmpdir.cpp
@@ -1,6 +1,5 @@
 #include "natalie.hpp"
 
-#include <stdio.h>
 #include <stdlib.h>
 
 using namespace Natalie;
@@ -15,7 +14,7 @@ Value Dir_mktmpdir(Env *env, Value self, Args &&args, Block *) {
         env->raise_errno();
     close(fh);
     unlink(tmpdir.c_str());
-    auto result = new StringObject { std::move(tmpdir) };
+    auto result = StringObject::create(std::move(tmpdir));
     self->send(env, "mkdir"_s, { result });
     return result;
 }
@@ -25,7 +24,7 @@ Value Dir_tmpdir(Env *env, Value self, Args &&args, Block *) {
 
     const auto tmpdir = getenv("TMPDIR");
     if (tmpdir)
-        return new StringObject { tmpdir, Encoding::ASCII_8BIT };
+        return StringObject::create(tmpdir, Encoding::ASCII_8BIT);
     return find_top_level_const(env, "Etc"_s).send(env, "systmpdir"_s, std::move(args));
 }
 

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -316,7 +316,7 @@ static Value load_scalar(Env *env, yaml_parser_t &parser, yaml_token_t &token) {
 }
 
 static Value load_array(Env *env, yaml_parser_t &parser) {
-    auto result = new ArrayObject {};
+    auto result = ArrayObject::create();
     while (true) {
         yaml_token_t token;
         Defer token_deleter { [&token]() { yaml_token_delete(&token); } };

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -337,7 +337,7 @@ static Value load_array(Env *env, yaml_parser_t &parser) {
 }
 
 static Value load_hash(Env *env, yaml_parser_t &parser) {
-    auto result = new HashObject {};
+    auto result = HashObject::create();
     while (true) {
         yaml_token_t token;
         Defer token_deleter { [&token]() { yaml_token_delete(&token); } };

--- a/lib/yaml.cpp
+++ b/lib/yaml.cpp
@@ -1,5 +1,4 @@
 #include "natalie.hpp"
-#include "natalie/integer_methods.hpp"
 #include <yaml.h>
 
 using namespace Natalie;
@@ -40,9 +39,9 @@ static void emit_value(Env *env, ExceptionObject *value, yaml_emitter_t &emitter
         0, YAML_ANY_MAPPING_STYLE);
     emit(env, emitter, event);
 
-    emit_value(env, new StringObject { "message" }, emitter, event);
+    emit_value(env, StringObject::create("message"), emitter, event);
     emit_value(env, value->message(env), emitter, event);
-    emit_value(env, new StringObject { "backtrace" }, emitter, event);
+    emit_value(env, StringObject::create("backtrace"), emitter, event);
     emit_value(env, value->backtrace(env), emitter, event);
 
     yaml_mapping_end_event_initialize(&event);
@@ -98,11 +97,11 @@ static void emit_value(Env *env, RangeObject *value, yaml_emitter_t &emitter, ya
         0, YAML_BLOCK_MAPPING_STYLE);
     emit(env, emitter, event);
 
-    emit_value(env, new StringObject { "begin" }, emitter, event);
+    emit_value(env, StringObject::create("begin"), emitter, event);
     emit_value(env, value->begin(), emitter, event);
-    emit_value(env, new StringObject { "end" }, emitter, event);
+    emit_value(env, StringObject::create("end"), emitter, event);
     emit_value(env, value->end(), emitter, event);
-    emit_value(env, new StringObject { "excl" }, emitter, event);
+    emit_value(env, StringObject::create("excl"), emitter, event);
     auto exclude_end = bool_object(value->exclude_end());
     emit_value(env, exclude_end, emitter, event);
 
@@ -189,7 +188,7 @@ static void emit_object_value(Env *env, Value value, yaml_emitter_t &emitter, ya
 
     auto ivars = value->instance_variables(env).as_array();
     for (auto ivar : *ivars) {
-        auto name = ivar.to_s(env)->delete_prefix(env, new StringObject { "@" });
+        auto name = ivar.to_s(env)->delete_prefix(env, StringObject::create("@"));
         auto val = value->ivar_get(env, ivar.as_symbol());
         emit_value(env, name, emitter, event);
         emit_value(env, val, emitter, event);
@@ -286,14 +285,14 @@ Value YAML_dump(Env *env, Value self, Args &&args, Block *) {
         return args.at(1);
     }
 
-    return new StringObject { std::move(buf) };
+    return StringObject::create(std::move(buf));
 }
 
 static Value load_value(Env *env, yaml_parser_t &parser, yaml_token_t &token);
 
 static Value load_scalar(Env *env, yaml_parser_t &parser, yaml_token_t &token) {
     const auto &scalar = token.data.scalar;
-    Value result = new StringObject { (char *)(scalar.value), scalar.length };
+    Value result = StringObject::create((char *)(scalar.value), scalar.length);
 
     // Quoted must be a String
     if (scalar.style == YAML_SINGLE_QUOTED_SCALAR_STYLE || scalar.style == YAML_DOUBLE_QUOTED_SCALAR_STYLE)

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -61,7 +61,7 @@ Value Zlib_deflate_initialize(Env *env, Value self, Args &&args, Block *) {
 
     auto stream = new z_stream {};
     self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_deflate_stream_cleanup));
-    self->ivar_set(env, "@result"_s, new StringObject("", Encoding::ASCII_8BIT));
+    self->ivar_set(env, "@result"_s, StringObject::create("", Encoding::ASCII_8BIT));
     auto in = new unsigned char[ZLIB_BUF_SIZE];
     self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
@@ -195,7 +195,7 @@ Value Zlib_inflate_initialize(Env *env, Value self, Args &&args, Block *) {
 
     auto stream = new z_stream {};
     self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_inflate_stream_cleanup));
-    self->ivar_set(env, "@result"_s, new StringObject("", Encoding::ASCII_8BIT));
+    self->ivar_set(env, "@result"_s, StringObject::create("", Encoding::ASCII_8BIT));
     auto in = new unsigned char[ZLIB_BUF_SIZE];
     self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
@@ -299,7 +299,7 @@ Value Zlib_inflate_close(Env *env, Value self, Args &&args, Block *) {
 
 Value Zlib_adler32(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_between(env, 0, 2);
-    auto string = args.at(0, new StringObject { "", Encoding::ASCII_8BIT }).to_str(env);
+    auto string = args.at(0, StringObject::create("", Encoding::ASCII_8BIT)).to_str(env);
     auto checksum = args.at(1, Value::integer(1)).to_int(env);
     IntegerMethods::assert_fixnum(env, checksum);
     const nat_int_t result = adler32_z(checksum.to_nat_int_t(), reinterpret_cast<const Bytef *>(string->c_str()), string->bytesize());
@@ -333,5 +333,5 @@ Value Zlib_crc_table(Env *env, Value self, Args &&args, Block *) {
 
 Value Zlib_zlib_version(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
-    return new StringObject { ZLIB_VERSION, Encoding::ASCII_8BIT };
+    return StringObject::create(ZLIB_VERSION, Encoding::ASCII_8BIT);
 }

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -60,12 +60,12 @@ Value Zlib_deflate_initialize(Env *env, Value self, Args &&args, Block *) {
     auto strategy = args.at(3, Zlib->const_fetch("DEFAULT_STRATEGY"_s)).integer_or_raise(env);
 
     auto stream = new z_stream {};
-    self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_deflate_stream_cleanup));
+    self->ivar_set(env, "@stream"_s, VoidPObject::create(stream, Zlib_deflate_stream_cleanup));
     self->ivar_set(env, "@result"_s, StringObject::create("", Encoding::ASCII_8BIT));
     auto in = new unsigned char[ZLIB_BUF_SIZE];
-    self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@in"_s, VoidPObject::create(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
-    self->ivar_set(env, "@out"_s, new VoidPObject(out, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@out"_s, VoidPObject::create(out, Zlib_buffer_cleanup));
     self->ivar_set(env, "@closed"_s, Value::False());
 
     int ret = deflateInit2(stream,
@@ -194,12 +194,12 @@ Value Zlib_inflate_initialize(Env *env, Value self, Args &&args, Block *) {
     auto window_bits = args.at(0, fetch_nested_const({ "Zlib"_s, "MAX_WBITS"_s })).integer_or_raise(env);
 
     auto stream = new z_stream {};
-    self->ivar_set(env, "@stream"_s, new VoidPObject(stream, Zlib_inflate_stream_cleanup));
+    self->ivar_set(env, "@stream"_s, VoidPObject::create(stream, Zlib_inflate_stream_cleanup));
     self->ivar_set(env, "@result"_s, StringObject::create("", Encoding::ASCII_8BIT));
     auto in = new unsigned char[ZLIB_BUF_SIZE];
-    self->ivar_set(env, "@in"_s, new VoidPObject(in, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@in"_s, VoidPObject::create(in, Zlib_buffer_cleanup));
     auto out = new unsigned char[ZLIB_BUF_SIZE];
-    self->ivar_set(env, "@out"_s, new VoidPObject(out, Zlib_buffer_cleanup));
+    self->ivar_set(env, "@out"_s, VoidPObject::create(out, Zlib_buffer_cleanup));
     self->ivar_set(env, "@closed"_s, Value::False());
 
     int ret = inflateInit2(stream, (int)window_bits.to_nat_int_t());
@@ -324,7 +324,7 @@ Value Zlib_crc32(Env *env, Value self, Args &&args, Block *) {
 
 Value Zlib_crc_table(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
-    auto res = ArrayObject::create({ 256 });
+    auto res = ArrayObject::create(256);
     auto table = get_crc_table();
     for (size_t i = 0; i < 256; i++)
         res->push(Value::integer(static_cast<nat_int_t>(table[i])));

--- a/lib/zlib.cpp
+++ b/lib/zlib.cpp
@@ -324,7 +324,7 @@ Value Zlib_crc32(Env *env, Value self, Args &&args, Block *) {
 
 Value Zlib_crc_table(Env *env, Value self, Args &&args, Block *) {
     args.ensure_argc_is(env, 0);
-    auto res = new ArrayObject { 256 };
+    auto res = ArrayObject::create({ 256 });
     auto table = get_crc_table();
     for (size_t i = 0; i < 256; i++)
         res->push(Value::integer(static_cast<nat_int_t>(table[i])));

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -85,7 +85,7 @@ Value Args::last() const {
 }
 
 ArrayObject *Args::to_array() const {
-    return new ArrayObject { m_args_size, tl_current_arg_stack->data() + m_args_start_index };
+    return ArrayObject::create(m_args_size, tl_current_arg_stack->data() + m_args_start_index);
 }
 
 ArrayObject *Args::to_array_for_block(Env *env, ssize_t min_count, ssize_t max_count, bool autosplat) const {
@@ -99,7 +99,7 @@ ArrayObject *Args::to_array_for_block(Env *env, ssize_t min_count, ssize_t max_c
         return ary;
     }
     auto len = max_count >= 0 ? std::min(m_args_size, (size_t)max_count) : m_args_size;
-    auto ary = new ArrayObject { len, tl_current_arg_stack->data() + m_args_start_index };
+    auto ary = ArrayObject::create(len, tl_current_arg_stack->data() + m_args_start_index);
     ssize_t count = ary->size();
     if (count < min_count)
         ary->fill(env, Value::nil(), Value::integer(ary->size()), Value::integer(min_count - ary->size()), nullptr);

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -450,7 +450,7 @@ bool ArrayObject::eql(Env *env, Value other) {
 
 Value ArrayObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 
@@ -463,7 +463,7 @@ Value ArrayObject::each(Env *env, Block *block) {
 
 Value ArrayObject::each_index(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_index"_s }, size_block);
     }
 
@@ -477,7 +477,7 @@ Value ArrayObject::each_index(Env *env, Block *block) {
 
 Value ArrayObject::map(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "map"_s }, size_block);
     }
 
@@ -488,7 +488,7 @@ Value ArrayObject::map(Env *env, Block *block) {
 
 Value ArrayObject::map_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "map!"_s }, size_block);
     }
 
@@ -690,7 +690,7 @@ Value ArrayObject::delete_at(Env *env, Value n) {
 
 Value ArrayObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -869,7 +869,7 @@ Value ArrayObject::sort(Env *env, Block *block) {
 
 Value ArrayObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 
@@ -1087,7 +1087,7 @@ bool array_sort_by_compare(Env *env, Value a, Value b, Block *block) {
 
 Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "sort_by!"_s }, size_block);
     }
 
@@ -1102,7 +1102,7 @@ Value ArrayObject::sort_by_in_place(Env *env, Block *block) {
 
 Value ArrayObject::select(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "select"_s }, size_block);
     }
 
@@ -1113,7 +1113,7 @@ Value ArrayObject::select(Env *env, Block *block) {
 
 Value ArrayObject::select_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "select!"_s }, size_block);
     }
 
@@ -1149,7 +1149,7 @@ bool ArrayObject::select_in_place(std::function<bool(Value &)> predicate) {
 
 Value ArrayObject::reject(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "reject"_s }, size_block);
     }
 
@@ -1160,7 +1160,7 @@ Value ArrayObject::reject(Env *env, Block *block) {
 
 Value ArrayObject::reject_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "reject!"_s }, size_block);
     }
 
@@ -1664,7 +1664,7 @@ Value ArrayObject::reverse(Env *env) {
 
 Value ArrayObject::reverse_each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, ArrayObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, ArrayObject::size_fn, 0);
         return send(env, "enum_for"_s, { "reverse_each"_s }, size_block);
     }
 

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1522,6 +1522,8 @@ Value ArrayObject::hash(Env *env) {
 Value ArrayObject::insert(Env *env, Args &&args) {
     this->assert_not_frozen(env);
 
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+
     if (args.size() == 1)
         return this;
 

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1395,7 +1395,7 @@ Value ArrayObject::uniq(Env *env, Block *block) {
 Value ArrayObject::uniq_in_place(Env *env, Block *block) {
     this->assert_not_frozen(env);
 
-    auto hash = new HashObject {};
+    auto hash = HashObject::create();
     for (auto item : *this) {
         Value key = item;
         if (block) {

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -7,7 +7,6 @@
 #include <natalie/array_packer/packer.hpp>
 #include <natalie/string_object.hpp>
 #include <natalie/symbol_object.hpp>
-#include <random>
 #include <tm/hashmap.hpp>
 #include <tm/recursion_guard.hpp>
 
@@ -154,12 +153,12 @@ Value ArrayObject::inspect(Env *env) {
 
     return guard.run([&](bool is_recursive) {
         if (is_recursive)
-            return new StringObject { "[...]" };
+            return StringObject::create("[...]");
 
         if (is_empty())
-            return new StringObject { "[]", Encoding::US_ASCII };
+            return StringObject::create("[]", Encoding::US_ASCII);
 
-        StringObject *out = new StringObject { "[" };
+        StringObject *out = StringObject::create("[");
         for (size_t i = 0; i < size(); i++) {
             Value obj = (*this)[i];
 
@@ -913,7 +912,7 @@ Value ArrayObject::join(Env *env, Optional<Value> joiner_arg) {
         if (is_recursive)
             env->raise("ArgumentError", "recursive array join");
         if (size() == 0) {
-            return (Value) new StringObject { "", Encoding::US_ASCII };
+            return (Value)StringObject::create("", Encoding::US_ASCII);
         } else {
             Value joiner;
             if (joiner_arg && !joiner_arg.value().is_nil())
@@ -921,12 +920,12 @@ Value ArrayObject::join(Env *env, Optional<Value> joiner_arg) {
             else
                 joiner = env->global_get("$,"_s);
             if (joiner.is_nil())
-                joiner = new StringObject { "" };
+                joiner = StringObject::create("");
 
             if (!joiner.is_string())
                 joiner = joiner.to_str(env);
 
-            StringObject *out = new StringObject {};
+            StringObject *out = StringObject::create();
             for (size_t i = 0; i < size(); i++) {
                 Value item = (*this)[i];
                 out->append(_subjoin(env, item, joiner));
@@ -979,7 +978,7 @@ Value ArrayObject::pack(Env *env, Value directives, Optional<Value> buffer_arg) 
 
     auto directives_string = directives.as_string()->string();
     if (directives_string.is_empty())
-        return new StringObject { "", Encoding::US_ASCII };
+        return StringObject::create("", Encoding::US_ASCII);
 
     if (buffer_arg) {
         auto buffer = buffer_arg.value();
@@ -987,7 +986,7 @@ Value ArrayObject::pack(Env *env, Value directives, Optional<Value> buffer_arg) 
             env->raise("TypeError", "buffer must be String, not {}", buffer.klass()->inspect_module());
         return ArrayPacker::Packer { this, directives_string }.pack(env, buffer.as_string());
     } else {
-        StringObject *start_buffer = new StringObject { "", Encoding::ASCII_8BIT };
+        StringObject *start_buffer = StringObject::create("", Encoding::ASCII_8BIT);
         return ArrayPacker::Packer { this, directives_string }.pack(env, start_buffer);
     }
 }

--- a/src/backtrace.cpp
+++ b/src/backtrace.cpp
@@ -2,7 +2,7 @@
 
 namespace Natalie {
 ArrayObject *Backtrace::to_ruby_array() {
-    ArrayObject *generated = new ArrayObject { m_items.size() };
+    ArrayObject *generated = ArrayObject::create(m_items.size());
     for (auto item : m_items) {
         generated->push(StringObject::format("{}:{}:in '{}'", item.file, item.line, item.source_location));
     }
@@ -10,7 +10,7 @@ ArrayObject *Backtrace::to_ruby_array() {
 }
 
 ArrayObject *Backtrace::to_ruby_backtrace_locations_array() {
-    ArrayObject *generated = new ArrayObject { m_items.size() };
+    ArrayObject *generated = ArrayObject::create(m_items.size());
     for (auto item : m_items) {
         generated->push(new Thread::Backtrace::LocationObject { item.source_location, item.file, item.line });
     }

--- a/src/binding_object.cpp
+++ b/src/binding_object.cpp
@@ -6,7 +6,7 @@ namespace Natalie {
 Value BindingObject::source_location() const {
     auto file = StringObject::create(m_env.file());
     auto line = Value::integer(m_env.line());
-    return new ArrayObject { file, line };
+    return ArrayObject::create({ file, line });
 }
 
 }

--- a/src/binding_object.cpp
+++ b/src/binding_object.cpp
@@ -4,7 +4,7 @@
 namespace Natalie {
 
 Value BindingObject::source_location() const {
-    auto file = new StringObject { m_env.file() };
+    auto file = StringObject::create(m_env.file());
     auto line = Value::integer(m_env.line());
     return new ArrayObject { file, line };
 }

--- a/src/bsearch.cpp
+++ b/src/bsearch.cpp
@@ -89,7 +89,7 @@ Value binary_search_float(Env *env, double left, double right, Block *block, boo
     nat_int_t right_int = double_to_integer(right);
 
     auto result = binary_search(env, left_int, right_int, [env, block](nat_int_t middle) -> Value {
-        return block->run(env, { new FloatObject(integer_to_double(middle)) }, nullptr);
+        return block->run(env, { FloatObject::create(integer_to_double(middle)) }, nullptr);
     });
 
     if (!result.present())
@@ -98,7 +98,7 @@ Value binary_search_float(Env *env, double left, double right, Block *block, boo
     if (exclude_end && result.value() == right_int)
         return Value::nil();
 
-    return new FloatObject { integer_to_double(result.value()) };
+    return FloatObject::create(integer_to_double(result.value()));
 }
 
 }

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -16,7 +16,7 @@ Value ClassObject::initialize(Env *env, Optional<Value> superclass_arg, Block *b
 ClassObject *ClassObject::subclass(Env *env, String name, Type object_type) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    ClassObject *subclass = new ClassObject { klass() };
+    ClassObject *subclass = ClassObject::create(klass());
     initialize_subclass(subclass, env, name, object_type);
     return subclass;
 }
@@ -35,7 +35,7 @@ void ClassObject::initialize_subclass_without_checks(ClassObject *subclass, Env 
         if (!name.is_empty())
             singleton_name = String::format("#<Class:{}>", name);
         auto my_singleton_class = singleton_class();
-        ClassObject *singleton = new ClassObject { my_singleton_class };
+        ClassObject *singleton = ClassObject::create(my_singleton_class);
         my_singleton_class->initialize_subclass_without_checks(singleton, env, singleton_name, my_singleton_class->object_type());
         subclass->set_singleton_class(singleton);
     }
@@ -60,14 +60,12 @@ ClassObject *ClassObject::bootstrap_class_class(Env *env) {
 }
 
 ClassObject *ClassObject::bootstrap_basic_object(Env *env, ClassObject *Class) {
-    ClassObject *BasicObject = new ClassObject {
-        reinterpret_cast<ClassObject *>(-1)
-    };
+    ClassObject *BasicObject = ClassObject::create();
     BasicObject->m_klass = Class;
     BasicObject->m_superclass = nullptr;
     BasicObject->m_is_initialized = true;
     BasicObject->set_name("BasicObject");
-    auto singleton = new ClassObject { Class };
+    auto singleton = ClassObject::create(Class);
     Class->initialize_subclass_without_checks(singleton, env, "#<Class:BasicObject>");
     BasicObject->set_singleton_class(singleton);
     return BasicObject;

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -10,7 +10,6 @@ void Constant::autoload(Env *env, Value self) {
 }
 
 void Constant::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     visitor.visit(m_name);
     if (m_value)
         visitor.visit(m_value.value());

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -182,7 +182,7 @@ Value DirObject::entries(Env *env) {
 
 Value DirObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, DirObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, DirObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
     if (!m_dir) env->raise("IOError", "closed directory");
@@ -196,7 +196,7 @@ Value DirObject::each(Env *env, Block *block) {
 
 Value DirObject::each_child(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, DirObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, DirObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_child"_s }, size_block);
     }
     if (!m_dir) env->raise("IOError", "closed directory");

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -16,7 +16,7 @@ DirObject::~DirObject() {
 }
 
 Value DirObject::open(Env *env, Value path, Optional<Value> encoding_kwarg, Block *block) {
-    auto dir = new DirObject {};
+    auto dir = DirObject::create();
     dir->initialize(env, path, encoding_kwarg);
     if (block) {
         Defer close_dir([&]() {
@@ -213,7 +213,7 @@ Value DirObject::each_child(Env *env, Block *block) {
 
 // class method of `children`
 Value DirObject::children(Env *env, Value path, Optional<Value> encoding_kwarg) {
-    auto dir = new DirObject {};
+    auto dir = DirObject::create();
     dir->initialize(env, path, encoding_kwarg);
     Defer close_dir([&]() {
         dir->close(env);
@@ -223,7 +223,7 @@ Value DirObject::children(Env *env, Value path, Optional<Value> encoding_kwarg) 
 
 // class method of `each_child`
 Value DirObject::each_child(Env *env, Value path, Optional<Value> encoding_kwarg, Block *block) {
-    auto dir = new DirObject {};
+    auto dir = DirObject::create();
     dir->initialize(env, path, encoding_kwarg);
     auto result = dir->each_child(env, block);
     if (!block) {
@@ -234,14 +234,14 @@ Value DirObject::each_child(Env *env, Value path, Optional<Value> encoding_kwarg
 
 // class method of `entries`
 Value DirObject::entries(Env *env, Value path, Optional<Value> encoding_kwarg) {
-    auto dir = new DirObject {};
+    auto dir = DirObject::create();
     dir->initialize(env, path, encoding_kwarg);
     return dir->entries(env);
 }
 
 // class method of `each`
 Value DirObject::foreach (Env *env, Value path, Optional<Value> encoding_kwarg, Block * block) {
-    auto dir = new DirObject {};
+    auto dir = DirObject::create();
     dir->initialize(env, path, encoding_kwarg);
     auto result = dir->each(env, block);
     if (!block) {

--- a/src/dir_object.cpp
+++ b/src/dir_object.cpp
@@ -157,7 +157,7 @@ Value DirObject::chdir_instance(Env *env, Block *block) {
 Value DirObject::children(Env *env) {
     if (!m_dir) env->raise("IOError", "closed directory");
     struct dirent *dirp;
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     while ((dirp = ::readdir(m_dir))) {
         auto name = String(dirp->d_name);
         if (name != "." && name != "..") {
@@ -172,7 +172,7 @@ Value DirObject::children(Env *env) {
 Value DirObject::entries(Env *env) {
     if (!m_dir) env->raise("IOError", "closed directory");
     struct dirent *dirp;
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     while ((dirp = ::readdir(m_dir))) {
         ary->push(StringObject::create(dirp->d_name, m_encoding));
     }

--- a/src/encoding/casefold.cpp
+++ b/src/encoding/casefold.cpp
@@ -2868,213 +2868,213 @@ Value EncodingObject::casefold_common(nat_int_t codepoint) {
 Value EncodingObject::casefold_full(nat_int_t codepoint) {
     switch (codepoint) {
     case 0x00DF:
-        return new ArrayObject({ Value::integer(0x0073), Value::integer(0x0073) });
+        return ArrayObject::create({ Value::integer(0x0073), Value::integer(0x0073) });
     case 0x0130:
-        return new ArrayObject({ Value::integer(0x0069), Value::integer(0x0307) });
+        return ArrayObject::create({ Value::integer(0x0069), Value::integer(0x0307) });
     case 0x0149:
-        return new ArrayObject({ Value::integer(0x02BC), Value::integer(0x006E) });
+        return ArrayObject::create({ Value::integer(0x02BC), Value::integer(0x006E) });
     case 0x01F0:
-        return new ArrayObject({ Value::integer(0x006A), Value::integer(0x030C) });
+        return ArrayObject::create({ Value::integer(0x006A), Value::integer(0x030C) });
     case 0x0390:
-        return new ArrayObject({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0301) });
+        return ArrayObject::create({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0301) });
     case 0x03B0:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0301) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0301) });
     case 0x0587:
-        return new ArrayObject({ Value::integer(0x0565), Value::integer(0x0582) });
+        return ArrayObject::create({ Value::integer(0x0565), Value::integer(0x0582) });
     case 0x1E96:
-        return new ArrayObject({ Value::integer(0x0068), Value::integer(0x0331) });
+        return ArrayObject::create({ Value::integer(0x0068), Value::integer(0x0331) });
     case 0x1E97:
-        return new ArrayObject({ Value::integer(0x0074), Value::integer(0x0308) });
+        return ArrayObject::create({ Value::integer(0x0074), Value::integer(0x0308) });
     case 0x1E98:
-        return new ArrayObject({ Value::integer(0x0077), Value::integer(0x030A) });
+        return ArrayObject::create({ Value::integer(0x0077), Value::integer(0x030A) });
     case 0x1E99:
-        return new ArrayObject({ Value::integer(0x0079), Value::integer(0x030A) });
+        return ArrayObject::create({ Value::integer(0x0079), Value::integer(0x030A) });
     case 0x1E9A:
-        return new ArrayObject({ Value::integer(0x0061), Value::integer(0x02BE) });
+        return ArrayObject::create({ Value::integer(0x0061), Value::integer(0x02BE) });
     case 0x1E9E:
-        return new ArrayObject({ Value::integer(0x0073), Value::integer(0x0073) });
+        return ArrayObject::create({ Value::integer(0x0073), Value::integer(0x0073) });
     case 0x1F50:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0313) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0313) });
     case 0x1F52:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0300) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0300) });
     case 0x1F54:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0301) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0301) });
     case 0x1F56:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0313), Value::integer(0x0342) });
     case 0x1F80:
-        return new ArrayObject({ Value::integer(0x1F00), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F00), Value::integer(0x03B9) });
     case 0x1F81:
-        return new ArrayObject({ Value::integer(0x1F01), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F01), Value::integer(0x03B9) });
     case 0x1F82:
-        return new ArrayObject({ Value::integer(0x1F02), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F02), Value::integer(0x03B9) });
     case 0x1F83:
-        return new ArrayObject({ Value::integer(0x1F03), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F03), Value::integer(0x03B9) });
     case 0x1F84:
-        return new ArrayObject({ Value::integer(0x1F04), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F04), Value::integer(0x03B9) });
     case 0x1F85:
-        return new ArrayObject({ Value::integer(0x1F05), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F05), Value::integer(0x03B9) });
     case 0x1F86:
-        return new ArrayObject({ Value::integer(0x1F06), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F06), Value::integer(0x03B9) });
     case 0x1F87:
-        return new ArrayObject({ Value::integer(0x1F07), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F07), Value::integer(0x03B9) });
     case 0x1F88:
-        return new ArrayObject({ Value::integer(0x1F00), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F00), Value::integer(0x03B9) });
     case 0x1F89:
-        return new ArrayObject({ Value::integer(0x1F01), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F01), Value::integer(0x03B9) });
     case 0x1F8A:
-        return new ArrayObject({ Value::integer(0x1F02), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F02), Value::integer(0x03B9) });
     case 0x1F8B:
-        return new ArrayObject({ Value::integer(0x1F03), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F03), Value::integer(0x03B9) });
     case 0x1F8C:
-        return new ArrayObject({ Value::integer(0x1F04), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F04), Value::integer(0x03B9) });
     case 0x1F8D:
-        return new ArrayObject({ Value::integer(0x1F05), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F05), Value::integer(0x03B9) });
     case 0x1F8E:
-        return new ArrayObject({ Value::integer(0x1F06), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F06), Value::integer(0x03B9) });
     case 0x1F8F:
-        return new ArrayObject({ Value::integer(0x1F07), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F07), Value::integer(0x03B9) });
     case 0x1F90:
-        return new ArrayObject({ Value::integer(0x1F20), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F20), Value::integer(0x03B9) });
     case 0x1F91:
-        return new ArrayObject({ Value::integer(0x1F21), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F21), Value::integer(0x03B9) });
     case 0x1F92:
-        return new ArrayObject({ Value::integer(0x1F22), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F22), Value::integer(0x03B9) });
     case 0x1F93:
-        return new ArrayObject({ Value::integer(0x1F23), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F23), Value::integer(0x03B9) });
     case 0x1F94:
-        return new ArrayObject({ Value::integer(0x1F24), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F24), Value::integer(0x03B9) });
     case 0x1F95:
-        return new ArrayObject({ Value::integer(0x1F25), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F25), Value::integer(0x03B9) });
     case 0x1F96:
-        return new ArrayObject({ Value::integer(0x1F26), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F26), Value::integer(0x03B9) });
     case 0x1F97:
-        return new ArrayObject({ Value::integer(0x1F27), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F27), Value::integer(0x03B9) });
     case 0x1F98:
-        return new ArrayObject({ Value::integer(0x1F20), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F20), Value::integer(0x03B9) });
     case 0x1F99:
-        return new ArrayObject({ Value::integer(0x1F21), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F21), Value::integer(0x03B9) });
     case 0x1F9A:
-        return new ArrayObject({ Value::integer(0x1F22), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F22), Value::integer(0x03B9) });
     case 0x1F9B:
-        return new ArrayObject({ Value::integer(0x1F23), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F23), Value::integer(0x03B9) });
     case 0x1F9C:
-        return new ArrayObject({ Value::integer(0x1F24), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F24), Value::integer(0x03B9) });
     case 0x1F9D:
-        return new ArrayObject({ Value::integer(0x1F25), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F25), Value::integer(0x03B9) });
     case 0x1F9E:
-        return new ArrayObject({ Value::integer(0x1F26), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F26), Value::integer(0x03B9) });
     case 0x1F9F:
-        return new ArrayObject({ Value::integer(0x1F27), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F27), Value::integer(0x03B9) });
     case 0x1FA0:
-        return new ArrayObject({ Value::integer(0x1F60), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F60), Value::integer(0x03B9) });
     case 0x1FA1:
-        return new ArrayObject({ Value::integer(0x1F61), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F61), Value::integer(0x03B9) });
     case 0x1FA2:
-        return new ArrayObject({ Value::integer(0x1F62), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F62), Value::integer(0x03B9) });
     case 0x1FA3:
-        return new ArrayObject({ Value::integer(0x1F63), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F63), Value::integer(0x03B9) });
     case 0x1FA4:
-        return new ArrayObject({ Value::integer(0x1F64), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F64), Value::integer(0x03B9) });
     case 0x1FA5:
-        return new ArrayObject({ Value::integer(0x1F65), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F65), Value::integer(0x03B9) });
     case 0x1FA6:
-        return new ArrayObject({ Value::integer(0x1F66), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F66), Value::integer(0x03B9) });
     case 0x1FA7:
-        return new ArrayObject({ Value::integer(0x1F67), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F67), Value::integer(0x03B9) });
     case 0x1FA8:
-        return new ArrayObject({ Value::integer(0x1F60), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F60), Value::integer(0x03B9) });
     case 0x1FA9:
-        return new ArrayObject({ Value::integer(0x1F61), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F61), Value::integer(0x03B9) });
     case 0x1FAA:
-        return new ArrayObject({ Value::integer(0x1F62), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F62), Value::integer(0x03B9) });
     case 0x1FAB:
-        return new ArrayObject({ Value::integer(0x1F63), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F63), Value::integer(0x03B9) });
     case 0x1FAC:
-        return new ArrayObject({ Value::integer(0x1F64), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F64), Value::integer(0x03B9) });
     case 0x1FAD:
-        return new ArrayObject({ Value::integer(0x1F65), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F65), Value::integer(0x03B9) });
     case 0x1FAE:
-        return new ArrayObject({ Value::integer(0x1F66), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F66), Value::integer(0x03B9) });
     case 0x1FAF:
-        return new ArrayObject({ Value::integer(0x1F67), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F67), Value::integer(0x03B9) });
     case 0x1FB2:
-        return new ArrayObject({ Value::integer(0x1F70), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F70), Value::integer(0x03B9) });
     case 0x1FB3:
-        return new ArrayObject({ Value::integer(0x03B1), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B1), Value::integer(0x03B9) });
     case 0x1FB4:
-        return new ArrayObject({ Value::integer(0x03AC), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03AC), Value::integer(0x03B9) });
     case 0x1FB6:
-        return new ArrayObject({ Value::integer(0x03B1), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03B1), Value::integer(0x0342) });
     case 0x1FB7:
-        return new ArrayObject({ Value::integer(0x03B1), Value::integer(0x0342), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B1), Value::integer(0x0342), Value::integer(0x03B9) });
     case 0x1FBC:
-        return new ArrayObject({ Value::integer(0x03B1), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B1), Value::integer(0x03B9) });
     case 0x1FC2:
-        return new ArrayObject({ Value::integer(0x1F74), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F74), Value::integer(0x03B9) });
     case 0x1FC3:
-        return new ArrayObject({ Value::integer(0x03B7), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B7), Value::integer(0x03B9) });
     case 0x1FC4:
-        return new ArrayObject({ Value::integer(0x03AE), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03AE), Value::integer(0x03B9) });
     case 0x1FC6:
-        return new ArrayObject({ Value::integer(0x03B7), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03B7), Value::integer(0x0342) });
     case 0x1FC7:
-        return new ArrayObject({ Value::integer(0x03B7), Value::integer(0x0342), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B7), Value::integer(0x0342), Value::integer(0x03B9) });
     case 0x1FCC:
-        return new ArrayObject({ Value::integer(0x03B7), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03B7), Value::integer(0x03B9) });
     case 0x1FD2:
-        return new ArrayObject({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0300) });
+        return ArrayObject::create({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0300) });
     case 0x1FD3:
-        return new ArrayObject({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0301) });
+        return ArrayObject::create({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0301) });
     case 0x1FD6:
-        return new ArrayObject({ Value::integer(0x03B9), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03B9), Value::integer(0x0342) });
     case 0x1FD7:
-        return new ArrayObject({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03B9), Value::integer(0x0308), Value::integer(0x0342) });
     case 0x1FE2:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0300) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0300) });
     case 0x1FE3:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0301) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0301) });
     case 0x1FE4:
-        return new ArrayObject({ Value::integer(0x03C1), Value::integer(0x0313) });
+        return ArrayObject::create({ Value::integer(0x03C1), Value::integer(0x0313) });
     case 0x1FE6:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0342) });
     case 0x1FE7:
-        return new ArrayObject({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03C5), Value::integer(0x0308), Value::integer(0x0342) });
     case 0x1FF2:
-        return new ArrayObject({ Value::integer(0x1F7C), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x1F7C), Value::integer(0x03B9) });
     case 0x1FF3:
-        return new ArrayObject({ Value::integer(0x03C9), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03C9), Value::integer(0x03B9) });
     case 0x1FF4:
-        return new ArrayObject({ Value::integer(0x03CE), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03CE), Value::integer(0x03B9) });
     case 0x1FF6:
-        return new ArrayObject({ Value::integer(0x03C9), Value::integer(0x0342) });
+        return ArrayObject::create({ Value::integer(0x03C9), Value::integer(0x0342) });
     case 0x1FF7:
-        return new ArrayObject({ Value::integer(0x03C9), Value::integer(0x0342), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03C9), Value::integer(0x0342), Value::integer(0x03B9) });
     case 0x1FFC:
-        return new ArrayObject({ Value::integer(0x03C9), Value::integer(0x03B9) });
+        return ArrayObject::create({ Value::integer(0x03C9), Value::integer(0x03B9) });
     case 0xFB00:
-        return new ArrayObject({ Value::integer(0x0066), Value::integer(0x0066) });
+        return ArrayObject::create({ Value::integer(0x0066), Value::integer(0x0066) });
     case 0xFB01:
-        return new ArrayObject({ Value::integer(0x0066), Value::integer(0x0069) });
+        return ArrayObject::create({ Value::integer(0x0066), Value::integer(0x0069) });
     case 0xFB02:
-        return new ArrayObject({ Value::integer(0x0066), Value::integer(0x006C) });
+        return ArrayObject::create({ Value::integer(0x0066), Value::integer(0x006C) });
     case 0xFB03:
-        return new ArrayObject({ Value::integer(0x0066), Value::integer(0x0066), Value::integer(0x0069) });
+        return ArrayObject::create({ Value::integer(0x0066), Value::integer(0x0066), Value::integer(0x0069) });
     case 0xFB04:
-        return new ArrayObject({ Value::integer(0x0066), Value::integer(0x0066), Value::integer(0x006C) });
+        return ArrayObject::create({ Value::integer(0x0066), Value::integer(0x0066), Value::integer(0x006C) });
     case 0xFB05:
-        return new ArrayObject({ Value::integer(0x0073), Value::integer(0x0074) });
+        return ArrayObject::create({ Value::integer(0x0073), Value::integer(0x0074) });
     case 0xFB06:
-        return new ArrayObject({ Value::integer(0x0073), Value::integer(0x0074) });
+        return ArrayObject::create({ Value::integer(0x0073), Value::integer(0x0074) });
     case 0xFB13:
-        return new ArrayObject({ Value::integer(0x0574), Value::integer(0x0576) });
+        return ArrayObject::create({ Value::integer(0x0574), Value::integer(0x0576) });
     case 0xFB14:
-        return new ArrayObject({ Value::integer(0x0574), Value::integer(0x0565) });
+        return ArrayObject::create({ Value::integer(0x0574), Value::integer(0x0565) });
     case 0xFB15:
-        return new ArrayObject({ Value::integer(0x0574), Value::integer(0x056B) });
+        return ArrayObject::create({ Value::integer(0x0574), Value::integer(0x056B) });
     case 0xFB16:
-        return new ArrayObject({ Value::integer(0x057E), Value::integer(0x0576) });
+        return ArrayObject::create({ Value::integer(0x057E), Value::integer(0x0576) });
     case 0xFB17:
-        return new ArrayObject({ Value::integer(0x0574), Value::integer(0x056D) });
+        return ArrayObject::create({ Value::integer(0x0574), Value::integer(0x056D) });
     }
     return casefold_common(codepoint);
 }

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -320,7 +320,7 @@ EncodingObject *EncodingObject::find_encoding(Env *env, Value encoding) {
 }
 
 ArrayObject *EncodingObject::list(Env *) {
-    auto ary = new ArrayObject { EncodingCount };
+    auto ary = ArrayObject::create(EncodingCount);
     for (auto encoding : s_encoding_list)
         ary->push(encoding);
     // dbg("size {} enccnt {}", ary->size(), EncodingCount);
@@ -332,7 +332,7 @@ ArrayObject *EncodingObject::name_list(Env *env) {
     size_t size = 0;
     for (const auto &encoding : s_encoding_list)
         size += encoding->m_names.size();
-    auto ary = new ArrayObject { size };
+    auto ary = ArrayObject::create(size);
     for (const auto encoding : s_encoding_list)
         ary->concat(*encoding->names(env));
     return ary;
@@ -357,7 +357,7 @@ const StringObject *EncodingObject::name() const {
 }
 
 ArrayObject *EncodingObject::names(Env *env) const {
-    auto array = new ArrayObject { m_names.size() };
+    auto array = ArrayObject::create(m_names.size());
     for (const auto &name : m_names)
         array->push(StringObject::create(name));
     if (this == s_locale) array->push(StringObject::create("locale"));

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -221,7 +221,7 @@ Value EncodingObject::encode(Env *env, EncodingObject *orig_encoding, StringObje
 }
 
 HashObject *EncodingObject::aliases(Env *env) {
-    auto aliases = new HashObject();
+    auto aliases = HashObject::create();
     for (auto encoding : *list(env)) {
         auto enc = encoding.as_encoding();
         const auto names = enc->names(env);

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -65,7 +65,7 @@ Integer ArithmeticSequenceObject::calculate_step_count(Env *env) {
         if (!exclude_end())
             step_count += 1;
     } else {
-        auto a = n.send(env, "+"_s, { n.send(env, "*"_s, { new FloatObject { std::numeric_limits<double>::epsilon() } }) });
+        auto a = n.send(env, "+"_s, { n.send(env, "*"_s, { FloatObject::create(std::numeric_limits<double>::epsilon()) }) });
         auto b = a.send(env, "floor"_s).integer();
         step_count = b + 1;
     }

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -13,7 +13,7 @@ ArithmeticSequenceObject::ArithmeticSequenceObject(Env *env, Origin origin, cons
     , m_exclude_end { exclude_end } {
     auto Enumerator = GlobalEnv::the()->Object()->const_fetch("Enumerator"_s).as_module();
     auto method_info = Enumerator->find_method(env, "initialize"_s);
-    method_info.method()->call(env, this, {}, new Block { *env, this, enum_block, 1 });
+    method_info.method()->call(env, this, {}, Block::create(*env, this, enum_block, 1));
 }
 
 ArithmeticSequenceObject::ArithmeticSequenceObject(Env *env, Origin origin, Value begin, Value end, Value step, bool exclude_end)

--- a/src/enumerator/arithmetic_sequence_object.cpp
+++ b/src/enumerator/arithmetic_sequence_object.cpp
@@ -222,7 +222,7 @@ Value ArithmeticSequenceObject::last(Env *env, Optional<Value> n) {
 
         IntegerMethods::assert_fixnum(env, n_as_int);
 
-        auto array = new ArrayObject { (size_t)count.to_nat_int_t() };
+        auto array = ArrayObject::create((size_t)count.to_nat_int_t());
 
         auto _begin = maybe_to_f(env, m_begin);
         auto last = _begin.send(env, "+"_s, { step().send(env, "*"_s, { steps }) });

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -381,7 +381,6 @@ Env *Env::non_block_env() {
 }
 
 void Env::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     visitor.visit(m_vars);
     visitor.visit(m_outer);
     visitor.visit(m_block);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -87,7 +87,7 @@ String Env::build_code_location_name() {
 }
 
 void Env::raise(ClassObject *klass, StringObject *message) {
-    ExceptionObject *exception = new ExceptionObject { klass, message };
+    ExceptionObject *exception = ExceptionObject::create(klass, message);
     this->raise_exception(exception);
 }
 
@@ -97,7 +97,7 @@ void Env::raise(ClassObject *klass, String message) {
 
 void Env::raise(const char *class_name, String message) {
     ClassObject *klass = GlobalEnv::the()->Object()->const_fetch(SymbolObject::intern(class_name)).as_class();
-    ExceptionObject *exception = new ExceptionObject { klass, StringObject::create(std::move(message)) };
+    ExceptionObject *exception = ExceptionObject::create(klass, StringObject::create(std::move(message)));
     this->raise_exception(exception);
 }
 
@@ -119,7 +119,7 @@ void Env::raise_exception(ExceptionObject *exception) {
 void Env::raise_key_error(Value receiver, Value key) {
     auto message = StringObject::create(String::format("key not found: {}", key.inspected(this)));
     auto key_error_class = GlobalEnv::the()->Object()->const_fetch("KeyError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { key_error_class, message };
+    ExceptionObject *exception = ExceptionObject::create(key_error_class, message);
     exception->ivar_set(this, "@receiver"_s, receiver);
     exception->ivar_set(this, "@key"_s, key);
     this->raise_exception(exception);
@@ -128,7 +128,7 @@ void Env::raise_key_error(Value receiver, Value key) {
 void Env::raise_local_jump_error(Value exit_value, LocalJumpErrorType type, nat_int_t break_point) {
     auto message = StringObject::create(type == LocalJumpErrorType::Return ? "unexpected return" : "break from proc-closure");
     auto lje_class = find_top_level_const(this, "LocalJumpError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { lje_class, message };
+    ExceptionObject *exception = ExceptionObject::create(lje_class, message);
     exception->set_local_jump_error_type(type);
     exception->ivar_set(this, "@exit_value"_s, exit_value);
     if (break_point != 0)
@@ -185,7 +185,7 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
         NAT_UNREACHABLE();
     }
     auto NoMethodError = find_top_level_const(this, "NoMethodError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NoMethodError, StringObject::create(std::move(message)) };
+    ExceptionObject *exception = ExceptionObject::create(NoMethodError, StringObject::create(std::move(message)));
     exception->ivar_set(this, "@receiver"_s, receiver);
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
@@ -193,14 +193,14 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
 
 void Env::raise_name_error(SymbolObject *name, String message) {
     auto NameError = find_top_level_const(this, "NameError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NameError, StringObject::create(std::move(message)) };
+    ExceptionObject *exception = ExceptionObject::create(NameError, StringObject::create(std::move(message)));
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
 }
 
 void Env::raise_name_error(StringObject *name, String message) {
     auto NameError = find_top_level_const(this, "NameError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NameError, StringObject::create(std::move(message)) };
+    ExceptionObject *exception = ExceptionObject::create(NameError, StringObject::create(std::move(message)));
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -92,12 +92,12 @@ void Env::raise(ClassObject *klass, StringObject *message) {
 }
 
 void Env::raise(ClassObject *klass, String message) {
-    raise(klass, new StringObject(std::move(message)));
+    raise(klass, StringObject::create(std::move(message)));
 }
 
 void Env::raise(const char *class_name, String message) {
     ClassObject *klass = GlobalEnv::the()->Object()->const_fetch(SymbolObject::intern(class_name)).as_class();
-    ExceptionObject *exception = new ExceptionObject { klass, new StringObject { std::move(message) } };
+    ExceptionObject *exception = new ExceptionObject { klass, StringObject::create(std::move(message)) };
     this->raise_exception(exception);
 }
 
@@ -117,7 +117,7 @@ void Env::raise_exception(ExceptionObject *exception) {
 }
 
 void Env::raise_key_error(Value receiver, Value key) {
-    auto message = new StringObject { String::format("key not found: {}", key.inspected(this)) };
+    auto message = StringObject::create(String::format("key not found: {}", key.inspected(this)));
     auto key_error_class = GlobalEnv::the()->Object()->const_fetch("KeyError"_s).as_class();
     ExceptionObject *exception = new ExceptionObject { key_error_class, message };
     exception->ivar_set(this, "@receiver"_s, receiver);
@@ -126,7 +126,7 @@ void Env::raise_key_error(Value receiver, Value key) {
 }
 
 void Env::raise_local_jump_error(Value exit_value, LocalJumpErrorType type, nat_int_t break_point) {
-    auto message = new StringObject { type == LocalJumpErrorType::Return ? "unexpected return" : "break from proc-closure" };
+    auto message = StringObject::create(type == LocalJumpErrorType::Return ? "unexpected return" : "break from proc-closure");
     auto lje_class = find_top_level_const(this, "LocalJumpError"_s).as_class();
     ExceptionObject *exception = new ExceptionObject { lje_class, message };
     exception->set_local_jump_error_type(type);
@@ -185,7 +185,7 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
         NAT_UNREACHABLE();
     }
     auto NoMethodError = find_top_level_const(this, "NoMethodError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NoMethodError, new StringObject { std::move(message) } };
+    ExceptionObject *exception = new ExceptionObject { NoMethodError, StringObject::create(std::move(message)) };
     exception->ivar_set(this, "@receiver"_s, receiver);
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
@@ -193,14 +193,14 @@ void Env::raise_no_method_error(Value receiver, SymbolObject *name, MethodMissin
 
 void Env::raise_name_error(SymbolObject *name, String message) {
     auto NameError = find_top_level_const(this, "NameError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NameError, new StringObject { std::move(message) } };
+    ExceptionObject *exception = new ExceptionObject { NameError, StringObject::create(std::move(message)) };
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
 }
 
 void Env::raise_name_error(StringObject *name, String message) {
     auto NameError = find_top_level_const(this, "NameError"_s).as_class();
-    ExceptionObject *exception = new ExceptionObject { NameError, new StringObject { std::move(message) } };
+    ExceptionObject *exception = new ExceptionObject { NameError, StringObject::create(std::move(message)) };
     exception->ivar_set(this, "@name"_s, name);
     this->raise_exception(exception);
 }
@@ -220,7 +220,7 @@ void Env::raise_not_comparable_error(Value lhs, Value rhs) {
 
 void Env::raise_type_error(const Value obj, const char *expected) {
     if (obj.is_nil()) {
-        auto lowercase_expected = new StringObject { expected };
+        auto lowercase_expected = StringObject::create(expected);
         lowercase_expected->downcase_in_place(this);
         raise("TypeError", "no implicit conversion from nil to {}", lowercase_expected->string());
     } else {
@@ -253,7 +253,7 @@ void Env::warn(String message) {
         message = String::format("{}:{}: {}", m_file, m_line, message);
     }
 
-    _stderr.send(this, "puts"_s, { new StringObject { std::move(message) } });
+    _stderr.send(this, "puts"_s, { StringObject::create(std::move(message)) });
 }
 
 void Env::ensure_block_given(Block *block) {

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -70,7 +70,7 @@ size_t EnvObject::size() const {
 
 Value EnvObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -109,7 +109,7 @@ Value EnvObject::each(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { *env, envhash.as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, envhash.as_hash(), HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 }
@@ -124,7 +124,7 @@ Value EnvObject::each_key(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { *env, envhash.as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, envhash.as_hash(), HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_key"_s }, size_block);
     }
 }
@@ -139,7 +139,7 @@ Value EnvObject::each_value(Env *env, Block *block) {
         return this;
     } else {
         auto envhash = to_hash(env, nullptr);
-        Block *size_block = new Block { *env, envhash.as_hash(), HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, envhash.as_hash(), HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_value"_s }, size_block);
     }
 }
@@ -215,7 +215,7 @@ Value EnvObject::refeq(Env *env, Value name, Value value) {
 
 Value EnvObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 
@@ -284,7 +284,7 @@ Value EnvObject::clone(Env *env) {
 
 Value EnvObject::reject(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "reject"_s }, size_block);
     }
 
@@ -293,7 +293,7 @@ Value EnvObject::reject(Env *env, Block *block) {
 
 Value EnvObject::reject_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "reject!"_s }, size_block);
     }
 
@@ -328,7 +328,7 @@ Value EnvObject::replace(Env *env, Value hash) {
 
 Value EnvObject::select(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "select"_s }, size_block);
     }
 
@@ -337,7 +337,7 @@ Value EnvObject::select(Env *env, Block *block) {
 
 Value EnvObject::select_in_place(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, env_size, 0 };
+        Block *size_block = Block::create(*env, this, env_size, 0);
         return send(env, "enum_for"_s, { "select!"_s }, size_block);
     }
 

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -30,7 +30,7 @@ Value EnvObject::inspect(Env *env) {
 }
 
 Value EnvObject::to_hash(Env *env, Block *block) {
-    HashObject *hash = new HashObject {};
+    HashObject *hash = HashObject::create();
     size_t i = 1;
     char *pair = *environ;
     if (!pair) return hash;
@@ -386,7 +386,7 @@ Value EnvObject::slice(Env *env, Args &&args) {
     if (args.has_keyword_hash())
         env->raise("TypeError", "no implicit conversion of Hash into String");
 
-    auto result = new HashObject;
+    auto result = HashObject::create();
     for (size_t i = 0; i < args.size(); i++) {
         auto name = args[i];
         auto namestr = name.to_str(env);

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -149,7 +149,7 @@ Value EnvObject::assoc(Env *env, Value name) {
     char *value = getenv(namestr->c_str());
     if (value) {
         StringObject *valuestr = StringObject::create(value);
-        return new ArrayObject { { namestr, valuestr } };
+        return ArrayObject::create({ namestr, valuestr });
     } else {
         return Value::nil();
     }
@@ -163,7 +163,7 @@ Value EnvObject::rassoc(Env *env, Value value) {
     auto name = key(env, value);
     if (name.is_nil())
         return Value::nil();
-    return new ArrayObject { name, value };
+    return ArrayObject::create({ name, value });
 }
 
 Value EnvObject::ref(Env *env, Value name) {
@@ -368,7 +368,7 @@ Value EnvObject::shift() {
     auto name = string_with_default_encoding(pair, static_cast<size_t>(eq - pair));
     auto value = string_with_default_encoding(getenv(name->c_str()));
     unsetenv(name->c_str());
-    return new ArrayObject { name, value };
+    return ArrayObject::create({ name, value });
 }
 
 Value EnvObject::invert(Env *env) {
@@ -428,7 +428,7 @@ Value EnvObject::values(Env *env) {
 }
 
 Value EnvObject::values_at(Env *env, Args &&args) {
-    auto result = new ArrayObject { args.size() };
+    auto result = ArrayObject::create(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         result->push(ref(env, args[i]));
     }

--- a/src/env_object.cpp
+++ b/src/env_object.cpp
@@ -1,6 +1,5 @@
 #include "natalie.hpp"
 #include "natalie/env.hpp"
-#include "tm/vector.hpp"
 
 #include <assert.h>
 #include <fcntl.h>
@@ -16,14 +15,14 @@ static Value env_size(Env *env, Value self, Args &&, Block *) {
 
 static inline StringObject *string_with_default_encoding(const char *str) {
     if (EncodingObject::default_internal())
-        return new StringObject { str, EncodingObject::default_internal() };
-    return new StringObject { str };
+        return StringObject::create(str, EncodingObject::default_internal());
+    return StringObject::create(str);
 }
 
 static inline StringObject *string_with_default_encoding(const char *str, size_t len) {
     if (EncodingObject::default_internal())
-        return new StringObject { str, len, EncodingObject::default_internal() };
-    return new StringObject { str, len };
+        return StringObject::create(str, len, EncodingObject::default_internal());
+    return StringObject::create(str, len);
 }
 
 Value EnvObject::inspect(Env *env) {
@@ -83,7 +82,7 @@ Value EnvObject::delete_key(Env *env, Value name, Block *block) {
     auto namestr = name.to_str(env);
     char *value = getenv(namestr->c_str());
     if (value) {
-        auto value_obj = new StringObject { value };
+        auto value_obj = StringObject::create(value);
         ::unsetenv(namestr->c_str());
         return value_obj;
     } else if (block) {
@@ -149,7 +148,7 @@ Value EnvObject::assoc(Env *env, Value name) {
     auto namestr = name.to_str(env);
     char *value = getenv(namestr->c_str());
     if (value) {
-        StringObject *valuestr = new StringObject { value };
+        StringObject *valuestr = StringObject::create(value);
         return new ArrayObject { { namestr, valuestr } };
     } else {
         return Value::nil();
@@ -189,7 +188,7 @@ Value EnvObject::fetch(Env *env, Value name, Optional<Value> default_arg, Block 
     name.assert_type(env, Object::Type::String, "String");
     char *value = getenv(name.as_string()->c_str());
     if (value) {
-        return new StringObject { value };
+        return StringObject::create(value);
     } else if (block) {
         if (default_arg)
             env->warn("block supersedes default value argument");
@@ -234,7 +233,7 @@ Value EnvObject::key(Env *env, Value value) {
         const char *eq = strchr(pair, '=');
         assert(eq);
         if (needle == eq + 1)
-            return new StringObject { pair, static_cast<size_t>(eq - pair) };
+            return StringObject::create(pair, static_cast<size_t>(eq - pair));
 
         pair = *(environ + i);
     }
@@ -262,7 +261,7 @@ Value EnvObject::has_value(Env *env, Value name) {
 }
 
 Value EnvObject::to_s() const {
-    return new StringObject { "ENV" };
+    return StringObject::create("ENV");
 }
 
 Value EnvObject::rehash() const {
@@ -394,7 +393,7 @@ Value EnvObject::slice(Env *env, Args &&args) {
 
         const char *value = getenv(namestr->c_str());
         if (value != nullptr) {
-            result->put(env, name, new StringObject { value });
+            result->put(env, name, StringObject::create(value));
         }
     }
     return result;

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -32,7 +32,7 @@ ExceptionObject *ExceptionObject::create_for_raise(Env *env, Args &&args, Except
 
     if (!klass) {
         klass = find_top_level_const(env, "RuntimeError"_s);
-        message = new StringObject { "" };
+        message = StringObject::create("");
     }
 
     if (!message) {
@@ -106,15 +106,15 @@ Value ExceptionObject::inspect(Env *env) {
     auto msgstr = send(env, "to_s"_s);
     msgstr.assert_type(env, Object::Type::String, "String");
     if (msgstr.as_string()->is_empty())
-        return new StringObject { klassname };
-    if (msgstr.as_string()->include(env, new StringObject { "\n" }))
+        return StringObject::create(klassname);
+    if (msgstr.as_string()->include(env, StringObject::create("\n")))
         return StringObject::format("#<{}: {}>", klassname, klassname);
     return StringObject::format("#<{}: {}>", klassname, msgstr);
 }
 
 StringObject *ExceptionObject::to_s(Env *env) {
     if (m_message.is_nil()) {
-        return new StringObject { m_klass->inspect_module() };
+        return StringObject::create(m_klass->inspect_module());
     } else if (m_message.is_string()) {
         return m_message.as_string();
     }

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -175,7 +175,7 @@ Value ExceptionObject::set_backtrace(Env *env, Value backtrace) {
         }
         m_backtrace_value = backtrace.as_array();
     } else if (backtrace.is_string()) {
-        m_backtrace_value = new ArrayObject { backtrace };
+        m_backtrace_value = ArrayObject::create({ backtrace });
     } else if (backtrace.is_nil()) {
         m_backtrace_value = nullptr;
         return Value::nil();

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -81,9 +81,9 @@ Value ExceptionObject::initialize(Env *env, Optional<Value> message) {
 Value ExceptionObject::exception(Env *env, ClassObject *klass, Optional<Value> message) {
     ExceptionObject *exc = nullptr;
     if (klass)
-        exc = new ExceptionObject { klass };
+        exc = ExceptionObject::create(klass);
     else
-        exc = new ExceptionObject;
+        exc = ExceptionObject::create();
     return exc->initialize(env, message);
 }
 

--- a/src/false_methods.cpp
+++ b/src/false_methods.cpp
@@ -12,7 +12,7 @@ bool FalseMethods::or_method(const Env *env, const Value, const Value other) {
 
 Value FalseMethods::to_s(const Env *env, const Value) {
     if (!s_string)
-        s_string = new StringObject { "false" };
+        s_string = StringObject::create("false");
     return s_string;
 }
 

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -187,7 +187,7 @@ NO_SANITIZE_ADDRESS Value FiberObject::resume(Env *env, Args args) {
     } else if (fiber_args.size() == 1) {
         return fiber_args.at(0);
     } else {
-        return new ArrayObject { fiber_args.size(), fiber_args.data() };
+        return ArrayObject::create(fiber_args.size(), fiber_args.data());
     }
 }
 
@@ -277,7 +277,7 @@ NO_SANITIZE_ADDRESS Value FiberObject::yield(Env *env, Args args) {
     } else if (fiber_args.size() == 1) {
         return fiber_args.at(0);
     } else {
-        return new ArrayObject { fiber_args.size(), fiber_args.data() };
+        return ArrayObject::create(fiber_args.size(), fiber_args.data());
     }
 }
 

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -136,7 +136,7 @@ Value FiberObject::refeq(Env *env, Value key, Value value) {
     if (!key.is_symbol())
         env->raise("TypeError", "wrong argument type {} (expected Symbol)", key.klass()->inspect_module());
     if (current()->m_storage == nullptr)
-        current()->m_storage = new HashObject {};
+        current()->m_storage = HashObject::create();
     if (value.is_nil()) {
         current()->m_storage->remove(env, key);
     } else {
@@ -352,7 +352,7 @@ void FiberObject::set_args(size_t arg_size, Value *arg_data) {
 
 HashObject *FiberObject::ensure_thread_storage() {
     if (!m_thread_storage)
-        m_thread_storage = new HashObject {};
+        m_thread_storage = HashObject::create();
     return m_thread_storage;
 }
 }

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -70,9 +70,9 @@ Value FileObject::initialize(Env *env, Args &&args, Block *block) {
 
 Value FileObject::absolute_path(Env *env, Value path, Optional<Value> dir_arg) {
     path = ioutil::convert_using_to_path(env, path);
-    if (path.as_string()->start_with(env, { new StringObject { "/" } }))
+    if (path.as_string()->start_with(env, { StringObject::create("/") }))
         return path;
-    if ((!dir_arg || dir_arg.value().is_nil()) && path.as_string()->eq(env, new StringObject { "~" }))
+    if ((!dir_arg || dir_arg.value().is_nil()) && path.as_string()->eq(env, StringObject::create("~")))
         return path;
 
     auto File = GlobalEnv::the()->Object()->const_fetch("File"_s);
@@ -141,7 +141,7 @@ Value FileObject::expand_path(Env *env, Value path, Optional<Value> dir_arg) {
     }
 
     if (fs_path.string().empty())
-        return new StringObject { std::filesystem::current_path().c_str() };
+        return StringObject::create(std::filesystem::current_path().c_str());
 
     if (fs_path.is_relative()) {
         try {
@@ -163,7 +163,7 @@ Value FileObject::expand_path(Env *env, Value path, Optional<Value> dir_arg) {
     if (!default_external->is_compatible_with(target_encoding))
         target_encoding->raise_compatibility_error(env, default_external);
 
-    auto expanded_string = new StringObject { expanded.c_str(), path_string_object->encoding() };
+    auto expanded_string = StringObject::create(expanded.c_str(), path_string_object->encoding());
     if (expanded_string->length() > 1 && expanded_string->string().last_char() == '/')
         expanded_string->truncate(expanded_string->length() - 1);
 
@@ -231,7 +231,7 @@ void FileObject::build_constants(Env *env, ModuleObject *fcmodule) {
     fcmodule->const_set("FNM_EXTGLOB"_s, Value::integer(FNM_EXTGLOB));
     fcmodule->const_set("FNM_SYSCASE"_s, Value::integer(FNM_SYSCASE));
     fcmodule->const_set("FNM_SHORTNAME"_s, Value::integer(FNM_SHORTNAME));
-    Value null_file = new StringObject { "/dev/null", Encoding::US_ASCII };
+    Value null_file = StringObject::create("/dev/null", Encoding::US_ASCII);
     null_file->freeze();
     fcmodule->const_set("NULL"_s, null_file);
 }
@@ -557,21 +557,21 @@ Value FileObject::ftype(Env *env, Value path) {
     }
     switch (st.type()) {
     case std::filesystem::file_type::regular:
-        return new StringObject { "file" };
+        return StringObject::create("file");
     case std::filesystem::file_type::directory:
-        return new StringObject { "directory" };
+        return StringObject::create("directory");
     case std::filesystem::file_type::symlink:
-        return new StringObject { "link" };
+        return StringObject::create("link");
     case std::filesystem::file_type::block:
-        return new StringObject { "blockSpecial" };
+        return StringObject::create("blockSpecial");
     case std::filesystem::file_type::character:
-        return new StringObject { "characterSpecial" };
+        return StringObject::create("characterSpecial");
     case std::filesystem::file_type::fifo:
-        return new StringObject { "fifo" };
+        return StringObject::create("fifo");
     case std::filesystem::file_type::socket:
-        return new StringObject { "socket" };
+        return StringObject::create("socket");
     default:
-        return new StringObject { "unknown" };
+        return StringObject::create("unknown");
     }
 }
 
@@ -599,7 +599,7 @@ Value FileObject::readlink(Env *env, Value filename) {
         if (size < 0)
             env->raise_errno();
         if (static_cast<size_t>(size) < buf.size())
-            return new StringObject { buf.c_str(), static_cast<size_t>(size) };
+            return StringObject::create(buf.c_str(), static_cast<size_t>(size));
         buf = TM::String(buf.size() * 2, '\0');
     }
 }
@@ -614,7 +614,7 @@ Value FileObject::realpath(Env *env, Value pathname, Optional<Value> dir_arg) {
     resolved_filepath = ::realpath(pathname.as_string()->c_str(), nullptr);
     if (!resolved_filepath)
         env->raise_errno();
-    auto outstr = new StringObject { resolved_filepath };
+    auto outstr = StringObject::create(resolved_filepath);
     free(resolved_filepath);
     return outstr;
 }

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -625,7 +625,7 @@ Value FileObject::lstat(Env *env, Value path) {
     path = ioutil::convert_using_to_path(env, path);
     int result = ::lstat(path.as_string()->c_str(), &sb);
     if (result < 0) env->raise_errno(path.as_string());
-    return new FileStatObject { sb };
+    return FileStatObject::create(sb);
 }
 
 // instance method
@@ -633,7 +633,7 @@ Value FileObject::lstat(Env *env) const {
     struct stat sb;
     int result = ::stat(get_path().as_string()->c_str(), &sb);
     if (result < 0) env->raise_errno();
-    return new FileStatObject { sb };
+    return FileStatObject::create(sb);
 }
 
 Value FileObject::lutime(Env *env, Args &&args) {
@@ -691,7 +691,7 @@ Value FileObject::stat(Env *env, Value path) {
     path = ioutil::convert_using_to_path(env, path);
     int result = ::stat(path.as_string()->c_str(), &sb);
     if (result < 0) env->raise_errno(path.as_string());
-    return new FileStatObject { sb };
+    return FileStatObject::create(sb);
 }
 
 // class methods

--- a/src/file_stat_object.cpp
+++ b/src/file_stat_object.cpp
@@ -31,7 +31,7 @@ Value FileStatObject::ftype() const {
     } else {
         ft = "unknown";
     }
-    return new StringObject { ft };
+    return StringObject::create(ft);
 }
 
 bool FileStatObject::is_blockdev() const {

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -53,7 +53,7 @@ bool FloatObject::eql(Value other) const {
             env->raise("FloatDomainError", inspected(env));              \
                                                                          \
         if (is_infinity())                                               \
-            return new FloatObject { m_double };                         \
+            return FloatObject::create(m_double);                        \
                                                                          \
         FloatObject *result;                                             \
         if (precision == 0)                                              \
@@ -62,13 +62,13 @@ bool FloatObject::eql(Value other) const {
         double f = ::pow(10, precision);                                 \
         double rounded = ::libm_name(m_double * f) / f;                  \
         if (isinf(f) || isinf(rounded)) {                                \
-            return new FloatObject { m_double };                         \
+            return FloatObject::create(m_double);                        \
         }                                                                \
         if (precision < 0)                                               \
             return f_to_i_or_bigint(rounded);                            \
                                                                          \
         /* precision > 0 */                                              \
-        return new FloatObject { rounded };                              \
+        return FloatObject::create(rounded);                             \
     }
 
 ROUNDING_OPERATION(floor, floor)
@@ -183,7 +183,7 @@ Value FloatObject::cmp(Env *env, Value rhs) {
 Value FloatObject::coerce(Env *env, Value arg) {
     ArrayObject *ary = new ArrayObject { 2 };
     if (arg.is_integer())
-        ary->push(new FloatObject { arg.integer().to_double() });
+        ary->push(FloatObject::create(arg.integer().to_double()));
     else if (arg.is_float())
         ary->push(arg);
     else
@@ -239,7 +239,7 @@ Value FloatObject::add(Env *env, Value rhs) {
 
     double addend1 = to_double();
     double addend2 = rhs.as_float()->to_double();
-    return new FloatObject { addend1 + addend2 };
+    return FloatObject::create(addend1 + addend2);
 }
 
 Value FloatObject::sub(Env *env, Value rhs) {
@@ -256,7 +256,7 @@ Value FloatObject::sub(Env *env, Value rhs) {
 
     double minuend = to_double();
     double subtrahend = rhs.as_float()->to_double();
-    return new FloatObject { minuend - subtrahend };
+    return FloatObject::create(minuend - subtrahend);
 }
 
 Value FloatObject::mul(Env *env, Value rhs) {
@@ -273,7 +273,7 @@ Value FloatObject::mul(Env *env, Value rhs) {
 
     double multiplicand = to_double();
     double multiplier = rhs.as_float()->to_double();
-    return new FloatObject { multiplicand * multiplier };
+    return FloatObject::create(multiplicand * multiplier);
 }
 
 Value FloatObject::div(Env *env, Value rhs) {
@@ -291,7 +291,7 @@ Value FloatObject::div(Env *env, Value rhs) {
     double dividend = to_double();
     double divisor = rhs.as_float()->to_double();
 
-    return new FloatObject { dividend / divisor };
+    return FloatObject::create(dividend / divisor);
 }
 
 Value FloatObject::mod(Env *env, Value rhs) {
@@ -299,8 +299,8 @@ Value FloatObject::mod(Env *env, Value rhs) {
 
     bool rhs_is_non_zero = (rhs.is_float() && !rhs.as_float()->is_zero()) || (rhs.is_integer() && !rhs.integer().is_zero());
 
-    if (rhs.is_float() && rhs.as_float()->is_negative_infinity()) return new FloatObject { rhs.as_float()->to_double() };
-    if (is_negative_zero() && rhs_is_non_zero) return new FloatObject { m_double };
+    if (rhs.is_float() && rhs.as_float()->is_negative_infinity()) return FloatObject::create(rhs.as_float()->to_double());
+    if (is_negative_zero() && rhs_is_non_zero) return FloatObject::create(m_double);
 
     if (!rhs.is_float()) {
         auto coerced = Natalie::coerce(env, rhs, lhs);
@@ -321,7 +321,7 @@ Value FloatObject::mod(Env *env, Value rhs) {
     if (result != 0.0 && signbit(dividend) != signbit(divisor))
         result += divisor;
 
-    return new FloatObject { result };
+    return FloatObject::create(result);
 }
 
 Value FloatObject::divmod(Env *env, Value arg) {
@@ -365,19 +365,19 @@ Value FloatObject::pow(Env *env, Value rhs) {
     if (base < 0 && ::floor(exponent) != exponent)
         env->raise("ArgumentError", "Not yet implemented: negative raised to a fractional power");
 
-    return new FloatObject { ::pow(base, exponent) };
+    return FloatObject::create(::pow(base, exponent));
 }
 
 Value FloatObject::abs(Env *env) const {
-    return new FloatObject { fabs(m_double) };
+    return FloatObject::create(fabs(m_double));
 }
 
 Value FloatObject::next_float(Env *env) const {
-    return new FloatObject { ::nextafter(to_double(), HUGE_VAL) };
+    return FloatObject::create(::nextafter(to_double(), HUGE_VAL));
 }
 
 Value FloatObject::prev_float(Env *env) const {
-    return new FloatObject { ::nextafter(to_double(), -HUGE_VAL) };
+    return FloatObject::create(::nextafter(to_double(), -HUGE_VAL));
 }
 
 Value FloatObject::arg(Env *env) {

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -1,6 +1,5 @@
 #include "natalie.hpp"
 #include "natalie/integer_methods.hpp"
-#include "string.h"
 
 #include <math.h>
 
@@ -82,11 +81,11 @@ extern "C" char *dtoa(double d, int mode, int ndigits, int *decpt, int *sign, ch
 
 Value FloatObject::to_s() const {
     if (is_nan()) {
-        return new StringObject { "NaN", Encoding::US_ASCII };
+        return StringObject::create("NaN", Encoding::US_ASCII);
     } else if (is_positive_infinity()) {
-        return new StringObject { "Infinity", Encoding::US_ASCII };
+        return StringObject::create("Infinity", Encoding::US_ASCII);
     } else if (is_negative_infinity()) {
-        return new StringObject { "-Infinity", Encoding::US_ASCII };
+        return StringObject::create("-Infinity", Encoding::US_ASCII);
     }
 
     int decpt, sign;
@@ -130,7 +129,7 @@ Value FloatObject::to_s() const {
         string.prepend_char('-');
     }
 
-    return new StringObject { string, Encoding::US_ASCII };
+    return StringObject::create(string, Encoding::US_ASCII);
 }
 
 Value FloatObject::cmp(Env *env, Value rhs) {

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -181,7 +181,7 @@ Value FloatObject::cmp(Env *env, Value rhs) {
 }
 
 Value FloatObject::coerce(Env *env, Value arg) {
-    ArrayObject *ary = new ArrayObject { 2 };
+    ArrayObject *ary = ArrayObject::create(2);
     if (arg.is_integer())
         ary->push(FloatObject::create(arg.integer().to_double()));
     else if (arg.is_float())
@@ -336,10 +336,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
     Value division = div(env, arg);
     Value modulus = mod(env, arg);
 
-    return new ArrayObject {
-        f_to_i_or_bigint(::floor(division.as_float()->to_double())),
-        modulus
-    };
+    return ArrayObject::create({ f_to_i_or_bigint(::floor(division.as_float()->to_double())), modulus });
 }
 
 Value FloatObject::pow(Env *env, Value rhs) {

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -343,7 +343,7 @@ Value FloatObject::pow(Env *env, Value rhs) {
     Value lhs = this;
 
     if ((rhs.is_float() || rhs.is_rational()) && to_double() < 0) {
-        auto comp = new ComplexObject { this };
+        auto comp = ComplexObject::create(this);
         return comp->send(env, "**"_s, { rhs });
     }
 

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -1,3 +1,6 @@
+#include <signal.h>
+#include <stdexcept>
+
 #include "natalie.hpp"
 
 extern "C" void GC_disable() {

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -124,7 +124,6 @@ void GlobalEnv::set_interned_strings(StringObject **interned_strings, const size
 }
 
 void GlobalEnv::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     for (auto pair : m_global_variables) {
         visitor.visit(pair.first);
         visitor.visit(pair.second);

--- a/src/global_env.cpp
+++ b/src/global_env.cpp
@@ -85,7 +85,7 @@ Value GlobalEnv::global_alias(Env *env, SymbolObject *new_name, SymbolObject *ol
 ArrayObject *GlobalEnv::global_list(Env *env) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    auto result = new ArrayObject { m_global_variables.size() };
+    auto result = ArrayObject::create(m_global_variables.size());
     for (const auto &[key, _] : m_global_variables) {
         result->push(key);
     }

--- a/src/global_variable_info.cpp
+++ b/src/global_variable_info.cpp
@@ -21,7 +21,6 @@ const String &GlobalVariableInfo::name() const {
 }
 
 void GlobalVariableInfo::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     visitor.visit(m_name);
     if (m_value)
         visitor.visit(m_value.value());

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -167,25 +167,19 @@ Natalie::HashKey *HashObject::key_list_append(Env *env, Value key, nat_int_t has
     if (m_key_list) {
         HashKey *first = m_key_list;
         HashKey *last = m_key_list->prev;
-        HashKey *new_last = new HashKey {};
-        new_last->key = key;
-        new_last->val = val;
+        HashKey *new_last = HashKey::create(key, val, hash);
         // <first> ... <last> <new_last> -|
         // ^______________________________|
         new_last->prev = last;
         new_last->next = first;
-        new_last->hash = hash;
         new_last->removed = false;
         first->prev = new_last;
         last->next = new_last;
         return new_last;
     } else {
-        HashKey *node = new HashKey {};
-        node->key = key;
-        node->val = val;
+        HashKey *node = HashKey::create(key, val, hash);
         node->prev = node;
         node->next = node;
-        node->hash = hash;
         node->removed = false;
         m_key_list = node;
         return node;

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -237,13 +237,13 @@ Value HashObject::initialize(Env *env, Optional<Value> default_arg, Optional<Val
 // Hash[]
 Value HashObject::square_new(Env *env, ClassObject *klass, Args &&args) {
     if (args.size() == 0) {
-        return new HashObject { klass };
+        return HashObject::create(klass);
     } else if (args.size() == 1) {
         Value value = args[0];
         if (!value.is_hash() && value.respond_to(env, "to_hash"_s))
             value = value.to_hash(env);
         if (value.is_hash()) {
-            auto hash = new HashObject { env, *value.as_hash() };
+            auto hash = HashObject::create(env, *value.as_hash());
             hash->m_default_proc = nullptr;
             hash->m_default_value = Value::nil();
             hash->m_klass = klass;
@@ -252,7 +252,7 @@ Value HashObject::square_new(Env *env, ClassObject *klass, Args &&args) {
             if (!value.is_array() && value.respond_to(env, "to_ary"_s))
                 value = value.to_ary(env);
             if (value.is_array()) {
-                HashObject *hash = new HashObject { klass };
+                HashObject *hash = HashObject::create(klass);
                 for (auto &pair : *value.as_array()) {
                     if (!pair.is_array()) {
                         env->raise("ArgumentError", "wrong element in array to Hash[]");
@@ -272,7 +272,7 @@ Value HashObject::square_new(Env *env, ClassObject *klass, Args &&args) {
     if (args.size() % 2 != 0) {
         env->raise("ArgumentError", "odd number of arguments for Hash");
     }
-    HashObject *hash = new HashObject { klass };
+    HashObject *hash = HashObject::create(klass);
     for (size_t i = 0; i < args.size(); i += 2) {
         Value key = args[i];
         Value value = args[i + 1];
@@ -364,7 +364,7 @@ Value HashObject::refeq(Env *env, Value key, Value val) {
 Value HashObject::rehash(Env *env) {
     assert_not_frozen(env);
 
-    auto copy = new HashObject { env, *this };
+    auto copy = HashObject::create(env, *this);
     HashObject::operator=(std::move(*copy));
 
     return this;
@@ -535,7 +535,7 @@ Value HashObject::each(Env *env, Block *block) {
 }
 
 Value HashObject::except(Env *env, Args &&args) {
-    HashObject *new_hash = new HashObject {};
+    HashObject *new_hash = HashObject::create();
     for (auto &node : *this) {
         new_hash->put(env, node.key, node.val);
     }
@@ -610,7 +610,7 @@ Value HashObject::to_h(Env *env, Block *block) {
         }
     }
 
-    auto copy = new HashObject {};
+    auto copy = HashObject::create();
     Value block_args[2];
     set_is_iterating(true);
     Defer no_longer_iterating([&]() { set_is_iterating(false); });
@@ -717,7 +717,7 @@ Value HashObject::merge_in_place(Env *env, Args &&args, Block *block) {
 }
 
 Value HashObject::slice(Env *env, Args &&args) {
-    auto new_hash = new HashObject {};
+    auto new_hash = HashObject::create();
     for (size_t i = 0; i < args.size(); i++) {
         Value key = args[i];
         auto value = this->get(env, key);
@@ -741,7 +741,7 @@ void HashObject::visit_children(Visitor &visitor) const {
 }
 
 Value HashObject::compact(Env *env) {
-    auto new_hash = new HashObject {};
+    auto new_hash = HashObject::create();
     new_hash->m_default_value = m_default_value;
     new_hash->m_default_proc = m_default_proc;
     new_hash->m_is_comparing_by_identity = m_is_comparing_by_identity;

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -221,7 +221,7 @@ Value HashObject::initialize(Env *env, Optional<Value> default_arg, Optional<Val
         if (default_arg) {
             env->raise("ArgumentError", "wrong number of arguments (given 1, expected 0)");
         }
-        set_default_proc(new ProcObject { block });
+        set_default_proc(ProcObject::create(block));
     } else {
         set_default(env, default_arg.value_or(Value::nil()));
     }

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -527,7 +527,7 @@ Value HashObject::each(Env *env, Block *block) {
     set_is_iterating(true);
     Defer no_longer_iterating([&]() { set_is_iterating(false); });
     for (HashKey &node : *this) {
-        auto ary = new ArrayObject { { node.key, node.val } };
+        auto ary = ArrayObject::create({ node.key, node.val });
         Value block_args[1] = { ary };
         block->run(env, Args(1, block_args), nullptr);
     }
@@ -565,9 +565,9 @@ Value HashObject::fetch(Env *env, Value key, Optional<Value> default_value, Bloc
 }
 
 Value HashObject::fetch_values(Env *env, Args &&args, Block *block) {
-    if (args.size() == 0) return new ArrayObject;
+    if (args.size() == 0) return ArrayObject::create();
 
-    auto array = new ArrayObject { args.size() };
+    auto array = ArrayObject::create(args.size());
     for (size_t i = 0; i < args.size(); ++i) {
         array->push(fetch(env, args[i], {}, block));
     }
@@ -575,7 +575,7 @@ Value HashObject::fetch_values(Env *env, Args &&args, Block *block) {
 }
 
 Value HashObject::keys(Env *env) {
-    ArrayObject *array = new ArrayObject { size() };
+    ArrayObject *array = ArrayObject::create(size());
     for (HashKey &node : *this) {
         array->push(node.key);
     }
@@ -632,7 +632,7 @@ Value HashObject::to_h(Env *env, Block *block) {
 }
 
 Value HashObject::values(Env *env) {
-    ArrayObject *array = new ArrayObject { size() };
+    ArrayObject *array = ArrayObject::create(size());
     for (HashKey &node : *this) {
         array->push(node.val);
     }

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -390,7 +390,7 @@ Value HashObject::replace(Env *env, Value other) {
 
 Value HashObject::delete_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "delete_if"_s }, size_block);
     }
 
@@ -519,7 +519,7 @@ bool HashObject::lt(Env *env, Value other) {
 
 Value HashObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 
@@ -584,7 +584,7 @@ Value HashObject::keys(Env *env) {
 
 Value HashObject::keep_if(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, HashObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, HashObject::size_fn, 0);
         return send(env, "enum_for"_s, { "keep_if"_s }, size_block);
     }
 

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -286,8 +286,8 @@ Value HashObject::inspect(Env *env) {
 
     return guard.run([&](bool is_recursive) {
         if (is_recursive)
-            return new StringObject("{...}");
-        StringObject *out = new StringObject { "{" };
+            return StringObject::create("{...}");
+        StringObject *out = StringObject::create("{");
         size_t last_index = size() - 1;
         size_t index = 0;
 
@@ -297,7 +297,7 @@ Value HashObject::inspect(Env *env) {
             if (obj.respond_to(env, "to_s"_s))
                 obj = obj.send(env, "to_s"_s);
             else
-                obj = new StringObject("?");
+                obj = StringObject::create("?");
             if (!obj.is_string())
                 obj = StringObject::format("#<{}:{}>", obj.klass()->inspect_module(), String::hex(object_id(obj), String::HexFormat::LowercaseAndPrefixed));
             return obj.as_string();
@@ -308,7 +308,7 @@ Value HashObject::inspect(Env *env) {
                 SymbolObject *key = node.key.as_symbol();
                 StringObject *key_repr = nullptr;
                 if (key->should_be_quoted()) {
-                    key_repr = key->inspect(env)->delete_prefix(env, new StringObject { ":" }).as_string();
+                    key_repr = key->inspect(env)->delete_prefix(env, StringObject::create(":")).as_string();
                 } else {
                     key_repr = key->to_s(env);
                 }

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -476,7 +476,7 @@ Value IntegerMethods::size(Env *env, Integer self) {
 }
 
 Value IntegerMethods::coerce(Env *env, Value self, Value arg) {
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     if (arg.is_integer()) {
         ary->push(arg);
         ary->push(self);

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -177,7 +177,7 @@ Value IntegerMethods::pow(Env *env, Integer self, Value arg) {
         return pow(env, self, arg.integer());
 
     if ((arg.is_float() || arg.is_rational()) && self < 0) {
-        auto comp = new ComplexObject { self };
+        auto comp = ComplexObject::create(self);
         return comp->send(env, "**"_s, { arg });
     }
 

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -6,7 +6,7 @@ namespace Natalie {
 
 Value IntegerMethods::to_s(Env *env, Integer self, Optional<Value> base_value) {
     if (self == 0)
-        return new StringObject { "0" };
+        return StringObject::create("0");
 
     nat_int_t base = 10;
     if (base_value) {
@@ -18,9 +18,9 @@ Value IntegerMethods::to_s(Env *env, Integer self, Optional<Value> base_value) {
     }
 
     if (base == 10)
-        return new StringObject { self.to_string(), Encoding::US_ASCII };
+        return StringObject::create(self.to_string(), Encoding::US_ASCII);
 
-    auto str = new StringObject { "", Encoding::US_ASCII };
+    auto str = StringObject::create("", Encoding::US_ASCII);
     auto num = self;
     bool negative = false;
     if (num < 0) {
@@ -569,7 +569,7 @@ Value IntegerMethods::chr(Env *env, Integer self, Optional<Value> encoding_arg) 
     }
 
     auto encoded = encoding_obj->encode_codepoint(self.to_nat_int_t());
-    return new StringObject { encoded, encoding_obj };
+    return StringObject::create(encoded, encoding_obj);
 }
 
 Value IntegerMethods::sqrt(Env *env, Value arg) {
@@ -577,7 +577,7 @@ Value IntegerMethods::sqrt(Env *env, Value arg) {
 
     if (argument < 0) {
         auto domain_error = fetch_nested_const({ "Math"_s, "DomainError"_s });
-        auto message = new StringObject { "Numerical argument is out of domain - \"isqrt\"" };
+        auto message = StringObject::create("Numerical argument is out of domain - \"isqrt\"");
         auto exception = new ExceptionObject { domain_error.as_class(), message };
         env->raise_exception(exception);
     }

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -43,14 +43,14 @@ Value IntegerMethods::to_s(Env *env, Integer self, Optional<Value> base_value) {
 }
 
 Value IntegerMethods::to_f(Integer self) {
-    return new FloatObject { self.to_double() };
+    return FloatObject::create(self.to_double());
 }
 
 Value IntegerMethods::add(Env *env, Integer self, Value arg) {
     if (arg.is_integer()) {
         return self + arg.integer();
     } else if (arg.is_float()) {
-        return new FloatObject { self + arg.as_float()->to_double() };
+        return FloatObject::create(self + arg.as_float()->to_double());
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -67,7 +67,7 @@ Value IntegerMethods::sub(Env *env, Integer self, Value arg) {
         return self - arg.integer();
     } else if (arg.is_float()) {
         double result = self.to_double() - arg.as_float()->to_double();
-        return new FloatObject { result };
+        return FloatObject::create(result);
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -82,7 +82,7 @@ Value IntegerMethods::sub(Env *env, Integer self, Value arg) {
 Value IntegerMethods::mul(Env *env, Integer self, Value arg) {
     if (arg.is_float()) {
         double result = self.to_double() * arg.as_float()->to_double();
-        return new FloatObject { result };
+        return FloatObject::create(result);
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -103,7 +103,7 @@ Value IntegerMethods::div(Env *env, Integer self, Value arg) {
         double result = self / arg.as_float()->to_double();
         if (isnan(result))
             return FloatObject::nan();
-        return new FloatObject { result };
+        return FloatObject::create(result);
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
         if (!lhs.is_integer())
@@ -122,7 +122,7 @@ Value IntegerMethods::div(Env *env, Integer self, Value arg) {
 Value IntegerMethods::mod(Env *env, Integer self, Value arg) {
     Integer argument;
     if (arg.is_float()) {
-        auto f = new FloatObject { self.to_double() };
+        auto f = FloatObject::create(self.to_double());
         return f->mod(env, arg);
     } else if (!arg.is_integer()) {
         auto [lhs, rhs] = Natalie::coerce(env, arg, self);
@@ -182,7 +182,7 @@ Value IntegerMethods::pow(Env *env, Integer self, Value arg) {
     }
 
     if (arg.is_float()) {
-        auto f = new FloatObject { self.to_double() };
+        auto f = FloatObject::create(self.to_double());
         return f->pow(env, arg);
     }
 

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -147,7 +147,7 @@ Value IntegerMethods::pow(Env *env, Integer self, Integer arg) {
     // NATFIXME: If a negative number is passed we want to return a Rational
     if (arg < 0) {
         auto denominator = Natalie::pow(self, -arg);
-        return new RationalObject { Value::integer(1), denominator };
+        return RationalObject::create(Value::integer(1), denominator);
     }
 
     if (arg == 0)

--- a/src/integer_methods.cpp
+++ b/src/integer_methods.cpp
@@ -578,7 +578,7 @@ Value IntegerMethods::sqrt(Env *env, Value arg) {
     if (argument < 0) {
         auto domain_error = fetch_nested_const({ "Math"_s, "DomainError"_s });
         auto message = StringObject::create("Numerical argument is out of domain - \"isqrt\"");
-        auto exception = new ExceptionObject { domain_error.as_class(), message };
+        auto exception = ExceptionObject::create(domain_error.as_class(), message);
         env->raise_exception(exception);
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -124,7 +124,7 @@ Value IoObject::binread(Env *env, Value filename, Optional<Value> length, Option
 Value IoObject::binwrite(Env *env, Args &&args) {
     auto kwargs = args.pop_keyword_hash();
     if (!kwargs)
-        kwargs = new HashObject {};
+        kwargs = HashObject::create();
     kwargs->put(env, "binmode"_s, Value::True());
     auto args_array = args.to_array();
     args_array->push(kwargs);

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -864,7 +864,7 @@ Value IoObject::stat(Env *env) const {
     auto file_desc = fileno(env); // current file descriptor
     int result = ::fstat(file_desc, &sb);
     if (result < 0) env->raise_errno();
-    return new FileStatObject { sb };
+    return FileStatObject::create(sb);
 }
 
 Value IoObject::sysopen(Env *env, Value path, Optional<Value> flags_obj, Optional<Value> perm) {

--- a/src/ioutil.cpp
+++ b/src/ioutil.cpp
@@ -51,9 +51,9 @@ namespace ioutil {
 
         switch (flags_obj.type()) {
         case Object::Type::String: {
-            Value colon = new StringObject { ":" };
+            Value colon = StringObject::create(":");
             auto flagsplit = flags_obj.as_string()->split(env, colon).as_array();
-            auto flags_str = flagsplit->fetch(env, Value::integer(static_cast<nat_int_t>(0)), Value(new StringObject { "" }), nullptr).as_string()->string();
+            auto flags_str = flagsplit->fetch(env, Value::integer(static_cast<nat_int_t>(0)), Value(StringObject::create("")), nullptr).as_string()->string();
             auto extenc = flagsplit->ref(env, Value::integer(static_cast<nat_int_t>(1)));
             auto intenc = flagsplit->ref(env, Value::integer(static_cast<nat_int_t>(2)));
             if (!extenc.is_nil()) m_external_encoding = EncodingObject::find_encoding(env, extenc);
@@ -133,7 +133,7 @@ namespace ioutil {
         } else {
             encoding = encoding.to_str(env);
             if (encoding.as_string()->include(":")) {
-                Value colon = new StringObject { ":" };
+                Value colon = StringObject::create(":");
                 auto encsplit = encoding.to_str(env)->split(env, colon).as_array();
                 encoding = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(0)));
                 auto internal_encoding = encsplit->ref(env, Value::integer(static_cast<nat_int_t>(1)));

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -425,9 +425,9 @@ module Kernel
               // dumb hack to fix -NAN on some systems
               dbl *= -1;
               if (snprintf(buf, 100, fmt, dbl) > 0)
-                  return new StringObject { buf };
+                  return StringObject::create(buf);
           } else {
-              return new StringObject { buf };
+              return StringObject::create(buf);
           }
       }
       env->raise("ArgumentError", "could not format value");

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -796,7 +796,7 @@ Value KernelModule::spawn(Env *env, Args &&args) {
                 const_cast<char *const *>(cmd),
                 new_env.is_empty() ? environ : new_env.data());
         } else {
-            auto splitter = new RegexpObject { env, "\\s+" };
+            auto splitter = RegexpObject::create(env, "\\s+");
             auto split = arg->split(env, splitter, 0).as_array();
             const char *cmd[split->size() + 1];
             for (size_t i = 0; i < split->size(); i++) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -121,7 +121,7 @@ Value KernelModule::caller_locations(Env *env, Optional<Value> start_arg, Option
 Value KernelModule::catch_method(Env *env, Optional<Value> name_arg, Block *block) {
     if (!block)
         env->raise("LocalJumpError", "no block given");
-    auto name = name_arg.value_or([]() { return new Object; });
+    auto name = name_arg.value_or([]() { return Object::create(); });
 
     try {
         Env block_env { env };

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -655,7 +655,7 @@ Value KernelModule::Rational(Env *env, Value x, Optional<Value> y_arg, bool exce
         return Rational(env, x.as_float()->to_double() / y.as_float()->to_double());
     } else {
         if (x.is_integer()) {
-            return new RationalObject { x.integer(), Value::integer(1) };
+            return RationalObject::create(x.integer(), Value::integer(1));
         }
 
         if (!exception)

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -147,7 +147,7 @@ Value KernelModule::Complex(Env *env, Value real, Optional<Value> imaginary, boo
         return real;
 
     if (real.is_complex() && imaginary.value().is_complex())
-        return real.send(env, "+"_s, { imaginary.value().send(env, "*"_s, { new ComplexObject { Value::integer(0), Value::integer(1) } }) });
+        return real.send(env, "+"_s, { imaginary.value().send(env, "*"_s, { ComplexObject::create(Value::integer(0), Value::integer(1)) }) });
 
     auto is_numeric = [&env](Value val) -> bool {
         if (val.is_numeric() || val.is_rational() || val.is_complex())
@@ -160,9 +160,9 @@ Value KernelModule::Complex(Env *env, Value real, Optional<Value> imaginary, boo
 
     if (is_numeric(real)) {
         if (!imaginary) {
-            return new ComplexObject { real };
+            return ComplexObject::create(real);
         } else if (is_numeric(imaginary.value())) {
-            return new ComplexObject { real, imaginary.value() };
+            return ComplexObject::create(real, imaginary.value());
         }
     }
 
@@ -180,7 +180,7 @@ Value KernelModule::Complex(Env *env, StringObject *input, bool exception, bool 
     };
     if (!input->is_ascii_only()) {
         if (string_to_c)
-            return new ComplexObject { Value::integer(0) };
+            return ComplexObject::create(Value::integer(0));
         return error();
     }
     enum class State {
@@ -330,7 +330,7 @@ Value KernelModule::Complex(Env *env, StringObject *input, bool exception, bool 
     switch (state) {
     case State::Start:
         if (string_to_c)
-            return new ComplexObject { Value::integer(0), Value::integer(0) };
+            return ComplexObject::create(Value::integer(0), Value::integer(0));
         return error();
     default: {
         if (real_start != nullptr && real_end != nullptr) {
@@ -373,7 +373,7 @@ Value KernelModule::Complex(Env *env, StringObject *input, bool exception, bool 
             auto Complex = GlobalEnv::the()->Object()->const_get(env, "Complex"_s);
             return Complex.send(env, "polar"_s, { new_real, new_imag });
         }
-        return new ComplexObject { new_real, new_imag };
+        return ComplexObject::create(new_real, new_imag);
     }
     }
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -55,7 +55,7 @@ Value KernelModule::abort_method(Env *env, Optional<Value> message_arg) {
 Value KernelModule::at_exit(Env *env, Block *block) {
     ArrayObject *at_exit_handlers = env->global_get("$NAT_at_exit_handlers"_s).as_array();
     env->ensure_block_given(block);
-    Value proc = new ProcObject { block };
+    Value proc = ProcObject::create(block);
     at_exit_handlers->push(proc);
     return proc;
 }
@@ -579,7 +579,7 @@ Value KernelModule::Hash(Env *env, Value value) {
 Value KernelModule::lambda(Env *env, Block *block) {
     if (block) {
         block->set_type(Block::BlockType::Lambda);
-        return new ProcObject { block };
+        return ProcObject::create(block);
     } else {
         env->raise("ArgumentError", "tried to create Proc object without a block");
     }
@@ -616,7 +616,7 @@ Value KernelModule::print(Env *env, Args &&args) {
 
 Value KernelModule::proc(Env *env, Block *block) {
     if (block)
-        return new ProcObject { block };
+        return ProcObject::create(block);
     else
         env->raise("ArgumentError", "tried to create Proc object without a block");
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -691,7 +691,7 @@ RationalObject *KernelModule::Rational(Env *env, double arg) {
     auto y = IntegerMethods::pow(env, radix, power).integer();
 
     int exponent;
-    FloatObject *significand = new FloatObject { std::frexp(arg, &exponent) };
+    FloatObject *significand = FloatObject::create(std::frexp(arg, &exponent));
     auto x = significand->mul(env, y).as_float()->to_i(env).integer();
 
     class Integer two(2);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -418,7 +418,7 @@ Value KernelModule::exit(Env *env, Optional<Value> status_arg) {
         }
     }
 
-    ExceptionObject *exception = new ExceptionObject { find_top_level_const(env, "SystemExit"_s).as_class(), StringObject::create("exit") };
+    ExceptionObject *exception = ExceptionObject::create(find_top_level_const(env, "SystemExit"_s).as_class(), StringObject::create("exit"));
     exception->ivar_set(env, "@status"_s, status.to_int(env));
     env->raise_exception(exception);
     return Value::nil();

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -593,7 +593,7 @@ Value KernelModule::p(Env *env, Args &&args) {
         puts(env, { arg });
         return args[0];
     } else {
-        ArrayObject *result = new ArrayObject { args.size() };
+        ArrayObject *result = ArrayObject::create(args.size());
         Vector<Value> puts_args(args.size());
         for (size_t i = 0; i < args.size(); i++) {
             result->push(args[i]);
@@ -1010,7 +1010,7 @@ Value KernelModule::instance_variable_set(Env *env, Value self, Value name_val, 
 
 Value KernelModule::instance_variables(Env *env, Value self) {
     if (!self.has_instance_variables())
-        return new ArrayObject;
+        return ArrayObject::create();
 
     return self->instance_variables(env);
 }
@@ -1079,7 +1079,7 @@ Value KernelModule::methods(Env *env, Value self, Optional<Value> regular_val) {
     if (self->singleton_class())
         return self->singleton_class()->instance_methods(env, Value::False());
     else
-        return new ArrayObject {};
+        return ArrayObject::create();
 }
 
 bool KernelModule::neqtilde(Env *env, Value self, Value other) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -1058,13 +1058,13 @@ Value KernelModule::method(Env *env, Value self, Value name) {
             if (respond_to_missing.method()->call(env, self, { name_symbol, Value::True() }, nullptr).is_truthy()) {
                 auto method_missing = module->find_method(env, "method_missing"_s);
                 if (method_missing.is_defined()) {
-                    return new MethodObject { self, method_missing.method(), name_symbol };
+                    return MethodObject::create(self, method_missing.method(), name_symbol);
                 }
             }
         }
         env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspected(env), self.klass()->inspect_module());
     }
-    return new MethodObject { self, method_info.method() };
+    return MethodObject::create(self, method_info.method());
 }
 
 Value KernelModule::methods(Env *env, Value self, Optional<Value> regular_val) {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -544,7 +544,7 @@ Value KernelModule::get_usage(Env *env) {
     if (getrusage(RUSAGE_SELF, &usage) != 0)
         return Value::nil();
 
-    HashObject *hash = new HashObject {};
+    HashObject *hash = HashObject::create();
     hash->put(env, StringObject::create("maxrss"), Value::integer(usage.ru_maxrss));
     hash->put(env, StringObject::create("ixrss"), Value::integer(usage.ru_ixrss));
     hash->put(env, StringObject::create("idrss"), Value::integer(usage.ru_idrss));
@@ -571,7 +571,7 @@ Value KernelModule::Hash(Env *env, Value value) {
         return value;
 
     if (value.is_nil() || (value.is_array() && value.as_array()->is_empty()))
-        return new HashObject;
+        return HashObject::create();
 
     return value.to_hash(env);
 }

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -1027,7 +1027,7 @@ Value KernelModule::loop(Env *env, Value self, Block *block) {
         auto infinity_fn = [](Env *env, Value, Args &&, Block *) -> Value {
             return FloatObject::positive_infinity(env);
         };
-        auto size_block = new Block { *env, self, infinity_fn, 0 };
+        auto size_block = Block::create(*env, self, infinity_fn, 0);
         return self.send(env, "enum_for"_s, { "loop"_s }, size_block);
     }
 

--- a/src/main_template.cpp
+++ b/src/main_template.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
         env->global_set("$exe"_s, exe);
     }
 
-    ArrayObject *ARGV = new ArrayObject { (size_t)argc };
+    ArrayObject *ARGV = ArrayObject::create((size_t)argc);
     GlobalEnv::the()->Object()->const_set("ARGV"_s, ARGV);
     for (int i = 1; i < argc; i++) {
         ARGV->push(StringObject::create(argv[i]));

--- a/src/main_template.cpp
+++ b/src/main_template.cpp
@@ -67,14 +67,14 @@ int main(int argc, char *argv[]) {
 #endif
 
     if (argc > 0) {
-        Value exe = new StringObject { argv[0] };
+        Value exe = StringObject::create(argv[0]);
         env->global_set("$exe"_s, exe);
     }
 
     ArrayObject *ARGV = new ArrayObject { (size_t)argc };
     GlobalEnv::the()->Object()->const_set("ARGV"_s, ARGV);
     for (int i = 1; i < argc; i++) {
-        ARGV->push(new StringObject { argv[i] });
+        ARGV->push(StringObject::create(argv[i]));
     }
 
     Value result = Value::nil();

--- a/src/marshal.rb
+++ b/src/marshal.rb
@@ -176,7 +176,7 @@ module Marshal
             if (sign) {
                 string.prepend_char('-');
             }
-            self.send(env, "write_string_bytes"_s, { new StringObject { string, Encoding::US_ASCII } });
+            self.send(env, "write_string_bytes"_s, { StringObject::create(string, Encoding::US_ASCII) });
         END
       end
     end

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -95,7 +95,7 @@ Value MatchDataObject::group(int index) const {
 
     const char *str = &m_string->c_str()[m_region->beg[index]];
     size_t length = m_region->end[index] - m_region->beg[index];
-    return new StringObject { str, length, m_string->encoding() };
+    return StringObject::create(str, length, m_string->encoding());
 }
 
 Value MatchDataObject::offset(Env *env, Value n) {
@@ -200,7 +200,7 @@ bool MatchDataObject::eq(Env *env, Value other) const {
 }
 
 Value MatchDataObject::inspect(Env *env) {
-    StringObject *out = new StringObject { "#<MatchData" };
+    StringObject *out = StringObject::create("#<MatchData");
     const auto names_size = static_cast<size_t>(onig_number_of_names(m_regexp->m_regex));
     // NATFIXME: TM::StringView would work too, but we need a constructor from char *
     auto names = TM::Vector<TM::Optional<TM::String>> { names_size };
@@ -274,7 +274,7 @@ Value MatchDataObject::named_captures(Env *env, Optional<Value> symbolize_names_
             if ((static_cast<named_captures_data *>(data))->symbolize_names) {
                 key = SymbolObject::intern(reinterpret_cast<const char *>(name), length, RegexpObject::onig_encoding_to_ruby_encoding(regex->enc));
             } else {
-                key = new StringObject { reinterpret_cast<const char *>(name), length, RegexpObject::onig_encoding_to_ruby_encoding(regex->enc) };
+                key = StringObject::create(reinterpret_cast<const char *>(name), length, RegexpObject::onig_encoding_to_ruby_encoding(regex->enc));
             }
             Value value = Value::nil();
             for (int i = groups_size - 1; i >= 0; i--) {
@@ -303,9 +303,9 @@ Value MatchDataObject::post_match(Env *env) {
 
     auto length = m_string->bytesize() - m_region->end[0];
     if (length == 0)
-        return new StringObject { "", m_string->encoding() };
+        return StringObject::create("", m_string->encoding());
 
-    return new StringObject { m_string->string().substring(m_region->end[0], length), m_string->encoding() };
+    return StringObject::create(m_string->string().substring(m_region->end[0], length), m_string->encoding());
 }
 
 Value MatchDataObject::pre_match(Env *env) {
@@ -314,9 +314,9 @@ Value MatchDataObject::pre_match(Env *env) {
 
     auto length = m_region->beg[0];
     if (length == 0)
-        return new StringObject { "", m_string->encoding() };
+        return StringObject::create("", m_string->encoding());
 
-    return new StringObject { m_string->string().substring(0, length), m_string->encoding() };
+    return StringObject::create(m_string->string().substring(0, length), m_string->encoding());
 }
 
 Value MatchDataObject::regexp() const {

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -13,7 +13,7 @@ namespace {
 
 Value MatchDataObject::array(int start) {
     auto size = (size_t)(m_region->num_regs - start);
-    auto array = new ArrayObject { size };
+    auto array = ArrayObject::create(size);
     for (int i = start; i < m_region->num_regs; i++) {
         array->push(group(i));
     }
@@ -43,9 +43,9 @@ Value MatchDataObject::byteoffset(Env *env, Value n) {
     auto begin = m_region->beg[index];
     auto end = m_region->end[index];
     if (begin == -1)
-        return new ArrayObject { Value::nil(), Value::nil() };
+        return ArrayObject::create({ Value::nil(), Value::nil() });
 
-    return new ArrayObject { Value::integer(begin), Value::integer(end) };
+    return ArrayObject::create({ Value::integer(begin), Value::integer(end) });
 }
 
 ssize_t MatchDataObject::beg_byte_index(size_t index) const {
@@ -106,7 +106,7 @@ Value MatchDataObject::offset(Env *env, Value n) {
     ssize_t begin = m_region->beg[index];
     ssize_t end = m_region->end[index];
     if (begin == -1)
-        return new ArrayObject { Value::nil(), Value::nil() };
+        return ArrayObject::create({ Value::nil(), Value::nil() });
 
     size_t current_byte_index = 0;
     size_t current_char_index = 0;
@@ -125,7 +125,7 @@ Value MatchDataObject::offset(Env *env, Value n) {
     }
     size_t end_char_index = current_char_index;
 
-    return new ArrayObject { Value::integer(begin_char_index), Value::integer(end_char_index) };
+    return ArrayObject::create({ Value::integer(begin_char_index), Value::integer(end_char_index) });
 }
 
 Value MatchDataObject::begin(Env *env, Value start) const {
@@ -293,7 +293,7 @@ Value MatchDataObject::named_captures(Env *env, Optional<Value> symbolize_names_
 
 Value MatchDataObject::names() const {
     if (!m_regexp)
-        return new ArrayObject {};
+        return ArrayObject::create();
     return m_regexp->names();
 }
 
@@ -335,7 +335,7 @@ Value MatchDataObject::to_s(Env *env) const {
 }
 
 ArrayObject *MatchDataObject::values_at(Env *env, Args &&args) {
-    auto result = new ArrayObject {};
+    auto result = ArrayObject::create();
     for (size_t i = 0; i < args.size(); i++) {
         auto key = args[i];
         if (key.is_range()) {
@@ -377,10 +377,10 @@ Value MatchDataObject::ref(Env *env, Value index_value, Optional<Value> size_arg
         if (range->exclude_end())
             last--;
         if (last < first)
-            return new ArrayObject {};
+            return ArrayObject::create();
         if (first + static_cast<nat_int_t>(size()) <= 0)
             return Value::nil();
-        auto result = new ArrayObject {};
+        auto result = ArrayObject::create();
         if (last >= static_cast<nat_int_t>(size())) last = size() - 1;
         for (auto i = first; i <= last; i++) {
             auto next_result = group(i);
@@ -406,13 +406,13 @@ Value MatchDataObject::ref(Env *env, Value index_value, Optional<Value> size_arg
         if (size < 0)
             return Value::nil();
         if (size == 0)
-            return new ArrayObject {};
+            return ArrayObject::create();
 
         auto first_result = group(index);
         if (first_result.is_nil())
             return Value::nil();
 
-        auto result = new ArrayObject { first_result };
+        auto result = ArrayObject::create({ first_result });
         for (auto i = index + 1; i < index + size; i++) {
             auto next_result = group(i);
             if (next_result.is_nil()) break;

--- a/src/match_data_object.cpp
+++ b/src/match_data_object.cpp
@@ -166,7 +166,7 @@ Value MatchDataObject::end(Env *env, Value end) const {
 
 Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
     if (keys.is_nil()) {
-        auto result = new HashObject {};
+        auto result = HashObject::create();
         for (auto name : *names().as_array()) {
             auto value = ref(env, name);
             result->put(env, name.as_string()->to_sym(env), value);
@@ -177,7 +177,7 @@ Value MatchDataObject::deconstruct_keys(Env *env, Value keys) {
     if (!keys.is_array())
         env->raise("TypeError", "wrong argument type {} (expected Array)", keys.klass()->inspect_module());
 
-    auto result = new HashObject {};
+    auto result = HashObject::create();
     if (keys.as_array()->size() > static_cast<size_t>(onig_number_of_names(m_regexp->m_regex)))
         return result;
 
@@ -259,9 +259,9 @@ Value MatchDataObject::match_length(Env *env, Value index) {
 
 Value MatchDataObject::named_captures(Env *env, Optional<Value> symbolize_names_kwarg) const {
     if (!m_regexp)
-        return new HashObject {};
+        return HashObject::create();
 
-    auto named_captures = new HashObject {};
+    auto named_captures = HashObject::create();
     named_captures_data data { this, env, named_captures, symbolize_names_kwarg && symbolize_names_kwarg.value().is_truthy() };
     onig_foreach_name(
         m_regexp->m_regex,

--- a/src/math.rb
+++ b/src/math.rb
@@ -186,7 +186,7 @@ module Math
       }
       int exponent;
       auto significand = std::frexp(value->to_double(), &exponent);
-      return new ArrayObject { { new FloatObject { significand }, Value::integer(exponent) } };
+      return new ArrayObject { { FloatObject::create(significand), Value::integer(exponent) } };
     END
 
     __function__('::tgamma', ['double'], 'double')
@@ -260,7 +260,7 @@ module Math
       }
       int sign = 1;
       auto v = ::lgamma_r(value->to_double(), &sign);
-      return new ArrayObject { {  new FloatObject { v }, Value::integer(sign) } };
+      return new ArrayObject { {  Value(FloatObject::create(v)), Value::integer(sign) } };
     END
 
     __function__('::log10', ['double'], 'double')

--- a/src/math.rb
+++ b/src/math.rb
@@ -186,7 +186,7 @@ module Math
       }
       int exponent;
       auto significand = std::frexp(value->to_double(), &exponent);
-      return new ArrayObject { { FloatObject::create(significand), Value::integer(exponent) } };
+      return ArrayObject::create({ FloatObject::create(significand), Value::integer(exponent) });
     END
 
     __function__('::tgamma', ['double'], 'double')
@@ -249,18 +249,18 @@ module Math
           }
       }
       if (value->is_positive_infinity()) {
-        return new ArrayObject { {  Value(FloatObject::positive_infinity(env)), Value::integer(1) } };
+        return ArrayObject::create({ Value(FloatObject::positive_infinity(env)), Value::integer(1) });
       } else if (value->is_negative_infinity()) {
         auto DomainError = Object::const_fetch(self, "DomainError"_s).as_class();
         env->raise(DomainError, "Numerical argument is out of domain");
       } else if (value->is_positive_zero()) {
-        return new ArrayObject { {  Value(FloatObject::positive_infinity(env)), Value::integer(1) } };
+        return ArrayObject::create({ Value(FloatObject::positive_infinity(env)), Value::integer(1) });
       } else if (value->is_negative_zero()) {
-        return new ArrayObject { {  Value(FloatObject::positive_infinity(env)), Value::integer(-1) } };
+        return ArrayObject::create({ Value(FloatObject::positive_infinity(env)), Value::integer(-1) });
       }
       int sign = 1;
       auto v = ::lgamma_r(value->to_double(), &sign);
-      return new ArrayObject { {  Value(FloatObject::create(v)), Value::integer(sign) } };
+      return ArrayObject::create({ Value(FloatObject::create(v)), Value::integer(sign) });
     END
 
     __function__('::log10', ['double'], 'double')

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -37,9 +37,9 @@ Value MethodObject::source_location() {
 
 Value MethodObject::unbind(Env *env) {
     if (m_object->singleton_class()) {
-        return new UnboundMethodObject { m_object->singleton_class(), m_method };
+        return UnboundMethodObject::create(m_object->singleton_class(), m_method);
     } else {
-        return new UnboundMethodObject { m_object.klass(), m_method };
+        return UnboundMethodObject::create(m_object.klass(), m_method);
     }
 }
 

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -32,7 +32,7 @@ Value MethodObject::source_location() {
     if (!method->get_file())
         return Value::nil();
 
-    return new ArrayObject { StringObject::create(method->get_file().value()), Value::integer(static_cast<nat_int_t>(method->get_line().value())) };
+    return ArrayObject::create({ StringObject::create(method->get_file().value()), Value::integer(static_cast<nat_int_t>(method->get_line().value())) });
 }
 
 Value MethodObject::unbind(Env *env) {

--- a/src/method_object.cpp
+++ b/src/method_object.cpp
@@ -32,7 +32,7 @@ Value MethodObject::source_location() {
     if (!method->get_file())
         return Value::nil();
 
-    return new ArrayObject { new StringObject { method->get_file().value() }, Value::integer(static_cast<nat_int_t>(method->get_line().value())) };
+    return new ArrayObject { StringObject::create(method->get_file().value()), Value::integer(static_cast<nat_int_t>(method->get_line().value())) };
 }
 
 Value MethodObject::unbind(Env *env) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -776,7 +776,7 @@ String ModuleObject::inspect_module() const {
 }
 
 Value ModuleObject::inspect(Env *env) const {
-    return new StringObject { inspect_module() };
+    return StringObject::create(inspect_module());
 }
 
 Value ModuleObject::name(Env *env) const {
@@ -790,7 +790,7 @@ Value ModuleObject::name(Env *env) const {
                 name.prepend(owner_name.value());
             }
         }
-        return new StringObject { name };
+        return StringObject::create(name);
     } else {
         return Value::nil();
     }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -327,7 +327,7 @@ Value ModuleObject::remove_const(Env *env, Value name) {
 }
 
 Value ModuleObject::constants(Env *env, Optional<Value> inherit) const {
-    auto ary = new ArrayObject;
+    auto ary = ArrayObject::create();
     for (auto pair : m_constants)
         ary->push(pair.first);
     if (!inherit || inherit.value().is_truthy()) {
@@ -461,7 +461,7 @@ Value ModuleObject::class_variable_set(Env *env, Value name, Value value) {
 ArrayObject *ModuleObject::class_variables(Optional<Value> inherit) const {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    auto result = new ArrayObject {};
+    auto result = ArrayObject::create();
     for (auto [cvar, _] : m_class_vars)
         result->push(cvar);
     if (singleton_class()) {
@@ -660,7 +660,7 @@ Value ModuleObject::public_instance_method(Env *env, Value name_value) {
 
 Value ModuleObject::instance_methods(Env *env, Optional<Value> include_super_value, std::function<bool(MethodVisibility)> predicate) {
     bool include_super = !include_super_value || include_super_value.value().is_truthy();
-    ArrayObject *array = new ArrayObject {};
+    ArrayObject *array = ArrayObject::create();
     methods(env, array, include_super);
     array->select_in_place([this, env, predicate](Value &name_value) -> bool {
         auto name = name_value.as_symbol();
@@ -698,7 +698,7 @@ ArrayObject *ModuleObject::ancestors(Env *env) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     ModuleObject *klass = this;
-    ArrayObject *ancestors = new ArrayObject {};
+    ArrayObject *ancestors = ArrayObject::create();
     do {
         if (klass->included_modules().is_empty()) {
             // note: if there are included modules, then they will include this klass
@@ -818,7 +818,7 @@ ArrayObject *ModuleObject::attr(Env *env, Args &&args) {
 }
 
 ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
-    auto ary = new ArrayObject { args.size() };
+    auto ary = ArrayObject::create(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         auto name = attr_reader(env, args[i]);
         ary->push(name);
@@ -843,7 +843,7 @@ Value ModuleObject::attr_reader_block_fn(Env *env, Value self, Args &&args, Bloc
 }
 
 ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
-    auto ary = new ArrayObject { args.size() };
+    auto ary = ArrayObject::create(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         auto name = attr_writer(env, args[i]);
         ary->push(name);
@@ -871,7 +871,7 @@ Value ModuleObject::attr_writer_block_fn(Env *env, Value self, Args &&args, Bloc
 }
 
 ArrayObject *ModuleObject::attr_accessor(Env *env, Args &&args) {
-    auto ary = new ArrayObject { args.size() * 2 };
+    auto ary = ArrayObject::create(args.size() * 2);
     for (size_t i = 0; i < args.size(); i++) {
         ary->push(attr_reader(env, args[i]));
         ary->push(attr_writer(env, args[i]));
@@ -894,7 +894,7 @@ void ModuleObject::included_modules(Env *env, ArrayObject *modules) {
 }
 
 Value ModuleObject::included_modules(Env *env) {
-    ArrayObject *modules = new ArrayObject {};
+    ArrayObject *modules = ArrayObject::create();
     included_modules(env, modules);
     return modules;
 }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -828,7 +828,7 @@ ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
 
 SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
     auto name = obj.to_symbol(env, Value::Conversion::Strict);
-    OwnedPtr<Env> block_env { new Env {} };
+    OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("name", 0, true, name);
     Block *attr_block = Block::create(std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0);
     define_method(env, name, attr_block);
@@ -854,7 +854,7 @@ ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
 SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
     auto name = obj.to_symbol(env, Value::Conversion::Strict);
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
-    OwnedPtr<Env> block_env { new Env {} };
+    OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("name", 0, true, name);
     Block *attr_block = Block::create(std::move(block_env), this, ModuleObject::attr_writer_block_fn, 1);
     define_method(env, method_name, attr_block);
@@ -1147,7 +1147,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
         return old_method->bind_call(env, self, std::move(new_args), block);
     };
 
-    OwnedPtr<Env> inner_env { new Env { *env } };
+    OwnedPtr<Env> inner_env { Env::create(*env) };
     inner_env->var_set("old_method", 1, true, instance_method(env, name));
     undef_method(env, { name });
     define_method(env, name.as_symbol(), Block::create(std::move(inner_env), this, method_wrapper, -1));

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -830,7 +830,7 @@ SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
     auto name = obj.to_symbol(env, Value::Conversion::Strict);
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, name);
-    Block *attr_block = new Block { std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0 };
+    Block *attr_block = Block::create(std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0);
     define_method(env, name, attr_block);
     return name;
 }
@@ -856,7 +856,7 @@ SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, name);
-    Block *attr_block = new Block { std::move(block_env), this, ModuleObject::attr_writer_block_fn, 1 };
+    Block *attr_block = Block::create(std::move(block_env), this, ModuleObject::attr_writer_block_fn, 1);
     define_method(env, method_name, attr_block);
     return method_name;
 }
@@ -1150,7 +1150,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
     OwnedPtr<Env> inner_env { new Env { *env } };
     inner_env->var_set("old_method", 1, true, instance_method(env, name));
     undef_method(env, { name });
-    define_method(env, name.as_symbol(), new Block { std::move(inner_env), this, method_wrapper, -1 });
+    define_method(env, name.as_symbol(), Block::create(std::move(inner_env), this, method_wrapper, -1));
 
     return Value::nil();
 }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -632,7 +632,7 @@ Value ModuleObject::instance_method(Env *env, Value name_value) {
     auto name = name_value.to_symbol(env, Value::Conversion::Strict);
     auto method_info = find_method(env, name);
     assert_method_defined(env, name, method_info);
-    return new UnboundMethodObject { this, method_info.method() };
+    return UnboundMethodObject::create(this, method_info.method());
 }
 
 Value ModuleObject::public_instance_method(Env *env, Value name_value) {
@@ -642,7 +642,7 @@ Value ModuleObject::public_instance_method(Env *env, Value name_value) {
 
     switch (method_info.visibility()) {
     case MethodVisibility::Public:
-        return new UnboundMethodObject { this, method_info.method() };
+        return UnboundMethodObject::create(this, method_info.method());
     case MethodVisibility::Protected:
         if (type() == Type::Class)
             env->raise_name_error(name, "method `{}' for class `{}' is protected", name->string(), inspect_module());

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -1139,7 +1139,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
     }
 
     auto method_wrapper = [](Env *env, Value self, Args &&args, Block *block) -> Value {
-        auto kwargs = args.has_keyword_hash() ? args.pop_keyword_hash() : new HashObject;
+        auto kwargs = args.has_keyword_hash() ? args.pop_keyword_hash() : HashObject::create();
         auto new_args = args.to_array_for_block(env, 0, -1, true);
         if (!kwargs->is_empty())
             new_args->push(HashObject::ruby2_keywords_hash(env, kwargs));

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -434,17 +434,17 @@ Env *build_top_env() {
     auto main_obj = new Natalie::Object {};
     GlobalEnv::the()->set_main_obj(main_obj);
 
-    Value _stdin = new IoObject { STDIN_FILENO };
+    Value _stdin = IoObject::create(STDIN_FILENO);
     env->global_set("$stdin"_s, _stdin);
     Object->const_set("STDIN"_s, _stdin);
 
-    Value _stdout = new IoObject { STDOUT_FILENO };
+    Value _stdout = IoObject::create(STDOUT_FILENO);
     env->global_set("$stdout"_s, _stdout);
     GlobalEnv::the()->global_set_write_hook(env, "$stdout"_s, GlobalVariableAccessHooks::WriteHooks::set_stdout);
     env->global_alias("$>"_s, "$stdout"_s);
     Object->const_set("STDOUT"_s, _stdout);
 
-    Value _stderr = new IoObject { STDERR_FILENO };
+    Value _stderr = IoObject::create(STDERR_FILENO);
     env->global_set("$stderr"_s, _stderr);
     Object->const_set("STDERR"_s, _stderr);
 

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -36,19 +36,19 @@ Env *build_top_env() {
     global_env->set_Module(Module);
     Object->const_set("Module"_s, Module);
     Class->set_superclass_DANGEROUSLY(Module);
-    auto class_singleton_class = new ClassObject { Module->singleton_class() };
+    auto class_singleton_class = ClassObject::create(Module->singleton_class());
     Module->singleton_class()->initialize_subclass_without_checks(class_singleton_class, env, "#<Class:Class>");
     Class->set_singleton_class(class_singleton_class);
 
-    ModuleObject *Kernel = new ModuleObject { "Kernel" };
+    ModuleObject *Kernel = ModuleObject::create("Kernel");
     Object->const_set("Kernel"_s, Kernel);
     Object->include_once(env, Kernel);
 
-    ModuleObject *Comparable = new ModuleObject { "Comparable" };
+    ModuleObject *Comparable = ModuleObject::create("Comparable");
     Object->const_set("Comparable"_s, Comparable);
     Symbol->include_once(env, Comparable);
 
-    ModuleObject *Enumerable = new ModuleObject { "Enumerable" };
+    ModuleObject *Enumerable = ModuleObject::create("Enumerable");
     Object->const_set("Enumerable"_s, Enumerable);
 
     ClassObject *Enumerator = Object->subclass(env, "Enumerator", Object::Type::Enumerator);
@@ -93,12 +93,12 @@ Env *build_top_env() {
     global_env->set_Rational(Rational);
     Object->const_set("Rational"_s, Rational);
 
-    ModuleObject *Math = new ModuleObject { "Math" };
+    ModuleObject *Math = ModuleObject::create("Math");
     Object->const_set("Math"_s, Math);
     Math->const_set("E"_s, FloatObject::create(M_E));
     Math->const_set("PI"_s, FloatObject::create(M_PI));
 
-    ModuleObject *Signal = new ModuleObject { "Signal" };
+    ModuleObject *Signal = ModuleObject::create("Signal");
     Object->const_set("Signal"_s, Signal);
 
     ClassObject *String = Object->subclass(env, "String", Object::Type::String);
@@ -125,7 +125,7 @@ Env *build_top_env() {
     Object->const_set("Random"_s, Random);
     Random->const_set("DEFAULT"_s, RandomObject::create()->initialize(env));
 
-    ModuleObject *RandomFormatter = new ModuleObject { "Formatter" };
+    ModuleObject *RandomFormatter = ModuleObject::create("Formatter");
     Random->const_set("Formatter"_s, RandomFormatter);
     Random->extend_once(env, RandomFormatter);
 
@@ -163,7 +163,7 @@ Env *build_top_env() {
     Object->const_set("File"_s, File);
     File->include_once(env, Enumerable);
 
-    ModuleObject *FileTest = new ModuleObject { "FileTest" };
+    ModuleObject *FileTest = ModuleObject::create("FileTest");
     Object->const_set("FileTest"_s, FileTest);
 
     ClassObject *FileStat = Object->subclass(env, "Stat", Object::Type::FileStat);
@@ -380,19 +380,19 @@ Env *build_top_env() {
     // Must set defaults after the encodings are defined above.
     EncodingObject::initialize_defaults(env);
 
-    ModuleObject *Process = new ModuleObject { "Process" };
+    ModuleObject *Process = ModuleObject::create("Process");
     Object->const_set("Process"_s, Process);
-    Value ProcessSys = new ModuleObject { "Sys" };
+    Value ProcessSys = ModuleObject::create("Sys");
     Process->const_set("Sys"_s, ProcessSys);
-    Value ProcessUID = new ModuleObject { "UID" };
+    Value ProcessUID = ModuleObject::create("UID");
     Process->const_set("UID"_s, ProcessUID);
-    Value ProcessGID = new ModuleObject { "GID" };
+    Value ProcessGID = ModuleObject::create("GID");
     Process->const_set("GID"_s, ProcessGID);
 
     ClassObject *Thread = Object->subclass(env, "Thread", Object::Type::Thread);
     Object->const_set("Thread"_s, Thread);
 
-    ModuleObject *ThreadBacktrace = new ModuleObject { "Backtrace" };
+    ModuleObject *ThreadBacktrace = ModuleObject::create("Backtrace");
     Thread->const_set("Backtrace"_s, ThreadBacktrace);
 
     ClassObject *ThreadBacktraceLocation = Object->subclass(env, "Location", Object::Type::ThreadBacktraceLocation);
@@ -418,7 +418,7 @@ Env *build_top_env() {
     ClassObject *UnboundMethod = Object->subclass(env, "UnboundMethod", Object::Type::UnboundMethod);
     Object->const_set("UnboundMethod"_s, UnboundMethod);
 
-    ModuleObject *FileConstants = new ModuleObject { "Constants" };
+    ModuleObject *FileConstants = ModuleObject::create("Constants");
     File->const_set("Constants"_s, FileConstants);
 
     // Build File Constants after Encodings are defined since some
@@ -524,7 +524,7 @@ Env *build_top_env() {
     RUBY_REVISION->freeze();
     Object->const_set("RUBY_REVISION"_s, RUBY_REVISION);
 
-    ModuleObject *GC = new ModuleObject { "GC" };
+    ModuleObject *GC = ModuleObject::create("GC");
     Object->const_set("GC"_s, GC);
 
     init_bindings(env);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -429,7 +429,7 @@ Env *build_top_env() {
     File->include_once(env, FileConstants);
     IO->include_once(env, FileConstants);
 
-    env->global_set("$NAT_at_exit_handlers"_s, new ArrayObject {});
+    env->global_set("$NAT_at_exit_handlers"_s, ArrayObject::create());
 
     auto main_obj = new Natalie::Object {};
     GlobalEnv::the()->set_main_obj(main_obj);
@@ -468,7 +468,7 @@ Env *build_top_env() {
 
     GlobalEnv::the()->global_set_read_hook(env, "$$"_s, true, GlobalVariableAccessHooks::ReadHooks::getpid);
 
-    env->global_set("$\""_s, new ArrayObject {}, true);
+    env->global_set("$\""_s, ArrayObject::create(), true);
     env->global_alias("$LOADED_FEATURES"_s, "$\""_s);
 
     env->global_set("$?"_s, Value::nil(), true);
@@ -534,7 +534,7 @@ Env *build_top_env() {
 
 Value splat(Env *env, Value obj) {
     if (obj.is_array()) {
-        return new ArrayObject { *obj.as_array() };
+        return ArrayObject::create(*obj.as_array());
     } else {
         return to_ary(env, obj, false);
     }
@@ -666,7 +666,7 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
         }
     }
 
-    return new ArrayObject { obj };
+    return ArrayObject::create({ obj });
 }
 
 Value to_ary_for_masgn(Env *env, Value obj) {
@@ -688,7 +688,7 @@ Value to_ary_for_masgn(Env *env, Value obj) {
         }
     }
 
-    return new ArrayObject { obj };
+    return ArrayObject::create({ obj });
 }
 
 void arg_spread(Env *env, const Args &args, const char *arrangement, ...) {

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -95,8 +95,8 @@ Env *build_top_env() {
 
     ModuleObject *Math = new ModuleObject { "Math" };
     Object->const_set("Math"_s, Math);
-    Math->const_set("E"_s, new FloatObject { M_E });
-    Math->const_set("PI"_s, new FloatObject { M_PI });
+    Math->const_set("E"_s, FloatObject::create(M_E));
+    Math->const_set("PI"_s, FloatObject::create(M_PI));
 
     ModuleObject *Signal = new ModuleObject { "Signal" };
     Object->const_set("Signal"_s, Signal);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -2,7 +2,6 @@
 #include "natalie/forward.hpp"
 #include "natalie/global_variable_info/access_hooks.hpp"
 #include "natalie/value.hpp"
-#include <ctype.h>
 #include <math.h>
 #include <stdarg.h>
 #include <sys/wait.h>
@@ -449,7 +448,7 @@ Env *build_top_env() {
     env->global_set("$stderr"_s, _stderr);
     Object->const_set("STDERR"_s, _stderr);
 
-    env->global_set("$/"_s, new StringObject { "\n", 1 });
+    env->global_set("$/"_s, StringObject::create("\n", 1));
     GlobalEnv::the()->global_set_write_hook(env, "$/"_s, GlobalVariableAccessHooks::WriteHooks::as_string_or_raise);
     env->global_alias("$-0"_s, "$/"_s);
 
@@ -493,11 +492,11 @@ Env *build_top_env() {
     Object->const_set("ENV"_s, ENV);
     ENV->extend_once(env, Enumerable);
 
-    auto RUBY_VERSION = new StringObject { "3.4.0" };
+    auto RUBY_VERSION = StringObject::create("3.4.0");
     RUBY_VERSION->freeze();
     Object->const_set("RUBY_VERSION"_s, RUBY_VERSION);
 
-    Value RUBY_COPYRIGHT = new StringObject { "natalie - Copyright (c) 2025 Tim Morgan and contributors" };
+    Value RUBY_COPYRIGHT = StringObject::create("natalie - Copyright (c) 2025 Tim Morgan and contributors");
     RUBY_COPYRIGHT->freeze();
     Object->const_set("RUBY_COPYRIGHT"_s, RUBY_COPYRIGHT);
 
@@ -506,22 +505,22 @@ Env *build_top_env() {
     RUBY_DESCRIPTION->freeze();
     Object->const_set("RUBY_DESCRIPTION"_s, RUBY_DESCRIPTION);
 
-    Value RUBY_ENGINE = new StringObject { "natalie" };
+    Value RUBY_ENGINE = StringObject::create("natalie");
     RUBY_ENGINE->freeze();
     Object->const_set("RUBY_ENGINE"_s, RUBY_ENGINE);
 
     Value RUBY_PATCHLEVEL = Value::integer(-1);
     Object->const_set("RUBY_PATCHLEVEL"_s, RUBY_PATCHLEVEL);
 
-    StringObject *RUBY_PLATFORM = new StringObject { ruby_platform };
+    StringObject *RUBY_PLATFORM = StringObject::create(ruby_platform);
     RUBY_PLATFORM->freeze();
     Object->const_set("RUBY_PLATFORM"_s, RUBY_PLATFORM);
 
-    Value RUBY_RELEASE_DATE = new StringObject { ruby_release_date };
+    Value RUBY_RELEASE_DATE = StringObject::create(ruby_release_date);
     RUBY_RELEASE_DATE->freeze();
     Object->const_set("RUBY_RELEASE_DATE"_s, RUBY_RELEASE_DATE);
 
-    Value RUBY_REVISION = new StringObject { ruby_revision };
+    Value RUBY_REVISION = StringObject::create(ruby_revision);
     RUBY_REVISION->freeze();
     Object->const_set("RUBY_REVISION"_s, RUBY_REVISION);
 
@@ -585,7 +584,7 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception, Thread
     if (exception->backtrace()) {
         ArrayObject *backtrace = exception->backtrace()->to_ruby_array();
         if (backtrace->size() > 0) {
-            out.send(env, "puts"_s, { new StringObject { "Traceback (most recent call last):" } });
+            out.send(env, "puts"_s, { StringObject::create("Traceback (most recent call last):") });
             for (int i = backtrace->size() - 1; i > 0; i--) {
                 auto line = backtrace->at(i).as_string_or_raise(env);
                 auto formatted = StringObject::format("        {}: from {}", i, line->string());

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -10,7 +10,7 @@ namespace Natalie {
 
 Env *build_top_env() {
     auto *global_env = GlobalEnv::the();
-    auto *env = new Env {};
+    auto *env = Env::create();
     global_env->set_main_env(env);
 
     ClassObject *Class = ClassObject::bootstrap_class_class(env);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -123,7 +123,7 @@ Env *build_top_env() {
     ClassObject *Random = Object->subclass(env, "Random", Object::Type::Random);
     global_env->set_Random(Random);
     Object->const_set("Random"_s, Random);
-    Random->const_set("DEFAULT"_s, (new RandomObject)->initialize(env));
+    Random->const_set("DEFAULT"_s, RandomObject::create()->initialize(env));
 
     ModuleObject *RandomFormatter = new ModuleObject { "Formatter" };
     Random->const_set("Formatter"_s, RandomFormatter);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -431,7 +431,7 @@ Env *build_top_env() {
 
     env->global_set("$NAT_at_exit_handlers"_s, ArrayObject::create());
 
-    auto main_obj = new Natalie::Object {};
+    auto main_obj = Object::create();
     GlobalEnv::the()->set_main_obj(main_obj);
 
     Value _stdin = IoObject::create(STDIN_FILENO);

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -25,7 +25,7 @@ Value NilMethods::to_s(const Value) {
 }
 
 Value NilMethods::to_a(const Value) {
-    return new ArrayObject {};
+    return ArrayObject::create();
 }
 
 Value NilMethods::to_c(const Value) {

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -33,7 +33,7 @@ Value NilMethods::to_c(const Value) {
 }
 
 Value NilMethods::to_h(const Value) {
-    return new HashObject {};
+    return HashObject::create();
 }
 
 Value NilMethods::to_f(const Value) {

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -29,7 +29,7 @@ Value NilMethods::to_a(const Value) {
 }
 
 Value NilMethods::to_c(const Value) {
-    return new ComplexObject { Value::integer(0) };
+    return ComplexObject::create(Value::integer(0));
 }
 
 Value NilMethods::to_h(const Value) {

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -20,7 +20,7 @@ Value NilMethods::rationalize(const Value self, const Optional<Value>) {
 
 Value NilMethods::to_s(const Value) {
     if (!s_string)
-        s_string = new StringObject { "" };
+        s_string = StringObject::create("");
     return s_string;
 }
 
@@ -49,7 +49,7 @@ Value NilMethods::to_r(const Value) {
 }
 
 Value NilMethods::inspect(const Value) {
-    return new StringObject { "nil" };
+    return StringObject::create("nil");
 }
 
 }

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -37,7 +37,7 @@ Value NilMethods::to_h(const Value) {
 }
 
 Value NilMethods::to_f(const Value) {
-    return new FloatObject { 0.0 };
+    return FloatObject::create(0.0);
 }
 
 Value NilMethods::to_i(const Value) {

--- a/src/nil_methods.cpp
+++ b/src/nil_methods.cpp
@@ -45,7 +45,7 @@ Value NilMethods::to_i(const Value) {
 }
 
 Value NilMethods::to_r(const Value) {
-    return new RationalObject { Value::integer(0), Value::integer(1) };
+    return RationalObject::create(Value::integer(0), Value::integer(1));
 }
 
 Value NilMethods::inspect(const Value) {

--- a/src/number_parser.cpp
+++ b/src/number_parser.cpp
@@ -184,7 +184,7 @@ namespace {
 FloatObject *NumberParser::string_to_f(TM::NonNullPtr<const StringObject> str) {
     FloatParser float_parser { str->string() };
     float_parser.parse();
-    return new FloatObject { float_parser.result(false).value_or(0.0) };
+    return FloatObject::create(float_parser.result(false).value_or(0.0));
 }
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -639,7 +639,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Range:
         return new RangeObject { *static_cast<const RangeObject *>(this) };
     case Object::Type::Rational:
-        return new RationalObject { *static_cast<const RationalObject *>(this) };
+        return RationalObject::create(*static_cast<const RationalObject *>(this));
     case Object::Type::Regexp:
         return RegexpObject::create(env, *static_cast<const RegexpObject *>(this));
     case Object::Type::String:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -78,7 +78,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Proc:
-        obj = new ProcObject { klass };
+        obj = ProcObject::create(klass);
         break;
 
     case Object::Type::Random:
@@ -635,7 +635,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Object:
         return Object::create(*this);
     case Object::Type::Proc:
-        return new ProcObject { *static_cast<const ProcObject *>(this) };
+        return ProcObject::create(*static_cast<const ProcObject *>(this));
     case Object::Type::Range:
         return RangeObject::create(*static_cast<const RangeObject *>(this));
     case Object::Type::Rational:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -34,7 +34,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Complex:
-        obj = new ComplexObject { klass };
+        obj = ComplexObject::create(klass);
         break;
 
     case Object::Type::Dir:
@@ -621,7 +621,7 @@ Value Object::duplicate(Env *env) const {
         return out;
     }
     case Object::Type::Complex:
-        return new ComplexObject { *static_cast<const ComplexObject *>(this) };
+        return ComplexObject::create(*static_cast<const ComplexObject *>(this));
     case Object::Type::Exception:
         return new ExceptionObject { *static_cast<const ExceptionObject *>(this) };
     case Object::Type::False:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -122,7 +122,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::FileStat:
-        obj = new FileStatObject { klass };
+        obj = FileStatObject::create(klass);
         break;
 
     case Object::Type::Binding:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -38,7 +38,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Dir:
-        obj = new DirObject { klass };
+        obj = DirObject::create(klass);
         break;
 
     case Object::Type::Enumerator:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -90,7 +90,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Regexp:
-        obj = new RegexpObject { klass };
+        obj = RegexpObject::create(klass);
         break;
 
     case Object::Type::String:
@@ -641,7 +641,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Rational:
         return new RationalObject { *static_cast<const RationalObject *>(this) };
     case Object::Type::Regexp:
-        return new RegexpObject { env, *static_cast<const RegexpObject *>(this) };
+        return RegexpObject::create(env, *static_cast<const RegexpObject *>(this));
     case Object::Type::String:
         return StringObject::create(*static_cast<const StringObject *>(this));
     case Object::Type::Symbol:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -118,7 +118,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::VoidP:
-        obj = new VoidPObject { klass };
+        obj = VoidPObject::create(klass);
         break;
 
     case Object::Type::FileStat:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -94,7 +94,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::String:
-        obj = new StringObject { klass };
+        obj = StringObject::create(klass);
         break;
 
     case Object::Type::Thread:
@@ -499,7 +499,7 @@ Value Object::main_obj_define_method(Env *env, Value name, Optional<Value> proc_
 }
 
 Value Object::main_obj_inspect(Env *) {
-    return new StringObject { "main" };
+    return StringObject::create("main");
 }
 
 void Object::private_method(Env *env, SymbolObject *name) {
@@ -643,7 +643,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Regexp:
         return new RegexpObject { env, *static_cast<const RegexpObject *>(this) };
     case Object::Type::String:
-        return new StringObject { *static_cast<const StringObject *>(this) };
+        return StringObject::create(*static_cast<const StringObject *>(this));
     case Object::Type::Symbol:
         return SymbolObject::intern(static_cast<const SymbolObject *>(this)->string());
     case Object::Type::Time:
@@ -739,7 +739,7 @@ const char *Object::defined(Env *env, SymbolObject *name, bool strict) {
 Value Object::defined_obj(Env *env, SymbolObject *name, bool strict) {
     const char *result = defined(env, name, strict);
     if (result) {
-        return new StringObject { result };
+        return StringObject::create(result);
     } else {
         return Value::nil();
     }
@@ -811,7 +811,7 @@ void Object::assert_not_frozen(Env *env, Value receiver) {
         auto FrozenError = GlobalEnv::the()->Object()->const_fetch("FrozenError"_s);
         String message = String::format("can't modify frozen {}: {}", klass()->inspect_module(), inspected(env));
         auto kwargs = new HashObject(env, { "receiver"_s, receiver });
-        auto args = Args({ new StringObject { message }, kwargs }, true);
+        auto args = Args({ StringObject::create(message), kwargs }, true);
         ExceptionObject *error = FrozenError.send(env, "new"_s, std::move(args)).as_exception();
         env->raise_exception(error);
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -82,7 +82,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Random:
-        obj = new RandomObject { klass };
+        obj = RandomObject::create(klass);
         break;
 
     case Object::Type::Range:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -86,7 +86,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Range:
-        obj = new RangeObject { klass };
+        obj = RangeObject::create(klass);
         break;
 
     case Object::Type::Regexp:
@@ -637,7 +637,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Proc:
         return new ProcObject { *static_cast<const ProcObject *>(this) };
     case Object::Type::Range:
-        return new RangeObject { *static_cast<const RangeObject *>(this) };
+        return RangeObject::create(*static_cast<const RangeObject *>(this));
     case Object::Type::Rational:
         return RationalObject::create(*static_cast<const RationalObject *>(this));
     case Object::Type::Regexp:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -66,7 +66,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::MatchData:
-        obj = new MatchDataObject { klass };
+        obj = MatchDataObject::create(klass);
         break;
 
     case Object::Type::Module:
@@ -653,7 +653,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::UnboundMethod:
         return UnboundMethodObject::create(*static_cast<const UnboundMethodObject *>(this));
     case Object::Type::MatchData:
-        return new MatchDataObject { *static_cast<const MatchDataObject *>(this) };
+        return MatchDataObject::create(*static_cast<const MatchDataObject *>(this));
     default:
         fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_module().c_str(), static_cast<int>(m_type));
         abort();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -42,7 +42,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Enumerator:
-        obj = new Object { klass };
+        obj = Object::create(klass);
         break;
 
     case Object::Type::Exception:
@@ -74,7 +74,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Object:
-        obj = new Object { klass };
+        obj = Object::create(klass);
         break;
 
     case Object::Type::Proc:
@@ -633,7 +633,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Module:
         return new ModuleObject { *static_cast<const ModuleObject *>(this) };
     case Object::Type::Object:
-        return new Object { *this };
+        return Object::create(*this);
     case Object::Type::Proc:
         return new ProcObject { *static_cast<const ProcObject *>(this) };
     case Object::Type::Range:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -25,7 +25,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Array:
-        obj = new ArrayObject {};
+        obj = ArrayObject::create();
         obj->m_klass = klass;
         break;
 
@@ -371,9 +371,9 @@ Value Object::ivar_set(Env *env, SymbolObject *name, Value val) {
 
 Value Object::instance_variables(Env *env) {
     if (m_type == Type::Float || !m_ivars)
-        return new ArrayObject;
+        return ArrayObject::create();
 
-    ArrayObject *ary = new ArrayObject { m_ivars->size() };
+    ArrayObject *ary = ArrayObject::create(m_ivars->size());
     for (auto pair : *m_ivars)
         ary->push(pair.first);
     return ary;
@@ -612,7 +612,7 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
 Value Object::duplicate(Env *env) const {
     switch (m_type) {
     case Object::Type::Array:
-        return new ArrayObject { *static_cast<const ArrayObject *>(this) };
+        return ArrayObject::create(*static_cast<const ArrayObject *>(this));
     case Object::Type::Class: {
         auto out = new ClassObject { *static_cast<const ClassObject *>(this) };
         auto s_class = singleton_class();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -114,7 +114,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Time:
-        obj = new TimeObject { klass };
+        obj = TimeObject::create(klass);
         break;
 
     case Object::Type::VoidP:
@@ -647,7 +647,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Symbol:
         return SymbolObject::intern(static_cast<const SymbolObject *>(this)->string());
     case Object::Type::Time:
-        return new TimeObject { *static_cast<const TimeObject *>(this) };
+        return TimeObject::create(*static_cast<const TimeObject *>(this));
     case Object::Type::True:
         return Value::True();
     case Object::Type::UnboundMethod:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -30,7 +30,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Class:
-        obj = new ClassObject { klass };
+        obj = ClassObject::create(klass);
         break;
 
     case Object::Type::Complex:
@@ -70,7 +70,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Module:
-        obj = new ModuleObject { klass };
+        obj = ModuleObject::create(klass);
         break;
 
     case Object::Type::Object:
@@ -225,7 +225,7 @@ ClassObject *Object::singleton_class(Env *env, Value self) {
     } else {
         singleton_superclass = self->m_klass;
     }
-    auto new_singleton_class = new ClassObject { singleton_superclass };
+    auto new_singleton_class = ClassObject::create(singleton_superclass);
     if (self->is_frozen()) new_singleton_class->freeze();
     singleton_superclass->initialize_subclass_without_checks(new_singleton_class, env, name);
     self->set_singleton_class(new_singleton_class);
@@ -614,7 +614,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Array:
         return ArrayObject::create(*static_cast<const ArrayObject *>(this));
     case Object::Type::Class: {
-        auto out = new ClassObject { *static_cast<const ClassObject *>(this) };
+        auto out = ClassObject::create(*static_cast<const ClassObject *>(this));
         auto s_class = singleton_class();
         if (s_class)
             out->set_singleton_class(s_class->clone(env).as_class());
@@ -631,7 +631,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Hash:
         return HashObject::create(env, *static_cast<const HashObject *>(this));
     case Object::Type::Module:
-        return new ModuleObject { *static_cast<const ModuleObject *>(this) };
+        return ModuleObject::create(*static_cast<const ModuleObject *>(this));
     case Object::Type::Object:
         return Object::create(*this);
     case Object::Type::Proc:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -46,7 +46,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Exception:
-        obj = new ExceptionObject { klass };
+        obj = ExceptionObject::create(klass);
         break;
 
     case Object::Type::Fiber:
@@ -623,7 +623,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Complex:
         return ComplexObject::create(*static_cast<const ComplexObject *>(this));
     case Object::Type::Exception:
-        return new ExceptionObject { *static_cast<const ExceptionObject *>(this) };
+        return ExceptionObject::create(*static_cast<const ExceptionObject *>(this));
     case Object::Type::False:
         return Value::False();
     case Object::Type::Float:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -849,7 +849,6 @@ Value Object::enum_for(Env *env, const char *method, Args &&args) {
 }
 
 void Object::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     visitor.visit(m_klass);
     visitor.visit(m_singleton_class);
     if (m_ivars) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -54,7 +54,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Hash:
-        obj = new HashObject { klass };
+        obj = HashObject::create(klass);
         break;
 
     case Object::Type::Io:
@@ -629,7 +629,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::Float:
         return FloatObject::create(*static_cast<const FloatObject *>(this));
     case Object::Type::Hash:
-        return new HashObject { env, *static_cast<const HashObject *>(this) };
+        return HashObject::create(env, *static_cast<const HashObject *>(this));
     case Object::Type::Module:
         return new ModuleObject { *static_cast<const ModuleObject *>(this) };
     case Object::Type::Object:
@@ -680,7 +680,7 @@ Value Object::clone(Env *env, Optional<Value> freeze_arg) {
     }
 
     if (freeze_arg) {
-        auto keyword_hash = new HashObject {};
+        auto keyword_hash = HashObject::create();
         keyword_hash->put(env, "freeze"_s, freeze_arg.value());
         auto args = Args({ this, keyword_hash }, true);
         duplicate.send(env, "initialize_clone"_s, std::move(args));
@@ -810,7 +810,7 @@ void Object::assert_not_frozen(Env *env, Value receiver) {
     if (is_frozen()) {
         auto FrozenError = GlobalEnv::the()->Object()->const_fetch("FrozenError"_s);
         String message = String::format("can't modify frozen {}: {}", klass()->inspect_module(), inspected(env));
-        auto kwargs = new HashObject(env, { "receiver"_s, receiver });
+        auto kwargs = HashObject::create(env, { "receiver"_s, receiver });
         auto args = Args({ StringObject::create(message), kwargs }, true);
         ExceptionObject *error = FrozenError.send(env, "new"_s, std::move(args)).as_exception();
         env->raise_exception(error);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -58,7 +58,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Io:
-        obj = new IoObject { klass };
+        obj = IoObject::create(klass);
         break;
 
     case Object::Type::File:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -98,7 +98,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Thread:
-        obj = new ThreadObject { klass };
+        obj = ThreadObject::create(klass);
         break;
 
     case Object::Type::ThreadBacktraceLocation:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -50,7 +50,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::Fiber:
-        obj = new FiberObject { klass };
+        obj = FiberObject::create(klass);
         break;
 
     case Object::Type::Hash:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -62,7 +62,7 @@ Optional<Value> Object::create(Env *env, ClassObject *klass) {
         break;
 
     case Object::Type::File:
-        obj = new FileObject { klass };
+        obj = FileObject::create(klass);
         break;
 
     case Object::Type::MatchData:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -627,7 +627,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::False:
         return Value::False();
     case Object::Type::Float:
-        return new FloatObject { *static_cast<const FloatObject *>(this) };
+        return FloatObject::create(*static_cast<const FloatObject *>(this));
     case Object::Type::Hash:
         return new HashObject { env, *static_cast<const HashObject *>(this) };
     case Object::Type::Module:

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -651,7 +651,7 @@ Value Object::duplicate(Env *env) const {
     case Object::Type::True:
         return Value::True();
     case Object::Type::UnboundMethod:
-        return new UnboundMethodObject { *static_cast<const UnboundMethodObject *>(this) };
+        return UnboundMethodObject::create(*static_cast<const UnboundMethodObject *>(this));
     case Object::Type::MatchData:
         return new MatchDataObject { *static_cast<const MatchDataObject *>(this) };
     default:

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -45,7 +45,7 @@ Value ProcObject::ltlt(Env *env, Value other) {
         env->raise("TypeError", "callable object is expected");
 
     env->var_set("other", 0, true, other);
-    auto block = new Block { *env, this, compose_ltlt, -1 };
+    auto block = Block::create(*env, this, compose_ltlt, -1);
     if (other.is_proc() && other.as_proc()->is_lambda())
         block->set_type(Block::BlockType::Lambda);
     return new ProcObject { block };
@@ -56,7 +56,7 @@ Value ProcObject::gtgt(Env *env, Value other) {
         env->raise("TypeError", "callable object is expected");
 
     env->var_set("other", 0, true, other);
-    auto block = new Block { *env, this, compose_gtgt, -1 };
+    auto block = Block::create(*env, this, compose_gtgt, -1);
     if (is_lambda())
         block->set_type(Block::BlockType::Lambda);
     return new ProcObject { block };
@@ -75,7 +75,7 @@ Value ProcObject::ruby2_keywords(Env *env) {
 
     OwnedPtr<Env> inner_env { new Env { *env } };
     inner_env->var_set("old_block", 1, true, new ProcObject { m_block });
-    m_block = new Block { std::move(inner_env), this, block_wrapper, -1 };
+    m_block = Block::create(std::move(inner_env), this, block_wrapper, -1);
 
     return this;
 }

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -73,7 +73,7 @@ Value ProcObject::ruby2_keywords(Env *env) {
         return old_block->call(env, std::move(new_args), block);
     };
 
-    OwnedPtr<Env> inner_env { new Env { *env } };
+    OwnedPtr<Env> inner_env { Env::create(*env) };
     inner_env->var_set("old_block", 1, true, ProcObject::create(m_block));
     m_block = Block::create(std::move(inner_env), this, block_wrapper, -1);
 

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -48,7 +48,7 @@ Value ProcObject::ltlt(Env *env, Value other) {
     auto block = Block::create(*env, this, compose_ltlt, -1);
     if (other.is_proc() && other.as_proc()->is_lambda())
         block->set_type(Block::BlockType::Lambda);
-    return new ProcObject { block };
+    return ProcObject::create(block);
 }
 
 Value ProcObject::gtgt(Env *env, Value other) {
@@ -59,7 +59,7 @@ Value ProcObject::gtgt(Env *env, Value other) {
     auto block = Block::create(*env, this, compose_gtgt, -1);
     if (is_lambda())
         block->set_type(Block::BlockType::Lambda);
-    return new ProcObject { block };
+    return ProcObject::create(block);
 }
 
 Value ProcObject::ruby2_keywords(Env *env) {
@@ -74,7 +74,7 @@ Value ProcObject::ruby2_keywords(Env *env) {
     };
 
     OwnedPtr<Env> inner_env { new Env { *env } };
-    inner_env->var_set("old_block", 1, true, new ProcObject { m_block });
+    inner_env->var_set("old_block", 1, true, ProcObject::create(m_block));
     m_block = Block::create(std::move(inner_env), this, block_wrapper, -1);
 
     return this;

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -84,7 +84,7 @@ Value ProcObject::source_location() {
     assert(m_block);
     auto file = m_block->env()->file();
     if (file == nullptr) return Value::nil();
-    return new ArrayObject { StringObject::create(file), Value::integer(static_cast<nat_int_t>(m_block->env()->line())) };
+    return ArrayObject::create({ StringObject::create(file), Value::integer(static_cast<nat_int_t>(m_block->env()->line())) });
 }
 
 StringObject *ProcObject::to_s(Env *env) {

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -64,7 +64,7 @@ Value ProcObject::gtgt(Env *env, Value other) {
 
 Value ProcObject::ruby2_keywords(Env *env) {
     auto block_wrapper = [](Env *env, Value self, Args &&args, Block *block) -> Value {
-        auto kwargs = args.has_keyword_hash() ? args.pop_keyword_hash() : new HashObject;
+        auto kwargs = args.has_keyword_hash() ? args.pop_keyword_hash() : HashObject::create();
         auto new_args = args.to_array_for_block(env, 0, -1, true);
         if (!kwargs->is_empty())
             new_args->push(HashObject::ruby2_keywords_hash(env, kwargs));

--- a/src/proc_object.cpp
+++ b/src/proc_object.cpp
@@ -84,7 +84,7 @@ Value ProcObject::source_location() {
     assert(m_block);
     auto file = m_block->env()->file();
     if (file == nullptr) return Value::nil();
-    return new ArrayObject { new StringObject { file }, Value::integer(static_cast<nat_int_t>(m_block->env()->line())) };
+    return new ArrayObject { StringObject::create(file), Value::integer(static_cast<nat_int_t>(m_block->env()->line())) };
 }
 
 StringObject *ProcObject::to_s(Env *env) {
@@ -97,7 +97,7 @@ StringObject *ProcObject::to_s(Env *env) {
     if (m_block->self().is_symbol())
         suffix.append(String::format(" (&:{})", m_block->self().as_symbol()->string()));
     auto str = String::format("#<{}:{}{}>", m_klass->inspect_module(), String::hex(object_id(this), String::HexFormat::LowercaseAndPrefixed), suffix);
-    return new StringObject { std::move(str), Encoding::ASCII_8BIT };
+    return StringObject::create(std::move(str), Encoding::ASCII_8BIT);
 }
 
 }

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -37,7 +37,7 @@ Value ProcessModule::clock_gettime(Env *env, Value clock_id) {
         env->raise_errno();
 
     double result = static_cast<double>(tp.tv_sec) + tp.tv_nsec / static_cast<double>(1000000000);
-    return new FloatObject { result };
+    return FloatObject::create(result);
 }
 
 Value ProcessModule::kill(Env *env, Args &&args) {
@@ -101,7 +101,7 @@ Value ProcessModule::times(Env *env) {
     if (getrusage(RUSAGE_CHILDREN, &rusage_children) == -1)
         env->raise_errno();
     auto tv_to_float = [](const timeval tv) {
-        return new FloatObject { static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) / 1e6 };
+        return FloatObject::create(static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) / 1e6);
     };
     auto utime = tv_to_float(rusage_self.ru_utime);
     auto stime = tv_to_float(rusage_self.ru_stime);

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -53,7 +53,7 @@ Value ProcessModule::kill(Env *env, Args &&args) {
     if (signal.is_integer()) {
         signo = IntegerMethods::convert_to_nat_int_t(env, signal);
     } else if (signal.is_string() || signal.respond_to(env, "to_str"_s)) {
-        auto signame = signal.to_str(env)->delete_prefix(env, new StringObject { "SIG" });
+        auto signame = signal.to_str(env)->delete_prefix(env, StringObject::create("SIG"));
         auto signo_val = SignalModule::list(env).as_hash()->ref(env, signame);
         if (signo_val.is_nil())
             env->raise("ArgumentError", "unsupported signal `SIG{}'", signame.to_s(env)->string());

--- a/src/process_module.cpp
+++ b/src/process_module.cpp
@@ -23,7 +23,7 @@ Value ProcessModule::groups(Env *env) {
     size = getgroups(size, list);
     if (size < 0)
         env->raise_errno();
-    auto result = new ArrayObject { static_cast<size_t>(size) };
+    auto result = ArrayObject::create(static_cast<size_t>(size));
     for (size_t i = 0; i < static_cast<size_t>(size); i++) {
         result->push(Value::integer(list[i]));
     }

--- a/src/random_object.cpp
+++ b/src/random_object.cpp
@@ -32,7 +32,7 @@ Value RandomObject::bytes(Env *env, Value size) {
     for (size_t i = 0; i < blocks; i++)
         output[i] = random_number(*m_generator);
 
-    return new StringObject { reinterpret_cast<char *>(output), static_cast<size_t>(isize), Encoding::ASCII_8BIT };
+    return StringObject::create(reinterpret_cast<char *>(output), static_cast<size_t>(isize), Encoding::ASCII_8BIT);
 }
 
 Value RandomObject::rand(Env *env, Optional<Value> max_arg) {

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -170,7 +170,7 @@ Value RangeObject::to_a(Env *env) {
 
 Value RangeObject::each(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, RangeObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, RangeObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each"_s }, size_block);
     }
 

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -124,9 +124,9 @@ Optional<Value> RangeObject::iterate_over_string_range(Env *env, Function &&func
 
     while ((current = iterator.next()).present()) {
         if constexpr (std::is_void_v<std::invoke_result_t<Function, Value>>) {
-            func(new StringObject { current.value() });
+            func(StringObject::create(current.value()));
         } else {
-            Optional<Value> result = func(new StringObject { current.value() });
+            Optional<Value> result = func(StringObject::create(current.value()));
             if (result)
                 return result;
         }
@@ -214,7 +214,7 @@ Value RangeObject::inspect(Env *env) {
     if (m_exclude_end) {
         if (m_end.is_nil()) {
             if (m_begin.is_nil()) {
-                return new StringObject { "nil...nil" };
+                return StringObject::create("nil...nil");
             } else {
                 return StringObject::format("{}...", m_begin.inspected(env));
             }
@@ -228,7 +228,7 @@ Value RangeObject::inspect(Env *env) {
     } else {
         if (m_end.is_nil()) {
             if (m_begin.is_nil()) {
-                return new StringObject { "nil..nil" };
+                return StringObject::create("nil..nil");
             } else {
                 return StringObject::format("{}..", m_begin.inspected(env));
             }

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -161,7 +161,7 @@ Value RangeObject::to_a(Env *env) {
     if (m_end.is_nil())
         env->raise("RangeError", "cannot convert endless range to an array");
 
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     iterate_over_range(env, [&](Value item) {
         ary->push(item);
     });
@@ -195,7 +195,7 @@ Value RangeObject::first(Env *env, Optional<Value> n) {
             env->raise("ArgumentError", "negative array size (or size too big)");
         }
 
-        ArrayObject *ary = new ArrayObject { (size_t)count };
+        ArrayObject *ary = ArrayObject::create((size_t)count);
         iterate_over_range(env, [&](Value item) -> Optional<Value> {
             if (count == 0) return n.value();
 

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -66,19 +66,19 @@ Value RationalObject::cmp(Env *env, Value other) {
 
 Value RationalObject::coerce(Env *env, Value other) {
     if (other.is_integer()) {
-        return new ArrayObject { new RationalObject(other.integer(), Value::integer(1)), this };
+        return ArrayObject::create({ new RationalObject(other.integer(), Value::integer(1)), this });
     } else if (other.is_float()) {
-        return new ArrayObject { other, this->to_f(env) };
+        return ArrayObject::create({ other, this->to_f(env) });
     } else if (other.is_rational()) {
-        return new ArrayObject { other, this };
+        return ArrayObject::create({ other, this });
     } else if (other.is_complex()) {
         auto complex = other.as_complex();
         if (complex->imaginary().integer().is_zero()) {
             auto a = new RationalObject { complex->real(), Value::integer(1) };
             auto b = new ComplexObject(this);
-            return new ArrayObject { a, b };
+            return ArrayObject::create({ a, b });
         } else {
-            return new ArrayObject { other, new ComplexObject(this) };
+            return ArrayObject::create({ other, new ComplexObject(this) });
         }
     }
 
@@ -160,7 +160,7 @@ Value RationalObject::inspect(Env *env) {
 }
 
 Value RationalObject::marshal_dump(Env *env) {
-    return new ArrayObject { m_numerator, m_denominator };
+    return ArrayObject::create({ m_numerator, m_denominator });
 }
 
 Value RationalObject::mul(Env *env, Value other) {

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -75,10 +75,10 @@ Value RationalObject::coerce(Env *env, Value other) {
         auto complex = other.as_complex();
         if (complex->imaginary().integer().is_zero()) {
             auto a = RationalObject::create(complex->real(), Value::integer(1));
-            auto b = new ComplexObject(this);
+            auto b = ComplexObject::create(this);
             return ArrayObject::create({ a, b });
         } else {
-            return ArrayObject::create({ other, new ComplexObject(this) });
+            return ArrayObject::create({ other, ComplexObject::create(this) });
         }
     }
 

--- a/src/rational_object.cpp
+++ b/src/rational_object.cpp
@@ -16,13 +16,13 @@ RationalObject *RationalObject::create(Env *env, Integer numerator, Integer deno
     numerator = numerator / gcd;
     denominator = denominator / gcd;
 
-    return new RationalObject { numerator, denominator };
+    return RationalObject::create(numerator, denominator);
 }
 
 Value RationalObject::add(Env *env, Value other) {
     if (other.is_integer()) {
         auto numerator = m_numerator + (m_denominator * other.integer());
-        return new RationalObject { numerator, m_denominator };
+        return RationalObject::create(numerator, m_denominator);
     } else if (other.is_float()) {
         return this->to_f(env).as_float()->add(env, other);
     } else if (other.is_rational()) {
@@ -45,7 +45,7 @@ Value RationalObject::cmp(Env *env, Value other) {
     if (other.is_integer()) {
         if (m_denominator == 1)
             return IntegerMethods::cmp(env, m_numerator, other.integer());
-        other = new RationalObject { other.integer(), Value::integer(1) };
+        other = RationalObject::create(other.integer(), Value::integer(1));
     }
     if (other.is_rational()) {
         auto rational = other.as_rational();
@@ -66,7 +66,7 @@ Value RationalObject::cmp(Env *env, Value other) {
 
 Value RationalObject::coerce(Env *env, Value other) {
     if (other.is_integer()) {
-        return ArrayObject::create({ new RationalObject(other.integer(), Value::integer(1)), this });
+        return ArrayObject::create({ RationalObject::create(other.integer(), Value::integer(1)), this });
     } else if (other.is_float()) {
         return ArrayObject::create({ other, this->to_f(env) });
     } else if (other.is_rational()) {
@@ -74,7 +74,7 @@ Value RationalObject::coerce(Env *env, Value other) {
     } else if (other.is_complex()) {
         auto complex = other.as_complex();
         if (complex->imaginary().integer().is_zero()) {
-            auto a = new RationalObject { complex->real(), Value::integer(1) };
+            auto a = RationalObject::create(complex->real(), Value::integer(1));
             auto b = new ComplexObject(this);
             return ArrayObject::create({ a, b });
         } else {
@@ -165,7 +165,7 @@ Value RationalObject::marshal_dump(Env *env) {
 
 Value RationalObject::mul(Env *env, Value other) {
     if (other.is_integer())
-        other = new RationalObject { other.integer(), Value::integer(1) };
+        other = RationalObject::create(other.integer(), Value::integer(1));
 
     if (other.is_rational()) {
         auto num1 = other.as_rational()->numerator(env).integer();
@@ -236,7 +236,7 @@ Value RationalObject::pow(Env *env, Value other) {
 Value RationalObject::sub(Env *env, Value other) {
     if (other.is_integer()) {
         auto numerator = m_numerator - m_denominator * other.integer();
-        return new RationalObject { numerator, m_denominator };
+        return RationalObject::create(numerator, m_denominator);
     } else if (other.is_float()) {
         return this->to_f(env).as_float()->sub(env, other);
     } else if (other.is_rational()) {

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -538,9 +538,9 @@ bool RegexpObject::has_match(Env *env, Value other, Optional<Value> start) {
 
 Value RegexpObject::named_captures(Env *env) const {
     if (!m_regex)
-        return new HashObject {};
+        return HashObject::create();
 
-    auto named_captures = new HashObject {};
+    auto named_captures = HashObject::create();
     named_captures_data data { env, named_captures };
     onig_foreach_name(
         m_regex,

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -201,7 +201,7 @@ Value RegexpObject::regexp_union(Env *env, Args &&args) {
             out.append(quoted.as_string()->string());
         }
     }
-    return new RegexpObject { env, out };
+    return RegexpObject::create(env, out);
 }
 
 Value RegexpObject::initialize(Env *env, Value pattern, Optional<Value> opts_arg) {

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -549,7 +549,7 @@ Value RegexpObject::named_captures(Env *env) const {
             auto named_captures = (static_cast<named_captures_data *>(data))->named_captures;
             const size_t length = name_end - name;
             auto key = StringObject::create(reinterpret_cast<const char *>(name), length, onig_encoding_to_ruby_encoding(regex->enc));
-            auto values = new ArrayObject { static_cast<size_t>(groups_size) };
+            auto values = ArrayObject::create(static_cast<size_t>(groups_size));
             for (size_t i = 0; i < static_cast<size_t>(groups_size); i++)
                 values->push(Value::integer(groups[i]));
             named_captures->put(env, key, values);
@@ -561,9 +561,9 @@ Value RegexpObject::named_captures(Env *env) const {
 
 Value RegexpObject::names() const {
     if (!m_regex)
-        return new ArrayObject {};
+        return ArrayObject::create();
 
-    auto names = new ArrayObject { static_cast<size_t>(onig_number_of_names(m_regex)) };
+    auto names = ArrayObject::create(static_cast<size_t>(onig_number_of_names(m_regex)));
     onig_foreach_name(
         m_regex,
         [](const UChar *name, const UChar *name_end, int, int *, regex_t *regex, void *data) -> int {

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -162,7 +162,7 @@ Value RegexpObject::quote(Env *env, Value string) {
         encoding = EncodingObject::get(Encoding::US_ASCII);
     else if (str->valid_encoding())
         encoding = str->encoding();
-    return new StringObject { std::move(out), encoding };
+    return StringObject::create(std::move(out), encoding);
 }
 
 Value RegexpObject::try_convert(Env *env, Value value) {
@@ -425,7 +425,7 @@ void RegexpObject::initialize_internal(Env *env, const StringObject *pattern, in
 Value RegexpObject::inspect(Env *env) {
     if (!is_initialized())
         return KernelModule::inspect(env, this);
-    StringObject *out = new StringObject { "/" };
+    StringObject *out = StringObject::create("/");
     auto str = pattern();
     size_t len = str->length();
     regexp_stringify(str->string(), 0, len, out);
@@ -548,7 +548,7 @@ Value RegexpObject::named_captures(Env *env) const {
             auto env = (static_cast<named_captures_data *>(data))->env;
             auto named_captures = (static_cast<named_captures_data *>(data))->named_captures;
             const size_t length = name_end - name;
-            auto key = new StringObject { reinterpret_cast<const char *>(name), length, onig_encoding_to_ruby_encoding(regex->enc) };
+            auto key = StringObject::create(reinterpret_cast<const char *>(name), length, onig_encoding_to_ruby_encoding(regex->enc));
             auto values = new ArrayObject { static_cast<size_t>(groups_size) };
             for (size_t i = 0; i < static_cast<size_t>(groups_size); i++)
                 values->push(Value::integer(groups[i]));
@@ -569,7 +569,7 @@ Value RegexpObject::names() const {
         [](const UChar *name, const UChar *name_end, int, int *, regex_t *regex, void *data) -> int {
             auto names = static_cast<ArrayObject *>(data);
             const size_t length = name_end - name;
-            names->push(new StringObject { reinterpret_cast<const char *>(name), length, onig_encoding_to_ruby_encoding(regex->enc) });
+            names->push(StringObject::create(reinterpret_cast<const char *>(name), length, onig_encoding_to_ruby_encoding(regex->enc)));
             return 0;
         },
         names);
@@ -603,12 +603,12 @@ long RegexpObject::search(Env *env, const StringObject *string_obj, long start, 
 Value RegexpObject::source(Env *env) const {
     assert_initialized(env);
     assert(m_pattern);
-    return new StringObject(*m_pattern);
+    return StringObject::create(*m_pattern);
 }
 
 Value RegexpObject::to_s(Env *env) const {
     assert_initialized(env);
-    StringObject *out = new StringObject { "(" };
+    StringObject *out = StringObject::create("(");
 
     auto is_m = options() & RegexOpts::MultiLine;
     auto is_i = options() & RegexOpts::IgnoreCase;

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -490,7 +490,7 @@ Value RegexpObject::match_at_byte_offset(Env *env, StringObject *str, size_t byt
     int result = search(env, str, byte_index, region, ONIG_OPTION_NONE);
 
     if (result >= 0) {
-        auto match = new MatchDataObject { region, str, this };
+        auto match = MatchDataObject::create(region, str, this);
         caller_env->set_last_match(match);
 
         return match;

--- a/src/signal_module.cpp
+++ b/src/signal_module.cpp
@@ -5,144 +5,144 @@
 namespace Natalie {
 
 Value SignalModule::list(Env *env) {
-    return new HashObject { env, {
-                                     StringObject::create("EXIT"),
-                                     Value::integer(static_cast<nat_int_t>(0)),
-                                     StringObject::create("HUP"),
-                                     Value::integer(static_cast<nat_int_t>(SIGHUP)),
-                                     StringObject::create("INT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGINT)),
-                                     StringObject::create("QUIT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGQUIT)),
-                                     StringObject::create("ILL"),
-                                     Value::integer(static_cast<nat_int_t>(SIGILL)),
+    return HashObject::create(env, {
+                                       StringObject::create("EXIT"),
+                                       Value::integer(static_cast<nat_int_t>(0)),
+                                       StringObject::create("HUP"),
+                                       Value::integer(static_cast<nat_int_t>(SIGHUP)),
+                                       StringObject::create("INT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGINT)),
+                                       StringObject::create("QUIT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGQUIT)),
+                                       StringObject::create("ILL"),
+                                       Value::integer(static_cast<nat_int_t>(SIGILL)),
 #ifdef SIGTRAP
-                                     StringObject::create("TRAP"),
-                                     Value::integer(static_cast<nat_int_t>(SIGTRAP)),
+                                       StringObject::create("TRAP"),
+                                       Value::integer(static_cast<nat_int_t>(SIGTRAP)),
 #endif
-                                     StringObject::create("ABRT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGABRT)),
+                                       StringObject::create("ABRT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGABRT)),
 #ifdef SIGIOT
-                                     StringObject::create("IOT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGIOT)),
+                                       StringObject::create("IOT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGIOT)),
 #endif
 #ifdef SIGEMT
-                                     StringObject::create("EMT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGEMT)),
+                                       StringObject::create("EMT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGEMT)),
 #endif
-                                     StringObject::create("FPE"),
-                                     Value::integer(static_cast<nat_int_t>(SIGFPE)),
-                                     StringObject::create("KILL"),
-                                     Value::integer(static_cast<nat_int_t>(SIGKILL)),
+                                       StringObject::create("FPE"),
+                                       Value::integer(static_cast<nat_int_t>(SIGFPE)),
+                                       StringObject::create("KILL"),
+                                       Value::integer(static_cast<nat_int_t>(SIGKILL)),
 #ifdef SIGBUS
-                                     StringObject::create("BUS"),
-                                     Value::integer(static_cast<nat_int_t>(SIGBUS)),
+                                       StringObject::create("BUS"),
+                                       Value::integer(static_cast<nat_int_t>(SIGBUS)),
 #endif
-                                     StringObject::create("SEGV"),
-                                     Value::integer(static_cast<nat_int_t>(SIGSEGV)),
-                                     StringObject::create("SYS"),
-                                     Value::integer(static_cast<nat_int_t>(SIGSYS)),
-                                     StringObject::create("PIPE"),
-                                     Value::integer(static_cast<nat_int_t>(SIGPIPE)),
-                                     StringObject::create("ALRM"),
-                                     Value::integer(static_cast<nat_int_t>(SIGALRM)),
-                                     StringObject::create("TERM"),
-                                     Value::integer(static_cast<nat_int_t>(SIGTERM)),
+                                       StringObject::create("SEGV"),
+                                       Value::integer(static_cast<nat_int_t>(SIGSEGV)),
+                                       StringObject::create("SYS"),
+                                       Value::integer(static_cast<nat_int_t>(SIGSYS)),
+                                       StringObject::create("PIPE"),
+                                       Value::integer(static_cast<nat_int_t>(SIGPIPE)),
+                                       StringObject::create("ALRM"),
+                                       Value::integer(static_cast<nat_int_t>(SIGALRM)),
+                                       StringObject::create("TERM"),
+                                       Value::integer(static_cast<nat_int_t>(SIGTERM)),
 #ifdef SIGURG
-                                     StringObject::create("URG"),
-                                     Value::integer(static_cast<nat_int_t>(SIGURG)),
+                                       StringObject::create("URG"),
+                                       Value::integer(static_cast<nat_int_t>(SIGURG)),
 #endif
-                                     StringObject::create("STOP"),
-                                     Value::integer(static_cast<nat_int_t>(SIGSTOP)),
-                                     StringObject::create("TSTP"),
-                                     Value::integer(static_cast<nat_int_t>(SIGTSTP)),
-                                     StringObject::create("CONT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGCONT)),
-                                     StringObject::create("CHLD"),
-                                     Value::integer(static_cast<nat_int_t>(SIGCHLD)),
-                                     StringObject::create("CLD"),
+                                       StringObject::create("STOP"),
+                                       Value::integer(static_cast<nat_int_t>(SIGSTOP)),
+                                       StringObject::create("TSTP"),
+                                       Value::integer(static_cast<nat_int_t>(SIGTSTP)),
+                                       StringObject::create("CONT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGCONT)),
+                                       StringObject::create("CHLD"),
+                                       Value::integer(static_cast<nat_int_t>(SIGCHLD)),
+                                       StringObject::create("CLD"),
 #ifdef SIGCLD
-                                     Value::integer(static_cast<nat_int_t>(SIGCLD)),
+                                       Value::integer(static_cast<nat_int_t>(SIGCLD)),
 #else
-                                     Value::integer(static_cast<nat_int_t>(SIGCHLD)),
+                                       Value::integer(static_cast<nat_int_t>(SIGCHLD)),
 #endif
-                                     StringObject::create("TTIN"),
-                                     Value::integer(static_cast<nat_int_t>(SIGTTIN)),
-                                     StringObject::create("TTOU"),
-                                     Value::integer(static_cast<nat_int_t>(SIGTTOU)),
+                                       StringObject::create("TTIN"),
+                                       Value::integer(static_cast<nat_int_t>(SIGTTIN)),
+                                       StringObject::create("TTOU"),
+                                       Value::integer(static_cast<nat_int_t>(SIGTTOU)),
 #ifdef SIGIO
-                                     StringObject::create("IO"),
-                                     Value::integer(static_cast<nat_int_t>(SIGIO)),
+                                       StringObject::create("IO"),
+                                       Value::integer(static_cast<nat_int_t>(SIGIO)),
 #endif
 #ifdef SIGXCPU
-                                     StringObject::create("XCPU"),
-                                     Value::integer(static_cast<nat_int_t>(SIGXCPU)),
+                                       StringObject::create("XCPU"),
+                                       Value::integer(static_cast<nat_int_t>(SIGXCPU)),
 #endif
 #ifdef SIGXFSZ
-                                     StringObject::create("XFSZ"),
-                                     Value::integer(static_cast<nat_int_t>(SIGXFSZ)),
+                                       StringObject::create("XFSZ"),
+                                       Value::integer(static_cast<nat_int_t>(SIGXFSZ)),
 #endif
 #ifdef SIGVTALRM
-                                     StringObject::create("VTALRM"),
-                                     Value::integer(static_cast<nat_int_t>(SIGVTALRM)),
+                                       StringObject::create("VTALRM"),
+                                       Value::integer(static_cast<nat_int_t>(SIGVTALRM)),
 #endif
 #ifdef SIGPROF
-                                     StringObject::create("PROF"),
-                                     Value::integer(static_cast<nat_int_t>(SIGPROF)),
+                                       StringObject::create("PROF"),
+                                       Value::integer(static_cast<nat_int_t>(SIGPROF)),
 #endif
 #ifdef SIGWINCH
-                                     StringObject::create("WINCH"),
-                                     Value::integer(static_cast<nat_int_t>(SIGWINCH)),
+                                       StringObject::create("WINCH"),
+                                       Value::integer(static_cast<nat_int_t>(SIGWINCH)),
 #endif
-                                     StringObject::create("USR1"),
-                                     Value::integer(static_cast<nat_int_t>(SIGUSR1)),
-                                     StringObject::create("USR2"),
-                                     Value::integer(static_cast<nat_int_t>(SIGUSR2)),
+                                       StringObject::create("USR1"),
+                                       Value::integer(static_cast<nat_int_t>(SIGUSR1)),
+                                       StringObject::create("USR2"),
+                                       Value::integer(static_cast<nat_int_t>(SIGUSR2)),
 #ifdef SIGLOST
-                                     StringObject::create("LOST"),
-                                     Value::integer(static_cast<nat_int_t>(SIGLOST)),
+                                       StringObject::create("LOST"),
+                                       Value::integer(static_cast<nat_int_t>(SIGLOST)),
 #endif
 #ifdef SIGMSG
-                                     StringObject::create("MSG"),
-                                     Value::integer(static_cast<nat_int_t>(SIGMSG)),
+                                       StringObject::create("MSG"),
+                                       Value::integer(static_cast<nat_int_t>(SIGMSG)),
 #endif
 #ifdef SIGPWR
-                                     StringObject::create("PWR"),
-                                     Value::integer(static_cast<nat_int_t>(SIGPWR)),
+                                       StringObject::create("PWR"),
+                                       Value::integer(static_cast<nat_int_t>(SIGPWR)),
 #endif
 #ifdef SIGPOLL
-                                     StringObject::create("POLL"),
-                                     Value::integer(static_cast<nat_int_t>(SIGPOLL)),
+                                       StringObject::create("POLL"),
+                                       Value::integer(static_cast<nat_int_t>(SIGPOLL)),
 #endif
 #ifdef SIGDANGER
-                                     StringObject::create("DANGER"),
-                                     Value::integer(static_cast<nat_int_t>(SIGDANGER)),
+                                       StringObject::create("DANGER"),
+                                       Value::integer(static_cast<nat_int_t>(SIGDANGER)),
 #endif
 #ifdef SIGMIGRATE
-                                     StringObject::create("MIGRATE"),
-                                     Value::integer(static_cast<nat_int_t>(SIGMIGRATE)),
+                                       StringObject::create("MIGRATE"),
+                                       Value::integer(static_cast<nat_int_t>(SIGMIGRATE)),
 #endif
 #ifdef SIGPRE
-                                     StringObject::create("PRE"),
-                                     Value::integer(static_cast<nat_int_t>(SIGPRE)),
+                                       StringObject::create("PRE"),
+                                       Value::integer(static_cast<nat_int_t>(SIGPRE)),
 #endif
 #ifdef SIGGRANT
-                                     StringObject::create("GRANT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGGRANT)),
+                                       StringObject::create("GRANT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGGRANT)),
 #endif
 #ifdef SIGRETRACT
-                                     StringObject::create("RETRACT"),
-                                     Value::integer(static_cast<nat_int_t>(SIGRETRACT)),
-#ifdef SIGSOUND
+                                       StringObject::create("RETRACT"),
+                                       Value::integer(static_cast<nat_int_t>(SIGRETRACT)),
 #endif
-                                     StringObject::create("SOUND"),
-                                     Value::integer(static_cast<nat_int_t>(SIGSOUND)),
+#ifdef SIGSOUND
+                                       StringObject::create("SOUND"),
+                                       Value::integer(static_cast<nat_int_t>(SIGSOUND)),
 #endif
 #ifdef SIGINFO
-                                     StringObject::create("INFO"),
-                                     Value::integer(static_cast<nat_int_t>(SIGINFO)),
+                                       StringObject::create("INFO"),
+                                       Value::integer(static_cast<nat_int_t>(SIGINFO)),
 #endif
-                                 } };
+                                   });
 }
 
 Value SignalModule::signame(Env *env, Value signal) {

--- a/src/signal_module.cpp
+++ b/src/signal_module.cpp
@@ -6,140 +6,140 @@ namespace Natalie {
 
 Value SignalModule::list(Env *env) {
     return new HashObject { env, {
-                                     new StringObject { "EXIT" },
+                                     StringObject::create("EXIT"),
                                      Value::integer(static_cast<nat_int_t>(0)),
-                                     new StringObject { "HUP" },
+                                     StringObject::create("HUP"),
                                      Value::integer(static_cast<nat_int_t>(SIGHUP)),
-                                     new StringObject { "INT" },
+                                     StringObject::create("INT"),
                                      Value::integer(static_cast<nat_int_t>(SIGINT)),
-                                     new StringObject { "QUIT" },
+                                     StringObject::create("QUIT"),
                                      Value::integer(static_cast<nat_int_t>(SIGQUIT)),
-                                     new StringObject { "ILL" },
+                                     StringObject::create("ILL"),
                                      Value::integer(static_cast<nat_int_t>(SIGILL)),
 #ifdef SIGTRAP
-                                     new StringObject { "TRAP" },
+                                     StringObject::create("TRAP"),
                                      Value::integer(static_cast<nat_int_t>(SIGTRAP)),
 #endif
-                                     new StringObject { "ABRT" },
+                                     StringObject::create("ABRT"),
                                      Value::integer(static_cast<nat_int_t>(SIGABRT)),
 #ifdef SIGIOT
-                                     new StringObject { "IOT" },
+                                     StringObject::create("IOT"),
                                      Value::integer(static_cast<nat_int_t>(SIGIOT)),
 #endif
 #ifdef SIGEMT
-                                     new StringObject { "EMT" },
+                                     StringObject::create("EMT"),
                                      Value::integer(static_cast<nat_int_t>(SIGEMT)),
 #endif
-                                     new StringObject { "FPE" },
+                                     StringObject::create("FPE"),
                                      Value::integer(static_cast<nat_int_t>(SIGFPE)),
-                                     new StringObject { "KILL" },
+                                     StringObject::create("KILL"),
                                      Value::integer(static_cast<nat_int_t>(SIGKILL)),
 #ifdef SIGBUS
-                                     new StringObject { "BUS" },
+                                     StringObject::create("BUS"),
                                      Value::integer(static_cast<nat_int_t>(SIGBUS)),
 #endif
-                                     new StringObject { "SEGV" },
+                                     StringObject::create("SEGV"),
                                      Value::integer(static_cast<nat_int_t>(SIGSEGV)),
-                                     new StringObject { "SYS" },
+                                     StringObject::create("SYS"),
                                      Value::integer(static_cast<nat_int_t>(SIGSYS)),
-                                     new StringObject { "PIPE" },
+                                     StringObject::create("PIPE"),
                                      Value::integer(static_cast<nat_int_t>(SIGPIPE)),
-                                     new StringObject { "ALRM" },
+                                     StringObject::create("ALRM"),
                                      Value::integer(static_cast<nat_int_t>(SIGALRM)),
-                                     new StringObject { "TERM" },
+                                     StringObject::create("TERM"),
                                      Value::integer(static_cast<nat_int_t>(SIGTERM)),
 #ifdef SIGURG
-                                     new StringObject { "URG" },
+                                     StringObject::create("URG"),
                                      Value::integer(static_cast<nat_int_t>(SIGURG)),
 #endif
-                                     new StringObject { "STOP" },
+                                     StringObject::create("STOP"),
                                      Value::integer(static_cast<nat_int_t>(SIGSTOP)),
-                                     new StringObject { "TSTP" },
+                                     StringObject::create("TSTP"),
                                      Value::integer(static_cast<nat_int_t>(SIGTSTP)),
-                                     new StringObject { "CONT" },
+                                     StringObject::create("CONT"),
                                      Value::integer(static_cast<nat_int_t>(SIGCONT)),
-                                     new StringObject { "CHLD" },
+                                     StringObject::create("CHLD"),
                                      Value::integer(static_cast<nat_int_t>(SIGCHLD)),
-                                     new StringObject { "CLD" },
+                                     StringObject::create("CLD"),
 #ifdef SIGCLD
                                      Value::integer(static_cast<nat_int_t>(SIGCLD)),
 #else
                                      Value::integer(static_cast<nat_int_t>(SIGCHLD)),
 #endif
-                                     new StringObject { "TTIN" },
+                                     StringObject::create("TTIN"),
                                      Value::integer(static_cast<nat_int_t>(SIGTTIN)),
-                                     new StringObject { "TTOU" },
+                                     StringObject::create("TTOU"),
                                      Value::integer(static_cast<nat_int_t>(SIGTTOU)),
 #ifdef SIGIO
-                                     new StringObject { "IO" },
+                                     StringObject::create("IO"),
                                      Value::integer(static_cast<nat_int_t>(SIGIO)),
 #endif
 #ifdef SIGXCPU
-                                     new StringObject { "XCPU" },
+                                     StringObject::create("XCPU"),
                                      Value::integer(static_cast<nat_int_t>(SIGXCPU)),
 #endif
 #ifdef SIGXFSZ
-                                     new StringObject { "XFSZ" },
+                                     StringObject::create("XFSZ"),
                                      Value::integer(static_cast<nat_int_t>(SIGXFSZ)),
 #endif
 #ifdef SIGVTALRM
-                                     new StringObject { "VTALRM" },
+                                     StringObject::create("VTALRM"),
                                      Value::integer(static_cast<nat_int_t>(SIGVTALRM)),
 #endif
 #ifdef SIGPROF
-                                     new StringObject { "PROF" },
+                                     StringObject::create("PROF"),
                                      Value::integer(static_cast<nat_int_t>(SIGPROF)),
 #endif
 #ifdef SIGWINCH
-                                     new StringObject { "WINCH" },
+                                     StringObject::create("WINCH"),
                                      Value::integer(static_cast<nat_int_t>(SIGWINCH)),
 #endif
-                                     new StringObject { "USR1" },
+                                     StringObject::create("USR1"),
                                      Value::integer(static_cast<nat_int_t>(SIGUSR1)),
-                                     new StringObject { "USR2" },
+                                     StringObject::create("USR2"),
                                      Value::integer(static_cast<nat_int_t>(SIGUSR2)),
 #ifdef SIGLOST
-                                     new StringObject { "LOST" },
+                                     StringObject::create("LOST"),
                                      Value::integer(static_cast<nat_int_t>(SIGLOST)),
 #endif
 #ifdef SIGMSG
-                                     new StringObject { "MSG" },
+                                     StringObject::create("MSG"),
                                      Value::integer(static_cast<nat_int_t>(SIGMSG)),
 #endif
 #ifdef SIGPWR
-                                     new StringObject { "PWR" },
+                                     StringObject::create("PWR"),
                                      Value::integer(static_cast<nat_int_t>(SIGPWR)),
 #endif
 #ifdef SIGPOLL
-                                     new StringObject { "POLL" },
+                                     StringObject::create("POLL"),
                                      Value::integer(static_cast<nat_int_t>(SIGPOLL)),
 #endif
 #ifdef SIGDANGER
-                                     new StringObject { "DANGER" },
+                                     StringObject::create("DANGER"),
                                      Value::integer(static_cast<nat_int_t>(SIGDANGER)),
 #endif
 #ifdef SIGMIGRATE
-                                     new StringObject { "MIGRATE" },
+                                     StringObject::create("MIGRATE"),
                                      Value::integer(static_cast<nat_int_t>(SIGMIGRATE)),
 #endif
 #ifdef SIGPRE
-                                     new StringObject { "PRE" },
+                                     StringObject::create("PRE"),
                                      Value::integer(static_cast<nat_int_t>(SIGPRE)),
 #endif
 #ifdef SIGGRANT
-                                     new StringObject { "GRANT" },
+                                     StringObject::create("GRANT"),
                                      Value::integer(static_cast<nat_int_t>(SIGGRANT)),
 #endif
 #ifdef SIGRETRACT
-                                     new StringObject { "RETRACT" },
+                                     StringObject::create("RETRACT"),
                                      Value::integer(static_cast<nat_int_t>(SIGRETRACT)),
 #ifdef SIGSOUND
 #endif
-                                     new StringObject { "SOUND" },
+                                     StringObject::create("SOUND"),
                                      Value::integer(static_cast<nat_int_t>(SIGSOUND)),
 #endif
 #ifdef SIGINFO
-                                     new StringObject { "INFO" },
+                                     StringObject::create("INFO"),
                                      Value::integer(static_cast<nat_int_t>(SIGINFO)),
 #endif
                                  } };

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -144,7 +144,7 @@ StringView StringObject::next_char(Env *env, size_t *index) const {
 
 Value StringObject::each_char(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, StringObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_char"_s }, size_block);
     }
 
@@ -171,7 +171,7 @@ Value StringObject::chars(Env *env, Block *block) {
 
 Value StringObject::each_codepoint(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, StringObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_codepoint"_s }, size_block);
     }
 
@@ -221,7 +221,7 @@ Value StringObject::codepoints(Env *env, Block *block) {
 
 Value StringObject::each_grapheme_cluster(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, StringObject::size_fn, 0 };
+        Block *size_block = Block::create(*env, this, StringObject::size_fn, 0);
         return send(env, "enum_for"_s, { "each_grapheme_cluster"_s }, size_block);
     }
 
@@ -1252,7 +1252,7 @@ Value StringObject::bytes(Env *env, Block *block) {
 
 Value StringObject::each_byte(Env *env, Block *block) {
     if (!block) {
-        Block *size_block = new Block { *env, this, StringObject::bytesize_fn, 0 };
+        Block *size_block = Block::create(*env, this, StringObject::bytesize_fn, 0);
         return send(env, "enum_for"_s, { "each_byte"_s }, size_block);
     }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3332,7 +3332,7 @@ Value StringObject::each_line(Env *env, Optional<Value> separator_arg, Optional<
             args.push(separator_arg.value());
         auto do_chomp = chomp ? chomp.value().is_truthy() : false;
         if (do_chomp) {
-            auto hash = new HashObject {};
+            auto hash = HashObject::create();
             hash->put(env, "chomp"_s, chomp.value_or(Value::False()));
             args.push(hash);
         }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -4,7 +4,6 @@
 #include "natalie/crypt.h"
 #include "natalie/integer_methods.hpp"
 #include "natalie/number_parser.hpp"
-#include "natalie/object_type.hpp"
 #include "natalie/string_unpacker.hpp"
 #include "string.h"
 
@@ -67,7 +66,7 @@ static auto character_class_handler(Env *env, Args &&args) {
                 if (last_character.cmp(next_value) == 1)
                     env->raise("ArgumentError", "invalid range \"{}-{}\" in string transliteration", last_character, next_value);
 
-                auto range = RangeObject::create(env, new StringObject { last_character }, new StringObject { next_value }, false);
+                auto range = RangeObject::create(env, StringObject::create(last_character), StringObject::create(next_value), false);
                 auto all_chars = range->to_a(env).as_array();
                 for (auto character : *all_chars) {
                     auto character_string = character.as_string()->string();
@@ -150,7 +149,7 @@ Value StringObject::each_char(Env *env, Block *block) {
     }
 
     for (auto c : *this) {
-        Value args[] = { new StringObject { c, m_encoding } };
+        Value args[] = { StringObject::create(c, m_encoding) };
         block->run(env, Args(1, args), nullptr);
     }
     return this;
@@ -159,14 +158,14 @@ Value StringObject::each_char(Env *env, Block *block) {
 Value StringObject::chars(Env *env, Block *block) {
     if (block) {
         for (auto c : *this) {
-            auto str = new StringObject { c, m_encoding };
+            auto str = StringObject::create(c, m_encoding);
             block->run(env, Args({ str }), nullptr);
         }
         return this;
     }
     ArrayObject *ary = new ArrayObject {};
     for (auto c : *this)
-        ary->push(new StringObject { c, m_encoding });
+        ary->push(StringObject::create(c, m_encoding));
     return ary;
 }
 
@@ -231,7 +230,7 @@ Value StringObject::each_grapheme_cluster(Env *env, Block *block) {
         auto view = m_encoding->next_grapheme_cluster(m_string, &index);
         if (view.is_empty())
             break;
-        Value args[] = { new StringObject { view, m_encoding } };
+        Value args[] = { StringObject::create(view, m_encoding) };
         block->run(env, Args(1, args), nullptr);
     }
     return this;
@@ -247,7 +246,7 @@ Value StringObject::grapheme_clusters(Env *env, Block *block) {
         auto view = m_encoding->next_grapheme_cluster(m_string, &index);
         if (view.is_empty())
             break;
-        ary->push(new StringObject { view, m_encoding });
+        ary->push(StringObject::create(view, m_encoding));
     }
     return ary;
 }
@@ -293,11 +292,11 @@ Value StringObject::center(Env *env, Value length, Optional<Value> pad_arg) {
     result.prepend(create_padding(pad, left_split));
     result.append(create_padding(pad, right_split));
 
-    return new StringObject { result, m_encoding };
+    return StringObject::create(result, m_encoding);
 }
 
 Value StringObject::chomp(Env *env, Optional<Value> record_separator) const {
-    auto new_str = new StringObject { m_string, m_encoding };
+    auto new_str = StringObject::create(m_string, m_encoding);
     new_str->chomp_in_place(env, record_separator);
     return new_str;
 }
@@ -433,11 +432,11 @@ Value StringObject::chomp_in_place(Env *env, Optional<Value> record_separator) {
 
 Value StringObject::chr(Env *env) {
     if (this->is_empty()) {
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     }
     size_t index = 0;
     auto c = next_char(&index);
-    return new StringObject { c, m_encoding };
+    return StringObject::create(c, m_encoding);
 }
 
 SymbolObject *StringObject::to_symbol(Env *env) const {
@@ -449,7 +448,7 @@ Value StringObject::to_sym(Env *env) const {
 }
 
 Value StringObject::tr(Env *env, Value from_value, Value to_value) const {
-    auto copy = new StringObject { m_string, m_encoding };
+    auto copy = StringObject::create(m_string, m_encoding);
     copy->tr_in_place(env, from_value, to_value);
     return copy;
 }
@@ -608,7 +607,7 @@ StringObject *StringObject::inspect(Env *env) const {
 
     out.append_char('"');
 
-    return new StringObject { std::move(out) };
+    return StringObject::create(std::move(out));
 }
 
 String StringObject::dbg_inspect(int indent) const {
@@ -617,7 +616,7 @@ String StringObject::dbg_inspect(int indent) const {
 
 StringObject *StringObject::successive(Env *env) {
     auto str = m_string.successive();
-    return new StringObject { str, m_encoding };
+    return StringObject::create(str, m_encoding);
 }
 
 StringObject *StringObject::successive_in_place(Env *env) {
@@ -630,14 +629,14 @@ StringObject *StringObject::to_s() {
     if (m_klass == GlobalEnv::the()->String()) {
         return this;
     } else {
-        return new StringObject { m_string, m_encoding };
+        return StringObject::create(m_string, m_encoding);
     }
 }
 
 bool StringObject::internal_start_with(Env *env, Value needle) {
     if (needle.is_regexp()) {
         needle = needle.as_regexp()->to_s(env);
-        needle.as_string()->prepend(env, { new StringObject { "\\A" } });
+        needle.as_string()->prepend(env, { StringObject::create("\\A") });
         needle = new RegexpObject { env, needle.as_string()->string() };
         return needle.as_regexp()->match(env, this).is_truthy();
     }
@@ -663,7 +662,7 @@ bool StringObject::end_with(Env *env, Value needle) const {
     needle.assert_type(env, Object::Type::String, "String");
     if (length() < needle.as_string()->length())
         return false;
-    auto from_end = new StringObject { c_str() + length() - needle.as_string()->length() };
+    auto from_end = StringObject::create(c_str() + length() - needle.as_string()->length());
     nat_int_t i = from_end->index_int(env, needle, 0);
     return i == 0;
 }
@@ -962,7 +961,7 @@ Value StringObject::ltlt(Env *env, Value arg) {
 
 Value StringObject::add(Env *env, Value arg) const {
     StringObject *str = arg.to_str(env);
-    StringObject *new_string = new StringObject { m_string, m_encoding };
+    StringObject *new_string = StringObject::create(m_string, m_encoding);
     Value args[] = { str };
     new_string->concat(env, Args(1, args));
     return new_string;
@@ -1001,7 +1000,7 @@ Value StringObject::mul(Env *env, Value arg) const {
         for (nat_int_t i = 0; i < nat_int; i++)
             new_string.replace_bytes(i * length(), length(), string());
     }
-    return new StringObject { std::move(new_string), m_encoding };
+    return StringObject::create(std::move(new_string), m_encoding);
 }
 
 Value StringObject::clear(Env *env) {
@@ -1052,7 +1051,7 @@ Value StringObject::cmp(Env *env, Value other) {
 Value StringObject::concat(Env *env, Args &&args) {
     assert_not_frozen(env);
 
-    StringObject *original = new StringObject(*this);
+    StringObject *original = StringObject::create(*this);
 
     for (size_t i = 0; i < args.size(); i++) {
         auto arg = args[i];
@@ -1124,11 +1123,11 @@ Value StringObject::crypt(Env *env, Value salt) {
     if (!crypted)
         env->raise_errno();
 
-    return new StringObject { crypted };
+    return StringObject::create(crypted);
 }
 
 Value StringObject::delete_str(Env *env, Args &&selectors) {
-    auto dup = new StringObject { m_string, m_encoding };
+    auto dup = StringObject::create(m_string, m_encoding);
     auto result = dup->delete_in_place(env, std::move(selectors));
     if (result.is_nil())
         return dup;
@@ -1207,7 +1206,7 @@ Value StringObject::ord(Env *env) const {
 Value StringObject::prepend(Env *env, Args &&args) {
     assert_not_frozen(env);
 
-    StringObject *original = new StringObject(*this);
+    StringObject *original = StringObject::create(*this);
 
     String appendable;
     for (size_t i = 0; i < args.size(); i++) {
@@ -1236,7 +1235,7 @@ Value StringObject::prepend(Env *env, Args &&args) {
 }
 
 Value StringObject::b(Env *env) const {
-    return new StringObject { m_string, Encoding::ASCII_8BIT };
+    return StringObject::create(m_string, Encoding::ASCII_8BIT);
 }
 
 Value StringObject::bytes(Env *env, Block *block) {
@@ -1631,7 +1630,7 @@ Value StringObject::ref(Env *env, Value index_obj, Optional<Value> length_arg) {
             // Shortcut here before doing anything else to return an empty
             // string if the index is right at the end of the string.
             if (index == count)
-                return new StringObject { "", m_encoding };
+                return StringObject::create("", m_encoding);
 
             // If the index is negative, then we know at this point that it's
             // only negative within one length of the string. So just make it
@@ -1664,7 +1663,7 @@ Value StringObject::ref(Env *env, Value index_obj, Optional<Value> length_arg) {
         // string if the index is right at the end of the string.
         auto count = static_cast<nat_int_t>(char_count(env));
         if (begin == count)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // Now, we're going to do some bounds checks on the beginning of the
         // range. If it's too far outside, we'll return nil.
@@ -1688,7 +1687,7 @@ Value StringObject::ref(Env *env, Value index_obj, Optional<Value> length_arg) {
         // Now, we're going to do some bounds checks on the ending of the range.
         // If it's too negative, we'll return nil.
         if (end + count < 0)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // If the ending is negative, we know it's within one length of the
         // string, so we'll add that here to make it a valid positive index.
@@ -1718,7 +1717,7 @@ Value StringObject::ref(Env *env, Value index_obj, Optional<Value> length_arg) {
         // If the index object is a string, then we return the string if it is
         // found as a substring of this string.
         if (m_string.find(index_obj.as_string()->m_string) != -1)
-            return new StringObject { index_obj.as_string()->m_string, index_obj.as_string()->m_encoding };
+            return StringObject::create(index_obj.as_string()->m_string, index_obj.as_string()->m_encoding);
 
         // Otherwise we return nil.
         return Value::nil();
@@ -1752,7 +1751,7 @@ Value StringObject::ref(Env *env, Value index_obj, Optional<Value> length_arg) {
             // Shortcut here before doing anything else to return an empty
             // string if the index is right at the end of the string.
             if (index == count)
-                return new StringObject { "", m_encoding };
+                return StringObject::create("", m_encoding);
 
             nat_int_t end = index + length > count ? count : index + length;
             return ref_fast_range(env, index, end);
@@ -1783,7 +1782,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // return an empty string.
         nat_int_t index = IntegerMethods::convert_to_nat_int_t(env, index_obj);
         if (index == m_length)
-            return new StringObject("", m_encoding);
+            return StringObject::create("", m_encoding);
 
         // Next, we're going to get the length that was passed in and make sure
         // that it's not negative. If it is, or the index is too far out of
@@ -1802,7 +1801,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // Finally, we'll determine the length of the substring and create a new
         // string with those bounds.
         nat_int_t s_length = index + length >= m_length ? m_length - index : length;
-        return new StringObject { m_string.substring(index, s_length), m_encoding };
+        return StringObject::create(m_string.substring(index, s_length), m_encoding);
     }
 
     if (index_obj.is_range()) {
@@ -1824,7 +1823,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // Shortcut here before doing anything else to return an empty
         // string if the index is right at the end of the string.
         if (begin == m_length)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // Now, we're going to do some bounds checks on the beginning of the
         // range. If it's too far outside, we'll return nil.
@@ -1839,7 +1838,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // Now, we're going to shortcut here if the range is endless since we
         // already have all of the information we need.
         if (end_obj.is_nil())
-            return new StringObject { m_string.substring(begin), m_encoding };
+            return StringObject::create(m_string.substring(begin), m_encoding);
 
         // If it's not endless, then we'll go ahead and grab the ending now by
         // converting to an integer and asserting it fits into a fixnum.
@@ -1848,7 +1847,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // Now, we're going to do some bounds checks on the ending of the range.
         // If it's too negative, we'll return nil.
         if (end + m_length < 0)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // If the ending is negative, we know it's within one length of the
         // string, so we'll add that here to make it a valid positive index.
@@ -1863,13 +1862,13 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         // Make sure we have a valid range here, otherwise return an empty
         // string.
         if (begin > end)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // Finally, we can return the substring.
         if (end >= m_length) {
-            return new StringObject { m_string.substring(begin), m_encoding };
+            return StringObject::create(m_string.substring(begin), m_encoding);
         } else {
-            return new StringObject { m_string.substring(begin, end - begin), m_encoding };
+            return StringObject::create(m_string.substring(begin, end - begin), m_encoding);
         }
     }
 
@@ -1889,7 +1888,7 @@ Value StringObject::byteslice(Env *env, Value index_obj, Optional<Value> length_
         index += m_length;
 
     // Finally, access the index in the string.
-    return new StringObject { m_string.at(index), m_encoding };
+    return StringObject::create(m_string.at(index), m_encoding);
 }
 
 /**
@@ -2072,7 +2071,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
         // string if the index is right at the end of the string.
         auto count = static_cast<nat_int_t>(char_count(env));
         if (begin == count)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // Now, we're going to do some bounds checks on the beginning of the
         // range. If it's too far outside, we'll return nil.
@@ -2095,7 +2094,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
         // Now, we're going to do some bounds checks on the ending of the range.
         // If it's too negative, we'll return an empty string.
         if (end + count < 0)
-            return new StringObject { "", m_encoding };
+            return StringObject::create("", m_encoding);
 
         // If the ending is negative, we know it's within one length of the
         // string, so we'll add that here to make it a valid positive index.
@@ -2148,7 +2147,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
         // Clone out the matched string for our result first before we mutate
         // the source string.
         ssize_t matched_length = end_byte_index - start_byte_index;
-        Value result = new StringObject(&m_string[start_byte_index], static_cast<size_t>(matched_length), m_encoding);
+        Value result = StringObject::create(&m_string[start_byte_index], static_cast<size_t>(matched_length), m_encoding);
 
         if (matched_length != 0) {
             // Make sure we back up the match data's source string, since we're
@@ -2178,7 +2177,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
         memmove(&m_string[start_byte_index], &m_string[end_byte_index], byte_length - end_byte_index);
         m_string.truncate(byte_length - end_byte_index + start_byte_index);
 
-        return new StringObject { index_obj.as_string()->m_string, index_obj.as_string()->m_encoding };
+        return StringObject::create(index_obj.as_string()->m_string, index_obj.as_string()->m_encoding);
     } else {
         // First, attempt to convert the index object into an integer, and
         // make sure it fits into a fixnum.
@@ -2197,7 +2196,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
             // Shortcut here before doing anything else to return an empty
             // string if the index is right at the end of the string.
             if (index == count || length == 0)
-                return new StringObject { "", m_encoding };
+                return StringObject::create("", m_encoding);
 
             // If the index is negative, then we know at this point that it's
             // only negative within one length of the string. So just make it
@@ -2238,7 +2237,7 @@ Value StringObject::slice_in_place(Env *env, Value index_obj, Optional<Value> le
             char_index++;
         } while (!c.is_empty());
 
-        Value result = new StringObject { c.clone(), m_encoding };
+        Value result = StringObject::create(c.clone(), m_encoding);
         memmove(&m_string[prev_byte_index], &m_string[prev_byte_index + 1], byte_length - prev_byte_index);
         m_string.truncate(byte_length - 1);
         return result;
@@ -2279,7 +2278,7 @@ Value StringObject::ref_slice_range_in_place(size_t begin, size_t end) {
 
     memmove(&m_string[0] + start_byte_index, &m_string[0] + prev_byte_index, byte_length - prev_byte_index);
     m_string.truncate(byte_length - prev_byte_index + start_byte_index);
-    return new StringObject { result, m_encoding };
+    return StringObject::create(result, m_encoding);
 }
 
 Value StringObject::ref_fast_index(Env *env, size_t index) const {
@@ -2289,7 +2288,7 @@ Value StringObject::ref_fast_index(Env *env, size_t index) const {
     do {
         c = next_char(&byte_index);
         if (!c.is_empty() && char_index == (size_t)index)
-            return new StringObject { c, m_encoding };
+            return StringObject::create(c, m_encoding);
         char_index++;
     } while (!c.is_empty());
     return Value::nil();
@@ -2302,7 +2301,7 @@ Value StringObject::ref_fast_range(Env *env, size_t begin, size_t end) const {
         if (end > bytesize())
             end = bytesize();
         auto length = end - begin;
-        return new StringObject { m_string.substring(begin, length), m_encoding };
+        return StringObject::create(m_string.substring(begin, length), m_encoding);
     }
 
     size_t byte_index = 0;
@@ -2314,7 +2313,7 @@ Value StringObject::ref_fast_range(Env *env, size_t begin, size_t end) const {
         c = next_char(&byte_index);
         if (!c.is_empty()) {
             if (char_index >= (size_t)end)
-                return new StringObject { result, m_encoding };
+                return StringObject::create(result, m_encoding);
             else if (char_index >= (size_t)begin) {
                 char_added = true;
                 result.append(c.clone());
@@ -2323,7 +2322,7 @@ Value StringObject::ref_fast_range(Env *env, size_t begin, size_t end) const {
         char_index++;
     } while (!c.is_empty());
     if (char_index > (size_t)begin || char_added)
-        return new StringObject { result, m_encoding };
+        return StringObject::create(result, m_encoding);
     return Value::nil();
 }
 
@@ -2332,7 +2331,7 @@ Value StringObject::ref_fast_range_endless(Env *env, size_t begin) const {
         if (begin >= bytesize())
             return Value::nil();
         auto length = bytesize() - begin;
-        return new StringObject { m_string.substring(begin, length), m_encoding };
+        return StringObject::create(m_string.substring(begin, length), m_encoding);
     }
 
     size_t byte_index = 0;
@@ -2352,7 +2351,7 @@ Value StringObject::ref_fast_range_endless(Env *env, size_t begin) const {
         return Value::nil();
     for (; byte_index < m_string.length(); byte_index++)
         result.append_char(m_string[byte_index]);
-    return new StringObject { result, m_encoding };
+    return StringObject::create(result, m_encoding);
 }
 
 size_t StringObject::byte_index_to_char_index(ArrayObject *chars, size_t byte_index) {
@@ -2556,7 +2555,7 @@ Value StringObject::sub(Env *env, Value find, Optional<Value> replacement_value,
             out.append(m_string.substring(byte_index));
     }
 
-    return new StringObject { out, m_encoding };
+    return StringObject::create(out, m_encoding);
 }
 
 Value StringObject::sub_in_place(Env *env, Value find, Optional<Value> replacement_value, Block *block) {
@@ -2607,7 +2606,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
         }
     } while (match);
 
-    return new StringObject { out, m_encoding };
+    return StringObject::create(out, m_encoding);
 }
 
 Value StringObject::gsub_in_place(Env *env, Value find, Optional<Value> replacement_value, Block *block) {
@@ -2693,7 +2692,7 @@ void StringObject::regexp_sub(Env *env, TM::String &out, StringObject *orig_stri
 StringObject *StringObject::expand_backrefs(Env *env, StringObject *str, MatchDataObject *match) {
     const char *c_str = str->c_str();
     size_t len = strlen(c_str);
-    StringObject *expanded = new StringObject { "" };
+    StringObject *expanded = StringObject::create("");
     for (size_t i = 0; i < len; i++) {
         auto c = c_str[i];
         switch (c) {
@@ -2994,7 +2993,7 @@ Value StringObject::undump(Env *env) const {
     it++;
     if (it != end())
         env->raise("RuntimeError", "invalid dumped string");
-    return new StringObject { std::move(result), m_encoding };
+    return StringObject::create(std::move(result), m_encoding);
 }
 
 nat_int_t StringObject::unpack_offset(Env *env, Optional<Value> offset_arg) const {
@@ -3034,21 +3033,21 @@ Value StringObject::split(Env *env, RegexpObject *splitter, int max_count) {
     OnigRegion *region = onig_region_new();
     int result = splitter->search(env, this, 0, region, ONIG_OPTION_NONE);
     if (result == ONIG_MISMATCH) {
-        ary->push(new StringObject { m_string, m_encoding });
+        ary->push(StringObject::create(m_string, m_encoding));
     } else {
         do {
             index = region->beg[0];
             len = region->end[0] - region->beg[0];
-            ary->push(new StringObject { &c_str()[last_index], index - last_index, m_encoding });
+            ary->push(StringObject::create(&c_str()[last_index], index - last_index, m_encoding));
             last_index = index + len;
             if (max_count > 0 && ary->size() >= static_cast<size_t>(max_count) - 1) {
-                ary->push(new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding });
+                ary->push(StringObject::create(&c_str()[last_index], bytesize() - last_index, m_encoding));
                 onig_region_free(region, true);
                 return ary;
             }
             result = splitter->search(env, this, last_index, region, ONIG_OPTION_NONE);
         } while (result != ONIG_MISMATCH);
-        auto part = new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding };
+        auto part = StringObject::create(&c_str()[last_index], bytesize() - last_index, m_encoding);
         part->force_validity(m_validity);
         ary->push(part);
     }
@@ -3063,19 +3062,19 @@ Value StringObject::split(Env *env, StringObject *splitstr, int max_count) {
     assert(splitlen > 0);
     nat_int_t index = index_int(env, splitstr, 0);
     if (index == -1) {
-        ary->push(new StringObject { m_string, m_encoding });
+        ary->push(StringObject::create(m_string, m_encoding));
     } else {
         do {
             size_t u_index = static_cast<size_t>(index);
-            ary->push(new StringObject { &c_str()[last_index], u_index - last_index, m_encoding });
+            ary->push(StringObject::create(&c_str()[last_index], u_index - last_index, m_encoding));
             last_index = u_index + splitlen;
             if (max_count > 0 && ary->size() >= static_cast<size_t>(max_count) - 1) {
-                ary->push(new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding });
+                ary->push(StringObject::create(&c_str()[last_index], bytesize() - last_index, m_encoding));
                 return ary;
             }
             index = index_int(env, splitstr, last_index);
         } while (index != -1);
-        ary->push(new StringObject { &c_str()[last_index], bytesize() - last_index, m_encoding });
+        ary->push(StringObject::create(&c_str()[last_index], bytesize() - last_index, m_encoding));
     }
     return ary;
 }
@@ -3105,7 +3104,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
     if (length() == 0) {
         return ary;
     } else if (max_count == 1 || splitter.is_nil()) {
-        ary->push(new StringObject { m_string, m_encoding });
+        ary->push(StringObject::create(m_string, m_encoding));
     } else if (splitter.is_regexp()) {
         // special empty-split-regexp case, just return characters
         if (splitter.as_regexp()->pattern()->is_empty()) {
@@ -3141,7 +3140,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
 }
 
 Value StringObject::squeeze(Env *env, Args &&selectors) {
-    auto copy = new StringObject { m_string, m_encoding };
+    auto copy = StringObject::create(m_string, m_encoding);
     copy->squeeze_in_place(env, std::move(selectors));
     return copy;
 }
@@ -3278,12 +3277,12 @@ void StringObject::each_line(Env *env, Optional<Value> separator_arg, Optional<V
     }
 
     if (separator.is_nil())
-        separator = new StringObject { "" };
+        separator = StringObject::create("");
 
     bool paragraph_mode = false;
     if (separator.as_string()->is_empty()) {
         paragraph_mode = true;
-        separator = new StringObject { "\n\n" };
+        separator = StringObject::create("\n\n");
     }
 
     const auto chomp = chomp_arg ? chomp_arg.value().is_truthy() : false;
@@ -3298,7 +3297,7 @@ void StringObject::each_line(Env *env, Optional<Value> separator_arg, Optional<V
             auto length = bytesize() - last_index;
             if (length == 0)
                 break;
-            auto out = new StringObject { ptr, bytesize() - last_index, encoding() };
+            auto out = StringObject::create(ptr, bytesize() - last_index, encoding());
             callback(out);
             break;
         }
@@ -3315,7 +3314,7 @@ void StringObject::each_line(Env *env, Optional<Value> separator_arg, Optional<V
             }
         }
 
-        auto out = new StringObject { ptr, length, encoding() };
+        auto out = StringObject::create(ptr, length, encoding());
 
         if (chomp)
             out->chomp_in_place(env, separator);
@@ -3368,12 +3367,12 @@ Value StringObject::ljust(Env *env, Value length_obj, Optional<Value> pad_arg) c
     if (pad_arg)
         padstr = pad_arg.value().to_str(env);
     else
-        padstr = new StringObject { " " };
+        padstr = StringObject::create(" ");
 
     if (padstr->string().is_empty())
         env->raise("ArgumentError", "zero width padding");
 
-    StringObject *copy = new StringObject { m_string, m_encoding };
+    StringObject *copy = StringObject::create(m_string, m_encoding);
     while (copy->length() < length) {
         bool truncate = copy->length() + padstr->length() > length;
         copy->append(padstr);
@@ -3386,7 +3385,7 @@ Value StringObject::ljust(Env *env, Value length_obj, Optional<Value> pad_arg) c
 
 Value StringObject::strip(Env *env) const {
     if (length() == 0)
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     assert(length() < NAT_INT_MAX);
     nat_int_t first_char, last_char;
     nat_int_t len = static_cast<nat_int_t>(length());
@@ -3401,10 +3400,10 @@ Value StringObject::strip(Env *env) const {
             break;
     }
     if (last_char < 0) {
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     } else {
         size_t new_length = static_cast<size_t>(last_char - first_char + 1);
-        return new StringObject { c_str() + first_char, new_length, m_encoding };
+        return StringObject::create(c_str() + first_char, new_length, m_encoding);
     }
 }
 
@@ -3418,7 +3417,7 @@ Value StringObject::strip_in_place(Env *env) {
 
 Value StringObject::lstrip(Env *env) const {
     if (length() == 0)
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     assert(length() < NAT_INT_MAX);
     nat_int_t first_char;
     nat_int_t len = static_cast<nat_int_t>(length());
@@ -3428,10 +3427,10 @@ Value StringObject::lstrip(Env *env) const {
             break;
     }
     if (first_char == len) {
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     } else {
         size_t new_length = static_cast<size_t>(len - first_char);
-        return new StringObject { c_str() + first_char, new_length, m_encoding };
+        return StringObject::create(c_str() + first_char, new_length, m_encoding);
     }
 }
 
@@ -3466,12 +3465,12 @@ Value StringObject::rjust(Env *env, Value length_obj, Optional<Value> pad_arg) c
     if (pad_arg)
         padstr = pad_arg.value().to_str(env);
     else
-        padstr = new StringObject { " " };
+        padstr = StringObject::create(" ");
 
     if (padstr->string().is_empty())
         env->raise("ArgumentError", "zero width padding");
 
-    StringObject *padding = new StringObject { "", m_encoding };
+    StringObject *padding = StringObject::create("", m_encoding);
     size_t padding_length = length < this->length() ? 0 : length - this->length();
 
     while (padding->length() < padding_length) {
@@ -3482,7 +3481,7 @@ Value StringObject::rjust(Env *env, Value length_obj, Optional<Value> pad_arg) c
         }
     }
 
-    StringObject *str_with_padding = new StringObject { "", m_encoding };
+    StringObject *str_with_padding = StringObject::create("", m_encoding);
     StringObject *copy = duplicate(env).as_string();
     str_with_padding->append(padding);
     str_with_padding->append(copy);
@@ -3492,7 +3491,7 @@ Value StringObject::rjust(Env *env, Value length_obj, Optional<Value> pad_arg) c
 
 Value StringObject::rstrip(Env *env) const {
     if (length() == 0)
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
 
     if (!valid_encoding())
         env->raise(m_encoding->klass()->const_find(env, "CompatibilityError"_s).value().as_class(), "invalid byte sequence in {}", m_encoding->name()->string());
@@ -3506,10 +3505,10 @@ Value StringObject::rstrip(Env *env) const {
             break;
     }
     if (last_char < 0) {
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
     } else {
         size_t new_length = static_cast<size_t>(last_char + 1);
-        return new StringObject { c_str(), new_length, m_encoding };
+        return StringObject::create(c_str(), new_length, m_encoding);
     }
 }
 
@@ -3617,7 +3616,7 @@ Value StringObject::is_casecmp(Env *env, Value other) {
 
 StringObject *StringObject::capitalize(Env *env, Optional<Value> arg1, Optional<Value> arg2) {
     auto flags = check_case_options(env, arg1, arg2);
-    auto str = new StringObject { "", m_encoding };
+    auto str = StringObject::create("", m_encoding);
     bool first_char = true;
     nat_int_t result[3] = {};
     uint8_t length = 0;
@@ -3647,7 +3646,7 @@ Value StringObject::capitalize_in_place(Env *env, Optional<Value> arg1, Optional
 
 StringObject *StringObject::downcase(Env *env, Optional<Value> arg1, Optional<Value> arg2) {
     auto flags = check_case_options(env, arg1, arg2, true);
-    auto str = new StringObject { "", m_encoding };
+    auto str = StringObject::create("", m_encoding);
     nat_int_t result[3] = {};
     for (StringView c : *this) {
         auto codepoint = m_encoding->decode_codepoint(c);
@@ -3746,12 +3745,12 @@ Value StringObject::dump(Env *env) {
     if (!m_encoding->is_ascii_compatible())
         out.append_sprintf(".force_encoding(\"%s\")", m_encoding->name()->c_str());
 
-    return new StringObject { std::move(out), m_encoding };
+    return StringObject::create(std::move(out), m_encoding);
 }
 
 StringObject *StringObject::upcase(Env *env, Optional<Value> arg1, Optional<Value> arg2) {
     auto flags = check_case_options(env, arg1, arg2);
-    auto str = new StringObject { "", m_encoding };
+    auto str = StringObject::create("", m_encoding);
     nat_int_t result[3] = {};
     for (StringView c : *this) {
         auto codepoint = m_encoding->decode_codepoint(c);
@@ -3777,7 +3776,7 @@ Value StringObject::upcase_in_place(Env *env, Optional<Value> arg1, Optional<Val
 StringObject *StringObject::swapcase(Env *env, Optional<Value> arg1, Optional<Value> arg2) {
     // currently not doing anything with the returned flags
     check_case_options(env, arg1, arg2);
-    auto str = new StringObject { "", m_encoding };
+    auto str = StringObject::create("", m_encoding);
     for (StringView c : *this) {
         nat_int_t codept = m_encoding->decode_codepoint(c);
         if (codept >= 'a' && codept <= 'z') {
@@ -3812,7 +3811,7 @@ Value StringObject::uplus(Env *env) {
     if (this->is_frozen()) {
         return this->duplicate(env);
     } else if (is_chilled()) {
-        return new StringObject { *this };
+        return StringObject::create(*this);
     } else {
         return this;
     }
@@ -3855,14 +3854,14 @@ Value StringObject::upto(Env *env, Value other, Optional<Value> exclusive_arg, B
         if (current.value().length() > string->length())
             return this;
 
-        block->run(env, { new StringObject(current.value(), m_encoding) }, nullptr);
+        block->run(env, { StringObject::create(current.value(), m_encoding) }, nullptr);
     }
 
     return this;
 }
 
 Value StringObject::reverse(Env *env) {
-    auto str = new StringObject { "", m_encoding };
+    auto str = StringObject::create("", m_encoding);
     if (length() == 0)
         return str;
     auto characters = chars(env).as_array();
@@ -4210,7 +4209,7 @@ Value StringObject::delete_prefix(Env *env, Value val) {
     auto arg_len = val.as_string()->length();
 
     if (start_with(env, { val })) {
-        auto after_delete = new StringObject { c_str() + arg_len, length() - arg_len, m_encoding };
+        auto after_delete = StringObject::create(c_str() + arg_len, length() - arg_len, m_encoding);
         return after_delete;
     }
 
@@ -4236,7 +4235,7 @@ Value StringObject::delete_suffix(Env *env, Value val) {
     auto arg_len = val.as_string()->length();
 
     if (end_with(env, val)) {
-        return new StringObject { c_str(), length() - arg_len, m_encoding };
+        return StringObject::create(c_str(), length() - arg_len, m_encoding);
     }
 
     return duplicate(env).as_string();
@@ -4256,9 +4255,9 @@ Value StringObject::delete_suffix_in_place(Env *env, Value val) {
 
 Value StringObject::chop(Env *env) const {
     if (this->is_empty())
-        return new StringObject { "", m_encoding };
+        return StringObject::create("", m_encoding);
 
-    auto new_str = new StringObject { m_string, m_encoding };
+    auto new_str = StringObject::create(m_string, m_encoding);
     new_str->chop_in_place(env);
     return new_str;
 }
@@ -4294,19 +4293,19 @@ Value StringObject::partition(Env *env, Value val) {
         ssize_t end_byte_index;
 
         if (match_result.is_nil()) {
-            return new ArrayObject { new StringObject(*this), new StringObject("", m_encoding), new StringObject("", m_encoding) };
+            return new ArrayObject { StringObject::create(*this), StringObject::create("", m_encoding), StringObject::create("", m_encoding) };
         } else {
             start_byte_index = match_result.as_match_data()->beg_byte_index(0);
             end_byte_index = match_result.as_match_data()->end_byte_index(0);
-            ary->push(new StringObject(m_string.substring(0, start_byte_index), m_encoding));
+            ary->push(StringObject::create(m_string.substring(0, start_byte_index), m_encoding));
         }
 
-        ary->push(new StringObject(m_string.substring(start_byte_index, end_byte_index - start_byte_index), m_encoding));
+        ary->push(StringObject::create(m_string.substring(start_byte_index, end_byte_index - start_byte_index), m_encoding));
 
         auto last_val_index = start_byte_index + (end_byte_index - start_byte_index);
         auto last_char_index = m_string.length() - 1;
         if (last_val_index < static_cast<long>(last_char_index)) {
-            ary->push(new StringObject(m_string.substring(end_byte_index, m_string.length() - end_byte_index), m_encoding));
+            ary->push(StringObject::create(m_string.substring(end_byte_index, m_string.length() - end_byte_index), m_encoding));
             return ary;
         }
     } else {
@@ -4318,9 +4317,9 @@ Value StringObject::partition(Env *env, Value val) {
         auto query_idx = m_string.find(query);
 
         if (query_idx == -1) {
-            return new ArrayObject { new StringObject { m_string, m_encoding }, new StringObject("", m_encoding), new StringObject("", m_encoding) };
+            return new ArrayObject { StringObject::create(m_string, m_encoding), StringObject::create("", m_encoding), StringObject::create("", m_encoding) };
         } else {
-            ary->push(new StringObject(m_string.substring(0, query_idx), m_encoding));
+            ary->push(StringObject::create(m_string.substring(0, query_idx), m_encoding));
         }
 
         ary->push(val);
@@ -4328,12 +4327,12 @@ Value StringObject::partition(Env *env, Value val) {
         auto last_val_index = query_idx + query.length();
         auto last_char_index = m_string.length() - 1;
         if (last_val_index < last_char_index) {
-            ary->push(new StringObject(m_string.substring(query_idx + 1, last_char_index - query_idx), m_encoding));
+            ary->push(StringObject::create(m_string.substring(query_idx + 1, last_char_index - query_idx), m_encoding));
             return ary;
         }
     }
 
-    ary->push(new StringObject("", m_encoding));
+    ary->push(StringObject::create("", m_encoding));
     return ary;
 }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -696,7 +696,7 @@ static Value byteindex_regexp_needle(Env *env, const StringObject *haystack, Reg
         return Value::nil();
     }
 
-    auto match = new MatchDataObject { region, haystack, needle };
+    auto match = MatchDataObject::create(region, haystack, needle);
     env->caller()->set_last_match(match);
     auto byte_index = region->beg[0];
     return Value::integer(byte_index);
@@ -821,7 +821,7 @@ nat_int_t StringObject::index_int(Env *env, Value needle, size_t byte_start) {
             return -1;
         }
 
-        auto match = new MatchDataObject { region, this, needle.as_regexp() };
+        auto match = MatchDataObject::create(region, this, needle.as_regexp());
         env->caller()->set_last_match(match);
         return region->beg[0];
     }
@@ -903,7 +903,7 @@ nat_int_t StringObject::rindex_int(Env *env, Value needle, size_t byte_start) co
             return -1;
         }
 
-        auto match = new MatchDataObject { region, this, needle_regexp };
+        auto match = MatchDataObject::create(region, this, needle_regexp);
         env->caller()->set_last_match(match);
         return region->beg[0];
     }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -440,7 +440,7 @@ Value StringObject::chr(Env *env) {
 }
 
 SymbolObject *StringObject::to_symbol(Env *env) const {
-    return SymbolObject::intern_with_lock(m_string, m_encoding.ptr());
+    return SymbolObject::intern(m_string, m_encoding.ptr());
 }
 
 Value StringObject::to_sym(Env *env) const {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -163,7 +163,7 @@ Value StringObject::chars(Env *env, Block *block) {
         }
         return this;
     }
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     for (auto c : *this)
         ary->push(StringObject::create(c, m_encoding));
     return ary;
@@ -207,7 +207,7 @@ Value StringObject::codepoints(Env *env, Block *block) {
     if (!this->valid_encoding())
         env->raise_invalid_byte_sequence_error(m_encoding.ptr());
 
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     for (;;) {
         auto [valid, length, codepoint] = m_encoding->next_codepoint(m_string, &index);
         if (!valid)
@@ -240,7 +240,7 @@ Value StringObject::grapheme_clusters(Env *env, Block *block) {
     if (block)
         return each_grapheme_cluster(env, block);
 
-    auto ary = new ArrayObject {};
+    auto ary = ArrayObject::create();
     size_t index = 0;
     for (;;) {
         auto view = m_encoding->next_grapheme_cluster(m_string, &index);
@@ -1242,7 +1242,7 @@ Value StringObject::bytes(Env *env, Block *block) {
     if (block) {
         return each_byte(env, block);
     }
-    ArrayObject *ary = new ArrayObject { length() };
+    ArrayObject *ary = ArrayObject::create(length());
     for (size_t i = 0; i < length(); ++i) {
         unsigned char c = m_string[i];
         ary->push(Value::integer(c));
@@ -1284,7 +1284,7 @@ Value StringObject::scan(Env *env, Value pattern, Block *block) {
     pattern.assert_type(env, Type::Regexp, "Regexp");
 
     auto regexp = pattern.as_regexp();
-    auto ary = new ArrayObject {};
+    auto ary = ArrayObject::create();
     size_t byte_index = 0;
     size_t new_byte_index = 0;
     size_t total_size = m_string.size();
@@ -3012,7 +3012,7 @@ Value StringObject::unpack(Env *env, Value format, Optional<Value> offset_kwarg)
     auto format_string = format.to_str(env)->string();
     auto offset = unpack_offset(env, offset_kwarg);
     if (offset == (nat_int_t)bytesize())
-        return new ArrayObject({ Value::nil() });
+        return ArrayObject::create({ Value::nil() });
     auto unpacker = new StringUnpacker { this, format_string, offset };
     return unpacker->unpack(env);
 }
@@ -3027,7 +3027,7 @@ Value StringObject::unpack1(Env *env, Value format, Optional<Value> offset_kwarg
 }
 
 Value StringObject::split(Env *env, RegexpObject *splitter, int max_count) {
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     size_t last_index = 0;
     size_t index, len;
     OnigRegion *region = onig_region_new();
@@ -3056,7 +3056,7 @@ Value StringObject::split(Env *env, RegexpObject *splitter, int max_count) {
 }
 
 Value StringObject::split(Env *env, StringObject *splitstr, int max_count) {
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     size_t last_index = 0;
     size_t splitlen = splitstr->length();
     assert(splitlen > 0);
@@ -3087,7 +3087,7 @@ Value StringObject::split(Env *env, StringObject *splitstr, int max_count) {
 Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value> max_count_arg) {
     assert_valid_encoding(env);
 
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     if (!splitter_arg || splitter_arg.value().is_nil()) {
         auto field_sep = env->global_get("$;"_s);
         if (!field_sep.is_nil()) {
@@ -3351,7 +3351,7 @@ Value StringObject::lines(Env *env, Optional<Value> separator, Optional<Value> c
     if (block)
         return each_line(env, separator, chomp, block);
 
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = ArrayObject::create();
     each_line(env, separator, chomp, [&](StringObject *part) -> Value {
         ary->push(part);
         return this;
@@ -4284,7 +4284,7 @@ Value StringObject::chop_in_place(Env *env) {
 }
 
 Value StringObject::partition(Env *env, Value val) {
-    auto ary = new ArrayObject;
+    auto ary = ArrayObject::create();
 
     if (val.is_regexp()) {
         auto match_result = val.as_regexp()->match(env, this);
@@ -4293,7 +4293,7 @@ Value StringObject::partition(Env *env, Value val) {
         ssize_t end_byte_index;
 
         if (match_result.is_nil()) {
-            return new ArrayObject { StringObject::create(*this), StringObject::create("", m_encoding), StringObject::create("", m_encoding) };
+            return ArrayObject::create({ StringObject::create(*this), StringObject::create("", m_encoding), StringObject::create("", m_encoding) });
         } else {
             start_byte_index = match_result.as_match_data()->beg_byte_index(0);
             end_byte_index = match_result.as_match_data()->end_byte_index(0);
@@ -4317,7 +4317,7 @@ Value StringObject::partition(Env *env, Value val) {
         auto query_idx = m_string.find(query);
 
         if (query_idx == -1) {
-            return new ArrayObject { StringObject::create(m_string, m_encoding), StringObject::create("", m_encoding), StringObject::create("", m_encoding) };
+            return ArrayObject::create({ StringObject::create(m_string, m_encoding), StringObject::create("", m_encoding), StringObject::create("", m_encoding) });
         } else {
             ary->push(StringObject::create(m_string.substring(0, query_idx), m_encoding));
         }

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -637,7 +637,7 @@ bool StringObject::internal_start_with(Env *env, Value needle) {
     if (needle.is_regexp()) {
         needle = needle.as_regexp()->to_s(env);
         needle.as_string()->prepend(env, { StringObject::create("\\A") });
-        needle = new RegexpObject { env, needle.as_string()->string() };
+        needle = RegexpObject::create(env, needle.as_string()->string());
         return needle.as_regexp()->match(env, this).is_truthy();
     }
 
@@ -1172,9 +1172,9 @@ Value StringObject::eqtilde(Env *env, Value other) {
 Value StringObject::match(Env *env, Value other, Optional<Value> index_arg, Block *block) {
     if (!other.is_regexp()) {
         if (other.is_string()) {
-            other = new RegexpObject { env, other.as_string()->string() };
+            other = RegexpObject::create(env, other.as_string()->string());
         } else if (other.respond_to(env, "to_str"_s)) {
-            other = new RegexpObject { env, other.to_str(env)->string() };
+            other = RegexpObject::create(env, other.to_str(env)->string());
         } else if (other.respond_to(env, "=~"_s)) {
             return other.send(env, "=~"_s, { this });
         }
@@ -2538,7 +2538,7 @@ Value StringObject::sub(Env *env, Value find, Optional<Value> replacement_value,
     if (find.is_string() || find.respond_to(env, "to_str"_s)) {
         const auto pattern = RegexpObject::quote(env, find.to_str(env)).as_string()->string();
         const int options = 0;
-        find = new RegexpObject { env, pattern, options };
+        find = RegexpObject::create(env, pattern, options);
     }
     if (!find.is_regexp())
         env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_module());
@@ -2576,7 +2576,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
     if (find.is_string() || find.respond_to(env, "to_str"_s)) {
         const auto pattern = RegexpObject::quote(env, find.to_str(env)).as_string()->string();
         const int options = 0;
-        find = new RegexpObject { env, pattern, options };
+        find = RegexpObject::create(env, pattern, options);
     }
     if (!find.is_regexp())
         env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_module());
@@ -3095,7 +3095,7 @@ Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value
             splitter_arg = field_sep;
         }
     }
-    Value splitter = splitter_arg.value_or([&env]() { return new RegexpObject { env, "\\s+" }; });
+    Value splitter = splitter_arg.value_or([&env]() { return RegexpObject::create(env, "\\s+"); });
 
     int max_count = 0;
     if (max_count_arg)

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -777,7 +777,7 @@ Value StringObject::byterindex(Env *env, Value needle_obj, Optional<Value> offse
     return byteindex_string_needle(env, this, needle, offset, true);
 }
 
-Value StringObject::index(Env *env, Value needle, Optional<Value> offset) {
+Value StringObject::index(Env *env, Value needle, Optional<Value> offset) const {
     int offset_i = offset ? IntegerMethods::convert_to_int(env, offset.value()) : 0;
     int len = char_count(env);
     if (offset_i < -1 * len) {
@@ -790,7 +790,7 @@ Value StringObject::index(Env *env, Value needle, Optional<Value> offset) {
     return index(env, needle, ::abs(offset_i));
 }
 
-Value StringObject::index(Env *env, Value needle, size_t start) {
+Value StringObject::index(Env *env, Value needle, size_t start) const {
     auto byte_start = char_index_to_byte_index(start);
     if (byte_start == -1)
         return Value::nil();
@@ -801,7 +801,7 @@ Value StringObject::index(Env *env, Value needle, size_t start) {
     return IntegerMethods::from_size_t(env, char_index);
 }
 
-nat_int_t StringObject::index_int(Env *env, Value needle, size_t byte_start) {
+nat_int_t StringObject::index_int(Env *env, Value needle, size_t byte_start) const {
     if (needle.is_regexp()) {
         // FIXME: use byteindex_regexp_needle shared code
         if (needle.as_regexp()->pattern()->is_empty())

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3984,8 +3984,8 @@ void StringObject::append(unsigned int i) {
 }
 
 void StringObject::append(double d) {
-    auto f = FloatObject(d);
-    m_string.append(f.to_s().as_string()->string());
+    auto f = FloatObject::create(d);
+    m_string.append(f->to_s().as_string()->string());
 }
 
 void StringObject::append(const FloatObject *f) {
@@ -4196,7 +4196,7 @@ Value StringObject::convert_float() {
     double value = strtod(string.c_str(), &endptr);
 
     if (endptr[0] == '\0') {
-        return new FloatObject { value };
+        return FloatObject::create(value);
     } else {
         return Value::nil();
     }

--- a/src/string_unpacker.cpp
+++ b/src/string_unpacker.cpp
@@ -196,7 +196,7 @@ void StringUnpacker::unpack_token(Env *env, Token &token) {
 
 void StringUnpacker::unpack_A(Token &token) {
     if (at_end()) {
-        append(new StringObject("", Encoding::ASCII_8BIT));
+        append(StringObject::create("", Encoding::ASCII_8BIT));
         return;
     }
 
@@ -218,12 +218,12 @@ void StringUnpacker::unpack_A(Token &token) {
         }
     }
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_a(Token &token) {
     if (at_end()) {
-        append(new StringObject("", Encoding::ASCII_8BIT));
+        append(StringObject::create("", Encoding::ASCII_8BIT));
         return;
     }
 
@@ -234,7 +234,7 @@ void StringUnpacker::unpack_a(Token &token) {
         return true;
     });
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_B(Token &token) {
@@ -248,7 +248,7 @@ void StringUnpacker::unpack_B(Token &token) {
         return c << 1;
     });
 
-    append(new StringObject { out, Encoding::US_ASCII });
+    append(StringObject::create(out, Encoding::US_ASCII));
 }
 
 void StringUnpacker::unpack_C(Token &token) {
@@ -292,7 +292,7 @@ void StringUnpacker::unpack_b(Token &token) {
         return c >> 1;
     });
 
-    append(new StringObject { out, Encoding::US_ASCII });
+    append(StringObject::create(out, Encoding::US_ASCII));
 }
 
 void StringUnpacker::unpack_H(Token &token) {
@@ -304,7 +304,7 @@ void StringUnpacker::unpack_H(Token &token) {
             out.append_sprintf("%x", c & 0x0F);
     });
 
-    append(new StringObject { out, Encoding::US_ASCII });
+    append(StringObject::create(out, Encoding::US_ASCII));
 }
 
 void StringUnpacker::unpack_h(Token &token) {
@@ -316,7 +316,7 @@ void StringUnpacker::unpack_h(Token &token) {
             out.append_sprintf("%x", c >> 4);
     });
 
-    append(new StringObject { out, Encoding::US_ASCII });
+    append(StringObject::create(out, Encoding::US_ASCII));
 }
 
 void StringUnpacker::unpack_M(Env *env, Token &token) {
@@ -367,7 +367,7 @@ void StringUnpacker::unpack_M(Env *env, Token &token) {
         out.append_char(c);
     }
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_m(Env *env, Token &token) {
@@ -433,7 +433,7 @@ void StringUnpacker::unpack_m(Env *env, Token &token) {
             env->raise("ArgumentError", "invalid base64");
     }
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_P(Token &token) {
@@ -444,7 +444,7 @@ void StringUnpacker::unpack_P(Token &token) {
 
     const char *p = *(const char **)pointer();
     const size_t size = std::min(static_cast<size_t>(token.count), strlen(p));
-    append(new StringObject(p, size));
+    append(StringObject::create(p, size));
     m_index += sizeof(uintptr_t);
 }
 
@@ -454,7 +454,7 @@ void StringUnpacker::unpack_p() {
         return;
     }
 
-    append(new StringObject(*(const char **)pointer()));
+    append(StringObject::create(*(const char **)pointer()));
     m_index += sizeof(uintptr_t);
 }
 
@@ -532,7 +532,7 @@ void StringUnpacker::unpack_u(Token &token) {
             continue;
     }
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_w(Env *env, Token &token) {
@@ -604,7 +604,7 @@ void StringUnpacker::unpack_x(Env *env, Token &token) {
 
 void StringUnpacker::unpack_Z(Token &token) {
     if (at_end()) {
-        append(new StringObject("", Encoding::ASCII_8BIT));
+        append(StringObject::create("", Encoding::ASCII_8BIT));
         return;
     }
 
@@ -620,7 +620,7 @@ void StringUnpacker::unpack_Z(Token &token) {
     if (token.count > 0 && (ssize_t)consumed < token.count)
         m_index += (token.count - consumed);
 
-    append(new StringObject(out, Encoding::ASCII_8BIT));
+    append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
 void StringUnpacker::unpack_at(Env *env, Token &token) {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -127,7 +127,7 @@ Value SymbolObject::is_casecmp(Env *env, Value other) {
 }
 
 ProcObject *SymbolObject::to_proc(Env *env) {
-    OwnedPtr<Env> block_env { new Env {} };
+    OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("name", 0, true, this);
     Block *proc_block = Block::create(std::move(block_env), this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda);
     return ProcObject::create(proc_block);

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -9,6 +9,7 @@ SymbolObject *SymbolObject::intern(const char *name, const size_t length, Encodi
 }
 
 SymbolObject *SymbolObject::intern(const String &name, EncodingObject *encoding) {
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
     SymbolObject *symbol = s_symbols.get(name);
     if (symbol)
         return symbol;

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -18,7 +18,7 @@ SymbolObject *SymbolObject::intern(const String &name, EncodingObject *encoding)
 }
 
 ArrayObject *SymbolObject::all_symbols(Env *env) {
-    ArrayObject *array = new ArrayObject(s_symbols.size());
+    ArrayObject *array = ArrayObject::create(s_symbols.size());
     for (auto pair : s_symbols) {
         array->push(pair.second);
     }

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -128,7 +128,7 @@ Value SymbolObject::is_casecmp(Env *env, Value other) {
 ProcObject *SymbolObject::to_proc(Env *env) {
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, this);
-    Block *proc_block = new Block { std::move(block_env), this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda };
+    Block *proc_block = Block::create(std::move(block_env), this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda);
     return new ProcObject { proc_block };
 }
 

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -129,7 +129,7 @@ ProcObject *SymbolObject::to_proc(Env *env) {
     OwnedPtr<Env> block_env { new Env {} };
     block_env->var_set("name", 0, true, this);
     Block *proc_block = Block::create(std::move(block_env), this, SymbolObject::to_proc_block_fn, -2, Block::BlockType::Lambda);
-    return new ProcObject { proc_block };
+    return ProcObject::create(proc_block);
 }
 
 Value SymbolObject::to_proc_block_fn(Env *env, Value self_value, Args &&args, Block *block) {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -28,19 +28,19 @@ ArrayObject *SymbolObject::all_symbols(Env *env) {
 StringObject *SymbolObject::to_s(Env *env) {
     StringObject *result = nullptr;
     if (m_encoding == nullptr) {
-        result = new StringObject { m_name };
+        result = StringObject::create(m_name);
     } else {
-        result = new StringObject { m_name, m_encoding };
+        result = StringObject::create(m_name, m_encoding);
     }
     result->set_chilled(StringObject::Chilled::Symbol);
     return result;
 }
 
 StringObject *SymbolObject::inspect(Env *env) {
-    StringObject *string = new StringObject { ":" };
+    StringObject *string = StringObject::create(":");
 
     if (should_be_quoted()) {
-        StringObject *quoted = StringObject { m_name }.inspect(env);
+        auto quoted = StringObject::create(m_name)->inspect(env);
         string->append(quoted);
     } else {
         string->append(m_name);

--- a/src/thread_group_object.cpp
+++ b/src/thread_group_object.cpp
@@ -32,7 +32,7 @@ Value ThreadGroupObject::enclose() {
 }
 
 ArrayObject *ThreadGroupObject::list() {
-    auto result = new ArrayObject { m_threads.size() };
+    auto result = ArrayObject::create(m_threads.size());
     for (auto thread : m_threads)
         result->push(thread);
     return result;

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -180,7 +180,7 @@ void ThreadObject::prepare_main_thread() {
     auto thread = new ThreadObject;
     thread->m_status = ThreadObject::Status::Active;
     thread->m_suspend_status = ThreadObject::SuspendStatus::Running;
-    thread->m_current_fiber = thread->m_main_fiber = new FiberObject;
+    thread->m_current_fiber = thread->m_main_fiber = FiberObject::create();
     tl_current_arg_stack = &thread->m_current_fiber->m_args_stack;
     s_main = thread;
     tl_current_thread = thread;
@@ -199,7 +199,7 @@ void ThreadObject::finish_main_thread_setup(Env *env, void *start_of_stack) {
 
 void ThreadObject::build_main_fiber() {
     if (!m_main_fiber)
-        m_main_fiber = m_current_fiber = new FiberObject;
+        m_main_fiber = m_current_fiber = FiberObject::create();
     tl_current_arg_stack = &m_current_fiber->m_args_stack;
     m_main_fiber->m_start_of_stack = m_start_of_stack;
     m_main_fiber->m_thread = this;

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -516,7 +516,7 @@ Value ThreadObject::fetch(Env *env, Value key, Optional<Value> default_value, Bl
     if (m_current_fiber)
         hash = m_current_fiber->thread_storage();
     if (!hash)
-        hash = new HashObject {};
+        hash = HashObject::create();
     return hash->fetch(env, key, default_value, block);
 }
 
@@ -576,7 +576,7 @@ Value ThreadObject::thread_variable_set(Env *env, Value key, Value value) {
         env->raise("FrozenError", "can't modify frozen thread locals");
     key = validate_key(env, key);
     if (!m_thread_variables)
-        m_thread_variables = new HashObject;
+        m_thread_variables = HashObject::create();
     if (value.is_nil()) {
         m_thread_variables->delete_key(env, key, nullptr);
         return value;

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -535,7 +535,7 @@ Value ThreadObject::keys(Env *env) {
     if (m_current_fiber)
         hash = m_current_fiber->thread_storage();
     if (!hash)
-        return new ArrayObject {};
+        return ArrayObject::create();
     return hash->keys(env);
 }
 
@@ -586,13 +586,13 @@ Value ThreadObject::thread_variable_set(Env *env, Value key, Value value) {
 
 Value ThreadObject::thread_variables(Env *env) const {
     if (!m_thread_variables)
-        return new ArrayObject;
+        return ArrayObject::create();
     return m_thread_variables->keys(env);
 }
 
 Value ThreadObject::list(Env *env) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
-    auto ary = new ArrayObject { s_list.size() };
+    auto ary = ArrayObject::create(s_list.size());
     for (auto thread : s_list) {
         if (thread->m_status != ThreadObject::Status::Dead)
             ary->push(thread);

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -177,7 +177,7 @@ bool ThreadObject::is_stopped() const {
 
 void ThreadObject::prepare_main_thread() {
     assert(!s_main); // can only be built once
-    auto thread = new ThreadObject;
+    auto thread = ThreadObject::create();
     thread->m_status = ThreadObject::Status::Active;
     thread->m_suspend_status = ThreadObject::SuspendStatus::Running;
     thread->m_current_fiber = thread->m_main_fiber = FiberObject::create();

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -340,7 +340,7 @@ Value ThreadObject::kill(Env *env) {
 
     m_status = Status::Aborting;
 
-    auto exception = new ExceptionObject { thread_kill_class(env) };
+    auto exception = ExceptionObject::create(thread_kill_class(env));
 
     if (m_exception) {
         // An pending exception was already raised on this thread,

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -3,7 +3,6 @@
 #include <signal.h>
 
 #include "natalie.hpp"
-#include "natalie/integer_methods.hpp"
 #include "natalie/thread/mutex_object.hpp"
 #include "natalie/thread_object.hpp"
 
@@ -270,7 +269,7 @@ Value ThreadObject::to_s(Env *env) {
         location,
         status());
 
-    return new StringObject { formatted, Encoding::ASCII_8BIT };
+    return StringObject::create(formatted, Encoding::ASCII_8BIT);
 }
 
 Value ThreadObject::status(Env *env) {
@@ -280,7 +279,7 @@ Value ThreadObject::status(Env *env) {
             return Value::nil();
         return Value::False();
     }
-    return new StringObject { status_string };
+    return StringObject::create(status_string);
 }
 
 String ThreadObject::status() {
@@ -471,7 +470,7 @@ Value ThreadObject::value(Env *env) {
 Value ThreadObject::name(Env *env) {
     if (!m_name)
         return Value::nil();
-    return new StringObject { *m_name };
+    return StringObject::create(*m_name);
 }
 
 Value ThreadObject::set_name(Env *env, Value name) {

--- a/src/throw_catch_exception.cpp
+++ b/src/throw_catch_exception.cpp
@@ -4,7 +4,6 @@
 namespace Natalie {
 
 void ThrowCatchException::visit_children(Visitor &visitor) const {
-    Cell::visit_children(visitor);
     visitor.visit(m_name);
     if (m_value)
         visitor.visit(m_value.value());

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -27,7 +27,7 @@ TimeObject *TimeObject::at(Env *env, ClassObject *klass, Value time, Optional<Va
 }
 
 TimeObject *TimeObject::local(Env *env, Value year, Optional<Value> month, Optional<Value> mday, Optional<Value> hour, Optional<Value> min, Optional<Value> sec, Optional<Value> usec) {
-    TimeObject *result = new TimeObject {};
+    TimeObject *result = TimeObject::create();
     result->build_time(env, year, month, mday, hour, min, sec);
     int seconds = mktime(&result->m_time);
     result->m_mode = Mode::Localtime;
@@ -77,9 +77,9 @@ TimeObject *TimeObject::now(Env *env, ClassObject *klass, Optional<Value> in) {
     struct tm time = *localtime(&ts.tv_sec);
     TimeObject *result;
     if (klass)
-        result = new TimeObject { klass };
+        result = TimeObject::create(klass);
     else
-        result = new TimeObject {};
+        result = TimeObject::create();
     result->m_time = time;
     result->m_mode = Mode::Localtime;
     result->m_integer = ts.tv_sec;
@@ -90,7 +90,7 @@ TimeObject *TimeObject::now(Env *env, ClassObject *klass, Optional<Value> in) {
 }
 
 TimeObject *TimeObject::utc(Env *env, Value year, Optional<Value> month, Optional<Value> mday, Optional<Value> hour, Optional<Value> min, Optional<Value> sec, Optional<Value> subsec_arg) {
-    TimeObject *result = new TimeObject {};
+    TimeObject *result = TimeObject::create();
     result->build_time(env, year, month, mday, hour, min, sec);
     result->m_time.tm_gmtoff = 0;
     int seconds = timegm(&result->m_time);
@@ -459,9 +459,9 @@ TimeObject *TimeObject::create(Env *env, ClassObject *klass, RationalObject *rat
     RationalObject *subseconds;
     TimeObject *result;
     if (klass)
-        result = new TimeObject { klass };
+        result = TimeObject::create(klass);
     else
-        result = new TimeObject {};
+        result = TimeObject::create();
     if (rational->send(env, "<"_s, { Value::integer(0) }).is_true()) {
         auto floor = rational->floor(env);
         integer = floor.send(env, "to_i"_s).integer();

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -39,6 +39,7 @@ TimeObject *TimeObject::local(Env *env, Value year, Optional<Value> month, Optio
 }
 
 TimeObject *TimeObject::create(Env *env) {
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
     return now(env, nullptr);
 }
 

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -254,7 +254,7 @@ Value TimeObject::subsec(Env *) {
 
 Value TimeObject::to_a(Env *env) const {
     auto dstval = bool_object(isdst(env));
-    return new ArrayObject { sec(env), min(env), hour(env), mday(env), month(env), year(env), wday(env), yday(env), dstval, zone(env) };
+    return ArrayObject::create({ sec(env), min(env), hour(env), mday(env), month(env), year(env), wday(env), yday(env), dstval, zone(env) });
 }
 
 Value TimeObject::to_f(Env *env) {

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -548,7 +548,7 @@ Value TimeObject::build_string(Env *, const char *format) {
     int maxsize = 32;
     char buffer[maxsize];
     auto length = ::strftime(buffer, maxsize, format, &m_time);
-    return new StringObject { buffer, length, Encoding::US_ASCII };
+    return StringObject::create(buffer, length, Encoding::US_ASCII);
 }
 
 Value TimeObject::strip_zeroes(StringObject *string) {
@@ -561,10 +561,10 @@ Value TimeObject::strip_zeroes(StringObject *string) {
             break;
     }
     if (last_char < 0) {
-        return new StringObject {};
+        return StringObject::create();
     } else {
         size_t new_length = static_cast<size_t>(last_char + 1);
-        return new StringObject { c_str, new_length };
+        return StringObject::create(c_str, new_length);
     }
 }
 
@@ -574,9 +574,9 @@ Value TimeObject::zone(Env *env) const {
         return Value::nil();
     }
     if (is_utc(env)) {
-        return new StringObject { "UTC", Encoding::US_ASCII };
+        return StringObject::create("UTC", Encoding::US_ASCII);
     }
-    return new StringObject { m_zone, Encoding::US_ASCII };
+    return StringObject::create(m_zone, Encoding::US_ASCII);
 }
 
 }

--- a/src/true_methods.cpp
+++ b/src/true_methods.cpp
@@ -16,7 +16,7 @@ bool TrueMethods::xor_method(const Env *env, const Value, const Value other) {
 
 Value TrueMethods::to_s(const Env *env, const Value) {
     if (!s_string)
-        s_string = new StringObject { "true" };
+        s_string = StringObject::create("true");
     return s_string;
 }
 

--- a/test/gc_lint.rb
+++ b/test/gc_lint.rb
@@ -145,7 +145,7 @@ def verify_visited(id, member)
   klass = @classes.fetch(id)
   type = member.fetch(:type)
   @seen_members = {}
-  if garbage_collected?(type) && klass[:name] != 'Natalie::Heap'
+  if garbage_collected?(type)
     if (method_lines = klass[:visit_children_method])
       name = member.fetch(:name)
       visits_directly = method_lines.grep(/^\s*visitor\.visit\(&?#{name}/).any?
@@ -171,7 +171,7 @@ def verify_visits_superclass(id)
   if (superclass_id = klass.dig(:superclass, :id)) && klass[:visit_children_method]
     superclass = @classes[superclass_id]
     superclass_name_without_namespace = superclass[:name].split('::').last
-    if class_name != 'Natalie::Object' &&
+    if class_name != 'Natalie::Object' && superclass[:name] != 'Natalie::Cell' &&
          klass[:visit_children_method].grep(/#{superclass_name_without_namespace}::visit_children\(visitor\)/).empty?
       @errors << "#{class_name}'s visit_children() method does not call #{superclass[:name]}::visit_children()!"
     end

--- a/test/gc_stress_test.rb
+++ b/test/gc_stress_test.rb
@@ -38,7 +38,7 @@ describe 'GC' do
         o7 = SomeObject.new('foo')
         o8 = SomeObject.new('bar')
         o9 = SomeObject.new('baz')
-        (Etc.nprocessors * 40).times do
+        Etc.nprocessors.times do
           r = rand(1000)
           work << r
           obj = SomeObject.new("bar#{r}")

--- a/test/gc_stress_test.rb
+++ b/test/gc_stress_test.rb
@@ -1,0 +1,69 @@
+# This convoluted mess stress the garbage collector when lots of threads
+# are creating objects.
+
+require_relative './spec_helper'
+require 'thread_pool'
+
+class SomeObject
+  def initialize(data)
+    @data = data
+  end
+
+  attr_reader :data
+
+  def foo(val) = bar(val)
+  def bar(val) = baz(val)
+  def baz(val) = val
+end
+
+JOBS = Etc.nprocessors * 4
+
+describe 'GC' do
+  it 'does not crash' do
+    work = []
+    hash = {}
+    objects = []
+    data = []
+    complete = 0
+    pool = ThreadPool.new(Etc.nprocessors)
+    JOBS.times do
+      pool.schedule do
+        # This looks dumb but it's just a bunch of busy work to create lots of objects. :-)
+        o1 = SomeObject.new('foo')
+        o2 = SomeObject.new('bar')
+        o3 = SomeObject.new('baz')
+        o4 = SomeObject.new('foo')
+        o5 = SomeObject.new('bar')
+        o6 = SomeObject.new('baz')
+        o7 = SomeObject.new('foo')
+        o8 = SomeObject.new('bar')
+        o9 = SomeObject.new('baz')
+        (Etc.nprocessors * 40).times do
+          r = rand(1000)
+          work << r
+          obj = SomeObject.new("bar#{r}")
+          objects << obj
+          hash["foo#{r}"] = obj.foo obj.foo obj.foo obj.foo obj.foo obj.foo obj.foo obj.foo obj.foo obj.foo obj # lol
+          data << objects.sample&.data
+          work << hash
+        end
+        work << o1.inspect
+        work << o2.inspect
+        work << o3.inspect
+        work << o4.inspect
+        work << o5.inspect
+        work << o6.inspect
+        work << o7.inspect
+        work << o8.inspect
+        work << o9.inspect
+        complete += 1
+      end
+    end
+    sleep 0.1 while work.empty?
+    while complete < JOBS
+      GC.start
+      puts "#{complete} of #{JOBS} complete"
+    end
+    pool.shutdown
+  end
+end

--- a/test/gdb-signals.gdb
+++ b/test/gdb-signals.gdb
@@ -1,0 +1,1 @@
+handle SIGUSR1 SIGUSR2 nostop noprint pass

--- a/test/natalie/gc_test.rb
+++ b/test/natalie/gc_test.rb
@@ -26,7 +26,6 @@ describe 'GC' do
       create_object
       $gc_ran.should == false
       GC.start
-      GC.start
       $gc_ran.should == true
     end
   end

--- a/test/natalie/gc_test.rb
+++ b/test/natalie/gc_test.rb
@@ -11,13 +11,13 @@ describe 'GC' do
     # the object is collected by the GC, so we can use that to
     # test that it did indeed run.
     __inline__ <<~END
-      ptr_var = new VoidPObject {
+      ptr_var = VoidPObject::create(
           nullptr,
           [](auto p) {
               Env e {};
               GlobalEnv::the()->global_set(&e, "$gc_ran"_s, Value::True());
           }
-      };
+      );
     END
   end
 

--- a/test/support/require/cpp_file.cpp
+++ b/test/support/require/cpp_file.cpp
@@ -3,7 +3,7 @@
 using namespace Natalie;
 
 Value defn_cpp_file(Env *env, Value self, Args &&, Block *block) {
-    return new StringObject { "cpp_file" };
+    return StringObject::create("cpp_file");
 }
 
 Value init_cpp_file(Env *env, Value self) {


### PR DESCRIPTION
This work attempts to fix a race condition wherein a multi-threaded program gets paused and the GC attempts to visit partially-constructed objects. Using factory functions for object creation should let us lock the `g_gc_recursive_mutex` until the object is fully constructed.