### PR TITLE
Encoding::compatible?

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -69,6 +69,7 @@
 #include "natalie/encoding/utf32_encoding_object.hpp"
 #include "natalie/encoding/utf32be_encoding_object.hpp"
 #include "natalie/encoding/utf32le_encoding_object.hpp"
+#include "natalie/encoding/utf7_encoding_object.hpp"
 #include "natalie/encoding/utf8_encoding_object.hpp"
 #include "natalie/encoding/windows1250_encoding_object.hpp"
 #include "natalie/encoding/windows1251_encoding_object.hpp"

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -44,6 +44,7 @@
 #include "natalie/encoding/ibm865_encoding_object.hpp"
 #include "natalie/encoding/ibm866_encoding_object.hpp"
 #include "natalie/encoding/ibm869_encoding_object.hpp"
+#include "natalie/encoding/iso2022jp_encoding_object.hpp"
 #include "natalie/encoding/iso885910_encoding_object.hpp"
 #include "natalie/encoding/iso885911_encoding_object.hpp"
 #include "natalie/encoding/iso885913_encoding_object.hpp"

--- a/include/natalie/encoding/iso2022jp_encoding_object.hpp
+++ b/include/natalie/encoding/iso2022jp_encoding_object.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "natalie/encoding/dummy_encoding_object.hpp"
+
+namespace Natalie {
+
+class Iso2022JpEncodingObject : public DummyEncodingObject {
+public:
+    Iso2022JpEncodingObject()
+        : DummyEncodingObject { Encoding::ISO_2022_JP, { "ISO-2022-JP", "ISO2022-JP" } } { }
+
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override { return codepoint; }
+};
+
+}

--- a/include/natalie/encoding/utf7_encoding_object.hpp
+++ b/include/natalie/encoding/utf7_encoding_object.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "natalie/encoding/dummy_encoding_object.hpp"
+
+namespace Natalie {
+
+class Utf7EncodingObject : public DummyEncodingObject {
+public:
+    Utf7EncodingObject()
+        : DummyEncodingObject { Encoding::UTF_7, { "UTF-7", "CP65000" } } { }
+
+    virtual nat_int_t to_unicode_codepoint(nat_int_t codepoint) const override { return codepoint; }
+};
+
+}

--- a/include/natalie/encoding_object.hpp
+++ b/include/natalie/encoding_object.hpp
@@ -120,6 +120,7 @@ public:
     [[noreturn]] void raise_encoding_invalid_byte_sequence_error(Env *, const String &, size_t) const;
     [[noreturn]] void raise_compatibility_error(Env *, const EncodingObject *) const;
 
+    static Value compatible(Env *, Value, Value);
     static HashObject *aliases(Env *);
     static Value find(Env *, Value);
     static ArrayObject *list(Env *env);

--- a/include/natalie/encodings.hpp
+++ b/include/natalie/encodings.hpp
@@ -60,6 +60,7 @@ enum class Encoding : size_t {
     Windows_1258,
     UTF_16,
     UTF_32,
+    UTF_7,
     TERMINATOR, // Keep this as the last entry
 };
 

--- a/include/natalie/encodings.hpp
+++ b/include/natalie/encodings.hpp
@@ -61,6 +61,7 @@ enum class Encoding : size_t {
     UTF_16,
     UTF_32,
     UTF_7,
+    ISO_2022_JP,
     TERMINATOR, // Keep this as the last entry
 };
 

--- a/include/natalie/regexp_object.hpp
+++ b/include/natalie/regexp_object.hpp
@@ -106,7 +106,12 @@ public:
         if (!is_initialized())
             return EncodingObject::get(Encoding::ASCII_8BIT);
 
-        return onig_encoding_to_ruby_encoding(onig_get_encoding(m_regex));
+        auto enc = onig_encoding_to_ruby_encoding(onig_get_encoding(m_regex));
+        // ONIG_ENCODING_ASCII maps to US-ASCII, but if the pattern was BINARY
+        // with non-ASCII content, we should return BINARY
+        if (enc->num() == Encoding::US_ASCII && (m_options & RegexOpts::FixedEncoding) && m_pattern && m_pattern->encoding()->num() == Encoding::ASCII_8BIT)
+            return EncodingObject::get(Encoding::ASCII_8BIT);
+        return enc;
     }
 
     int options() const { return m_options; }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -508,6 +508,7 @@ gen.static_binding_as_class_method('Encoding', 'default_internal=', 'EncodingObj
 gen.static_binding_as_class_method('Encoding', 'locale_charmap', 'EncodingObject', 'locale_charmap', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 
 gen.static_binding_as_class_method('Encoding', 'find', 'EncodingObject', 'find', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
+gen.static_binding_as_class_method('Encoding', 'compatible?', 'EncodingObject', 'compatible', argc: 2, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_class_method('Encoding', 'list', 'EncodingObject', 'list', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_class_method('Encoding', 'name_list', 'EncodingObject', 'name_list', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Encoding', 'ascii_compatible?', 'EncodingObject', 'is_ascii_compatible', argc: 0, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/encoding/compatible_spec.rb
+++ b/spec/core/encoding/compatible_spec.rb
@@ -1,0 +1,772 @@
+# encoding: binary
+
+require_relative '../../spec_helper'
+
+# TODO: add IO
+
+describe "Encoding.compatible? String, String" do
+  describe "when the first's Encoding is valid US-ASCII" do
+    before :each do
+      @str = "abc".dup.force_encoding Encoding::US_ASCII
+    end
+
+    it "returns US-ASCII when the second's is US-ASCII" do
+      Encoding.compatible?(@str, "def".encode("us-ascii")).should == Encoding::US_ASCII
+    end
+
+    it "returns US-ASCII if the second String is BINARY and ASCII only" do
+      Encoding.compatible?(@str, "\x7f").should == Encoding::US_ASCII
+    end
+
+    it "returns BINARY if the second String is BINARY but not ASCII only" do
+      Encoding.compatible?(@str, "\xff").should == Encoding::BINARY
+    end
+
+    it "returns US-ASCII if the second String is UTF-8 and ASCII only" do
+      Encoding.compatible?(@str, "\x7f".encode("utf-8")).should == Encoding::US_ASCII
+    end
+
+    it "returns UTF-8 if the second String is UTF-8 but not ASCII only" do
+      Encoding.compatible?(@str, "\u3042".encode("utf-8")).should == Encoding::UTF_8
+    end
+  end
+
+  describe "when the first's Encoding is ASCII compatible and ASCII only" do
+    it "returns the first's Encoding if the second is ASCII compatible and ASCII only" do
+      [ [Encoding, "abc".dup.force_encoding("UTF-8"), "123".dup.force_encoding("Shift_JIS"), Encoding::UTF_8],
+        [Encoding, "123".dup.force_encoding("Shift_JIS"), "abc".dup.force_encoding("UTF-8"), Encoding::Shift_JIS]
+      ].should be_computed_by(:compatible?)
+    end
+
+    it "returns the first's Encoding if the second is ASCII compatible and ASCII only" do
+      [ [Encoding, "abc".dup.force_encoding("BINARY"), "123".dup.force_encoding("US-ASCII"), Encoding::BINARY],
+        [Encoding, "123".dup.force_encoding("US-ASCII"), "abc".dup.force_encoding("BINARY"), Encoding::US_ASCII]
+      ].should be_computed_by(:compatible?)
+    end
+
+    it "returns the second's Encoding if the second is ASCII compatible but not ASCII only" do
+      [ [Encoding, "abc".dup.force_encoding("UTF-8"), "\xff".dup.force_encoding("Shift_JIS"), Encoding::Shift_JIS],
+        [Encoding, "123".dup.force_encoding("Shift_JIS"), "\xff".dup.force_encoding("UTF-8"), Encoding::UTF_8],
+        [Encoding, "abc".dup.force_encoding("BINARY"), "\xff".dup.force_encoding("US-ASCII"), Encoding::US_ASCII],
+        [Encoding, "123".dup.force_encoding("US-ASCII"), "\xff".dup.force_encoding("BINARY"), Encoding::BINARY],
+      ].should be_computed_by(:compatible?)
+    end
+
+    it "returns nil if the second's Encoding is not ASCII compatible" do
+      a = "abc".dup.force_encoding("UTF-8")
+      b = "1234".dup.force_encoding("UTF-16LE")
+      Encoding.compatible?(a, b).should be_nil
+    end
+  end
+
+  describe "when the first's Encoding is ASCII compatible but not ASCII only" do
+    it "returns the first's Encoding if the second's is valid US-ASCII" do
+      Encoding.compatible?("\xff", "def".encode("us-ascii")).should == Encoding::BINARY
+    end
+
+    it "returns the first's Encoding if the second's is UTF-8 and ASCII only" do
+      Encoding.compatible?("\xff", "\u{7f}".encode("utf-8")).should == Encoding::BINARY
+    end
+
+    it "returns nil if the second encoding is ASCII compatible but neither String's encoding is ASCII only" do
+      Encoding.compatible?("\xff", "\u3042".encode("utf-8")).should be_nil
+    end
+  end
+
+  describe "when the first's Encoding is not ASCII compatible" do
+    before :each do
+      @str = "abc".dup.force_encoding Encoding::UTF_7
+    end
+
+    it "returns nil when the second String is US-ASCII" do
+      Encoding.compatible?(@str, "def".encode("us-ascii")).should be_nil
+    end
+
+    it "returns nil when the second String is BINARY and ASCII only" do
+      Encoding.compatible?(@str, "\x7f").should be_nil
+    end
+
+    it "returns nil when the second String is BINARY but not ASCII only" do
+      Encoding.compatible?(@str, "\xff").should be_nil
+    end
+
+    it "returns the Encoding when the second's Encoding is not ASCII compatible but the same as the first's Encoding" do
+      encoding = Encoding.compatible?(@str, "def".dup.force_encoding("utf-7"))
+      encoding.should == Encoding::UTF_7
+    end
+  end
+
+  describe "when the first's Encoding is invalid" do
+    before :each do
+      @str = "\xff".dup.force_encoding Encoding::UTF_8
+    end
+
+    it "returns the first's Encoding when the second's Encoding is US-ASCII" do
+      Encoding.compatible?(@str, "def".encode("us-ascii")).should == Encoding::UTF_8
+    end
+
+    it "returns the first's Encoding when the second String is ASCII only" do
+      Encoding.compatible?(@str, "\x7f").should == Encoding::UTF_8
+    end
+
+    it "returns nil when the second's Encoding is BINARY but not ASCII only" do
+      Encoding.compatible?(@str, "\xff").should be_nil
+    end
+
+    it "returns nil when the second's Encoding is invalid and ASCII only" do
+      Encoding.compatible?(@str, "\x7f\x7f".dup.force_encoding("utf-16be")).should be_nil
+    end
+
+    it "returns nil when the second's Encoding is invalid and not ASCII only" do
+      Encoding.compatible?(@str, "\xff\xff".dup.force_encoding("utf-16be")).should be_nil
+    end
+
+    it "returns the Encoding when the second's Encoding is invalid but the same as the first" do
+      Encoding.compatible?(@str, @str).should == Encoding::UTF_8
+    end
+  end
+
+  describe "when the first String is empty and the second is not" do
+    describe "and the first's Encoding is ASCII compatible" do
+      before :each do
+        @str = "".dup.force_encoding("utf-8")
+      end
+
+      it "returns the first's encoding when the second String is ASCII only" do
+        Encoding.compatible?(@str, "def".encode("us-ascii")).should == Encoding::UTF_8
+      end
+
+      it "returns the second's encoding when the second String is not ASCII only" do
+        Encoding.compatible?(@str, "def".encode("utf-32le")).should == Encoding::UTF_32LE
+      end
+    end
+
+    describe "when the first's Encoding is not ASCII compatible" do
+      before :each do
+        @str = "".dup.force_encoding Encoding::UTF_7
+      end
+
+      it "returns the second string's encoding" do
+        Encoding.compatible?(@str, "def".encode("us-ascii")).should == Encoding::US_ASCII
+      end
+    end
+  end
+
+  describe "when the second String is empty" do
+    before :each do
+      @str = "abc".dup.force_encoding("utf-7")
+    end
+
+    it "returns the first Encoding" do
+      Encoding.compatible?(@str, "").should == Encoding::UTF_7
+    end
+  end
+
+  # Encoding negotiation depends on whether encodings are ASCII-compatible, empty
+  # and contain only ASCII characters (that take 7 bits). Check US-ASCII, UTF-8 and
+  # BINARY encodings (as most common) as well as an ASCII-compatible, a non-ASCII-compatible and a dummy
+  # encodings in all possible combinations.
+  describe "compatibility matrix" do
+
+#     Use the following script to regenerate the matrix:
+#
+#     ```
+#       # encoding: binary
+#
+#       ENCODINGS = [
+#         "US-ASCII",
+#         "UTF-8",
+#         "ASCII-8BIT",
+#         "ISO-8859-1",  # ASCII-compatible
+#         "UTF-16BE",    # non-ASCII-compatible
+#         "ISO-2022-JP"  # dummy
+#       ]
+#
+#       TYPES = [:empty, :"7bits", :non7bits]
+#
+#       VALUES = {
+#         empty: "",
+#         :"7bits" => "\x01\x01",
+#         non7bits: "\x01\x81"
+#       }
+#
+#       ENCODINGS.product(TYPES, ENCODINGS, TYPES).each do |encoding1, type1, encoding2, type2|
+#         value1 = VALUES[type1].dup.force_encoding(encoding1)
+#         value2 = VALUES[type2].dup.force_encoding(encoding2)
+#
+#         result_encoding = Encoding.compatible?(value1, value2)
+#
+#         puts "[#{encoding1.inspect}, #{value1.inspect}, #{encoding2.inspect}, #{value2.inspect}, #{result_encoding&.name.inspect}],"
+#       end
+#     ```
+
+    matrix = [
+      ["US-ASCII", "", "US-ASCII", "", "US-ASCII"],
+      ["US-ASCII", "", "US-ASCII", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["US-ASCII", "", "UTF-8", "", "US-ASCII"],
+      ["US-ASCII", "", "UTF-8", "\u0001\u0001", "US-ASCII"],
+      ["US-ASCII", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["US-ASCII", "", "ASCII-8BIT", "", "US-ASCII"],
+      ["US-ASCII", "", "ASCII-8BIT", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["US-ASCII", "", "ISO-8859-1", "", "US-ASCII"],
+      ["US-ASCII", "", "ISO-8859-1", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["US-ASCII", "", "UTF-16BE", "", "US-ASCII"],
+      ["US-ASCII", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["US-ASCII", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["US-ASCII", "", "ISO-2022-JP", "", "US-ASCII"],
+      ["US-ASCII", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["US-ASCII", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["US-ASCII", "\x01\x01", "US-ASCII", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "US-ASCII", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "UTF-8", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "UTF-8", "\u0001\u0001", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["US-ASCII", "\x01\x01", "ASCII-8BIT", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "ASCII-8BIT", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["US-ASCII", "\x01\x01", "ISO-8859-1", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "ISO-8859-1", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["US-ASCII", "\x01\x01", "UTF-16BE", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "UTF-16BE", "\u0101", nil],
+      ["US-ASCII", "\x01\x01", "UTF-16BE", "\u0181", nil],
+      ["US-ASCII", "\x01\x01", "ISO-2022-JP", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x01", "ISO-2022-JP", "\x01\x01", nil],
+      ["US-ASCII", "\x01\x01", "ISO-2022-JP", "\x01\x81", nil],
+      ["US-ASCII", "\x01\x81", "US-ASCII", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "US-ASCII", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "UTF-8", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "UTF-8", "\u0001\u0001", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "UTF-8", "\u0001\x81", nil],
+      ["US-ASCII", "\x01\x81", "ASCII-8BIT", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "ASCII-8BIT", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "ASCII-8BIT", "\x01\x81", nil],
+      ["US-ASCII", "\x01\x81", "ISO-8859-1", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "ISO-8859-1", "\x01\x01", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "ISO-8859-1", "\x01\x81", nil],
+      ["US-ASCII", "\x01\x81", "UTF-16BE", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "UTF-16BE", "\u0101", nil],
+      ["US-ASCII", "\x01\x81", "UTF-16BE", "\u0181", nil],
+      ["US-ASCII", "\x01\x81", "ISO-2022-JP", "", "US-ASCII"],
+      ["US-ASCII", "\x01\x81", "ISO-2022-JP", "\x01\x01", nil],
+      ["US-ASCII", "\x01\x81", "ISO-2022-JP", "\x01\x81", nil],
+      ["UTF-8", "", "US-ASCII", "", "UTF-8"],
+      ["UTF-8", "", "US-ASCII", "\x01\x01", "UTF-8"],
+      ["UTF-8", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["UTF-8", "", "UTF-8", "", "UTF-8"],
+      ["UTF-8", "", "UTF-8", "\u0001\u0001", "UTF-8"],
+      ["UTF-8", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["UTF-8", "", "ASCII-8BIT", "", "UTF-8"],
+      ["UTF-8", "", "ASCII-8BIT", "\x01\x01", "UTF-8"],
+      ["UTF-8", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["UTF-8", "", "ISO-8859-1", "", "UTF-8"],
+      ["UTF-8", "", "ISO-8859-1", "\x01\x01", "UTF-8"],
+      ["UTF-8", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["UTF-8", "", "UTF-16BE", "", "UTF-8"],
+      ["UTF-8", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["UTF-8", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["UTF-8", "", "ISO-2022-JP", "", "UTF-8"],
+      ["UTF-8", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["UTF-8", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["UTF-8", "\u0001\u0001", "US-ASCII", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "US-ASCII", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["UTF-8", "\u0001\u0001", "UTF-8", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "UTF-8", "\u0001\u0001", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ASCII-8BIT", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ASCII-8BIT", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["UTF-8", "\u0001\u0001", "ISO-8859-1", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ISO-8859-1", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["UTF-8", "\u0001\u0001", "UTF-16BE", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "UTF-16BE", "\u0101", nil],
+      ["UTF-8", "\u0001\u0001", "UTF-16BE", "\u0181", nil],
+      ["UTF-8", "\u0001\u0001", "ISO-2022-JP", "", "UTF-8"],
+      ["UTF-8", "\u0001\u0001", "ISO-2022-JP", "\x01\x01", nil],
+      ["UTF-8", "\u0001\u0001", "ISO-2022-JP", "\x01\x81", nil],
+      ["UTF-8", "\u0001\x81", "US-ASCII", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "US-ASCII", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "US-ASCII", "\x01\x81", nil],
+      ["UTF-8", "\u0001\x81", "UTF-8", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "UTF-8", "\u0001\u0001", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ASCII-8BIT", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ASCII-8BIT", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ASCII-8BIT", "\x01\x81", nil],
+      ["UTF-8", "\u0001\x81", "ISO-8859-1", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ISO-8859-1", "\x01\x01", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ISO-8859-1", "\x01\x81", nil],
+      ["UTF-8", "\u0001\x81", "UTF-16BE", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "UTF-16BE", "\u0101", nil],
+      ["UTF-8", "\u0001\x81", "UTF-16BE", "\u0181", nil],
+      ["UTF-8", "\u0001\x81", "ISO-2022-JP", "", "UTF-8"],
+      ["UTF-8", "\u0001\x81", "ISO-2022-JP", "\x01\x01", nil],
+      ["UTF-8", "\u0001\x81", "ISO-2022-JP", "\x01\x81", nil],
+      ["ASCII-8BIT", "", "US-ASCII", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "US-ASCII", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["ASCII-8BIT", "", "UTF-8", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "UTF-8", "\u0001\u0001", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["ASCII-8BIT", "", "ASCII-8BIT", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ASCII-8BIT", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ISO-8859-1", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ISO-8859-1", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ASCII-8BIT", "", "UTF-16BE", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["ASCII-8BIT", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["ASCII-8BIT", "", "ISO-2022-JP", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["ASCII-8BIT", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["ASCII-8BIT", "\x01\x01", "US-ASCII", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "US-ASCII", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["ASCII-8BIT", "\x01\x01", "UTF-8", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "UTF-8", "\u0001\u0001", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["ASCII-8BIT", "\x01\x01", "ASCII-8BIT", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ASCII-8BIT", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ISO-8859-1", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ISO-8859-1", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ASCII-8BIT", "\x01\x01", "UTF-16BE", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "UTF-16BE", "\u0101", nil],
+      ["ASCII-8BIT", "\x01\x01", "UTF-16BE", "\u0181", nil],
+      ["ASCII-8BIT", "\x01\x01", "ISO-2022-JP", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x01", "ISO-2022-JP", "\x01\x01", nil],
+      ["ASCII-8BIT", "\x01\x01", "ISO-2022-JP", "\x01\x81", nil],
+      ["ASCII-8BIT", "\x01\x81", "US-ASCII", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "US-ASCII", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "US-ASCII", "\x01\x81", nil],
+      ["ASCII-8BIT", "\x01\x81", "UTF-8", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "UTF-8", "\u0001\u0001", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "UTF-8", "\u0001\x81", nil],
+      ["ASCII-8BIT", "\x01\x81", "ASCII-8BIT", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ASCII-8BIT", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ISO-8859-1", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ISO-8859-1", "\x01\x01", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ISO-8859-1", "\x01\x81", nil],
+      ["ASCII-8BIT", "\x01\x81", "UTF-16BE", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "UTF-16BE", "\u0101", nil],
+      ["ASCII-8BIT", "\x01\x81", "UTF-16BE", "\u0181", nil],
+      ["ASCII-8BIT", "\x01\x81", "ISO-2022-JP", "", "ASCII-8BIT"],
+      ["ASCII-8BIT", "\x01\x81", "ISO-2022-JP", "\x01\x01", nil],
+      ["ASCII-8BIT", "\x01\x81", "ISO-2022-JP", "\x01\x81", nil],
+      ["ISO-8859-1", "", "US-ASCII", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "US-ASCII", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["ISO-8859-1", "", "UTF-8", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "UTF-8", "\u0001\u0001", "ISO-8859-1"],
+      ["ISO-8859-1", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["ISO-8859-1", "", "ASCII-8BIT", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "ASCII-8BIT", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ISO-8859-1", "", "ISO-8859-1", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "ISO-8859-1", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ISO-8859-1", "", "UTF-16BE", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["ISO-8859-1", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["ISO-8859-1", "", "ISO-2022-JP", "", "ISO-8859-1"],
+      ["ISO-8859-1", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["ISO-8859-1", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["ISO-8859-1", "\x01\x01", "US-ASCII", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "US-ASCII", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["ISO-8859-1", "\x01\x01", "UTF-8", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "UTF-8", "\u0001\u0001", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["ISO-8859-1", "\x01\x01", "ASCII-8BIT", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "ASCII-8BIT", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ISO-8859-1", "\x01\x01", "ISO-8859-1", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "ISO-8859-1", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "UTF-16BE", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "UTF-16BE", "\u0101", nil],
+      ["ISO-8859-1", "\x01\x01", "UTF-16BE", "\u0181", nil],
+      ["ISO-8859-1", "\x01\x01", "ISO-2022-JP", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x01", "ISO-2022-JP", "\x01\x01", nil],
+      ["ISO-8859-1", "\x01\x01", "ISO-2022-JP", "\x01\x81", nil],
+      ["ISO-8859-1", "\x01\x81", "US-ASCII", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "US-ASCII", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "US-ASCII", "\x01\x81", nil],
+      ["ISO-8859-1", "\x01\x81", "UTF-8", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "UTF-8", "\u0001\u0001", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "UTF-8", "\u0001\x81", nil],
+      ["ISO-8859-1", "\x01\x81", "ASCII-8BIT", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "ASCII-8BIT", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "ASCII-8BIT", "\x01\x81", nil],
+      ["ISO-8859-1", "\x01\x81", "ISO-8859-1", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "ISO-8859-1", "\x01\x01", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "UTF-16BE", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "UTF-16BE", "\u0101", nil],
+      ["ISO-8859-1", "\x01\x81", "UTF-16BE", "\u0181", nil],
+      ["ISO-8859-1", "\x01\x81", "ISO-2022-JP", "", "ISO-8859-1"],
+      ["ISO-8859-1", "\x01\x81", "ISO-2022-JP", "\x01\x01", nil],
+      ["ISO-8859-1", "\x01\x81", "ISO-2022-JP", "\x01\x81", nil],
+      ["UTF-16BE", "", "US-ASCII", "", "UTF-16BE"],
+      ["UTF-16BE", "", "US-ASCII", "\x01\x01", "US-ASCII"],
+      ["UTF-16BE", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["UTF-16BE", "", "UTF-8", "", "UTF-16BE"],
+      ["UTF-16BE", "", "UTF-8", "\u0001\u0001", "UTF-8"],
+      ["UTF-16BE", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["UTF-16BE", "", "ASCII-8BIT", "", "UTF-16BE"],
+      ["UTF-16BE", "", "ASCII-8BIT", "\x01\x01", "ASCII-8BIT"],
+      ["UTF-16BE", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["UTF-16BE", "", "ISO-8859-1", "", "UTF-16BE"],
+      ["UTF-16BE", "", "ISO-8859-1", "\x01\x01", "ISO-8859-1"],
+      ["UTF-16BE", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["UTF-16BE", "", "UTF-16BE", "", "UTF-16BE"],
+      ["UTF-16BE", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["UTF-16BE", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["UTF-16BE", "", "ISO-2022-JP", "", "UTF-16BE"],
+      ["UTF-16BE", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["UTF-16BE", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["UTF-16BE", "\u0101", "US-ASCII", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "US-ASCII", "\x01\x01", nil],
+      ["UTF-16BE", "\u0101", "US-ASCII", "\x01\x81", nil],
+      ["UTF-16BE", "\u0101", "UTF-8", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "UTF-8", "\u0001\u0001", nil],
+      ["UTF-16BE", "\u0101", "UTF-8", "\u0001\x81", nil],
+      ["UTF-16BE", "\u0101", "ASCII-8BIT", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "ASCII-8BIT", "\x01\x01", nil],
+      ["UTF-16BE", "\u0101", "ASCII-8BIT", "\x01\x81", nil],
+      ["UTF-16BE", "\u0101", "ISO-8859-1", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "ISO-8859-1", "\x01\x01", nil],
+      ["UTF-16BE", "\u0101", "ISO-8859-1", "\x01\x81", nil],
+      ["UTF-16BE", "\u0101", "UTF-16BE", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "ISO-2022-JP", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0101", "ISO-2022-JP", "\x01\x01", nil],
+      ["UTF-16BE", "\u0101", "ISO-2022-JP", "\x01\x81", nil],
+      ["UTF-16BE", "\u0181", "US-ASCII", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "US-ASCII", "\x01\x01", nil],
+      ["UTF-16BE", "\u0181", "US-ASCII", "\x01\x81", nil],
+      ["UTF-16BE", "\u0181", "UTF-8", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "UTF-8", "\u0001\u0001", nil],
+      ["UTF-16BE", "\u0181", "UTF-8", "\u0001\x81", nil],
+      ["UTF-16BE", "\u0181", "ASCII-8BIT", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "ASCII-8BIT", "\x01\x01", nil],
+      ["UTF-16BE", "\u0181", "ASCII-8BIT", "\x01\x81", nil],
+      ["UTF-16BE", "\u0181", "ISO-8859-1", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "ISO-8859-1", "\x01\x01", nil],
+      ["UTF-16BE", "\u0181", "ISO-8859-1", "\x01\x81", nil],
+      ["UTF-16BE", "\u0181", "UTF-16BE", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "ISO-2022-JP", "", "UTF-16BE"],
+      ["UTF-16BE", "\u0181", "ISO-2022-JP", "\x01\x01", nil],
+      ["UTF-16BE", "\u0181", "ISO-2022-JP", "\x01\x81", nil],
+      ["ISO-2022-JP", "", "US-ASCII", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "US-ASCII", "\x01\x01", "US-ASCII"],
+      ["ISO-2022-JP", "", "US-ASCII", "\x01\x81", "US-ASCII"],
+      ["ISO-2022-JP", "", "UTF-8", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "UTF-8", "\u0001\u0001", "UTF-8"],
+      ["ISO-2022-JP", "", "UTF-8", "\u0001\x81", "UTF-8"],
+      ["ISO-2022-JP", "", "ASCII-8BIT", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "ASCII-8BIT", "\x01\x01", "ASCII-8BIT"],
+      ["ISO-2022-JP", "", "ASCII-8BIT", "\x01\x81", "ASCII-8BIT"],
+      ["ISO-2022-JP", "", "ISO-8859-1", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "ISO-8859-1", "\x01\x01", "ISO-8859-1"],
+      ["ISO-2022-JP", "", "ISO-8859-1", "\x01\x81", "ISO-8859-1"],
+      ["ISO-2022-JP", "", "UTF-16BE", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "UTF-16BE", "\u0101", "UTF-16BE"],
+      ["ISO-2022-JP", "", "UTF-16BE", "\u0181", "UTF-16BE"],
+      ["ISO-2022-JP", "", "ISO-2022-JP", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["ISO-2022-JP", "", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "US-ASCII", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "US-ASCII", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x01", "US-ASCII", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x01", "UTF-8", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "UTF-8", "\u0001\u0001", nil],
+      ["ISO-2022-JP", "\x01\x01", "UTF-8", "\u0001\x81", nil],
+      ["ISO-2022-JP", "\x01\x01", "ASCII-8BIT", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "ASCII-8BIT", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x01", "ASCII-8BIT", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x01", "ISO-8859-1", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "ISO-8859-1", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x01", "ISO-8859-1", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x01", "UTF-16BE", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "UTF-16BE", "\u0101", nil],
+      ["ISO-2022-JP", "\x01\x01", "UTF-16BE", "\u0181", nil],
+      ["ISO-2022-JP", "\x01\x01", "ISO-2022-JP", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x01", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "US-ASCII", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "US-ASCII", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x81", "US-ASCII", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x81", "UTF-8", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "UTF-8", "\u0001\u0001", nil],
+      ["ISO-2022-JP", "\x01\x81", "UTF-8", "\u0001\x81", nil],
+      ["ISO-2022-JP", "\x01\x81", "ASCII-8BIT", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "ASCII-8BIT", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x81", "ASCII-8BIT", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x81", "ISO-8859-1", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "ISO-8859-1", "\x01\x01", nil],
+      ["ISO-2022-JP", "\x01\x81", "ISO-8859-1", "\x01\x81", nil],
+      ["ISO-2022-JP", "\x01\x81", "UTF-16BE", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "UTF-16BE", "\u0101", nil],
+      ["ISO-2022-JP", "\x01\x81", "UTF-16BE", "\u0181", nil],
+      ["ISO-2022-JP", "\x01\x81", "ISO-2022-JP", "", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "ISO-2022-JP", "\x01\x01", "ISO-2022-JP"],
+      ["ISO-2022-JP", "\x01\x81", "ISO-2022-JP", "\x01\x81", "ISO-2022-JP"],
+    ]
+
+    matrix.each do |encoding1, value1, encoding2, value2, compatible_encoding|
+      it "returns #{compatible_encoding} for #{value1.inspect} in #{encoding1} and #{value2.inspect} in #{encoding2}" do
+        actual_encoding = Encoding.compatible?(value1.dup.force_encoding(encoding1), value2.dup.force_encoding(encoding2))
+        actual_encoding&.name.should == compatible_encoding
+      end
+    end
+  end
+end
+
+describe "Encoding.compatible? String, Regexp" do
+  it "returns US-ASCII if both are US-ASCII" do
+    str = "abc".dup.force_encoding("us-ascii")
+    Encoding.compatible?(str, /abc/).should == Encoding::US_ASCII
+  end
+
+  it "returns the String's Encoding if it is not US-ASCII but both are ASCII only" do
+    [ [Encoding, "abc",                     Encoding::BINARY],
+      [Encoding, "abc".encode("utf-8"),     Encoding::UTF_8],
+      [Encoding, "abc".encode("euc-jp"),    Encoding::EUC_JP],
+      [Encoding, "abc".encode("shift_jis"), Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, /abc/)
+  end
+
+  it "returns the String's Encoding if the String is not ASCII only" do
+    [ [Encoding, "\xff",                                  Encoding::BINARY],
+      [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, /abc/)
+  end
+
+  it "returns the Regexp's Encoding if the String is ASCII only and the Regexp is not" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?("hello".dup.force_encoding("utf-8"), r).should == Encoding::EUC_JP
+  end
+end
+
+describe "Encoding.compatible? String, Symbol" do
+  it "returns US-ASCII if both are ASCII only" do
+    str = "abc".dup.force_encoding("us-ascii")
+    Encoding.compatible?(str, :abc).should == Encoding::US_ASCII
+  end
+
+  it "returns the String's Encoding if it is not US-ASCII but both are ASCII only" do
+    [ [Encoding, "abc",                     Encoding::BINARY],
+      [Encoding, "abc".encode("utf-8"),     Encoding::UTF_8],
+      [Encoding, "abc".encode("euc-jp"),    Encoding::EUC_JP],
+      [Encoding, "abc".encode("shift_jis"), Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, :abc)
+  end
+
+  it "returns the String's Encoding if the String is not ASCII only" do
+    [ [Encoding, "\xff",                                  Encoding::BINARY],
+      [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, :abc)
+  end
+end
+
+describe "Encoding.compatible? String, Encoding" do
+  it "returns nil if the String's encoding is not ASCII compatible" do
+    Encoding.compatible?("abc".encode("utf-32le"), Encoding::US_ASCII).should be_nil
+  end
+
+  it "returns nil if the Encoding is not ASCII compatible" do
+    Encoding.compatible?("abc".encode("us-ascii"), Encoding::UTF_32LE).should be_nil
+  end
+
+  it "returns the String's encoding if the Encoding is US-ASCII" do
+    [ [Encoding, "\xff",                                  Encoding::BINARY],
+      [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, Encoding::US_ASCII)
+  end
+
+  it "returns the Encoding if the String's encoding is ASCII compatible and the String is ASCII only" do
+    str = "abc".encode("utf-8")
+
+    Encoding.compatible?(str, Encoding::BINARY).should == Encoding::BINARY
+    Encoding.compatible?(str, Encoding::UTF_8).should == Encoding::UTF_8
+    Encoding.compatible?(str, Encoding::EUC_JP).should == Encoding::EUC_JP
+    Encoding.compatible?(str, Encoding::Shift_JIS).should == Encoding::Shift_JIS
+  end
+
+  it "returns nil if the String's encoding is ASCII compatible but the string is not ASCII only" do
+    Encoding.compatible?("\u3042".encode("utf-8"), Encoding::BINARY).should be_nil
+  end
+end
+
+describe "Encoding.compatible? Regexp, String" do
+  it "returns US-ASCII if both are US-ASCII" do
+    str = "abc".dup.force_encoding("us-ascii")
+    Encoding.compatible?(/abc/, str).should == Encoding::US_ASCII
+  end
+
+  it "returns the String's Encoding when the String is ASCII only with a different encoding" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?(r, "hello".dup.force_encoding("utf-8")).should == Encoding::UTF_8
+  end
+
+  it "returns the Regexp's Encoding if the String has the same non-ASCII encoding" do
+    r = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    Encoding.compatible?(r, "hello".dup.force_encoding("euc-jp")).should == Encoding::EUC_JP
+  end
+end
+
+describe "Encoding.compatible? Regexp, Regexp" do
+  it "returns US-ASCII if both are US-ASCII" do
+    Encoding.compatible?(/abc/, /def/).should == Encoding::US_ASCII
+  end
+
+  it "returns the first's Encoding if it is not US-ASCII and not ASCII only" do
+    [ [Encoding, Regexp.new("\xff"),                                  Encoding::BINARY],
+      [Encoding, Regexp.new("\u3042".encode("utf-8")),                Encoding::UTF_8],
+      [Encoding, Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp")),     Encoding::EUC_JP],
+      [Encoding, Regexp.new("\x82\xa0".dup.force_encoding("shift_jis")),  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, /abc/)
+  end
+end
+
+describe "Encoding.compatible? Regexp, Symbol" do
+  it "returns US-ASCII if both are US-ASCII" do
+    Encoding.compatible?(/abc/, :def).should == Encoding::US_ASCII
+  end
+
+  it "returns the first's Encoding if it is not US-ASCII and not ASCII only" do
+    [ [Encoding, Regexp.new("\xff"),                                  Encoding::BINARY],
+      [Encoding, Regexp.new("\u3042".encode("utf-8")),                Encoding::UTF_8],
+      [Encoding, Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp")),     Encoding::EUC_JP],
+      [Encoding, Regexp.new("\x82\xa0".dup.force_encoding("shift_jis")),  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, /abc/)
+  end
+end
+
+describe "Encoding.compatible? Symbol, String" do
+  it "returns US-ASCII if both are ASCII only" do
+    str = "abc".dup.force_encoding("us-ascii")
+    Encoding.compatible?(str, :abc).should == Encoding::US_ASCII
+  end
+end
+
+describe "Encoding.compatible? Symbol, Regexp" do
+  it "returns US-ASCII if both are US-ASCII" do
+    Encoding.compatible?(:abc, /def/).should == Encoding::US_ASCII
+  end
+
+  it "returns the Regexp's Encoding if it is not US-ASCII and not ASCII only" do
+    a = Regexp.new("\xff")
+    b = Regexp.new("\u3042".encode("utf-8"))
+    c = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    d = Regexp.new("\x82\xa0".dup.force_encoding("shift_jis"))
+
+    [ [Encoding, :abc, a, Encoding::BINARY],
+      [Encoding, :abc, b, Encoding::UTF_8],
+      [Encoding, :abc, c, Encoding::EUC_JP],
+      [Encoding, :abc, d, Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?)
+  end
+end
+
+describe "Encoding.compatible? Symbol, Symbol" do
+  it "returns US-ASCII if both are US-ASCII" do
+    Encoding.compatible?(:abc, :def).should == Encoding::US_ASCII
+  end
+
+  it "returns the first's Encoding if it is not ASCII only" do
+    [ [Encoding, "\xff".to_sym,                                  Encoding::BINARY],
+      [Encoding, "\u3042".encode("utf-8").to_sym,                Encoding::UTF_8],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp").to_sym,     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis").to_sym,  Encoding::Shift_JIS],
+    ].should be_computed_by(:compatible?, :abc)
+  end
+end
+
+describe "Encoding.compatible? Encoding, Encoding" do
+  it "returns nil if one of the encodings is a dummy encoding" do
+    [ [Encoding, Encoding::UTF_7, Encoding::US_ASCII,   nil],
+      [Encoding, Encoding::US_ASCII, Encoding::UTF_7,   nil],
+      [Encoding, Encoding::EUC_JP, Encoding::UTF_7,     nil],
+      [Encoding, Encoding::UTF_7, Encoding::EUC_JP,     nil],
+      [Encoding, Encoding::UTF_7, Encoding::BINARY, nil],
+      [Encoding, Encoding::BINARY, Encoding::UTF_7, nil],
+    ].should be_computed_by(:compatible?)
+  end
+
+  it "returns nil if one of the encodings is not US-ASCII" do
+    [ [Encoding, Encoding::UTF_8, Encoding::BINARY,   nil],
+      [Encoding, Encoding::BINARY, Encoding::UTF_8,   nil],
+      [Encoding, Encoding::BINARY, Encoding::EUC_JP,  nil],
+      [Encoding, Encoding::Shift_JIS, Encoding::EUC_JP,   nil],
+    ].should be_computed_by(:compatible?)
+  end
+
+  it "returns the first if the second is US-ASCII" do
+    [ [Encoding, Encoding::UTF_8, Encoding::US_ASCII,       Encoding::UTF_8],
+      [Encoding, Encoding::EUC_JP, Encoding::US_ASCII,      Encoding::EUC_JP],
+      [Encoding, Encoding::Shift_JIS, Encoding::US_ASCII,   Encoding::Shift_JIS],
+      [Encoding, Encoding::BINARY, Encoding::US_ASCII,  Encoding::BINARY],
+    ].should be_computed_by(:compatible?)
+  end
+
+  it "returns the Encoding if both are the same" do
+    [ [Encoding, Encoding::UTF_8, Encoding::UTF_8,            Encoding::UTF_8],
+      [Encoding, Encoding::US_ASCII, Encoding::US_ASCII,      Encoding::US_ASCII],
+      [Encoding, Encoding::BINARY, Encoding::BINARY,  Encoding::BINARY],
+      [Encoding, Encoding::UTF_7, Encoding::UTF_7,            Encoding::UTF_7],
+    ].should be_computed_by(:compatible?)
+  end
+end
+
+describe "Encoding.compatible? Object, Object" do
+  it "returns nil for Object, String" do
+    Encoding.compatible?(Object.new, "abc").should be_nil
+  end
+
+  it "returns nil for Object, Regexp" do
+    Encoding.compatible?(Object.new, /./).should be_nil
+  end
+
+  it "returns nil for Object, Symbol" do
+    Encoding.compatible?(Object.new, :sym).should be_nil
+  end
+
+  it "returns nil for String, Object" do
+    Encoding.compatible?("abc", Object.new).should be_nil
+  end
+
+  it "returns nil for Regexp, Object" do
+    Encoding.compatible?(/./, Object.new).should be_nil
+  end
+
+  it "returns nil for Symbol, Object" do
+    Encoding.compatible?(:sym, Object.new).should be_nil
+  end
+end
+
+describe "Encoding.compatible? nil, nil" do
+  it "returns nil" do
+    Encoding.compatible?(nil, nil).should be_nil
+  end
+end

--- a/spec/core/encoding/converter/asciicompat_encoding_spec.rb
+++ b/spec/core/encoding/converter/asciicompat_encoding_spec.rb
@@ -13,16 +13,14 @@ describe "Encoding::Converter.asciicompat_encoding" do
   end
 
   it "accepts an Encoding object as an argument" do
-    NATFIXME 'ISO-2022-JP encoding not implemented', exception: ArgumentError do
-      Encoding::Converter.
-        asciicompat_encoding(Encoding.find("ISO-2022-JP")).
-        should == Encoding::Converter.asciicompat_encoding("ISO-2022-JP")
-    end
+    Encoding::Converter.
+      asciicompat_encoding(Encoding.find("ISO-2022-JP")).
+      should == Encoding::Converter.asciicompat_encoding("ISO-2022-JP")
   end
 
   it "returns a corresponding ASCII compatible encoding for ASCII-incompatible encodings" do
     Encoding::Converter.asciicompat_encoding('UTF-16BE').should == Encoding::UTF_8
-    NATFIXME 'ISO-2022-JP encoding not implemented', exception: ArgumentError do
+    NATFIXME 'stateless-ISO-2022-JP encoding not implemented', exception: ArgumentError do
       Encoding::Converter.asciicompat_encoding("ISO-2022-JP").should == Encoding.find("stateless-ISO-2022-JP")
     end
   end

--- a/spec/core/encoding/converter/last_error_spec.rb
+++ b/spec/core/encoding/converter/last_error_spec.rb
@@ -14,7 +14,7 @@ describe "Encoding::Converter#last_error" do
   end
 
   it "returns nil when #primitive_convert last returned :destination_buffer_full" do
-    NATFIXME 'iso-2022-jp encoding not implemented', exception: ArgumentError do
+    NATFIXME 'iso-2022-jp conversion not supported (dummy encoding)', exception: Encoding::UndefinedConversionError do
       ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
       ec.primitive_convert(+"\u{9999}", +"", 0, 0, partial_input: false) \
         .should == :destination_buffer_full

--- a/spec/core/encoding/converter/primitive_convert_spec.rb
+++ b/spec/core/encoding/converter/primitive_convert_spec.rb
@@ -172,7 +172,7 @@ describe "Encoding::Converter#primitive_convert" do
   end
 
   it "returns :destination_buffer_full when the destination buffer is too small" do
-    NATFIXME 'iso-2022-jp encoding not implemented', exception: ArgumentError do
+    NATFIXME 'iso-2022-jp conversion not supported (dummy encoding)', exception: Encoding::UndefinedConversionError do
       ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
       source = "\u{9999}"
       destination_bytesize = source.bytesize - 1
@@ -183,7 +183,7 @@ describe "Encoding::Converter#primitive_convert" do
   end
 
   it "clears the source buffer when returning :destination_buffer_full" do
-    NATFIXME 'iso-2022-jp encoding not implemented', exception: ArgumentError do
+    NATFIXME 'iso-2022-jp conversion not supported (dummy encoding)', exception: Encoding::UndefinedConversionError do
       ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
       s = "\u{9999}"
       destination_bytesize = s.bytesize - 1

--- a/spec/core/encoding/converter/primitive_errinfo_spec.rb
+++ b/spec/core/encoding/converter/primitive_errinfo_spec.rb
@@ -21,7 +21,7 @@ describe "Encoding::Converter#primitive_errinfo" do
   end
 
   it "returns [:destination_buffer_full,nil,nil,nil,nil] when #primitive_convert last returned :destination_buffer_full" do
-    NATFIXME 'iso-2022-jp encoding not implemented', exception: ArgumentError do
+    NATFIXME 'iso-2022-jp conversion not supported (dummy encoding)', exception: Encoding::UndefinedConversionError do
       ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
       ec.primitive_convert("\u{9999}", "", 0, 0, partial_input: false).should == :destination_buffer_full
       ec.primitive_errinfo.should == [:destination_buffer_full, nil, nil, nil, nil]

--- a/spec/core/encoding/dummy_spec.rb
+++ b/spec/core/encoding/dummy_spec.rb
@@ -7,9 +7,7 @@ describe "Encoding#dummy?" do
   end
 
   it "returns true for dummy encodings" do
-    NATFIXME 'Implement ISO_2022_JP', exception: NameError, message: 'uninitialized constant Encoding::ISO_2022_JP' do
-      Encoding::ISO_2022_JP.dummy?.should be_true
-    end
+    Encoding::ISO_2022_JP.dummy?.should be_true
     NATFIXME 'Implement CP50221', exception: NameError, message: 'uninitialized constant Encoding::CP50221' do
       Encoding::CP50221.dummy?.should be_true
     end

--- a/spec/core/encoding/dummy_spec.rb
+++ b/spec/core/encoding/dummy_spec.rb
@@ -13,9 +13,7 @@ describe "Encoding#dummy?" do
     NATFIXME 'Implement CP50221', exception: NameError, message: 'uninitialized constant Encoding::CP50221' do
       Encoding::CP50221.dummy?.should be_true
     end
-    NATFIXME 'Implement UTF_7', exception: NameError, message: 'uninitialized constant Encoding::UTF_7' do
-      Encoding::UTF_7.dummy?.should be_true
-    end
+    Encoding::UTF_7.dummy?.should be_true
   end
 
   it "returns true for UTF_16 and UTF_32" do

--- a/spec/core/marshal/shared/load.rb
+++ b/spec/core/marshal/shared/load.rb
@@ -1047,12 +1047,10 @@ describe :marshal_load, shared: true do
 
     it "preserves Regexp encoding" do
       source_object = Regexp.new("a".encode("utf-32le"))
-      NATFIXME 'Support encoding in regexp dump', exception: SpecFailedException do
-        regexp = Marshal.send(@method, Marshal.dump(source_object))
+      regexp = Marshal.send(@method, Marshal.dump(source_object))
 
-        regexp.encoding.should == Encoding::UTF_32LE
-        regexp.source.should == "a".encode("utf-32le")
-      end
+      regexp.encoding.should == Encoding::UTF_32LE
+      regexp.source.should == "a".encode("utf-32le")
     end
 
     it "raises ArgumentError when end of byte sequence reached before source string end" do

--- a/spec/core/string/comparison_spec.rb
+++ b/spec/core/string/comparison_spec.rb
@@ -77,9 +77,7 @@ describe "String#<=> with String" do
   end
 
   it "returns 0 when comparing 2 empty strings but one is not ASCII-compatible" do
-    NATFIXME 'Implement ISO-2022-JP', exception: ArgumentError, message: 'unknown encoding name - iso-2022-jp' do
-      ("" <=> "".dup.force_encoding('iso-2022-jp')).should == 0
-    end
+    ("" <=> "".dup.force_encoding('iso-2022-jp')).should == 0
   end
 end
 

--- a/spec/core/string/index_spec.rb
+++ b/spec/core/string/index_spec.rb
@@ -169,12 +169,10 @@ describe "String#index with String" do
   end
 
   it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
-    NATFIXME 'Implement ISO-2022-JP', exception: ArgumentError, message: 'unknown encoding name - ISO-2022-JP' do
-      str = 'abc'.dup.force_encoding("ISO-2022-JP")
-      pattern = 'b'.dup.force_encoding("EUC-JP")
+    str = 'abc'.dup.force_encoding("ISO-2022-JP")
+    pattern = 'b'.dup.force_encoding("EUC-JP")
 
-      -> { str.index(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
-    end
+    -> { str.index(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
   end
 end
 

--- a/spec/core/string/rindex_spec.rb
+++ b/spec/core/string/rindex_spec.rb
@@ -207,12 +207,10 @@ describe "String#rindex with String" do
   end
 
   it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
-    NATFIXME 'Implement ISO-2022-JP', exception: ArgumentError, message: 'unknown encoding name - ISO-2022-JP' do
-      str = 'abc'.dup.force_encoding("ISO-2022-JP")
-      pattern = 'b'.dup.force_encoding("EUC-JP")
+    str = 'abc'.dup.force_encoding("ISO-2022-JP")
+    pattern = 'b'.dup.force_encoding("EUC-JP")
 
-      -> { str.rindex(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
-    end
+    -> { str.rindex(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
   end
 end
 

--- a/spec/core/string/shared/chars.rb
+++ b/spec/core/string/shared/chars.rb
@@ -64,12 +64,10 @@ describe :string_chars, shared: true do
   end
 
   it "returns individual chars for dummy encodings" do
-    NATFIXME 'Implement UTF-7 encoding', exception: NameError, message: 'uninitialized constant Encoding::UTF_7' do
-      "ab".dup.force_encoding(Encoding::UTF_7).send(@method).to_a.should == [
-        "\x61".dup.force_encoding(Encoding::UTF_7),
-        "\x62".dup.force_encoding(Encoding::UTF_7)
-      ]
-    end
+    "ab".dup.force_encoding(Encoding::UTF_7).send(@method).to_a.should == [
+      "\x61".dup.force_encoding(Encoding::UTF_7),
+      "\x62".dup.force_encoding(Encoding::UTF_7)
+    ]
 
     "abcd".dup.force_encoding(Encoding::UTF_16).send(@method).to_a.should == [
       "\x61".dup.force_encoding(Encoding::UTF_16),

--- a/spec/core/string/shared/each_line.rb
+++ b/spec/core/string/shared/each_line.rb
@@ -170,7 +170,7 @@ describe :string_each_line, shared: true do
   end
 
   it "raises Encoding::ConverterNotFoundError for dummy UTF-7" do
-    NATFIXME 'Implement UTF-7', exception: NameError, message: 'uninitialized constant Encoding::UTF_7' do
+    NATFIXME 'should raise ConverterNotFoundError for dummy encoding', exception: SpecFailedException do
       str = "a\nb".dup.force_encoding(Encoding::UTF_7)
       -> { str.lines }.should raise_error(Encoding::ConverterNotFoundError)
     end

--- a/spec/core/string/shared/encode.rb
+++ b/spec/core/string/shared/encode.rb
@@ -50,7 +50,7 @@ describe :string_encode, shared: true do
     end
 
     it "transcodes Japanese multibyte characters" do
-      NATFIXME 'need ISO_2022_JP encoding', exception: NameError, message: /uninitialized constant Encoding::ISO_2022_JP/ do
+      NATFIXME 'ISO-2022-JP conversion not supported (dummy encoding)', exception: Encoding::UndefinedConversionError do
         str = "あいうえお"
         str.send(@method, Encoding::ISO_2022_JP).should ==
           "\e\x24\x42\x24\x22\x24\x24\x24\x26\x24\x28\x24\x2A\e\x28\x42".force_encoding(Encoding::ISO_2022_JP)

--- a/spec/core/string/shared/eql.rb
+++ b/spec/core/string/shared/eql.rb
@@ -37,8 +37,6 @@ describe :string_eql_value, shared: true do
   end
 
   it "returns true when comparing 2 empty strings but one is not ASCII-compatible" do
-    NATFIXME 'Implement ISO-2022-JP', exception: ArgumentError, message: 'unknown encoding name - iso-2022-jp' do
-      "".send(@method, "".dup.force_encoding('iso-2022-jp')).should == true
-    end
+    "".send(@method, "".dup.force_encoding('iso-2022-jp')).should == true
   end
 end

--- a/spec/core/string/valid_encoding_spec.rb
+++ b/spec/core/string/valid_encoding_spec.rb
@@ -156,9 +156,7 @@ describe "String#valid_encoding?" do
     NATFIXME 'Implement MacJapanese encoding', exception: ArgumentError do
       str.force_encoding('MacJapanese').valid_encoding?.should be_false
     end
-    NATFIXME 'Implement UTF-7 encoding', exception: ArgumentError do
-      str.force_encoding('UTF-7').valid_encoding?.should be_true
-    end
+    str.force_encoding('UTF-7').valid_encoding?.should be_true
     NATFIXME 'Implement UTF8-MAC encoding', exception: ArgumentError do
       str.force_encoding('UTF8-MAC').valid_encoding?.should be_true
     end

--- a/spec/core/string/valid_encoding_spec.rb
+++ b/spec/core/string/valid_encoding_spec.rb
@@ -128,9 +128,7 @@ describe "String#valid_encoding?" do
     NATFIXME 'Implement GB12345 encoding', exception: ArgumentError do
       str.force_encoding('GB12345').valid_encoding?.should be_false
     end
-    NATFIXME 'Implement ISO-2022-JP encoding', exception: ArgumentError do
-      str.force_encoding('ISO-2022-JP').valid_encoding?.should be_true
-    end
+    str.force_encoding('ISO-2022-JP').valid_encoding?.should be_true
     NATFIXME 'Implement ISO-2022-JP-2 encoding', exception: ArgumentError do
       str.force_encoding('ISO-2022-JP-2').valid_encoding?.should be_true
     end

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -8,6 +8,81 @@ namespace Natalie {
 EncodingObject::EncodingObject()
     : Object { Object::Type::Encoding, GlobalEnv::the()->Object()->const_fetch("Encoding"_s).as_class() } { }
 
+// Returns the encoding of an object, or nullptr if it doesn't have one
+static EncodingObject *encoding_of(Env *env, Value obj) {
+    if (obj.is_string())
+        return obj.as_string()->encoding();
+    if (obj.is_encoding())
+        return obj.as_encoding();
+    if (obj.is_symbol())
+        return obj.as_symbol()->encoding(env);
+    if (obj.is_regexp())
+        return obj.as_regexp()->encoding();
+    return nullptr;
+}
+
+static bool is_ascii_only(Env *env, Value obj) {
+    if (obj.is_string())
+        return obj.as_string()->is_ascii_only();
+    if (obj.is_symbol()) {
+        auto enc = obj.as_symbol()->encoding(env);
+        return enc->num() == Encoding::US_ASCII;
+    }
+    return false;
+}
+
+Value EncodingObject::compatible(Env *env, Value obj1, Value obj2) {
+    auto enc1 = encoding_of(env, obj1);
+    auto enc2 = encoding_of(env, obj2);
+
+    if (!enc1 || !enc2)
+        return Value::nil();
+
+    if (enc1 == enc2)
+        return enc1;
+
+    // If str2 is empty string, return enc1
+    if (is_empty_string(obj2))
+        return enc1;
+
+    // If str1 is empty string
+    if (is_empty_string(obj1)) {
+        if (enc1->is_ascii_compatible() && is_ascii_only(env, obj2))
+            return enc1;
+        return enc2;
+    }
+
+    if (!enc1->is_ascii_compatible() || !enc2->is_ascii_compatible())
+        return Value::nil();
+
+    // Non-string objects with US-ASCII encoding are compatible with anything ASCII-compatible
+    if (!obj1.is_string() && enc1->num() == Encoding::US_ASCII)
+        return enc2;
+    if (!obj2.is_string() && enc2->num() == Encoding::US_ASCII)
+        return enc1;
+
+    // If one is not a string, swap so str1 is a string
+    if (!obj1.is_string() && obj2.is_string()) {
+        std::swap(obj1, obj2);
+        std::swap(enc1, enc2);
+    }
+
+    if (obj1.is_string()) {
+        bool cr1_ascii = is_ascii_only(env, obj1);
+        if (obj2.is_string()) {
+            bool cr2_ascii = is_ascii_only(env, obj2);
+            if (cr1_ascii != cr2_ascii) {
+                if (cr1_ascii) return enc2;
+                if (cr2_ascii) return enc1;
+            }
+            if (cr2_ascii) return enc1;
+        }
+        if (cr1_ascii) return enc2;
+    }
+
+    return Value::nil();
+}
+
 HashObject *EncodingObject::aliases(Env *env) {
     auto aliases = HashObject::create();
     for (auto encoding : *list(env)) {

--- a/src/encoding_object.cpp
+++ b/src/encoding_object.cpp
@@ -41,44 +41,51 @@ Value EncodingObject::compatible(Env *env, Value obj1, Value obj2) {
     if (enc1 == enc2)
         return enc1;
 
-    // If str2 is empty string, return enc1
-    if (is_empty_string(obj2))
+    bool isstr1 = obj1.is_string();
+    bool isstr2 = obj2.is_string();
+
+    if (isstr2 && obj2.as_string()->is_empty())
         return enc1;
 
-    // If str1 is empty string
-    if (is_empty_string(obj1)) {
-        if (enc1->is_ascii_compatible() && is_ascii_only(env, obj2))
-            return enc1;
-        return enc2;
-    }
+    if (isstr1 && isstr2 && obj1.as_string()->is_empty())
+        return (enc1->is_ascii_compatible() && obj2.as_string()->is_ascii_only()) ? enc1 : enc2;
 
     if (!enc1->is_ascii_compatible() || !enc2->is_ascii_compatible())
         return Value::nil();
 
-    // Non-string objects with US-ASCII encoding are compatible with anything ASCII-compatible
-    if (!obj1.is_string() && enc1->num() == Encoding::US_ASCII)
-        return enc2;
-    if (!obj2.is_string() && enc2->num() == Encoding::US_ASCII)
+    if (!isstr2 && enc2->num() == Encoding::US_ASCII)
         return enc1;
+    if (!isstr1 && enc1->num() == Encoding::US_ASCII)
+        return enc2;
 
-    // If one is not a string, swap so str1 is a string
-    if (!obj1.is_string() && obj2.is_string()) {
+    if (!isstr1 && !isstr2) {
+        if (is_ascii_only(env, obj1) && !is_ascii_only(env, obj2)) return enc2;
+        if (!is_ascii_only(env, obj1) && is_ascii_only(env, obj2)) return enc1;
+        return Value::nil();
+    }
+
+    // Swap so obj1 is a string, but keep enc1/enc2 as the ORIGINAL encodings
+    // (matches MRI's enc_compatible_latter which does not swap enc1/enc2)
+    if (!isstr1 && isstr2) {
         std::swap(obj1, obj2);
-        std::swap(enc1, enc2);
+        std::swap(isstr1, isstr2);
     }
 
-    if (obj1.is_string()) {
-        bool cr1_ascii = is_ascii_only(env, obj1);
-        if (obj2.is_string()) {
-            bool cr2_ascii = is_ascii_only(env, obj2);
-            if (cr1_ascii != cr2_ascii) {
-                if (cr1_ascii) return enc2;
-                if (cr2_ascii) return enc1;
-            }
-            if (cr2_ascii) return enc1;
+    if (!isstr1)
+        return Value::nil();
+
+    bool cr1_7bit = obj1.as_string()->is_ascii_only();
+    if (isstr2) {
+        bool cr2_7bit = obj2.as_string()->is_ascii_only();
+        if (cr1_7bit != cr2_7bit) {
+            if (cr1_7bit) return enc2;
+            if (cr2_7bit) return enc1;
         }
-        if (cr1_ascii) return enc2;
+        if (cr2_7bit)
+            return enc1;
     }
+    if (cr1_7bit)
+        return enc2;
 
     return Value::nil();
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -224,6 +224,9 @@ Env *build_top_env() {
     Value EncodingUTF32 = new Utf32EncodingObject {};
     Encoding->const_set("UTF_32"_s, EncodingUTF32);
 
+    Value EncodingUTF7 = new Utf7EncodingObject {};
+    Encoding->const_set("UTF_7"_s, EncodingUTF7);
+
     Value EncodingIBM037 = new Ibm037EncodingObject {};
     Encoding->const_set("IBM037"_s, EncodingIBM037);
     Value EncodingIBM437 = new Ibm437EncodingObject {};

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -227,6 +227,9 @@ Env *build_top_env() {
     Value EncodingUTF7 = new Utf7EncodingObject {};
     Encoding->const_set("UTF_7"_s, EncodingUTF7);
 
+    Value EncodingISO2022JP = new Iso2022JpEncodingObject {};
+    Encoding->const_set("ISO_2022_JP"_s, EncodingISO2022JP);
+
     Value EncodingIBM037 = new Ibm037EncodingObject {};
     Encoding->const_set("IBM037"_s, EncodingIBM037);
     Value EncodingIBM437 = new Ibm437EncodingObject {};

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -409,6 +409,9 @@ void RegexpObject::initialize_internal(Env *env, const StringObject *pattern, in
         enc = ruby_encoding_to_onig_encoding(encoding);
     } else if (fixed_encoding && !no_encoding) {
         enc = ruby_encoding_to_onig_encoding(pattern->encoding());
+    } else if (!pattern->is_ascii_only()) {
+        enc = ruby_encoding_to_onig_encoding(pattern->encoding());
+        options |= RegexOpts::FixedEncoding;
     } else {
         enc = ONIG_ENCODING_ASCII;
     }


### PR DESCRIPTION
* Encoding::compatible?
* UTF-7 dummy encoding (does nothing)
* ISO-2022-JP dummy encoding (does nothing)
* Regexp.new encoding negotiation