### PR TITLE
fix tcp sock initialize econnrefused scenario on macos

### DIFF
--- a/spec/library/socket/tcpsocket/initialize_spec.rb
+++ b/spec/library/socket/tcpsocket/initialize_spec.rb
@@ -33,9 +33,7 @@ describe 'TCPSocket#initialize' do
   SocketSpecs.each_ip_protocol do |family, ip_address|
     describe 'when no server is listening on the given address' do
       it 'raises Errno::ECONNREFUSED' do
-        NATFIXME 'fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-          -> { TCPSocket.new(ip_address, 666) }.should raise_error(Errno::ECONNREFUSED)
-        end
+        -> { TCPSocket.new(ip_address, 666) }.should raise_error(Errno::ECONNREFUSED)
       end
     end
 


### PR DESCRIPTION
Fix `TCPSocket#initialize` on MacOS when no server is listening
on the given address.

`poll(2)` can indicate that a socket is writable following
`connect(2)` returning an `EINPROGRESS` result.

We need to check with `getsockopt(2)` again to be sure the socket
is truly writable.