### PR TITLE
Remove space in `*operator"" _s`

### DIFF
--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -120,7 +120,7 @@ private:
     EncodingObject *m_encoding = nullptr;
 };
 
-[[nodiscard]] __attribute__((always_inline)) inline SymbolObject *operator"" _s(const char *cstring, size_t) {
+[[nodiscard]] __attribute__((always_inline)) inline SymbolObject *operator""_s(const char *cstring, size_t) {
     return SymbolObject::intern(cstring);
 }
 


### PR DESCRIPTION
The syntax with space is deprecated, Clang++ 20 will warn when using this.