### PR TITLE
Fix StringObject::append with float value

### DIFF
--- a/lib/natalie/compiler/flags.rb
+++ b/lib/natalie/compiler/flags.rb
@@ -27,6 +27,7 @@ module Natalie
         -DNAT_GC_GUARD
         -Wno-vla-cxx-extension
         -Wno-unknown-warning-option
+        -Wsign-promo
       ].freeze
 
       SANITIZE_FLAG = "-fsanitize=#{ENV.fetch('NAT_SANITIZE_FLAG_VALUE', 'address')}".freeze

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -4023,7 +4023,7 @@ void StringObject::append(Value val) {
         append("false");
         break;
     case Type::Float:
-        append(val.is_float());
+        append(val.as_float());
         break;
     case Type::Nil:
         append("nil");

--- a/test/natalie/string_object_test.rb
+++ b/test/natalie/string_object_test.rb
@@ -1,0 +1,30 @@
+# skip-ruby
+
+require_relative '../spec_helper'
+
+require 'natalie/inline'
+
+describe 'StringObject' do
+  it 'should be able to append any type with StringObject::append' do
+    o = Object.new
+    def o.stringobject_append(str, val)
+      __inline__ <<~END
+        str_var.assert_type(env, Object::Type::String, "String");
+        str_var.as_string()->append(val_var);
+        return str_var;
+      END
+    end
+    o.stringobject_append('foo ', false).should == 'foo false'
+    o.stringobject_append('foo ', true).should == 'foo true'
+    o.stringobject_append('foo ', nil).should == 'foo nil'
+    o.stringobject_append('foo ', :bar).should == 'foo bar'
+    o.stringobject_append('foo ', 'bar').should == 'foo bar'
+    o.stringobject_append('foo ', 123).should == 'foo 123'
+    o.stringobject_append('foo ', 123.4).should == 'foo 123.4'
+
+    # This is the current behaviour, and probably not what we want
+    o.stringobject_append('foo ', %w[a b]).should =~ /ArrayObject.*StringObject.*StringObject/m
+    o.stringobject_append('foo ', { a: 'x' }).should =~ /HashObject.*SymbolObject.*StringObject/m
+    o.stringobject_append('foo ', o).should =~ /^foo <Object 0x/
+  end
+end


### PR DESCRIPTION
There was a typo in the method call, so instead of converting it to a float type, it was using a boolean.

This was found using `-Wsign-promo` in compilation. This flag is now added to the debug build.