### PR TITLE
fix strftime with %z  on MacOS

### DIFF
--- a/include/natalie/time_object.hpp
+++ b/include/natalie/time_object.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <string.h>
 #include <time.h>
 
@@ -121,6 +122,8 @@ private:
     void set_subsec(Env *, Integer);
     void set_subsec(Env *, RationalObject *);
     Value strip_zeroes(StringObject *);
+
+    static inline std::mutex s_tz_env_mutex;
 
     Integer m_integer;
     Mode m_mode;

--- a/spec/core/time/new_spec.rb
+++ b/spec/core/time/new_spec.rb
@@ -582,9 +582,7 @@ describe "Time.new with a timezone argument" do
     end
 
     it "returns Time of Jan 1 for string with just year in timezone specified with in keyword argument" do
-      NATFIXME 'Fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-        Time.new("2021", in: "+17:00").to_s.should == "2021-01-01 00:00:00 +1700"
-      end
+      Time.new("2021", in: "+17:00").to_s.should == "2021-01-01 00:00:00 +1700"
     end
 
     it "converts precision keyword argument into Integer if is not nil" do

--- a/spec/shared/time/strftime_for_time.rb
+++ b/spec/shared/time/strftime_for_time.rb
@@ -121,27 +121,19 @@ describe :strftime_time, shared: true do
     end
 
     it "formats a local time with positive UTC offset as '+HHMM'" do
-      NATFIXME 'fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-        @new_time_in_zone["CET", 1, 2005].strftime("%z").should == "+0100"
-      end
+      @new_time_in_zone["CET", 1, 2005].strftime("%z").should == "+0100"
     end
 
     it "formats a local time with negative UTC offset as '-HHMM'" do
-      NATFIXME 'fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-        @new_time_in_zone["PST", -8, 2005].strftime("%z").should == "-0800"
-      end
+      @new_time_in_zone["PST", -8, 2005].strftime("%z").should == "-0800"
     end
 
     it "formats a time with fixed positive offset as '+HHMM'" do
-      NATFIXME 'fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-        @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3660].strftime("%z").should == "+0101"
-      end
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3660].strftime("%z").should == "+0101"
     end
 
     it "formats a time with fixed negative offset as '-HHMM'" do
-      NATFIXME 'fails on MacOS', condition: RUBY_PLATFORM.include?('darwin'), exception: SpecFailedException do
-        @new_time_with_offset[2012, 1, 1, 0, 0, 0, -3660].strftime("%z").should == "-0101"
-      end
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, -3660].strftime("%z").should == "-0101"
     end
 
     it "formats a time with fixed offset as '+/-HH:MM' with ':' specifier" do


### PR DESCRIPTION
Fix strftime on MacOS when the %z conversion specification is included in the format string.

On MacOS, the `tm_gmtoff` member of the `time` struct is ignored by `strftime(3)` which uses the curent set timezone of the machine regardless of the value.

To fix this issue, on MacOS, the `build_string` member function is updated to convert the  value of the `tm_gmtoff` member of the `time` to a timezone representation and update the `TZ` environment variable accordingly.

The original `TZ` value is restored once `strftime(3)` has been called.

A lock is employed to make the process of reading/updating the environment variable thread safe.