### PR TITLE
Split a NATFIXME block in the specs of Time#utc?

### DIFF
--- a/spec/core/time/utc_spec.rb
+++ b/spec/core/time/utc_spec.rb
@@ -21,6 +21,8 @@ describe "Time#utc?" do
     Time.new(2022, 1, 1, 0, 0, 0, "UTC").utc?.should == true
     NATFIXME 'Implement Time#localtime', exception: NoMethodError, message: "undefined method 'localtime' for an instance of Time" do
       Time.now.localtime("UTC").utc?.should == true
+    end
+    NATFIXME "it does treat time with 'UTC' offset as UTC", exception: SpecFailedException do
       Time.at(Time.now, in: 'UTC').utc?.should == true
     end
 


### PR DESCRIPTION
These are two separate issues, the second line did not depend on Time#localtime