### PR TITLE
String#dump and String#undump updates

### DIFF
--- a/spec/core/string/undump_spec.rb
+++ b/spec/core/string/undump_spec.rb
@@ -313,86 +313,80 @@ describe "String#undump" do
   end
 
   it "returns a string with \\u{} notation replaced with multi-byte UTF-8 characters" do
-    NATFIXME 'it returns a string with \\u{} notation replaced with multi-byte UTF-8 characters', exception: SpecFailedException do
-      [ ['"\u{80}"', 0200.chr('utf-8')],
-        ['"\u{81}"', 0201.chr('utf-8')],
-        ['"\u{82}"', 0202.chr('utf-8')],
-        ['"\u{83}"', 0203.chr('utf-8')],
-        ['"\u{84}"', 0204.chr('utf-8')],
-        ['"\u{86}"', 0206.chr('utf-8')],
-        ['"\u{87}"', 0207.chr('utf-8')],
-        ['"\u{88}"', 0210.chr('utf-8')],
-        ['"\u{89}"', 0211.chr('utf-8')],
-        ['"\u{8a}"', 0212.chr('utf-8')],
-        ['"\u{8b}"', 0213.chr('utf-8')],
-        ['"\u{8c}"', 0214.chr('utf-8')],
-        ['"\u{8d}"', 0215.chr('utf-8')],
-        ['"\u{8e}"', 0216.chr('utf-8')],
-        ['"\u{8f}"', 0217.chr('utf-8')],
-        ['"\u{90}"', 0220.chr('utf-8')],
-        ['"\u{91}"', 0221.chr('utf-8')],
-        ['"\u{92}"', 0222.chr('utf-8')],
-        ['"\u{93}"', 0223.chr('utf-8')],
-        ['"\u{94}"', 0224.chr('utf-8')],
-        ['"\u{95}"', 0225.chr('utf-8')],
-        ['"\u{96}"', 0226.chr('utf-8')],
-        ['"\u{97}"', 0227.chr('utf-8')],
-        ['"\u{98}"', 0230.chr('utf-8')],
-        ['"\u{99}"', 0231.chr('utf-8')],
-        ['"\u{9a}"', 0232.chr('utf-8')],
-        ['"\u{9b}"', 0233.chr('utf-8')],
-        ['"\u{9c}"', 0234.chr('utf-8')],
-        ['"\u{9d}"', 0235.chr('utf-8')],
-        ['"\u{9e}"', 0236.chr('utf-8')],
-        ['"\u{9f}"', 0237.chr('utf-8')],
-      ].should be_computed_by(:undump)
-    end
+    [ ['"\u{80}"', 0200.chr('utf-8')],
+      ['"\u{81}"', 0201.chr('utf-8')],
+      ['"\u{82}"', 0202.chr('utf-8')],
+      ['"\u{83}"', 0203.chr('utf-8')],
+      ['"\u{84}"', 0204.chr('utf-8')],
+      ['"\u{86}"', 0206.chr('utf-8')],
+      ['"\u{87}"', 0207.chr('utf-8')],
+      ['"\u{88}"', 0210.chr('utf-8')],
+      ['"\u{89}"', 0211.chr('utf-8')],
+      ['"\u{8a}"', 0212.chr('utf-8')],
+      ['"\u{8b}"', 0213.chr('utf-8')],
+      ['"\u{8c}"', 0214.chr('utf-8')],
+      ['"\u{8d}"', 0215.chr('utf-8')],
+      ['"\u{8e}"', 0216.chr('utf-8')],
+      ['"\u{8f}"', 0217.chr('utf-8')],
+      ['"\u{90}"', 0220.chr('utf-8')],
+      ['"\u{91}"', 0221.chr('utf-8')],
+      ['"\u{92}"', 0222.chr('utf-8')],
+      ['"\u{93}"', 0223.chr('utf-8')],
+      ['"\u{94}"', 0224.chr('utf-8')],
+      ['"\u{95}"', 0225.chr('utf-8')],
+      ['"\u{96}"', 0226.chr('utf-8')],
+      ['"\u{97}"', 0227.chr('utf-8')],
+      ['"\u{98}"', 0230.chr('utf-8')],
+      ['"\u{99}"', 0231.chr('utf-8')],
+      ['"\u{9a}"', 0232.chr('utf-8')],
+      ['"\u{9b}"', 0233.chr('utf-8')],
+      ['"\u{9c}"', 0234.chr('utf-8')],
+      ['"\u{9d}"', 0235.chr('utf-8')],
+      ['"\u{9e}"', 0236.chr('utf-8')],
+      ['"\u{9f}"', 0237.chr('utf-8')],
+    ].should be_computed_by(:undump)
   end
 
   it "returns a string with \\uXXXX notation replaced with multi-byte UTF-8 characters" do
-    NATFIXME 'it returns a string with \\uXXXX notation replaced with multi-byte UTF-8 characters', exception: SpecFailedException do
-      [ ['"\u0080"', 0200.chr('utf-8')],
-        ['"\u0081"', 0201.chr('utf-8')],
-        ['"\u0082"', 0202.chr('utf-8')],
-        ['"\u0083"', 0203.chr('utf-8')],
-        ['"\u0084"', 0204.chr('utf-8')],
-        ['"\u0086"', 0206.chr('utf-8')],
-        ['"\u0087"', 0207.chr('utf-8')],
-        ['"\u0088"', 0210.chr('utf-8')],
-        ['"\u0089"', 0211.chr('utf-8')],
-        ['"\u008a"', 0212.chr('utf-8')],
-        ['"\u008b"', 0213.chr('utf-8')],
-        ['"\u008c"', 0214.chr('utf-8')],
-        ['"\u008d"', 0215.chr('utf-8')],
-        ['"\u008e"', 0216.chr('utf-8')],
-        ['"\u008f"', 0217.chr('utf-8')],
-        ['"\u0090"', 0220.chr('utf-8')],
-        ['"\u0091"', 0221.chr('utf-8')],
-        ['"\u0092"', 0222.chr('utf-8')],
-        ['"\u0093"', 0223.chr('utf-8')],
-        ['"\u0094"', 0224.chr('utf-8')],
-        ['"\u0095"', 0225.chr('utf-8')],
-        ['"\u0096"', 0226.chr('utf-8')],
-        ['"\u0097"', 0227.chr('utf-8')],
-        ['"\u0098"', 0230.chr('utf-8')],
-        ['"\u0099"', 0231.chr('utf-8')],
-        ['"\u009a"', 0232.chr('utf-8')],
-        ['"\u009b"', 0233.chr('utf-8')],
-        ['"\u009c"', 0234.chr('utf-8')],
-        ['"\u009d"', 0235.chr('utf-8')],
-        ['"\u009e"', 0236.chr('utf-8')],
-        ['"\u009f"', 0237.chr('utf-8')],
-      ].should be_computed_by(:undump)
-    end
+    [ ['"\u0080"', 0200.chr('utf-8')],
+      ['"\u0081"', 0201.chr('utf-8')],
+      ['"\u0082"', 0202.chr('utf-8')],
+      ['"\u0083"', 0203.chr('utf-8')],
+      ['"\u0084"', 0204.chr('utf-8')],
+      ['"\u0086"', 0206.chr('utf-8')],
+      ['"\u0087"', 0207.chr('utf-8')],
+      ['"\u0088"', 0210.chr('utf-8')],
+      ['"\u0089"', 0211.chr('utf-8')],
+      ['"\u008a"', 0212.chr('utf-8')],
+      ['"\u008b"', 0213.chr('utf-8')],
+      ['"\u008c"', 0214.chr('utf-8')],
+      ['"\u008d"', 0215.chr('utf-8')],
+      ['"\u008e"', 0216.chr('utf-8')],
+      ['"\u008f"', 0217.chr('utf-8')],
+      ['"\u0090"', 0220.chr('utf-8')],
+      ['"\u0091"', 0221.chr('utf-8')],
+      ['"\u0092"', 0222.chr('utf-8')],
+      ['"\u0093"', 0223.chr('utf-8')],
+      ['"\u0094"', 0224.chr('utf-8')],
+      ['"\u0095"', 0225.chr('utf-8')],
+      ['"\u0096"', 0226.chr('utf-8')],
+      ['"\u0097"', 0227.chr('utf-8')],
+      ['"\u0098"', 0230.chr('utf-8')],
+      ['"\u0099"', 0231.chr('utf-8')],
+      ['"\u009a"', 0232.chr('utf-8')],
+      ['"\u009b"', 0233.chr('utf-8')],
+      ['"\u009c"', 0234.chr('utf-8')],
+      ['"\u009d"', 0235.chr('utf-8')],
+      ['"\u009e"', 0236.chr('utf-8')],
+      ['"\u009f"', 0237.chr('utf-8')],
+    ].should be_computed_by(:undump)
   end
 
   it "undumps correctly string produced from non ASCII-compatible one" do
     s = "\u{876}".encode('utf-16be')
-    NATFIXME 'it undumps correctly string produced from non ASCII-compatible one', exception: Encoding::CompatibilityError, message: /ASCII incompatible encoding/ do
-      s.dump.undump.should == s
+    s.dump.undump.should == s
 
-      '"\\bv".force_encoding("UTF-16BE")'.undump.should == "\u0876".encode('utf-16be')
-    end
+    '"\\bv".force_encoding("UTF-16BE")'.undump.should == "\u0876".encode('utf-16be')
   end
 
   it "returns a String in the same encoding as self" do
@@ -420,20 +414,16 @@ describe "String#undump" do
     end
 
     it "raises RuntimeError in there is incorrect \\u sequence" do
-      NATFIXME 'it raises RuntimeError in there is incorrect \\u sequence', exception: SpecFailedException do
-        -> { '"\\u"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
-        -> { '"\\u{"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
-        -> { '"\\u{3042"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
-        -> { '"\\u"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
-      end
+      -> { '"\\u"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
+      -> { '"\\u{"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
+      -> { '"\\u{3042"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
+      -> { '"\\u"'.undump }.should raise_error(RuntimeError, /invalid Unicode escape/)
     end
 
     it "raises RuntimeError if there is malformed dump of non ASCII-compatible string" do
-      NATFIXME 'it raises RuntimeError if there is malformed dump of non ASCII-compatible string', exception: SpecFailedException do
-        -> { '"".force_encoding("BINARY"'.undump }.should raise_error(RuntimeError, /invalid dumped string/)
-        -> { '"".force_encoding("Unknown")'.undump }.should raise_error(RuntimeError, /dumped string has unknown encoding name/)
-        -> { '"".force_encoding()'.undump }.should raise_error(RuntimeError, /invalid dumped string/)
-      end
+      -> { '"".force_encoding("BINARY"'.undump }.should raise_error(RuntimeError, /invalid dumped string/)
+      -> { '"".force_encoding("Unknown")'.undump }.should raise_error(RuntimeError, /dumped string has unknown encoding name/)
+      -> { '"".force_encoding()'.undump }.should raise_error(RuntimeError, /invalid dumped string/)
     end
 
     it "raises RuntimeError if string contains \0 character" do

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2987,6 +2987,64 @@ Value StringObject::undump(Env *env) const {
                     result.append("\\#");
                     result.append(c);
                 }
+            } else if (c == 'u') {
+                if (it == end())
+                    env->raise("RuntimeError", "invalid Unicode escape");
+
+                auto utf8 = EncodingObject::get(Encoding::UTF_8);
+
+                if (*it == '{') {
+                    it++;
+                    bool closed = false;
+
+                    while (it != end() && (*it)[0] != '"') {
+                        if ((*it)[0] == '}') {
+                            it++;
+                            closed = true;
+                            break;
+                        }
+                        if ((*it)[0] == ' ') {
+                            it++;
+                            continue;
+                        }
+
+                        size_t hex_start = (*it).offset();
+                        while (it != end() && (*it)[0] != '}' && (*it)[0] != ' ' && (*it)[0] != '"')
+                            it++;
+
+                        size_t hex_len = (it != end() ? (*it).offset() : bytesize()) - hex_start;
+                        if (hex_len == 0 || hex_len > 6)
+                            env->raise("RuntimeError", "invalid Unicode escape");
+
+                        char hex_buf[7] = {};
+                        memcpy(hex_buf, c_str() + hex_start, hex_len);
+                        auto codepoint = std::strtoul(hex_buf, nullptr, 16);
+                        if (codepoint > 0x10ffff)
+                            env->raise("RuntimeError", "invalid Unicode codepoint (too large)");
+                        if (codepoint >= 0xd800 && codepoint <= 0xdfff)
+                            env->raise("RuntimeError", "invalid Unicode codepoint");
+
+                        result.append(utf8->encode_codepoint(codepoint));
+                    }
+
+                    if (!closed)
+                        env->raise("RuntimeError", "invalid Unicode escape");
+                } else {
+                    size_t hex_start = (*it).offset();
+                    for (int idx = 0; idx < 4; idx++) {
+                        if (it == end())
+                            env->raise("RuntimeError", "invalid Unicode escape");
+                        it++;
+                    }
+
+                    char hex_buf[5] = {};
+                    memcpy(hex_buf, c_str() + hex_start, 4);
+                    auto codepoint = std::strtoul(hex_buf, nullptr, 16);
+                    if (codepoint >= 0xd800 && codepoint <= 0xdfff)
+                        env->raise("RuntimeError", "invalid Unicode codepoint");
+
+                    result.append(utf8->encode_codepoint(codepoint));
+                }
             } else if (c == 'x') {
                 if (it == end())
                     env->raise("RuntimeError", "invalid hex escape");
@@ -3010,12 +3068,42 @@ Value StringObject::undump(Env *env) const {
             result.append(c);
         }
     }
+
     if (it == end() || *it != '"')
         env->raise("RuntimeError", "unterminated dumped string");
+
     it++;
-    if (it != end())
-        env->raise("RuntimeError", "invalid dumped string");
-    return StringObject::create(std::move(result), m_encoding);
+    auto result_encoding = m_encoding;
+
+    if (it != end()) {
+        size_t suffix_start = (*it).offset();
+        const char *suffix = c_str() + suffix_start;
+        size_t suffix_len = bytesize() - suffix_start;
+
+        if (suffix_len >= 4 && memcmp(suffix, ".dup", 4) == 0) {
+            suffix += 4;
+            suffix_len -= 4;
+        }
+
+        const char *fe = ".force_encoding(\"";
+        auto fe_len = strlen(fe);
+        if (suffix_len < fe_len + 2 || memcmp(suffix, fe, fe_len) != 0)
+            error();
+
+        auto encname_ptr = suffix + fe_len;
+        auto encname_end = static_cast<const char *>(memchr(encname_ptr, '"', suffix_len - fe_len));
+        if (!encname_end || encname_end + 2 != suffix + suffix_len || encname_end[1] != ')')
+            error();
+
+        auto encname = String(encname_ptr, encname_end - encname_ptr);
+        auto enc = EncodingObject::find_encoding_by_name(env, encname);
+        if (!enc)
+            env->raise("RuntimeError", "dumped string has unknown encoding name");
+
+        result_encoding = enc;
+    }
+
+    return StringObject::create(std::move(result), result_encoding);
 }
 
 nat_int_t StringObject::unpack_offset(Env *env, Optional<Value> offset_arg) const {
@@ -3731,64 +3819,67 @@ Value StringObject::downcase_in_place(Env *env, Optional<Value> arg1, Optional<V
 Value StringObject::dump(Env *env) {
     String out { "\"" };
     auto encoding = m_encoding.ptr();
-
     auto utf8_encoding = EncodingObject::get(Encoding::UTF_8);
+    bool is_utf8 = (encoding == utf8_encoding);
 
-    size_t index = 0;
-    auto [valid, ch] = next_char_result(&index);
-    while (!ch.is_empty()) {
-        if (!valid) {
-            for (size_t i = 0; i < ch.size(); i++)
-                out.append_sprintf("\\x%02X", static_cast<uint8_t>(ch[i]));
-            auto pair = next_char_result(&index);
-            valid = pair.first;
-            ch = pair.second;
-            continue;
-        }
-        const auto c = encoding->decode_codepoint(ch);
-        auto pair = next_char_result(&index);
-        valid = pair.first;
-        const auto c2 = !valid || ch.is_empty() ? 0 : encoding->decode_codepoint(pair.second);
+    for (size_t i = 0; i < bytesize(); i++) {
+        unsigned char c = c_str()[i];
 
-        if (c == '"' || c == '\\' || (c == '#' && (c2 == '{' || c2 == '$' || c2 == '@'))) {
+        if (c == '"' || c == '\\') {
             out.append_char('\\');
             out.append_char(c);
-        } else if (c == '\a') {
-            out.append("\\a");
-        } else if (c == '\b') {
-            out.append("\\b");
-        } else if (c == 27) {
-            out.append("\\e");
-        } else if (c == '\f') {
-            out.append("\\f");
+        } else if (c == '#') {
+            if (i + 1 < bytesize()) {
+                unsigned char c2 = c_str()[i + 1];
+                if (c2 == '{' || c2 == '$' || c2 == '@')
+                    out.append_char('\\');
+            }
+            out.append_char('#');
         } else if (c == '\n') {
             out.append("\\n");
         } else if (c == '\r') {
             out.append("\\r");
         } else if (c == '\t') {
             out.append("\\t");
+        } else if (c == '\f') {
+            out.append("\\f");
         } else if (c == '\v') {
             out.append("\\v");
-        } else if (encoding->is_printable_char(c) && c <= 0xFFFF) {
-            if (encoding == utf8_encoding || c <= 255)
-                out.append(utf8_encoding->encode_codepoint(c));
-            else
-                encoding->append_escaped_char(out, c);
+        } else if (c == '\b') {
+            out.append("\\b");
+        } else if (c == '\a') {
+            out.append("\\a");
+        } else if (c == 27) {
+            out.append("\\e");
+        } else if (c >= 0x20 && c < 0x7F) {
+            out.append_char(c);
         } else {
-            if (c < 128)
-                out.append_sprintf("\\x%02X", c);
-            else
-                encoding->append_escaped_char(out, c);
+            if (is_utf8 && c > 0x7F) {
+                size_t char_index = i;
+                auto [valid, ch] = encoding->next_char(m_string, &char_index);
+                if (valid && ch.size() > 1) {
+                    auto cp = encoding->decode_codepoint(ch);
+                    if (cp <= 0xFFFF)
+                        out.append_sprintf("\\u%04X", cp);
+                    else
+                        out.append_sprintf("\\u{%X}", cp);
+                    i = char_index - 1;
+                    continue;
+                }
+            }
+            out.append_sprintf("\\x%02X", c);
         }
-        ch = pair.second;
     }
 
     out.append_char('"');
 
-    if (!m_encoding->is_ascii_compatible())
-        out.append_sprintf(".force_encoding(\"%s\")", m_encoding->name()->c_str());
+    EncodingObject *result_encoding = m_encoding.ptr();
+    if (!m_encoding->is_ascii_compatible()) {
+        out.append_sprintf(".dup.force_encoding(\"%s\")", m_encoding->name()->c_str());
+        result_encoding = EncodingObject::get(Encoding::ASCII_8BIT);
+    }
 
-    return StringObject::create(std::move(out), m_encoding);
+    return StringObject::create(std::move(out), result_encoding);
 }
 
 StringObject *StringObject::upcase(Env *env, Optional<Value> arg1, Optional<Value> arg2) {


### PR DESCRIPTION
* Make String#dump add .dup.force_encoding() when not ASCII-compatible (This is the strangest behavior I have ever seen in Ruby stdlib)
* Make String#undump respect the .dup.force_encoding() suffix
* Make String#undump properly handle Unicode escapes
* Make String#dump explicitly check UTF-8 before using hex escapes (Also pretty wild)