### PR TITLE
Don't execute block in TCPServer#initialize

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -1739,15 +1739,6 @@ Value TCPSocket_initialize(Env *env, Value self, Args &&args, Block *block) {
     }
     self->ivar_set(env, "@do_not_reverse_lookup"_s, find_top_level_const(env, "BasicSocket"_s).send(env, "do_not_reverse_lookup"_s));
 
-    if (block) {
-        try {
-            block->run(env, { self }, nullptr);
-            Socket_close(env, self, {}, nullptr);
-        } catch (ExceptionObject *exception) {
-            Socket_close(env, self, {}, nullptr);
-        }
-    }
-
     return self;
 }
 

--- a/spec/library/socket/tcpsocket/initialize_spec.rb
+++ b/spec/library/socket/tcpsocket/initialize_spec.rb
@@ -13,9 +13,7 @@ describe 'TCPSocket#initialize' do
 
     after :each do
       if @socket
-        NATFIXME 'Trying to write to a closed stream', exception: IOError, message: 'closed stream' do
-          @socket.write "QUIT"
-        end
+        @socket.write "QUIT"
         @socket.close
       end
       @server.shutdown


### PR DESCRIPTION
Even though it did print the generic "does not take a block. use open instead" error, the block was still executed. Even worse, any exception raised in the block is caught and ignored, so the code in the spec with `{ raise }` did actually raise the exception in the block, but we never saw that.