### PR TITLE
Add protocol info in BasicSocket#local_address and #remote_address

### DIFF
--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -563,8 +563,17 @@ Value BasicSocket_local_address(Env *env, Value self, Args &&args, Block *) {
     if (getsockopt(self.as_io()->fileno(), SOL_SOCKET, SO_TYPE, &socktype, &socktype_len) == -1)
         env->raise_errno();
 
+    int protocol = 0;
+    if (addr.ss_family == AF_INET || addr.ss_family == AF_INET6) {
+        if (socktype == SOCK_STREAM) {
+            protocol = IPPROTO_TCP;
+        } else if (socktype == SOCK_DGRAM) {
+            protocol = IPPROTO_UDP;
+        }
+    }
+
     auto Addrinfo = find_top_level_const(env, "Addrinfo"_s);
-    return Addrinfo.send(env, "new"_s, { packed, Value::integer(addr.ss_family), Value::integer(socktype) });
+    return Addrinfo.send(env, "new"_s, { packed, Value::integer(addr.ss_family), Value::integer(socktype), Value::integer(protocol) });
 }
 
 static ssize_t blocking_recv(Env *env, IoObject *io, char *buf, size_t len, int flags) {
@@ -665,8 +674,17 @@ Value BasicSocket_remote_address(Env *env, Value self, Args &&args, Block *) {
     if (getsockopt(self.as_io()->fileno(), SOL_SOCKET, SO_TYPE, &socktype, &socktype_len) == -1)
         env->raise_errno();
 
+    int protocol = 0;
+    if (addr.ss_family == AF_INET || addr.ss_family == AF_INET6) {
+        if (socktype == SOCK_STREAM) {
+            protocol = IPPROTO_TCP;
+        } else if (socktype == SOCK_DGRAM) {
+            protocol = IPPROTO_UDP;
+        }
+    }
+
     auto Addrinfo = find_top_level_const(env, "Addrinfo"_s);
-    return Addrinfo.send(env, "new"_s, { packed, Value::integer(addr.ss_family), Value::integer(socktype) });
+    return Addrinfo.send(env, "new"_s, { packed, Value::integer(addr.ss_family), Value::integer(socktype), Value::integer(protocol) });
 }
 
 Value BasicSocket_send(Env *env, Value self, Args &&args, Block *) {


### PR DESCRIPTION
The following script:
```ruby
server = TCPServer.new("127.0.0.1", 0)
sock = TCPSocket.new(nil, server.connect_address.ip_port)
p sock.remote_address;
p sock.local_address
sock.close
```
Now prints similar information in MRI and Natalie.

The code is a copy-paste, and we have similar code in the socket lib (just search for `SOL_SOCKET`), we probably need to add some abstraction to this.