### PR TITLE
Replace some TM::String constructors with calls to append_snprintf

### DIFF
--- a/ext/tm/include/tm/string.hpp
+++ b/ext/tm/include/tm/string.hpp
@@ -154,10 +154,7 @@ public:
      * ```
      */
     String(const long long number) {
-        const int length = snprintf(NULL, 0, "%lli", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%lli", number);
-        set_str(buf);
+        append_snprintf("%lli", number);
     }
 
     /**
@@ -170,10 +167,7 @@ public:
      */
 
     String(const unsigned long long number) {
-        const int length = snprintf(NULL, 0, "%llu", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%llu", number);
-        set_str(buf);
+        append_snprintf("%llu", number);
     }
 
     /**
@@ -187,10 +181,7 @@ public:
      * ```
      */
     String(const long int number) {
-        const int length = snprintf(NULL, 0, "%li", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%li", number);
-        set_str(buf);
+        append_snprintf("%li", number);
     }
 
     /**
@@ -202,10 +193,7 @@ public:
      * ```
      */
     String(const int number) {
-        const int length = snprintf(NULL, 0, "%d", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%d", number);
-        set_str(buf);
+        append_snprintf("%d", number);
     }
 
     /**
@@ -217,10 +205,7 @@ public:
      * ```
      */
     String(const unsigned long number) {
-        const int length = snprintf(NULL, 0, "%lu", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%lu", number);
-        set_str(buf);
+        append_snprintf("%lu", number);
     }
 
     /**
@@ -232,10 +217,7 @@ public:
      * ```
      */
     String(const unsigned int number) {
-        const int length = snprintf(NULL, 0, "%u", number);
-        char buf[length + 1];
-        snprintf(buf, length + 1, "%u", number);
-        set_str(buf);
+        append_snprintf("%u", number);
     }
 
     /**


### PR DESCRIPTION
This removes some code duplication
The following script:
```c++
auto str =
    TM::String { static_cast<int>(1) } +
    TM::String { static_cast<size_t>(2) } +
    TM::String { static_cast<ssize_t>(3) } +
    TM::String { static_cast<double>(4.5) };
str.print();
```
roughly reduced 100 operations in callgrind.

Compilation time went slightly down: 100 times in a row with G++ (14.2.0) and -O3 decreased from 35.0 to 34.5 seconds.