### PR TITLE
Fix flaky back references spec

### DIFF
--- a/spec/language/regexp/back-references_spec.rb
+++ b/spec/language/regexp/back-references_spec.rb
@@ -31,23 +31,20 @@ describe "Regexps with back-references" do
     }.should complain(/warning: ('|`)\$4294967296' is too big for a number variable, always nil/)
   end
 
-  # NATFIXME
-  unless RUBY_PLATFORM =~ /darwin/
-    it "will not clobber capture variables across threads" do
-      cap1, cap2, cap3 = nil
-      "foo" =~ /(o+)/
-      cap1 = [$~.to_a, $1]
-      Thread.new do
-        cap2 = [$~.to_a, $1]
-        "bar" =~ /(a)/
-        cap3 = [$~.to_a, $1]
-      end.join
-      cap4 = [$~.to_a, $1]
-      cap1.should == [["oo", "oo"], "oo"]
-      cap2.should == [[], nil]
-      cap3.should == [["a", "a"], "a"]
-      cap4.should == [["oo", "oo"], "oo"]
-    end
+  it "will not clobber capture variables across threads" do
+    cap1, cap2, cap3 = nil
+    "foo" =~ /(o+)/
+    cap1 = [$~.to_a, $1]
+    Thread.new do
+      cap2 = [$~.to_a, $1]
+      "bar" =~ /(a)/
+      cap3 = [$~.to_a, $1]
+    end.join
+    cap4 = [$~.to_a, $1]
+    cap1.should == [["oo", "oo"], "oo"]
+    cap2.should == [[], nil]
+    cap3.should == [["a", "a"], "a"]
+    cap4.should == [["oo", "oo"], "oo"]
   end
 
   it "supports \<n> (backreference to previous group match)" do

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -242,6 +242,11 @@ ThreadObject *ThreadObject::initialize(Env *env, Args &&args, Block *block) {
 
     m_block = block;
 
+    // Clear the block's calling_env before the child thread starts, so
+    // non_block_env() inside the thread does not walk into the env of the
+    // parent and leak per-thread state like $~.
+    block->clear_calling_env();
+
     m_file = env->file();
     m_line = env->line();
 


### PR DESCRIPTION
**Not entirely confident about this one.** I think it's correct? I ran that spec a bunch of times locally on my mac and it failed a bunch, and then with the fix it passed. But not super sure.

Clear calling_env of the block to ThreadObject::initialize so $~ and other per-thread state are not leaked from the parent thread.