### PR TITLE
IO#set_encoding work

### DIFF
--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -29,8 +29,8 @@ public:
         return new IoObject(type, klass);
     }
 
-    static IoObject *create(int fileno) {
-        return new IoObject(fileno);
+    static IoObject *create(int fileno, int fmode) {
+        return new IoObject(fileno, fmode);
     }
 
     virtual ~IoObject() override {
@@ -94,7 +94,13 @@ public:
     Value set_close_on_exec(Env *, Value);
     Value set_encoding(Env *, Optional<EncodingObject *>, Optional<EncodingObject *>);
     Value set_encoding(Env *, Optional<Value>, Optional<Value> = {});
-    void set_fileno(int fileno);
+    void set_fileno(int fileno) { m_fileno = fileno; }
+
+    enum FMode : int {
+        FMODE_READABLE = 0x1,
+        FMODE_WRITABLE = 0x2,
+        FMODE_SYNC = 0x4,
+    };
     Value set_lineno(Env *, Value);
     Value set_sync(Env *, Value);
     void set_nonblock(Env *, bool) const;
@@ -129,7 +135,7 @@ public:
     void set_path(String path) { m_path = StringObject::create(path); }
 
     Value external_encoding() const {
-        if (m_internal_encoding || m_writable)
+        if (m_internal_encoding || fmode_writable())
             return m_external_encoding ? Value(m_external_encoding) : Value::nil();
         if (m_external_encoding)
             return m_external_encoding;
@@ -159,16 +165,22 @@ protected:
     IoObject(Type type, ClassObject *klass)
         : Object { type, klass } { }
 
-    IoObject(int fileno)
-        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() }
-        , m_sync { fileno == STDERR_FILENO } {
+    IoObject(int fileno, int fmode)
+        : Object { Object::Type::Io, GlobalEnv::the()->Object()->const_fetch("IO"_s).as_class() } {
         set_fileno(fileno);
+        set_fmode(fmode);
     }
 
     void raise_if_closed(Env *) const;
     int write(Env *, Value);
 
+    static int fmode_from_oflags(int oflags);
+    void set_fmode(int fmode) { m_fmode = fmode; }
+
 private:
+    bool fmode_writable() const { return (m_fmode & FMODE_WRITABLE) != 0; }
+    bool fmode_sync() const { return (m_fmode & FMODE_SYNC) != 0; }
+
     static const nat_int_t WAIT_READABLE = 1;
     static const nat_int_t WAIT_PRIORITY = 2;
     static const nat_int_t WAIT_WRITABLE = 4;
@@ -177,14 +189,13 @@ private:
 
     EncodingObject *m_external_encoding { nullptr };
     EncodingObject *m_internal_encoding { nullptr };
-    bool m_writable { false };
+    int m_fmode { 0 };
     int m_fileno { -1 };
     FILE *m_fileptr { nullptr };
     int m_pid { -1 };
     int m_lineno { 0 };
     std::atomic<bool> m_closed { false };
     bool m_autoclose { true };
-    bool m_sync { false };
     StringObject *m_path { nullptr };
     TM::String m_read_buffer {};
 };

--- a/include/natalie/io_object.hpp
+++ b/include/natalie/io_object.hpp
@@ -94,7 +94,7 @@ public:
     Value set_close_on_exec(Env *, Value);
     Value set_encoding(Env *, Optional<EncodingObject *>, Optional<EncodingObject *>);
     Value set_encoding(Env *, Optional<Value>, Optional<Value> = {});
-    void set_fileno(int fileno) { m_fileno = fileno; }
+    void set_fileno(int fileno);
     Value set_lineno(Env *, Value);
     Value set_sync(Env *, Value);
     void set_nonblock(Env *, bool) const;
@@ -129,9 +129,13 @@ public:
     void set_path(String path) { m_path = StringObject::create(path); }
 
     Value external_encoding() const {
-        if (!m_external_encoding)
-            return Value::nil();
-        return m_external_encoding;
+        if (m_internal_encoding || m_writable)
+            return m_external_encoding ? Value(m_external_encoding) : Value::nil();
+        if (m_external_encoding)
+            return m_external_encoding;
+        if (auto def = EncodingObject::default_external())
+            return def;
+        return Value::nil();
     }
 
     Value internal_encoding() const {
@@ -173,6 +177,7 @@ private:
 
     EncodingObject *m_external_encoding { nullptr };
     EncodingObject *m_internal_encoding { nullptr };
+    bool m_writable { false };
     int m_fileno { -1 };
     FILE *m_fileptr { nullptr };
     int m_pid { -1 };

--- a/spec/core/io/external_encoding_spec.rb
+++ b/spec/core/io/external_encoding_spec.rb
@@ -35,9 +35,7 @@ describe :io_external_encoding_write, shared: true do
     it "returns the value of Encoding.default_external when the instance was created" do
       @io = new_io @name, @object
       Encoding.default_external = Encoding::UTF_8
-      NATFIXME 'returns the value of Encoding.default_external when the instance was created', exception: SpecFailedException do
-        @io.external_encoding.should equal(Encoding::IBM437)
-      end
+      @io.external_encoding.should equal(Encoding::IBM437)
     end
 
     it "returns the external encoding specified when the instance was created" do
@@ -62,9 +60,7 @@ describe :io_external_encoding_write, shared: true do
     it "returns the value of Encoding.default_external when the instance was created" do
       @io = new_io @name, @object
       Encoding.default_external = Encoding::UTF_8
-      NATFIXME 'returns the value of Encoding.default_external when the instance was created', exception: SpecFailedException do
-        @io.external_encoding.should equal(Encoding::IBM866)
-      end
+      @io.external_encoding.should equal(Encoding::IBM866)
     end
 
     it "returns the external encoding specified when the instance was created" do
@@ -101,9 +97,7 @@ describe "IO#external_encoding" do
   it "can be retrieved from a closed stream" do
     io = IOSpecs.io_fixture("lines.txt", "r")
     io.close
-    NATFIXME 'can be retrieved from a closed stream', exception: SpecFailedException do
-      io.external_encoding.should equal(Encoding.default_external)
-    end
+    io.external_encoding.should equal(Encoding.default_external)
   end
 
   describe "with 'r' mode" do
@@ -115,17 +109,13 @@ describe "IO#external_encoding" do
 
       it "returns Encoding.default_external if the external encoding is not set" do
         @io = new_io @name, "r"
-        NATFIXME 'returns Encoding.default_external if the external encoding is not set', exception: SpecFailedException do
-          @io.external_encoding.should equal(Encoding::IBM866)
-        end
+        @io.external_encoding.should equal(Encoding::IBM866)
       end
 
       it "returns Encoding.default_external when that encoding is changed after the instance is created" do
         @io = new_io @name, "r"
         Encoding.default_external = Encoding::IBM437
-        NATFIXME 'returns Encoding.default_external when that encoding is changed after the instance is created', exception: SpecFailedException do
-          @io.external_encoding.should equal(Encoding::IBM437)
-        end
+        @io.external_encoding.should equal(Encoding::IBM437)
       end
 
       it "returns the external encoding specified when the instance was created" do
@@ -150,9 +140,7 @@ describe "IO#external_encoding" do
       it "returns the value of Encoding.default_external when the instance was created" do
         @io = new_io @name, "r"
         Encoding.default_external = Encoding::IBM437
-        NATFIXME 'returns the value of Encoding.default_external when the instance was created', exception: SpecFailedException do
-          @io.external_encoding.should equal(Encoding::IBM866)
-        end
+        @io.external_encoding.should equal(Encoding::IBM866)
       end
 
       it "returns the external encoding specified when the instance was created" do

--- a/spec/core/io/internal_encoding_spec.rb
+++ b/spec/core/io/internal_encoding_spec.rb
@@ -57,17 +57,13 @@ describe :io_internal_encoding, shared: true do
 
     it "returns the value of Encoding.default_internal when the instance was created if the internal encoding is not set" do
       @io = new_io @name, @object
-      NATFIXME 'returns the value of Encoding.default_internal when the instance was created if the internal encoding is not set', exception: SpecFailedException do
-        @io.internal_encoding.should equal(Encoding::IBM866)
-      end
+      @io.internal_encoding.should equal(Encoding::IBM866)
     end
 
     it "does not change when Encoding.default_internal is changed" do
       @io = new_io @name, @object
       Encoding.default_internal = Encoding::IBM437
-      NATFIXME 'does not change when Encoding.default_internal is changed', exception: SpecFailedException do
-        @io.internal_encoding.should equal(Encoding::IBM866)
-      end
+      @io.internal_encoding.should equal(Encoding::IBM866)
     end
 
     it "returns the internal encoding set when the instance was created" do

--- a/spec/core/io/pipe_spec.rb
+++ b/spec/core/io/pipe_spec.rb
@@ -96,37 +96,31 @@ describe "IO.pipe" do
   end
 
   it "sets the external encoding of the read end to the default when passed no arguments" do
-    NATFIXME 'Encodings', exception: SpecFailedException do
-      Encoding.default_external = Encoding::ISO_8859_1
+    Encoding.default_external = Encoding::ISO_8859_1
 
-      IO.pipe do |r, w|
-        r.external_encoding.should == Encoding::ISO_8859_1
-        r.internal_encoding.should be_nil
-      end
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::ISO_8859_1
+      r.internal_encoding.should be_nil
     end
   end
 
   it "sets the internal encoding of the read end to the default when passed no arguments" do
-    NATFIXME 'Encodings', exception: SpecFailedException do
-      Encoding.default_external = Encoding::ISO_8859_1
-      Encoding.default_internal = Encoding::UTF_8
+    Encoding.default_external = Encoding::ISO_8859_1
+    Encoding.default_internal = Encoding::UTF_8
 
-      IO.pipe do |r, w|
-        r.external_encoding.should == Encoding::ISO_8859_1
-        r.internal_encoding.should == Encoding::UTF_8
-      end
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::ISO_8859_1
+      r.internal_encoding.should == Encoding::UTF_8
     end
   end
 
   it "sets the internal encoding to nil if the same as the external" do
-    NATFIXME 'Encodings', exception: SpecFailedException do
-      Encoding.default_external = Encoding::UTF_8
-      Encoding.default_internal = Encoding::UTF_8
+    Encoding.default_external = Encoding::UTF_8
+    Encoding.default_internal = Encoding::UTF_8
 
-      IO.pipe do |r, w|
-        r.external_encoding.should == Encoding::UTF_8
-        r.internal_encoding.should be_nil
-      end
+    IO.pipe do |r, w|
+      r.external_encoding.should == Encoding::UTF_8
+      r.internal_encoding.should be_nil
     end
   end
 

--- a/spec/core/io/set_encoding_spec.rb
+++ b/spec/core/io/set_encoding_spec.rb
@@ -196,17 +196,13 @@ describe "IO#set_encoding" do
   it "ignores the internal encoding if the same as external when passed Encoding objects" do
     @io.set_encoding(Encoding::UTF_8, Encoding::UTF_8)
     @io.external_encoding.should == Encoding::UTF_8
-    NATFIXME 'ignores the internal encoding if the same as external when passed Encoding objects', exception: SpecFailedException do
-      @io.internal_encoding.should be_nil
-    end
+    @io.internal_encoding.should be_nil
   end
 
   it "ignores the internal encoding if the same as external when passed encoding names separated by ':'" do
     @io.set_encoding("utf-8:utf-8")
     @io.external_encoding.should == Encoding::UTF_8
-    NATFIXME "ignores the internal encoding if the same as external when passed encoding names separated by ':'", exception: SpecFailedException do
-      @io.internal_encoding.should be_nil
-    end
+    @io.internal_encoding.should be_nil
   end
 
   it "sets the external and internal encoding when passed the names of Encodings separated by ':'" do

--- a/spec/core/io/set_encoding_spec.rb
+++ b/spec/core/io/set_encoding_spec.rb
@@ -5,10 +5,8 @@ describe :io_set_encoding_write, shared: true do
     @io = new_io @name, "#{@object}:ibm437:ibm866"
     @io.set_encoding nil, nil
 
-    NATFIXME 'sets the encodings to nil when they were set previously', exception: SpecFailedException do
-      @io.external_encoding.should be_nil
-      @io.internal_encoding.should be_nil
-    end
+    @io.external_encoding.should be_nil
+    @io.internal_encoding.should be_nil
   end
 
   it "sets the encodings to nil when the IO is built with no explicit encoding" do
@@ -31,10 +29,8 @@ describe :io_set_encoding_write, shared: true do
     Encoding.default_external = Encoding::IBM437
     Encoding.default_internal = Encoding::IBM866
 
-    NATFIXME 'prevents the encodings from changing when Encoding defaults are changed', exception: SpecFailedException do
-      @io.external_encoding.should be_nil
-      @io.internal_encoding.should be_nil
-    end
+    @io.external_encoding.should be_nil
+    @io.internal_encoding.should be_nil
   end
 
   it "sets the encodings to the current Encoding defaults" do
@@ -151,10 +147,8 @@ describe "IO#set_encoding when passed nil, nil" do
         STDOUT.set_encoding(nil, nil)
       end
 
-      NATFIXME 'It correctly resets standard IOs', exception: SpecFailedException do
-        STDOUT.external_encoding.should == nil
-        STDOUT.internal_encoding.should == nil
-      end
+      STDOUT.external_encoding.should == nil
+      STDOUT.internal_encoding.should == nil
     end
   end
 end

--- a/spec/core/io/set_encoding_spec.rb
+++ b/spec/core/io/set_encoding_spec.rb
@@ -41,10 +41,8 @@ describe :io_set_encoding_write, shared: true do
 
     @io.set_encoding nil, nil
 
-    NATFIXME 'sets the encodings to the current Encoding defaults', exception: SpecFailedException do
-      @io.external_encoding.should == Encoding::IBM437
-      @io.internal_encoding.should == Encoding::IBM866
-    end
+    @io.external_encoding.should == Encoding::IBM437
+    @io.internal_encoding.should == Encoding::IBM866
   end
 end
 
@@ -77,10 +75,8 @@ describe "IO#set_encoding when passed nil, nil" do
       Encoding.default_internal = Encoding::IBM866
 
       @io.set_encoding nil, nil
-      NATFIXME 'sets the encodings to the current Encoding defaults', exception: SpecFailedException do
-        @io.external_encoding.should equal(Encoding::IBM437)
-        @io.internal_encoding.should equal(Encoding::IBM866)
-      end
+      @io.external_encoding.should equal(Encoding::IBM437)
+      @io.internal_encoding.should equal(Encoding::IBM866)
     end
 
     it "prevents the #internal_encoding from changing when Encoding.default_internal is changed" do
@@ -98,9 +94,7 @@ describe "IO#set_encoding when passed nil, nil" do
 
       Encoding.default_external = Encoding::IBM437
 
-      NATFIXME 'allows the #external_encoding to change when Encoding.default_external is changed', exception: SpecFailedException do
-        @io.external_encoding.should equal(Encoding::IBM437)
-      end
+      @io.external_encoding.should equal(Encoding::IBM437)
     end
   end
 
@@ -110,9 +104,7 @@ describe "IO#set_encoding when passed nil, nil" do
       @io.external_encoding.should equal(Encoding::BINARY)
 
       @io.set_encoding nil, nil
-      NATFIXME "returns Encoding.default_external with 'rb' mode", exception: SpecFailedException do
-        @io.external_encoding.should equal(Encoding.default_external)
-      end
+      @io.external_encoding.should equal(Encoding.default_external)
     end
   end
 

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -1486,16 +1486,12 @@ describe "The predefined global constant" do
   describe "STDIN" do
     platform_is_not :windows do
       it "has the same external encoding as Encoding.default_external" do
-        NATFIXME 'Encodings', exception: SpecFailedException do
-          STDIN.external_encoding.should equal(Encoding.default_external)
-        end
+        STDIN.external_encoding.should equal(Encoding.default_external)
       end
 
       it "has the same external encoding as Encoding.default_external when that encoding is changed" do
         Encoding.default_external = Encoding::ISO_8859_16
-        NATFIXME 'Encodings', exception: SpecFailedException do
-          STDIN.external_encoding.should equal(Encoding::ISO_8859_16)
-        end
+        STDIN.external_encoding.should equal(Encoding::ISO_8859_16)
       end
 
       it "has nil for the internal encoding" do

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -63,6 +63,7 @@ Value FileObject::initialize(Env *env, Args &&args, Block *block) {
         set_fileno(fileno);
         set_path(filename.as_string());
     }
+    set_fmode(fmode_from_oflags(flags.flags()));
     set_encoding(env, flags.external_encoding(), flags.internal_encoding());
     if (block)
         env->warn("File::new() does not take block; use File::open() instead");

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -160,6 +160,15 @@ int IoObject::fileno() const {
     return m_fileno;
 }
 
+void IoObject::set_fileno(int fileno) {
+    m_fileno = fileno;
+    if (fileno >= 0) {
+        int flags = ::fcntl(fileno, F_GETFL);
+        if (flags >= 0)
+            m_writable = flags_is_writable(flags);
+    }
+}
+
 int IoObject::fileno(Env *env) const {
     raise_if_closed(env);
     return m_fileno;
@@ -808,9 +817,19 @@ Value IoObject::set_encoding(Env *env, Optional<Value> ext_arg, Optional<Value> 
     Value ext_enc = ext_arg.value_or(Value::nil());
     Value int_enc = int_arg.value_or(Value::nil());
 
-    if (ext_arg && ext_enc.is_nil()) {
-        m_external_encoding = nullptr;
-        m_internal_encoding = nullptr;
+    if (ext_arg && ext_enc.is_nil() && (!int_arg || int_enc.is_nil())) {
+        auto default_internal = EncodingObject::default_internal();
+        auto default_external = EncodingObject::default_external();
+        auto binary = EncodingObject::get(Encoding::ASCII_8BIT);
+        if (default_internal && default_external != binary) {
+            m_external_encoding = default_external;
+            m_internal_encoding = default_internal;
+            if (m_external_encoding == m_internal_encoding)
+                m_internal_encoding = nullptr;
+        } else {
+            m_external_encoding = nullptr;
+            m_internal_encoding = nullptr;
+        }
         return this;
     }
 

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -808,6 +808,12 @@ Value IoObject::set_encoding(Env *env, Optional<Value> ext_arg, Optional<Value> 
     Value ext_enc = ext_arg.value_or(Value::nil());
     Value int_enc = int_arg.value_or(Value::nil());
 
+    if (ext_arg && ext_enc.is_nil()) {
+        m_external_encoding = nullptr;
+        m_internal_encoding = nullptr;
+        return this;
+    }
+
     if (int_enc.is_nil() && ext_arg && (ext_enc.is_string() || ext_enc.respond_to(env, "to_str"_s))) {
         ext_enc = ext_enc.to_str(env);
         if (ext_enc.as_string()->include(":")) {

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -68,6 +68,7 @@ Value IoObject::initialize(Env *env, Args &&args, Block *block) {
             env->raise_errno(EINVAL);
     }
     set_fileno(fileno);
+    set_fmode(fmode_from_oflags(wanted_flags.has_mode() ? wanted_flags.flags() : actual_flags));
     set_encoding(env, wanted_flags.external_encoding(), wanted_flags.internal_encoding());
     m_autoclose = wanted_flags.autoclose();
     m_path = wanted_flags.path();
@@ -160,13 +161,11 @@ int IoObject::fileno() const {
     return m_fileno;
 }
 
-void IoObject::set_fileno(int fileno) {
-    m_fileno = fileno;
-    if (fileno >= 0) {
-        int flags = ::fcntl(fileno, F_GETFL);
-        if (flags >= 0)
-            m_writable = flags_is_writable(flags);
-    }
+int IoObject::fmode_from_oflags(int oflags) {
+    int fmode = 0;
+    if (flags_is_readable(oflags)) fmode |= FMODE_READABLE;
+    if (flags_is_writable(oflags)) fmode |= FMODE_WRITABLE;
+    return fmode;
 }
 
 int IoObject::fileno(Env *env) const {
@@ -508,7 +507,7 @@ int IoObject::write(Env *env, Value obj) {
         total_written += written;
     }
 
-    if (m_sync) ::fsync(m_fileno);
+    if (fmode_sync()) ::fsync(m_fileno);
 
     return total_written;
 }
@@ -881,7 +880,10 @@ Value IoObject::set_lineno(Env *env, Value lineno) {
 
 Value IoObject::set_sync(Env *env, Value value) {
     raise_if_closed(env);
-    m_sync = value.is_truthy();
+    if (value.is_truthy())
+        m_fmode |= FMODE_SYNC;
+    else
+        m_fmode &= ~FMODE_SYNC;
     return value;
 }
 
@@ -1061,7 +1063,7 @@ int IoObject::set_pos(Env *env, Value position) {
 
 bool IoObject::sync(Env *env) const {
     raise_if_closed(env);
-    return m_sync;
+    return fmode_sync();
 }
 
 Value IoObject::sysread(Env *env, Value amount, Optional<Value> buffer) {
@@ -1096,7 +1098,7 @@ Value IoObject::syswrite(Env *env, Value obj) {
     if (result == -1)
         throw_unless_writable(env, this);
 
-    if (m_sync) ::fsync(m_fileno);
+    if (fmode_sync()) ::fsync(m_fileno);
 
     return Value::integer(result);
 }

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -818,20 +818,30 @@ Value IoObject::set_encoding(Env *env, Optional<Value> ext_arg, Optional<Value> 
         }
     }
 
+    EncodingObject *new_ext = nullptr;
+    EncodingObject *new_int = nullptr;
+
     if (ext_enc != nullptr && !ext_enc.is_nil()) {
         if (ext_enc.is_encoding()) {
-            m_external_encoding = ext_enc.as_encoding();
+            new_ext = ext_enc.as_encoding();
         } else {
-            m_external_encoding = EncodingObject::find_encoding(env, ext_enc.to_str(env));
+            new_ext = EncodingObject::find_encoding(env, ext_enc.to_str(env));
         }
     }
     if (int_enc != nullptr && !int_enc.is_nil()) {
         if (int_enc.is_encoding()) {
-            m_internal_encoding = int_enc.as_encoding();
+            new_int = int_enc.as_encoding();
         } else {
-            m_internal_encoding = EncodingObject::find_encoding(env, int_enc.to_str(env));
+            new_int = EncodingObject::find_encoding(env, int_enc.to_str(env));
         }
     }
+
+    // If internal matches external, drop internal.
+    if (new_ext && new_int && new_ext == new_int)
+        new_int = nullptr;
+
+    if (new_ext) m_external_encoding = new_ext;
+    if (new_int) m_internal_encoding = new_int;
 
     return this;
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -453,17 +453,18 @@ Env *build_top_env() {
     auto main_obj = Object::create();
     GlobalEnv::the()->set_main_obj(main_obj);
 
-    Value _stdin = IoObject::create(STDIN_FILENO);
+    Value _stdin = IoObject::create(STDIN_FILENO, IoObject::FMODE_READABLE);
     env->global_set("$stdin"_s, _stdin);
     Object->const_set("STDIN"_s, _stdin);
 
-    Value _stdout = IoObject::create(STDOUT_FILENO);
+    Value _stdout = IoObject::create(STDOUT_FILENO, IoObject::FMODE_WRITABLE);
     env->global_set("$stdout"_s, _stdout);
     GlobalEnv::the()->global_set_write_hook(env, "$stdout"_s, GlobalVariableAccessHooks::WriteHooks::set_stdout);
     env->global_alias("$>"_s, "$stdout"_s);
     Object->const_set("STDOUT"_s, _stdout);
 
-    Value _stderr = IoObject::create(STDERR_FILENO);
+    // stderr is unbuffered
+    Value _stderr = IoObject::create(STDERR_FILENO, IoObject::FMODE_WRITABLE | IoObject::FMODE_SYNC);
     env->global_set("$stderr"_s, _stderr);
     Object->const_set("STDERR"_s, _stderr);
 


### PR DESCRIPTION
Explicitly use FMODE_* flags for IOs, matching MRI's enum (minus a few that we don't support yet). This makes it a little easier to handle things like readable/writeable/sync checks.

This also works on what happens when you call external_encoding, which goes through a whole conditional chain to see what to return.