### PR TITLE
String#slice

### DIFF
--- a/spec/core/string/slice_spec.rb
+++ b/spec/core/string/slice_spec.rb
@@ -126,12 +126,10 @@ describe "String#slice! with index, length" do
     def obj.to_int() 2 end
     "hello".slice!(obj, obj).should == "ll"
 
-    NATFIXME 'calls to_int on range arguments', exception: NoMethodError, message: "undefined method 'to_int' for an instance of MockObject" do
-      obj = mock('2')
-      def obj.respond_to?(name, *) name == :to_int; end
-      def obj.method_missing(name, *) name == :to_int ? 2 : super; end
-      "hello".slice!(obj, obj).should == "ll"
-    end
+    obj = mock('2')
+    def obj.respond_to?(name, *) name == :to_int; end
+    def obj.method_missing(name, *) name == :to_int ? 2 : super; end
+    "hello".slice!(obj, obj).should == "ll"
   end
 
   it "returns String instances" do
@@ -207,9 +205,7 @@ describe "String#slice! Range" do
     def to.respond_to?(name, *) name == :to_int; end
     def to.method_missing(name) name == :to_int ? -2 : super; end
 
-    NATFIXME 'calls to_int on range arguments', exception: NoMethodError, message: "undefined method 'to_int' for an instance of MockObject" do
-      "hello there".slice!(from..to).should == "ello ther"
-    end
+    "hello there".slice!(from..to).should == "ello ther"
   end
 
   it "works with Range subclasses" do

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -717,7 +717,7 @@ Value Object::send(Env *env, SymbolObject *name, Args &&args, Block *block, Meth
         if (name == initialize)
             result = this;
         return result;
-    } else if (respond_to(env, "method_missing"_s)) {
+    } else if (KernelModule::respond_to_method(env, this, "method_missing"_s, true)) {
         return method_missing_send(env, name, std::move(args), block);
     } else {
         env->raise_no_method_error(this, name, GlobalEnv::the()->method_missing_reason(), std::move(args));


### PR DESCRIPTION
This is a very small fix that has very large implications. Instead of checking the user defined respond_to? for method_missing, we instead go straight to the method lookup. This is because Ruby does not actually respect respond_to? when going through method dispatch, it is on the user side only. This inadvertently fixes the slice spec because there is a custom method_missing+respond_to there.