### PR TITLE
Fixes to TM::Optional

### DIFF
--- a/ext/tm/include/tm/optional.hpp
+++ b/ext/tm/include/tm/optional.hpp
@@ -172,14 +172,14 @@ public:
      *
      * ```
      * auto obj = Thing(1);
-     * auto opt = Optional<Thing>(obj);
+     * const auto opt = Optional<Thing>(obj);
      * assert_eq(obj, opt.value());
      * ```
      *
      * This method aborts if the value not present.
      *
      * ```should_abort
-     * auto opt = Optional<Thing>();
+     * const auto opt = Optional<Thing>();
      * opt.value();
      * ```
      */
@@ -255,6 +255,26 @@ public:
      * ```
      */
     T operator*() {
+        assert(m_present);
+        return m_value;
+    }
+    /**
+     * Returns a reference to the underlying value.
+     *
+     * ```
+     * auto obj = Thing(1);
+     * const auto opt = Optional<Thing>(obj);
+     * assert_eq(obj, *opt);
+     * ```
+     *
+     * This method aborts if the value not present.
+     *
+     * ```should_abort
+     * const auto opt = Optional<Thing>();
+     * *opt;
+     * ```
+     */
+    T const &operator*() const {
         assert(m_present);
         return m_value;
     }

--- a/ext/tm/include/tm/optional.hpp
+++ b/ext/tm/include/tm/optional.hpp
@@ -280,6 +280,48 @@ public:
     }
 
     /**
+     * Calls a method on the underlying value.
+     *
+     * ```
+     * auto obj = Thing(1);
+     * auto opt = Optional<Thing>(obj);
+     * assert_eq(1, opt->value());
+     * ```
+     *
+     * This method aborts if the value not present.
+     *
+     * ```should_abort
+     * auto opt = Optional<Thing>();
+     * opt->value();
+     * ```
+     */
+    T *operator->() {
+        assert(m_present);
+        return &m_value;
+    }
+
+    /**
+     * Calls a method on the underlying value.
+     *
+     * ```
+     * auto obj = Thing(1);
+     * const auto opt = Optional<Thing>(obj);
+     * assert_eq(1, opt->value());
+     * ```
+     *
+     * This method aborts if the value not present.
+     *
+     * ```should_abort
+     * const auto opt = Optional<Thing>();
+     * opt->value();
+     * ```
+     */
+    T const *operator->() const {
+        assert(m_present);
+        return &m_value;
+    }
+
+    /**
      * Sets the Optional to not present.
      *
      * ```

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -910,15 +910,14 @@ Value KernelModule::klass_obj(Env *env, Value self) {
 
 Value KernelModule::define_singleton_method(Env *env, Value self, Value name, Optional<Value> arg_block, Block *block) {
     if (arg_block) {
-        auto next_block = arg_block.value();
-        if (next_block.is_proc()) {
-            block = next_block.as_proc()->block();
-        } else if (next_block.is_method()) {
-            block = next_block.as_method()->to_proc(env)->block();
-        } else if (next_block.is_unbound_method()) {
-            block = next_block.as_unbound_method()->bind(env, self)->to_proc(env)->block();
+        if (arg_block->is_proc()) {
+            block = arg_block->as_proc()->block();
+        } else if (arg_block->is_method()) {
+            block = arg_block->as_method()->to_proc(env)->block();
+        } else if (arg_block->is_unbound_method()) {
+            block = arg_block->as_unbound_method()->bind(env, self)->to_proc(env)->block();
         } else {
-            env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod", next_block.klass()->inspected(env));
+            env->raise("TypeError", "wrong argument type {} (expected Proc/Method/UnboundMethod", arg_block->klass()->inspected(env));
         }
     } else {
         env->ensure_block_given(block);


### PR DESCRIPTION
* Add `operator*` for const objects
* Add `operator->` and use that to clean up code for `define_singleton_method`