### PR TITLE
Preload support helpers when running specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ end
 desc 'Run the most-recently-modified test'
 task test_last_modified: :build do
   last_edited = Dir['test/**/*_test.rb', 'spec/**/*_spec.rb'].max_by { |path| File.stat(path).mtime.to_i }
-  sh ['bin/natalie', '-I', 'test/support', ENV['FLAGS'], last_edited].compact.join(' ')
+  sh ['bin/natalie', '-I', 'test/support', '-r', 'spec', ENV['FLAGS'], last_edited].compact.join(' ')
 end
 
 desc 'Run a folder with tests'

--- a/bin/natalie
+++ b/bin/natalie
@@ -254,11 +254,9 @@ class Runner
     if options[:execute].any?
       @source_path = '-e'
       @code = options[:execute].join("\n").gsub(/\\n/, "\n")
-      @code = options[:require].map { |l| "require #{l.inspect}" }.join("\n") + "\n" + @code if options[:require].any?
     elsif ARGV.any?
       @source_path = ARGV.shift
       @code = File.read(source_path)
-      @code = options[:require].map { |l| "require #{l.inspect}" }.join("\n") + "\n" + @code if options[:require].any?
     elsif options[:bytecode]
       @source_path = options[:bytecode]
     elsif options[:expecting_script]
@@ -268,7 +266,6 @@ class Runner
       @source_path = File.expand_path('../lib/natalie/repl.rb', __dir__)
       @code = File.read(source_path)
     end
-    @code = '$VERBOSE = true' + "\n" + @code if options[:warnings] && !@code.nil?
   end
 
   def extension
@@ -282,7 +279,7 @@ class Runner
   def compiler
     return @compiler if @compiler
 
-    ast = parser.ast
+    ast = prepend_to_ast(parser.ast, build_preamble_nodes)
     encoding = parser.encoding
     warnings = parser.warnings
     data_loc = parser.data_loc
@@ -290,6 +287,52 @@ class Runner
       Natalie::Compiler
         .new(ast:, path: source_path, encoding:, warnings:, data_loc:, options: options)
         .tap { |c| c.load_path = options[:load_path] }
+  end
+
+  # Prepend AST nodes (for -r requires and -w $VERBOSE) to the program's
+  # statements instead of injecting source text, so line numbers and magic
+  # comments in the original source are preserved.
+  def prepend_to_ast(ast, nodes)
+    return ast if nodes.empty?
+    return ast unless ast.is_a?(Prism::ProgramNode)
+
+    stmts = ast.statements
+    new_stmts =
+      if stmts
+        Prism::StatementsNode.new(nil, nil, stmts.location, 0, nodes + stmts.body)
+      else
+        Prism::StatementsNode.new(nil, nil, ast.location, 0, nodes)
+      end
+    Prism::ProgramNode.new(nil, nil, ast.location, 0, ast.locals, new_stmts)
+  end
+
+  def build_preamble_nodes
+    loc = parser.ast.location
+    nodes = options[:require].map { |lib| build_require_node(lib, loc) }
+    nodes << build_verbose_node(loc) if options[:warnings]
+    nodes
+  end
+
+  def build_require_node(lib, location)
+    Prism.call_node(
+      receiver: nil,
+      name: :require,
+      location: location,
+      arguments: [Prism.string_node(unescaped: lib, location: location)],
+    )
+  end
+
+  def build_verbose_node(location)
+    Prism::GlobalVariableWriteNode.new(
+      nil,
+      nil,
+      location,
+      0,
+      :$VERBOSE,
+      location,
+      Prism.true_node(location: location),
+      location,
+    )
   end
 
   def parser

--- a/test/ruby/ruby_specs_test.rb
+++ b/test/ruby/ruby_specs_test.rb
@@ -40,7 +40,18 @@ describe 'ruby/spec' do
     describe path do
       it 'passes all specs' do
         timeout = spec_timeout(path)
-        out = Command.new(NAT_BINARY, '--build-dir=test/build', '--build-quietly', path, timeout:).run
+        out =
+          Command.new(
+            NAT_BINARY,
+            '--build-dir=test/build',
+            '--build-quietly',
+            '-I',
+            'test/support',
+            '-r',
+            'spec',
+            path,
+            timeout:,
+          ).run
         puts out if ENV['DEBUG']
         expect(out).wont_match(/traceback|error/i)
       end

--- a/test/runner.rb
+++ b/test/runner.rb
@@ -18,7 +18,7 @@ flags = []
 flags << ARGV.shift while ARGV.first.to_s.start_with?('-')
 
 if flags.delete('--run-grouped')
-  flags.prepend('-I.', '-Itest/support')
+  flags.prepend('-I.', '-Itest/support', '-rspec')
   require 'tempfile'
   Tempfile.create('test_runner') do |f|
     ARGV.each do |path|
@@ -39,6 +39,7 @@ if flags.delete('--run-grouped')
   end
   exit $?.exitstatus unless $?.success?
 else
+  flags.prepend('-Itest/support', '-rspec')
   ARGV.each do |path|
     if File.directory?(path)
       $stderr.puts "WARNING: skipping directory #{path}"


### PR DESCRIPTION
Some specs do not have a require for the necessary spec helpers, but still use them before any requires happen. This works in MRI because the spec helpers are preloaded.