### PR TITLE
Require spec first in the nightly spec runner

### DIFF
--- a/spec/support/nightly_ruby_spec_runner.rb
+++ b/spec/support/nightly_ruby_spec_runner.rb
@@ -89,7 +89,7 @@ Dir[specs].each do |path|
     stderr = Tempfile.new('stderr')
     stderr.close
 
-    unless system("bin/natalie -c #{binary_name} #{path} 2> #{stderr.path}")
+    unless system("bin/natalie -I test/support -r spec -c #{binary_name} #{path} 2> #{stderr.path}")
       compile_errors += 1
       lines = File.readlines(stderr.path).map(&:chomp)
       error_message = lines.reject(&:empty?).first.split(':', 4).last.strip


### PR DESCRIPTION
This mirrors changes from the other paths that trigger tests. I didn't realize this was a different path. We need this to avoid things like "undefined method ruby_version_is".