### PR TITLE
Fix return type of TM::Optional::operator*

### DIFF
--- a/ext/tm/include/tm/optional.hpp
+++ b/ext/tm/include/tm/optional.hpp
@@ -257,10 +257,11 @@ public:
      * *opt;
      * ```
      */
-    T operator*() {
+    T &operator*() {
         assert(m_present);
         return m_value;
     }
+
     /**
      * Returns a reference to the underlying value.
      *


### PR DESCRIPTION
This should prevent some unnecessary object creations.