### PR TITLE
Locale-agnostic ctype

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -82,6 +82,7 @@
 #include "natalie/encoding/windows1257_encoding_object.hpp"
 #include "natalie/encoding/windows1258_encoding_object.hpp"
 
+#include "natalie/ctype.hpp"
 #include "natalie/encoding_object.hpp"
 #include "natalie/enumerator/arithmetic_sequence_object.hpp"
 #include "natalie/env.hpp"

--- a/include/natalie/array_packer/tokenizer.hpp
+++ b/include/natalie/array_packer/tokenizer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "natalie/ctype.hpp"
 #include "tm/optional.hpp"
 #include "tm/string.hpp"
 #include "tm/vector.hpp"

--- a/include/natalie/ctype.hpp
+++ b/include/natalie/ctype.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+// ASCII-only ctype helpers. Unlike the standard <ctype.h> functions, these
+// are locale-independent and safe to call with any int value: only bytes in
+// the ASCII range (0-127) can match. This matches MRI's ISPRINT/ISSPACE/etc.
+// macros (include/ruby/internal/ctype.h), which exist for the same reasons:
+// locale independence and sign-extension safety.
+
+namespace Natalie {
+
+constexpr bool is_ascii(int c) {
+    return (unsigned)c <= 0x7f;
+}
+
+constexpr bool is_ascii_printable(int c) {
+    return c >= 0x20 && c <= 0x7e;
+}
+
+constexpr bool is_ascii_space(int c) {
+    return c == ' ' || (c >= '\t' && c <= '\r');
+}
+
+constexpr bool is_ascii_digit(int c) {
+    return c >= '0' && c <= '9';
+}
+
+constexpr bool is_ascii_upper(int c) {
+    return c >= 'A' && c <= 'Z';
+}
+
+constexpr bool is_ascii_lower(int c) {
+    return c >= 'a' && c <= 'z';
+}
+
+constexpr bool is_ascii_alpha(int c) {
+    return is_ascii_upper(c) || is_ascii_lower(c);
+}
+
+constexpr bool is_ascii_alnum(int c) {
+    return is_ascii_alpha(c) || is_ascii_digit(c);
+}
+
+constexpr bool is_ascii_xdigit(int c) {
+    return is_ascii_digit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+}
+
+constexpr bool is_ascii_cntrl(int c) {
+    return (c >= 0 && c < 0x20) || c == 0x7f;
+}
+
+constexpr bool is_ascii_punct(int c) {
+    return is_ascii_printable(c) && !is_ascii_alnum(c) && c != ' ';
+}
+
+constexpr bool is_ascii_graph(int c) {
+    return c >= 0x21 && c <= 0x7e;
+}
+
+}

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <assert.h>
-#include <ctype.h>
 
 #include "natalie/class_object.hpp"
+#include "natalie/ctype.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/macros.hpp"
@@ -37,7 +37,7 @@ public:
     Value cmp(Env *, Value);
 
     bool is_constant_name() {
-        return m_name.length() > 0 && isupper(m_name[0]);
+        return m_name.length() > 0 && is_ascii_upper(m_name[0]);
     }
 
     bool is_global_name() {
@@ -45,7 +45,7 @@ public:
     }
 
     bool is_ivar_name() {
-        return m_name.length() > 1 && m_name[0] == '@' && (isalpha(m_name[1]) || m_name[1] == '_');
+        return m_name.length() > 1 && m_name[0] == '@' && (is_ascii_alpha(m_name[1]) || m_name[1] == '_');
     }
 
     bool is_cvar_name() {

--- a/src/array_packer/string_handler.cpp
+++ b/src/array_packer/string_handler.cpp
@@ -180,7 +180,7 @@ namespace ArrayPacker {
         for (size_t index = 0; index < m_source.size(); index++) {
             unsigned char c = m_source[index];
 
-            if (c == '\t' || c == '\n' || (isprint(c) && c != '=' && (unsigned int)c <= 0176)) {
+            if (c == '\t' || c == '\n' || (is_ascii_printable(c) && c != '=')) {
                 m_packed.append_char(c);
                 line_size++;
                 if (c == '\n')

--- a/src/array_packer/tokenizer.cpp
+++ b/src/array_packer/tokenizer.cpp
@@ -63,10 +63,10 @@ namespace ArrayPacker {
         if (apply_endianness_modifier(token, modifier))
             modifier = next_char();
 
-        if (isdigit(modifier)) {
+        if (is_ascii_digit(modifier)) {
             token.count = (int)modifier - '0';
             modifier = next_char();
-            while (isdigit(modifier)) {
+            while (is_ascii_digit(modifier)) {
                 token.count *= 10;
                 token.count += ((int)modifier - '0');
                 modifier = next_char();
@@ -91,7 +91,7 @@ namespace ArrayPacker {
     signed char Tokenizer::current_char() {
         signed char c = char_at_index(m_index);
 
-        while (m_index < m_directives.size() && (isspace(c) || c == '\0'))
+        while (m_index < m_directives.size() && (is_ascii_space(c) || c == '\0'))
             c = char_at_index(++m_index);
 
         if (c == '#') {

--- a/src/regexp_object.cpp
+++ b/src/regexp_object.cpp
@@ -305,9 +305,9 @@ static String prepare_pattern_for_onigmo(Env *env, const StringObject *pattern, 
                     c = next_char();
                     do {
                         long codepoint = 0;
-                        while (isxdigit(c)) {
+                        while (is_ascii_xdigit(c)) {
                             codepoint *= 16;
-                            if (isdigit(c))
+                            if (is_ascii_digit(c))
                                 codepoint += c - '0';
                             else if (c >= 'a' && c <= 'f')
                                 codepoint += c - 'a' + 10;
@@ -335,12 +335,12 @@ static String prepare_pattern_for_onigmo(Env *env, const StringObject *pattern, 
                 default:
                     new_pattern.append_char('\\');
                     new_pattern.append_char('u');
-                    if (!isxdigit(c))
+                    if (!is_ascii_xdigit(c))
                         env->raise("RegexpError", "invalid Unicode escape: /{}/", pattern->string());
                     new_pattern.append_char(c);
                     for (int i = 1; i < 4; i++) {
                         c = next_char();
-                        if (!isxdigit(c))
+                        if (!is_ascii_xdigit(c))
                             env->raise("RegexpError", "invalid Unicode escape: /{}/", pattern->string());
                         new_pattern.append_char(c);
                     }
@@ -353,7 +353,7 @@ static String prepare_pattern_for_onigmo(Env *env, const StringObject *pattern, 
 
             case 'x': {
                 c = next_char();
-                if (!std::isxdigit(c))
+                if (!is_ascii_xdigit(c))
                     env->raise("RegexpError", "invalid hex escape: /{}/", pattern->string());
 
                 *fixed_encoding = true;

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -1620,7 +1620,7 @@ Value StringObject::convert_integer(int base, int default_base) const {
     size_t len = length();
     size_t index = 0;
 
-    while (index < len && isspace(str[index])) {
+    while (index < len && is_ascii_space(str[index])) {
         index++;
     }
 
@@ -1661,7 +1661,7 @@ Value StringObject::convert_integer(int base, int default_base) const {
                 index += 2;
                 break;
             default:
-                if (isdigit(prefix)) {
+                if (is_ascii_digit(prefix)) {
                     base = 8;
                 }
                 break;
@@ -2981,7 +2981,7 @@ Value StringObject::to_r(Env *env) const {
     nat_int_t denominator = 1;
 
     // ignore leading whitespace
-    while (idx < m_string.size() && isspace(m_string.at(idx)))
+    while (idx < m_string.size() && is_ascii_space(m_string.at(idx)))
         idx++;
 
     // optional hyphen
@@ -2995,7 +2995,7 @@ Value StringObject::to_r(Env *env) const {
     // numerator digits
     for (; idx < m_string.size(); ++idx) {
         auto c = m_string[idx];
-        if (isdigit(c)) {
+        if (is_ascii_digit(c)) {
             numerator_digits.append_char(c);
         } else if (c == '_') {
             // ignore underscores between digits
@@ -3007,7 +3007,7 @@ Value StringObject::to_r(Env *env) const {
     // optional decimal point and fractional digits
     if (idx < m_string.size() && m_string.at(idx) == '.') {
         idx++;
-        while (idx < m_string.size() && isdigit(m_string.at(idx))) {
+        while (idx < m_string.size() && is_ascii_digit(m_string.at(idx))) {
             numerator_digits.append_char(m_string.at(idx));
             denominator = denominator * 10;
             idx++;
@@ -3017,7 +3017,7 @@ Value StringObject::to_r(Env *env) const {
     // optional slash and denominator digits
     if (idx < m_string.size() && m_string.at(idx) == '/') {
         idx++;
-        while (idx < m_string.size() && isdigit(m_string.at(idx))) {
+        while (idx < m_string.size() && is_ascii_digit(m_string.at(idx))) {
             denominator_digits.append_char(m_string.at(idx));
             idx++;
         }
@@ -3141,12 +3141,12 @@ Value StringObject::undump(Env *env) const {
                 if (it == end())
                     env->raise("RuntimeError", "invalid hex escape");
                 auto c1 = *it++;
-                if (c1.length() != 1 || !std::isxdigit(static_cast<unsigned char>(c1[0])))
+                if (c1.length() != 1 || !is_ascii_xdigit(static_cast<unsigned char>(c1[0])))
                     env->raise("RuntimeError", "invalid hex escape");
                 if (it == end())
                     env->raise("RuntimeError", "invalid hex escape");
                 auto c2 = *it++;
-                if (c2.length() != 1 || !std::isxdigit(static_cast<unsigned char>(c2[0])))
+                if (c2.length() != 1 || !is_ascii_xdigit(static_cast<unsigned char>(c2[0])))
                     env->raise("RuntimeError", "invalid hex escape");
                 const char hex[] = { c1[0], c2[0], 0 };
                 result.append_char(static_cast<char>(std::strtol(hex, nullptr, 0x10)));
@@ -4427,11 +4427,11 @@ Value StringObject::strict_convert_integer(Env *env, nat_int_t base) {
             }
             break;
         default:
-            if ((base == 0 || base == 8) && isdigit(str[1])) {
+            if ((base == 0 || base == 8) && is_ascii_digit(str[1])) {
                 // "implicit" octal with leading zero
                 prefix_base = 8;
                 str = str.substring(1);
-            } else if ((base == 0 || base == 8) && str.length() > 2 && str[1] == '_' && isdigit(str[2])) {
+            } else if ((base == 0 || base == 8) && str.length() > 2 && str[1] == '_' && is_ascii_digit(str[2])) {
                 prefix_base = 8;
                 str = str.substring(2);
             }

--- a/src/string_unpacker.cpp
+++ b/src/string_unpacker.cpp
@@ -352,7 +352,7 @@ void StringUnpacker::unpack_M(Env *env, Token &token) {
 
             if (c == '\n') {
                 void(); // skip it
-            } else if (isxdigit(c) && isxdigit(peek())) {
+            } else if (is_ascii_xdigit(c) && is_ascii_xdigit(peek())) {
                 auto value = hex_char_to_decimal_value(c);
                 value *= 16;
                 value += hex_char_to_decimal_value(next());

--- a/src/time_object.cpp
+++ b/src/time_object.cpp
@@ -355,7 +355,7 @@ nat_int_t TimeObject::normalize_timezone(Env *env, Value val, NonNullPtr<SymbolO
             // other single characters are illegal
         } else if (ssize == 6 || ssize == 9) {
             char sign = str.at(0);
-            if ((sign == '+' || sign == '-') && isdigit(str[1]) && isdigit(str[2]) && str[3] == ':' && isdigit(str[4]) && isdigit(str[5]) && (ssize == 6 || (str[6] == ':' && isdigit(str[7]) && isdigit(str[8])))) {
+            if ((sign == '+' || sign == '-') && is_ascii_digit(str[1]) && is_ascii_digit(str[2]) && str[3] == ':' && is_ascii_digit(str[4]) && is_ascii_digit(str[5]) && (ssize == 6 || (str[6] == ':' && is_ascii_digit(str[7]) && is_ascii_digit(str[8])))) {
 
                 nat_int_t isign = (sign == '+') ? 1 : -1;
                 auto hour = atoi(str.substring(1, 2).c_str());


### PR DESCRIPTION
There are a bunch of places in MRI that uses these ctype helpers that are locale-agnostic because in some locals things like \xFF are printable. Here we centralize all of that into our own include/natalie/ctype.hpp to match that behavior.