### PR TITLE
Pack and unpack updates

### DIFF
--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -27,6 +27,7 @@ namespace ArrayPacker {
         virtual void visit_children(Visitor &visitor) const override {
             visitor.visit(m_source);
             visitor.visit(m_encoding);
+            visitor.visit(m_associates);
         }
 
         virtual TM::String dbg_inspect(int indent = 0) const override {
@@ -63,6 +64,7 @@ namespace ArrayPacker {
         TM::Vector<Token> *m_directives;
         String m_packed {};
         EncodingObject *m_encoding;
+        ArrayObject *m_associates { nullptr };
         size_t m_index { 0 };
     };
 

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -18,6 +18,7 @@ namespace ArrayPacker {
         Packer(ArrayObject *source, String directives)
             : m_source { source }
             , m_directives { Tokenizer { directives }.tokenize() }
+            , m_directives_string { directives }
             , m_encoding { EncodingObject::get(Encoding::ASCII_8BIT) } { }
 
         ~Packer() { delete m_directives; }
@@ -62,6 +63,7 @@ namespace ArrayPacker {
 
         ArrayObject *m_source;
         TM::Vector<Token> *m_directives;
+        String m_directives_string;
         String m_packed {};
         EncodingObject *m_encoding;
         ArrayObject *m_associates { nullptr };

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -45,8 +45,8 @@ private:
     void unpack_h(Token &token);
     void unpack_M(Env *env, Token &token);
     void unpack_m(Env *env, Token &token);
-    void unpack_P(Token &token);
-    void unpack_p();
+    void unpack_P(Env *env, Token &token);
+    void unpack_p(Env *env);
     void unpack_U(Env *env, Token &token);
     void unpack_u(Token &token);
     void unpack_w(Env *env, Token &token);
@@ -173,6 +173,9 @@ private:
                 bits_remaining = 0;
         }
     }
+
+    ArrayObject *str_associated(Env *env) const;
+    Value associated_pointer(Env *env, ArrayObject *associates, const char *t) const;
 
     const char *pointer() const { return m_source->c_str() + m_index; }
 

--- a/include/natalie/string_unpacker.hpp
+++ b/include/natalie/string_unpacker.hpp
@@ -14,6 +14,7 @@ public:
     StringUnpacker(const StringObject *source, String directives, nat_int_t offset)
         : m_source { source }
         , m_directives { Tokenizer { directives }.tokenize() }
+        , m_directives_string { directives }
         , m_index { (size_t)std::max(offset, (nat_int_t)0) } { }
 
     ~StringUnpacker() { delete m_directives; }
@@ -221,6 +222,7 @@ private:
 
     const StringObject *m_source;
     TM::Vector<Token> *m_directives;
+    String m_directives_string;
     Optional<Value> m_unpacked_value {};
     ArrayObject *m_unpacked_array { nullptr };
     size_t m_index { 0 };

--- a/spec/core/array/pack/shared/basic.rb
+++ b/spec/core/array/pack/shared/basic.rb
@@ -36,9 +36,7 @@ describe :array_pack_basic_non_float, shared: true do
     # additional directive ('a') is required for the X directive
     # Exact error class depends on caller, both SpecFailedException and ArgumentError have been seen
     -> { [@obj, @obj].pack("a R" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive 'R'/)
-    NATFIXME 'tokenizer treats digits after whitespace as count modifiers', exception: SpecFailedException do
-      -> { [@obj, @obj].pack("a 0" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive '0'/)
-    end
+    -> { [@obj, @obj].pack("a 0" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive '0'/)
     -> { [@obj, @obj].pack("a :" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive ':'/)
 
   end

--- a/spec/core/array/pack/shared/basic.rb
+++ b/spec/core/array/pack/shared/basic.rb
@@ -35,11 +35,12 @@ describe :array_pack_basic_non_float, shared: true do
   it "raise ArgumentError when a directive is unknown" do
     # additional directive ('a') is required for the X directive
     # Exact error class depends on caller, both SpecFailedException and ArgumentError have been seen
-    NATFIXME 'raise ArgumentError when a directive is unknown' do
-      -> { [@obj, @obj].pack("a R" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive 'R'/)
+    -> { [@obj, @obj].pack("a R" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive 'R'/)
+    NATFIXME 'tokenizer treats digits after whitespace as count modifiers', exception: SpecFailedException do
       -> { [@obj, @obj].pack("a 0" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive '0'/)
-      -> { [@obj, @obj].pack("a :" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive ':'/)
     end
+    -> { [@obj, @obj].pack("a :" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive ':'/)
+
   end
 
   it "calls #to_str to coerce the directives string" do

--- a/spec/core/string/unpack/p_spec.rb
+++ b/spec/core/string/unpack/p_spec.rb
@@ -15,9 +15,7 @@ describe "String#unpack with format 'P'" do
     packed = ["hello"].pack("P")
     packed.unpack("P5").should == ["hello"]
     packed.dup.unpack("P5").should == ["hello"]
-    NATFIXME 'cannot unpack a string except from the same object that created it, or a duplicate of it', exception: SpecFailedException do
-      -> { packed.to_sym.to_s.unpack("P5") }.should raise_error(ArgumentError, /no associated pointer/)
-    end
+    -> { packed.to_sym.to_s.unpack("P5") }.should raise_error(ArgumentError, /no associated pointer/)
   end
 
   it "reads as many characters as specified" do
@@ -41,8 +39,6 @@ describe "String#unpack with format 'p'" do
     packed = ["hello"].pack("p")
     packed.unpack("p").should == ["hello"]
     packed.dup.unpack("p").should == ["hello"]
-    NATFIXME "cannot unpack a string except from the same object that created it, or a duplicate of it", exception: SpecFailedException do
-      -> { packed.to_sym.to_s.unpack("p") }.should raise_error(ArgumentError, /no associated pointer/)
-    end
+    -> { packed.to_sym.to_s.unpack("p") }.should raise_error(ArgumentError, /no associated pointer/)
   end
 end

--- a/spec/core/string/unpack/shared/basic.rb
+++ b/spec/core/string/unpack/shared/basic.rb
@@ -10,11 +10,11 @@ describe :string_unpack_basic, shared: true do
   end
 
   it "raises ArgumentError when a directive is unknown" do
-    NATFIXME 'it raise ArgumentError when a directive is unknown', exception: SpecFailedException do
-      -> { "abcdefgh".unpack("a K" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive 'K' in 'a K#{unpack_format}'")
+    -> { "abcdefgh".unpack("a K" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive 'K' in 'a K#{unpack_format}'")
+    NATFIXME 'tokenizer treats digits after whitespace as count modifiers', exception: SpecFailedException do
       -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive '0' in 'a 0#{unpack_format}'")
-      -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive ':' in 'a :#{unpack_format}'")
     end
+    -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive ':' in 'a :#{unpack_format}'")
   end
 end
 

--- a/spec/core/string/unpack/shared/basic.rb
+++ b/spec/core/string/unpack/shared/basic.rb
@@ -11,9 +11,7 @@ describe :string_unpack_basic, shared: true do
 
   it "raises ArgumentError when a directive is unknown" do
     -> { "abcdefgh".unpack("a K" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive 'K' in 'a K#{unpack_format}'")
-    NATFIXME 'tokenizer treats digits after whitespace as count modifiers', exception: SpecFailedException do
-      -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive '0' in 'a 0#{unpack_format}'")
-    end
+    -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive '0' in 'a 0#{unpack_format}'")
     -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive ':' in 'a :#{unpack_format}'")
   end
 end

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -167,9 +167,8 @@ namespace ArrayPacker {
                 m_packed.truncate(count);
                 break;
             }
-            default: {
-                env->raise("ArgumentError", "{} is not supported", d);
-            }
+            default:
+                env->raise("ArgumentError", "unknown pack directive '{}' in '{}'", d, m_directives_string);
             }
         }
         // must force str length in case m_packed was stuffed with '\0's

--- a/src/array_packer/packer.cpp
+++ b/src/array_packer/packer.cpp
@@ -58,8 +58,20 @@ namespace ArrayPacker {
                     NAT_UNREACHABLE();
                 }
 
+                if (d == 'P' && string_object && token.count >= 0) {
+                    if (static_cast<size_t>(token.count) > string_object->bytesize())
+                        env->raise("ArgumentError", "too short buffer for P({} for {})",
+                            string_object->bytesize(), token.count);
+                }
+
                 auto packer = StringHandler { string, string_object, token };
                 m_packed.append(packer.pack(env));
+
+                if (d == 'p' || d == 'P') {
+                    if (!m_associates)
+                        m_associates = ArrayObject::create();
+                    m_associates->push(item);
+                }
 
                 if (d == 'm' || d == 'M' || d == 'u')
                     m_encoding = EncodingObject::get(Encoding::US_ASCII);
@@ -163,6 +175,8 @@ namespace ArrayPacker {
         // must force str length in case m_packed was stuffed with '\0's
         buffer->set_str(m_packed.c_str(), m_packed.length());
         buffer->set_encoding(m_encoding);
+        if (m_associates)
+            buffer->ivar_set(env, "@__associated__"_s, m_associates);
         return buffer;
     }
 

--- a/src/array_packer/string_handler.cpp
+++ b/src/array_packer/string_handler.cpp
@@ -272,26 +272,18 @@ namespace ArrayPacker {
     }
 
     void StringHandler::pack_P() {
-        if (!m_string_object) {
-            for (size_t i = 0; i < sizeof(uintptr_t); i++)
-                m_packed.append_char(0x0);
-            return;
-        }
-        auto c_str = m_string_object->c_str();
-        auto ptr = (const char *)&c_str;
-        for (size_t i = 0; i < sizeof(uintptr_t); i++)
-            m_packed.append_char(ptr[i]);
+        pack_p();
     }
 
     void StringHandler::pack_p() {
+        const char *t;
         if (!m_string_object) {
-            for (size_t i = 0; i < sizeof(uintptr_t); i++)
-                m_packed.append_char(0x0);
-            return;
+            t = nullptr;
+        } else {
+            t = m_string_object->c_str();
         }
-        auto c_str = m_string_object->c_str();
-        auto ptr = (const char *)&c_str;
-        for (size_t i = 0; i < sizeof(uintptr_t); i++)
+        auto ptr = (const char *)&t;
+        for (size_t i = 0; i < sizeof(char *); i++)
             m_packed.append_char(ptr[i]);
     }
 

--- a/src/array_packer/tokenizer.cpp
+++ b/src/array_packer/tokenizer.cpp
@@ -85,7 +85,7 @@ namespace ArrayPacker {
         if (m_index >= m_directives.length())
             return 0;
         m_index++;
-        return current_char();
+        return char_at_index(m_index);
     }
 
     signed char Tokenizer::current_char() {

--- a/src/array_packer/tokenizer.cpp
+++ b/src/array_packer/tokenizer.cpp
@@ -78,8 +78,6 @@ namespace ArrayPacker {
             token.star = true;
         }
 
-        // printf("token { directive='%c', count=%d, star=%d, native_size=%d, endianness=%d }\n", token.directive, token.count, (int)token.star, (int)token.native_size, (int)token.endianness);
-
         return token;
     }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -3129,8 +3129,7 @@ Value StringObject::unpack(Env *env, Value format, Optional<Value> offset_kwarg)
     auto offset = unpack_offset(env, offset_kwarg);
     if (offset == (nat_int_t)bytesize())
         return ArrayObject::create({ Value::nil() });
-    auto unpacker = new StringUnpacker { this, format_string, offset };
-    return unpacker->unpack(env);
+    return StringUnpacker { this, format_string, offset }.unpack(env);
 }
 
 Value StringObject::unpack1(Env *env, Value format, Optional<Value> offset_kwarg) const {
@@ -3138,8 +3137,7 @@ Value StringObject::unpack1(Env *env, Value format, Optional<Value> offset_kwarg
     auto offset = unpack_offset(env, offset_kwarg);
     if (offset == (nat_int_t)bytesize())
         return Value::nil();
-    auto unpacker = new StringUnpacker { this, format_string, offset };
-    return unpacker->unpack1(env);
+    return StringUnpacker { this, format_string, offset }.unpack1(env);
 }
 
 Value StringObject::split(Env *env, Optional<Value> splitter_arg, Optional<Value> max_count_arg, Block *block) {

--- a/src/string_unpacker.cpp
+++ b/src/string_unpacker.cpp
@@ -190,7 +190,7 @@ void StringUnpacker::unpack_token(Env *env, Token &token) {
         unpack_at(env, token);
         break;
     default:
-        env->raise("ArgumentError", "{} is not supported", token.directive);
+        env->raise("ArgumentError", "unknown unpack directive '{}' in '{}'", token.directive, m_directives_string);
     }
 }
 

--- a/src/string_unpacker.cpp
+++ b/src/string_unpacker.cpp
@@ -145,10 +145,10 @@ void StringUnpacker::unpack_token(Env *env, Token &token) {
         unpack_int<uint16_t>(token, false);
         break;
     case 'P':
-        unpack_P(token);
+        unpack_P(env, token);
         break;
     case 'p':
-        unpack_p();
+        unpack_p(env);
         break;
     case 'Q':
         unpack_int<uint64_t>(token);
@@ -436,26 +436,56 @@ void StringUnpacker::unpack_m(Env *env, Token &token) {
     append(StringObject::create(out, Encoding::ASCII_8BIT));
 }
 
-void StringUnpacker::unpack_P(Token &token) {
-    if (m_index + sizeof(uintptr_t) > m_source->length()) {
-        append(Value::nil());
-        return;
-    }
-
-    const char *p = *(const char **)pointer();
-    const size_t size = std::min(static_cast<size_t>(token.count), strlen(p));
-    append(StringObject::create(p, size));
-    m_index += sizeof(uintptr_t);
+ArrayObject *StringUnpacker::str_associated(Env *env) const {
+    auto associates = const_cast<StringObject *>(m_source)->ivar_get(env, "@__associated__"_s);
+    if (associates.is_nil())
+        env->raise("ArgumentError", "no associated pointer");
+    return associates.as_array();
 }
 
-void StringUnpacker::unpack_p() {
+Value StringUnpacker::associated_pointer(Env *env, ArrayObject *associates, const char *t) const {
+    for (size_t i = 0; i < associates->size(); i++) {
+        auto tmp = associates->at(i);
+        if (tmp.is_string() && tmp.as_string()->c_str() == t)
+            return tmp;
+    }
+    env->raise("ArgumentError", "non associated pointer");
+}
+
+void StringUnpacker::unpack_P(Env *env, Token &token) {
     if (m_index + sizeof(uintptr_t) > m_source->length()) {
         append(Value::nil());
         return;
     }
 
-    append(StringObject::create(*(const char **)pointer()));
+    Value tmp = Value::nil();
+    const char *t = *(const char **)pointer();
     m_index += sizeof(uintptr_t);
+    if (t) {
+        auto associates = str_associated(env);
+        tmp = associated_pointer(env, associates, t);
+        auto len = static_cast<size_t>(token.count);
+        if (len < tmp.as_string()->bytesize()) {
+            tmp = StringObject::create(t, len);
+        }
+    }
+    append(tmp);
+}
+
+void StringUnpacker::unpack_p(Env *env) {
+    if (m_index + sizeof(uintptr_t) > m_source->length()) {
+        append(Value::nil());
+        return;
+    }
+
+    Value tmp = Value::nil();
+    const char *t = *(const char **)pointer();
+    m_index += sizeof(uintptr_t);
+    if (t) {
+        auto associates = str_associated(env);
+        tmp = associated_pointer(env, associates, t);
+    }
+    append(tmp);
 }
 
 void StringUnpacker::unpack_U(Env *env, Token &token) {


### PR DESCRIPTION
* p and P directives keep the string they are packing, on unpacking those strings are read
* Make sure the pack and unpack messages match MRI by using the directives in the original string
* Put the StringUnpacker on the stack instead of a heap allocation
* Packing should not skip whitespace when looking for quantities/modifiers

Fixes https://github.com/natalie-lang/natalie/issues/2939