### PR TITLE
Add limit to gets proxy in IO#getc

### DIFF
--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -206,7 +206,7 @@ Value IoObject::getbyte(Env *env) {
 
 Value IoObject::getc(Env *env) {
     raise_if_closed(env);
-    auto line = gets(env);
+    auto line = gets(env, Value::integer(1024));
     if (line.is_nil())
         return line;
     auto line_str = line.as_string();


### PR DESCRIPTION
This resolves a timeout if no full line is available (#2792). Keep in mind: this does not yet implement `IO#readpartial`.

I'm not fully satisfied with the implementation, this sets the globals for last line ans lineno, even though we don't do anything related to lines. A future is probably to move some of the logic of `gets` to `read`, and use that directly from `getc`.