### PR TITLE
Enable spec "Warning.warn is called by parser warnings"

### DIFF
--- a/spec/core/warning/warn_spec.rb
+++ b/spec/core/warning/warn_spec.rb
@@ -40,7 +40,7 @@ describe "Warning.warn" do
     ruby_exe(code, args: "2>&1").should == %Q[A WARNING!\nwarning from stderr\n]
   end
 
-  xit "is called by parser warnings" do
+  it "is called by parser warnings" do
     Warning.should_receive(:warn)
     verbose = $VERBOSE
     $VERBOSE = false


### PR DESCRIPTION
This is probably fixed in #2613