### PR TITLE
Classify symbols

### DIFF
--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -36,21 +36,27 @@ public:
 
     Value cmp(Env *, Value);
 
-    bool is_constant_name() {
-        return m_name.length() > 0 && is_ascii_upper(m_name[0]);
-    }
+    // Classification of a symbol name in the style of MRI's rb_enc_symname_type.
+    // Computed once in the constructor and cached; symbols are immutable.
+    enum class NameType : uint8_t {
+        Local, // foo, _bar, föö
+        Const, // Foo
+        Global, // $foo, $0, $!, $-w
+        IVar, // @foo
+        CVar, // @@foo
+        AttrSet, // foo=
+        Junk, // foo?, foo!, and operator names (==, <<, []=, ...)
+        Invalid, // anything that can't be written as a bare symbol literal
+    };
 
-    bool is_global_name() {
-        return m_name.length() > 0 && m_name[0] == '$';
-    }
+    NameType name_type() const { return m_type; }
 
-    bool is_ivar_name() {
-        return m_name.length() > 1 && m_name[0] == '@' && (is_ascii_alpha(m_name[1]) || m_name[1] == '_');
-    }
-
-    bool is_cvar_name() {
-        return m_name.length() > 2 && m_name[0] == '@' && m_name[1] == '@';
-    }
+    bool is_local_name() const { return m_type == NameType::Local; }
+    bool is_constant_name() const { return m_type == NameType::Const; }
+    bool is_global_name() const { return m_type == NameType::Global; }
+    bool is_ivar_name() const { return m_type == NameType::IVar; }
+    bool is_cvar_name() const { return m_type == NameType::CVar; }
+    bool is_invalid_name() const { return m_type == NameType::Invalid; }
 
     bool is_empty() {
         return m_name.is_empty();
@@ -68,8 +74,6 @@ public:
 
     const String &string() const { return m_name; }
     EncodingObject *encoding(Env *env) const { return m_encoding; }
-
-    bool should_be_quoted() const;
 
     virtual String dbg_inspect(int indent = 0) const override;
 
@@ -91,7 +95,6 @@ public:
 
 private:
     inline static TM::Hashmap<TM::String, SymbolObject *> s_symbols { 1000 };
-    inline static regex_t *s_inspect_quote_regex { nullptr };
 
     SymbolObject(const String &name, EncodingObject *encoding)
         : Object { Object::Type::Symbol, GlobalEnv::the()->Symbol() }
@@ -111,13 +114,17 @@ private:
             }
             if (all_ascii) m_encoding = EncodingObject::get(Encoding::US_ASCII);
         }
+        m_type = classify_name();
         freeze();
     }
+
+    NameType classify_name() const;
 
     const TM::String m_name {};
 
     StringObject *m_string = nullptr;
     EncodingObject *m_encoding = nullptr;
+    NameType m_type { NameType::Invalid };
 };
 
 [[nodiscard]] __attribute__((always_inline)) inline SymbolObject *operator""_s(const char *cstring, size_t length) {

--- a/spec/core/kernel/instance_variable_set_spec.rb
+++ b/spec/core/kernel/instance_variable_set_spec.rb
@@ -92,10 +92,8 @@ describe "Kernel#instance_variable_set" do
 
     it "accepts unicode instance variable names" do
       o = Object.new
-      NATFIXME 'accepts unicode instance variable names', exception: NameError, message: "`@💙' is not allowed as an instance variable name" do
-        o.instance_variable_set(:@💙, 42)
-        o.instance_variable_get(:@💙).should == 42
-      end
+      o.instance_variable_set(:@💙, 42)
+      o.instance_variable_get(:@💙).should == 42
     end
 
     it "raises for frozen objects" do

--- a/spec/core/symbol/inspect_spec.rb
+++ b/spec/core/symbol/inspect_spec.rb
@@ -103,26 +103,10 @@ describe "Symbol#inspect" do
   }
 
   expected_by_encoding = Encoding::default_external == Encoding::UTF_8 ? 0 : 1
-  natalie_expected_failures = Set[
-    :"$ruby!", :"$ruby?", :"@ruby!", :"@ruby?", :"@@ruby!",
-    :"@@ruby?", :"$-w", :"$+", :"$:", :"$<",
-    :"$/", :"$'", :"$\"", :"$$", :"$.",
-    :"$,", :"$`", :"$;", :"$\\", :"$=",
-    :"$*", :"$>", :"$&", :"$@", :"$1234",
-    :"-@", :"+@", :"<=", :"<=>", :"===",
-    :"=~", :">=", :"^", :"`", :"~",
-    :"|", :"!~", :"ê", :"测", :"🦊"
-  ]
   symbols.each do |input, expected|
     expected = expected[expected_by_encoding] if expected.is_a?(Array)
     it "returns self as a symbol literal for #{expected}" do
-      if natalie_expected_failures.include?(input)
-        NATFIXME "Failure for #{input}", exception: SpecFailedException do
-          input.inspect.should == expected
-        end
-      else
-        input.inspect.should == expected
-      end
+      input.inspect.should == expected
     end
   end
 

--- a/src/exception.rb
+++ b/src/exception.rb
@@ -87,12 +87,14 @@ class NameError < StandardError
   end
 end
 class NoMethodError < NameError
-  attr_reader :args, :private_call?
+  attr_reader :args
   def initialize(message = nil, name = nil, args = nil, priv = false, receiver: nil)
     super(message, name, receiver: receiver)
-    # Set instance variables on NoMethodError but not NameError
     @args = args
-    instance_variable_set('@private_call?', !!priv)
+    @private_call = !!priv
+  end
+  def private_call?
+    @private_call
   end
 end
 # end NameError subclasses

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -305,7 +305,7 @@ Value HashObject::inspect(Env *env) {
             if (node.key.is_symbol()) {
                 SymbolObject *key = node.key.as_symbol();
                 StringObject *key_repr = nullptr;
-                if (key->should_be_quoted()) {
+                if (key->is_invalid_name()) {
                     key_repr = key->inspect(env)->delete_prefix(env, StringObject::create(":")).as_string();
                 } else {
                     key_repr = key->to_s(env);

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -752,6 +752,8 @@ ArrayObject *ModuleObject::attr_reader(Env *env, Args &&args) {
 
 SymbolObject *ModuleObject::attr_reader(Env *env, Value obj) {
     auto name = obj.to_symbol(env, Value::Conversion::Strict);
+    if (!name->is_local_name() && !name->is_constant_name())
+        env->raise_name_error(name, "invalid attribute name '{}'", name->string());
     OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("name", 0, true, name);
     Block *attr_block = Block::create(std::move(block_env), this, ModuleObject::attr_reader_block_fn, 0);
@@ -777,6 +779,8 @@ ArrayObject *ModuleObject::attr_writer(Env *env, Args &&args) {
 
 SymbolObject *ModuleObject::attr_writer(Env *env, Value obj) {
     auto name = obj.to_symbol(env, Value::Conversion::Strict);
+    if (!name->is_local_name() && !name->is_constant_name())
+        env->raise_name_error(name, "invalid attribute name '{}'", name->string());
     auto method_name = SymbolObject::intern(TM::String::format("{}=", name->string()));
     OwnedPtr<Env> block_env { Env::create() };
     block_env->var_set("name", 0, true, name);

--- a/src/struct.rb
+++ b/src/struct.rb
@@ -15,6 +15,12 @@ class Struct
       attrs.shift
     end
 
+    attrs.map! do |attr|
+      next attr if attr.is_a?(Symbol)
+      next attr.to_sym if attr.is_a?(String)
+      raise TypeError, "#{attr.inspect} is not a symbol nor a string"
+    end
+
     result =
       Class.new(Struct) do
         include Enumerable
@@ -189,9 +195,16 @@ class Struct
           result
         end
 
-        # These are generated for Struct.new(...).methods, but will be redefined
-        # The actual values are not stored as ivars (requirement of Ruby specs)
-        attrs.each { |attr| attr_accessor attr }
+        # Hash-backed fallback accessors used when an instance is created via
+        # `.allocate` directly (e.g. Marshal.restore). The reader is side-effect
+        # free so `undef_method`, which triggers `inspect` internally, doesn't
+        # spuriously create the backing ivar. Hand-rolled rather than
+        # attr_accessor so names like :"current-state" are accepted.
+        attrs.each do |attr|
+          key = attr.to_sym
+          define_method(key) { @__struct_values&.dig(key) }
+          define_method(:"#{attr}=") { |val| (@__struct_values ||= {})[key] = val }
+        end
 
         instance_eval(&block) if block
       end
@@ -201,24 +214,23 @@ class Struct
       Struct.const_set(klass, result)
     end
 
+    # Override `.new` to install closure-based accessors on each instance,
+    # keeping values out of the ivar table (a Ruby spec requirement). The
+    # singleton methods shadow the hash-backed stubs defined above. Objects
+    # built via `allocate` (e.g. Marshal.restore) use those stubs.
     def result.new(*args)
       object = allocate
-      # The `values` variable will store the actual values of the struct. We redefine the
-      # getter and setter methods in a closure to capture this variable and make it
-      # invisible to the user.
-      values = members.map { nil }
-      members.each_with_index do |attr, idx|
-        object.singleton_class.undef_method(attr)
-        object.singleton_class.undef_method(:"#{attr}=")
-
+      attrs = members
+      values = Array.new(attrs.size)
+      attrs.each_with_index do |attr, idx|
         object.define_singleton_method(attr) { values[idx] }
-
         object.define_singleton_method(:"#{attr}=") do |value|
           raise FrozenError, "can't modify frozen #{self.class}: #{self}" if frozen?
           values[idx] = value
         end
       end
       object.__send__(:initialize, *args)
+      object
     end
 
     result

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -40,7 +40,7 @@ StringObject *SymbolObject::to_s(Env *env) {
 StringObject *SymbolObject::inspect(Env *env) {
     StringObject *string = StringObject::create(":");
 
-    if (should_be_quoted()) {
+    if (is_invalid_name()) {
         auto quoted = StringObject::create(m_name)->inspect(env);
         string->append(quoted);
     } else {
@@ -49,22 +49,109 @@ StringObject *SymbolObject::inspect(Env *env) {
     return string;
 }
 
-bool SymbolObject::should_be_quoted() const {
-    if (!s_inspect_quote_regex) {
-        auto pattern = String(
-            "\\A\\$(\\d|\\?|\\!|~)\\z|" // :$0 :$? :$!
-            "\\A(@{0,2}|\\$)[a-z_][a-z0-9_]*[\\?\\!=]?\\z|" // :foo :@bar :baz=
-            "\\A(%|==|\\!|\\!=|\\+|\\-|/|\\*{1,2}|<<?|>>?|\\[\\]\\=?|&)\\z" // :% :== :**
-        );
-        UChar *pat = (UChar *)pattern.c_str();
-        assert(onig_new(&s_inspect_quote_regex, pat, pat + pattern.size(), ONIG_OPTION_IGNORECASE, ONIG_ENCODING_UTF_8, ONIG_SYNTAX_DEFAULT, nullptr) == ONIG_NORMAL);
+SymbolObject::NameType SymbolObject::classify_name() const {
+    const auto size = m_name.size();
+    if (size == 0) return NameType::Invalid;
+    const auto *s = (const unsigned char *)m_name.c_str();
+
+    const bool non_ascii_ok = m_encoding
+        && m_encoding->num() != Encoding::ASCII_8BIT
+        && m_encoding->is_ascii_compatible()
+        && !m_encoding->is_dummy();
+
+    auto ident_start = [&](unsigned char c) {
+        return c >= 0x80 ? non_ascii_ok : (is_ascii_alpha(c) || c == '_');
+    };
+    auto ident_cont = [&](unsigned char c) {
+        return c >= 0x80 ? non_ascii_ok : (is_ascii_alnum(c) || c == '_');
+    };
+
+    const auto c0 = s[0];
+
+    switch (c0) {
+    case '$': {
+        if (size == 1) return NameType::Invalid;
+        const auto c1 = s[1];
+        if (size == 2 && strchr("!?~&`'+=\\/,;.<>:\"*$@_", c1)) return NameType::Global;
+        if (c1 == '-') {
+            if (size != 3 || !ident_cont(s[2])) return NameType::Invalid;
+            return NameType::Global;
+        }
+        if (is_ascii_digit(c1)) {
+            for (size_t i = 2; i < size; i++)
+                if (!is_ascii_digit(s[i])) return NameType::Invalid;
+            return NameType::Global;
+        }
+        if (!ident_start(c1)) return NameType::Invalid;
+        for (size_t i = 2; i < size; i++)
+            if (!ident_cont(s[i])) return NameType::Invalid;
+        return NameType::Global;
     }
-
-    auto unsigned_str = (unsigned char *)m_name.c_str();
-    auto char_end = unsigned_str + m_name.size();
-    int result = onig_search(s_inspect_quote_regex, unsigned_str, char_end, unsigned_str, char_end, nullptr, ONIG_OPTION_NONE);
-
-    return result < 0;
+    case '@': {
+        const bool cvar = size > 1 && s[1] == '@';
+        const size_t start = cvar ? 2 : 1;
+        if (start >= size || !ident_start(s[start])) return NameType::Invalid;
+        for (size_t i = start + 1; i < size; i++)
+            if (!ident_cont(s[i])) return NameType::Invalid;
+        return cvar ? NameType::CVar : NameType::IVar;
+    }
+    case '!':
+        if (size == 1) return NameType::Junk;
+        if (size == 2 && (s[1] == '=' || s[1] == '~')) return NameType::Junk;
+        return NameType::Invalid;
+    case '%':
+    case '&':
+    case '/':
+    case '^':
+    case '`':
+    case '|':
+    case '~':
+        return size == 1 ? NameType::Junk : NameType::Invalid;
+    case '*':
+        if (size == 1) return NameType::Junk;
+        if (size == 2 && s[1] == '*') return NameType::Junk;
+        return NameType::Invalid;
+    case '+':
+    case '-':
+        if (size == 1) return NameType::Junk;
+        if (size == 2 && s[1] == '@') return NameType::Junk;
+        return NameType::Invalid;
+    case '<':
+        if (size == 1) return NameType::Junk;
+        if (size == 2 && (s[1] == '<' || s[1] == '=')) return NameType::Junk;
+        if (size == 3 && s[1] == '=' && s[2] == '>') return NameType::Junk;
+        return NameType::Invalid;
+    case '>':
+        if (size == 1) return NameType::Junk;
+        if (size == 2 && (s[1] == '>' || s[1] == '=')) return NameType::Junk;
+        return NameType::Invalid;
+    case '=':
+        if (size == 2 && (s[1] == '=' || s[1] == '~')) return NameType::Junk;
+        if (size == 3 && s[1] == '=' && s[2] == '=') return NameType::Junk;
+        return NameType::Invalid;
+    case '[':
+        if (size == 2 && s[1] == ']') return NameType::Junk;
+        if (size == 3 && s[1] == ']' && s[2] == '=') return NameType::Junk;
+        return NameType::Invalid;
+    default: {
+        if (!ident_start(c0)) return NameType::Invalid;
+        size_t i = 1;
+        while (i < size && ident_cont(s[i]))
+            i++;
+        if (i == size)
+            return is_ascii_upper(c0) ? NameType::Const : NameType::Local;
+        if (i + 1 == size) {
+            switch (s[i]) {
+            case '=':
+                return NameType::AttrSet;
+            case '?':
+            case '!':
+                return NameType::Junk;
+            }
+        }
+        return NameType::Invalid;
+    }
+    }
 }
 
 String SymbolObject::dbg_inspect(int indent) const {


### PR DESCRIPTION
Mirror MRI's classification of symbols based on their contents, and cache that classification on the symbol itself. This makes it much easier to determine when symbols are valid for which constructs.

This also makes it invalid to do things like attr_reader :foo? and instance_variable_set(:@foo?, ...). Now things match MRI semantics.