### PR TITLE
Add IPv6 support to TCPSocket.gethostbyname

### DIFF
--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -68,8 +68,10 @@ end
 class TCPSocket < IPSocket
   __bind_method__ :initialize, :TCPSocket_initialize
 
-  class << self
-    __bind_method__ :gethostbyname, :TCPSocket_gethostbyname
+  def self.gethostbyname(hostname)
+    warn('TCPSocket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.')
+    result = Addrinfo.getaddrinfo(hostname, nil, :AF_UNSPEC, :SOCK_STREAM, Socket::IPPROTO_TCP)
+    [hostname, [], result[0].afamily, *result.map(&:ip_address)]
   end
 end
 


### PR DESCRIPTION
By removing the call to gethostbyname(3) and forwarding it to Addrinfo.getaddrinfo instead. This is what MRI does too, shown by the exception you get when calling this method with an unknown hostname.

The function gethostbyname(3) has been removed from POSIX.1-2008, the fact that this still worked is very much by accident.
