### PR TITLE
StringIO#puts and IO#puts

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -211,12 +211,37 @@ class StringIO
 
   def puts(*args)
     args = [$_] if args.empty?
-    args.flatten.each do |arg|
-      arg = arg.to_s unless arg.is_a?(String)
-      write(arg)
-      write("\n") unless arg.end_with?("\n")
-    end
+    args.each { |arg| puts_arg(arg, nil) }
     nil
+  end
+
+  private def puts_arg(arg, seen)
+    ary =
+      if arg.is_a?(Array)
+        arg
+      elsif !arg.is_a?(String) && arg.respond_to?(:to_ary)
+        arg.to_ary
+      end
+
+    if ary
+      seen ||= {}.compare_by_identity
+      if seen.include?(ary)
+        write("[...]\n")
+        return
+      end
+
+      seen[ary] = true
+      begin
+        ary.each { |item| puts_arg(item, seen) }
+      ensure
+        seen.delete(ary)
+      end
+    else
+      str = arg.is_a?(String) ? arg : arg.to_s
+      str = arg.inspect unless str.is_a?(String)
+      write(str)
+      write("\n") unless str.end_with?("\n")
+    end
   end
 
   def read(length = nil, out_string = nil)

--- a/spec/core/io/puts_spec.rb
+++ b/spec/core/io/puts_spec.rb
@@ -91,8 +91,7 @@ describe "IO#puts" do
     @io.puts(x).should == nil
   end
 
-  # NATFIXME: recursion case not handled yet
-  xit "writes [...] for a recursive array arg" do
+  it "writes [...] for a recursive array arg" do
     x = []
     x << 2 << x
     @io.puts(x).should == nil

--- a/spec/library/stringio/puts_spec.rb
+++ b/spec/library/stringio/puts_spec.rb
@@ -24,10 +24,8 @@ describe "StringIO#puts when passed an Array" do
   it "handles self-recursive arrays correctly" do
     (ary = [5])
     ary << ary
-    NATFIXME 'handles self-recursive arrays correctly, likely a generic issue', exception: ArgumentError, message: 'tried to flatten recursive array' do
-      @io.puts(ary)
-      @io.string.should == "5\n[...]\n"
-    end
+    @io.puts(ary)
+    @io.string.should == "5\n[...]\n"
   end
 
   it "does not honor the global output record separator $\\" do
@@ -59,8 +57,8 @@ describe "StringIO#puts when passed an Array" do
     object = mock('hola')
     object.should_receive(:to_s).and_return(false)
 
-    NATFIXME 'Return general object info if to_s does not return a string, likely a generic issue', exception: NoMethodError, message: "undefined method 'end_with?' for false" do
-      @io.puts(object).should == nil
+    @io.puts(object).should == nil
+    NATFIXME "Object#inspect missing instance-variables causes this to break" do
       @io.string.should == object.inspect.split(" ")[0] + ">\n"
     end
   end

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -2,6 +2,7 @@
 #include "natalie/integer_methods.hpp"
 #include "natalie/ioutil.hpp"
 #include "tm/defer.hpp"
+#include "tm/recursion_guard.hpp"
 
 #include <fcntl.h>
 #include <limits.h>
@@ -662,9 +663,16 @@ void IoObject::putstr(Env *env, StringObject *str) {
 }
 
 void IoObject::putary(Env *env, ArrayObject *ary) {
-    for (auto &item : *ary) {
-        this->puts(env, item);
-    }
+    TM::RecursionGuard guard { ary };
+    guard.run([&](bool is_recursive) {
+        if (is_recursive) {
+            this->putstr(env, StringObject::create("[...]"));
+        } else {
+            for (auto &item : *ary) {
+                this->puts(env, item);
+            }
+        }
+    });
 }
 
 void IoObject::puts(Env *env, Value val) {


### PR DESCRIPTION
Both of these need recursion guards to fix crashes. Now they properly emit [...] to match MRI.

Sidenote I love TM::RecursionGuard, that's very convenient.