### PR TITLE
Object#send(:initialize) should not return self

### DIFF
--- a/src/data.rb
+++ b/src/data.rb
@@ -26,6 +26,7 @@ class Data
 
           members.zip(args) { |name, value| instance_variable_set(:"@#{name}", value) }
         end
+        self
       end
 
       define_method(:inspect) do

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -6,6 +6,7 @@ class Enumerator
       @current_feed = []
       @enumerables = enumerables
       @enum_block = Proc.new { |yielder| enumerables.each { |enumerable| enumerable.each { |item| yielder << item } } }
+      self
     end
 
     def inspect
@@ -25,6 +26,7 @@ class Enumerator
   class Yielder
     def initialize(&block)
       @block = block
+      self
     end
 
     def yield(*item)
@@ -194,6 +196,7 @@ class Enumerator
       end
 
       super(size, &enum_block)
+      self
     end
 
     def chunk(&block)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -708,15 +708,11 @@ Value Object::module_function(Env *env, Args &&args) {
 }
 
 Value Object::send(Env *env, SymbolObject *name, Args &&args, Block *block, MethodVisibility visibility_at_least, Optional<Value> sent_from) {
-    static const auto initialize = SymbolObject::intern("initialize");
     Method *method = find_method(env, name, visibility_at_least, sent_from);
     // TODO: make a copy if has empty keyword hash (unless that's not rare)
     args.pop_empty_keyword_hash();
     if (method) {
-        auto result = method->call(env, this, std::move(args), block);
-        if (name == initialize)
-            result = this;
-        return result;
+        return method->call(env, this, std::move(args), block);
     } else if (KernelModule::respond_to_method(env, this, "method_missing"_s, true)) {
         return method_missing_send(env, name, std::move(args), block);
     } else {

--- a/src/struct.rb
+++ b/src/struct.rb
@@ -34,11 +34,13 @@ class Struct
             invalid_keywords = args.each_key.reject { |arg| attrs.include?(arg) }
             raise ArgumentError, "unknown keywords: #{invalid_keywords.join(', ')}" unless invalid_keywords.empty?
             args.each { |attr, value| send("#{attr}=", value) }
+            self
           end
         else
           define_method :initialize do |*vals|
             raise ArgumentError, 'struct size differs' if vals.size > attrs.size
             attrs.each_with_index { |attr, index| send("#{attr}=", vals[index]) }
+            self
           end
         end
 


### PR DESCRIPTION
send(:initialize) should return whatever the initialize method returned, not self necessarily. Class.new is the place where we need the override to explicitly ignore the return value of initialize.

There are some builtins that explicitly return self in their initialize (namely the enumerator chain object). That I updated in order to maintain the right behavior.

This has an added benefit of making every send just a little faster to have one fewer comparison.