### PR TITLE
fix wrong spawn error on macos

### DIFF
--- a/spec/core/process/spawn_spec.rb
+++ b/spec/core/process/spawn_spec.rb
@@ -814,9 +814,7 @@ describe "Process.spawn" do
   unless File.executable?(__FILE__) # Some FS (e.g. vboxfs) locate all files executable
     platform_is_not :windows do
       it "raises an Errno::EACCES when the file does not have execute permissions" do
-        NATFIXME 'Raised the wrong error on macos', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-          -> { Process.spawn __FILE__ }.should raise_error(Errno::EACCES)
-        end
+        -> { Process.spawn __FILE__ }.should raise_error(Errno::EACCES)
       end
     end
 
@@ -830,11 +828,9 @@ describe "Process.spawn" do
   end
 
   it "raises an Errno::EACCES or Errno::EISDIR when passed a directory" do
-    NATFIXME 'Raised the wrong error on macos', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-      -> { Process.spawn __dir__ }.should raise_error(SystemCallError) { |e|
-        [Errno::EACCES, Errno::EISDIR].should include(e.class)
-      }
-    end
+    -> { Process.spawn __dir__ }.should raise_error(SystemCallError) { |e|
+      [Errno::EACCES, Errno::EISDIR].should include(e.class)
+    }
   end
 
   it "raises an ArgumentError when passed a string key in options" do

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -827,8 +827,14 @@ Value KernelModule::spawn(Env *env, Args &&args) {
             new_env.is_empty() ? environ : new_env.data());
     }
 
-    if (result != 0)
+    if (result != 0) {
+// MacOS posix_spawnp(2) can return a non-zero value without setting errno.
+// We need to set errno manually to ensure that the error is reported correctly.
+#ifdef __APPLE__
+        errno = result;
+#endif
         env->raise_errno();
+    }
 
     return Value::integer(pid);
 }


### PR DESCRIPTION
Fix an issue where the wrong error was being raise on MacOS
when Process.spawn was called on a file without execute permissions
or a directory instead of a file.