### PR TITLE
raise_consistent_error mspec helper

### DIFF
--- a/spec/core/array/try_convert_spec.rb
+++ b/spec/core/array/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "Array.try_convert" do
   it "sends #to_ary to the argument and raises TypeError if it's not a kind of Array" do
     obj = mock("to_ary")
     obj.should_receive(:to_ary).and_return(Object.new)
-    -> { Array.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to Array (MockObject#to_ary gives Object)")
+    -> { Array.try_convert obj }.should raise_consistent_error(TypeError, "can't convert MockObject to Array (MockObject#to_ary gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_ary" do

--- a/spec/core/basicobject/instance_eval_spec.rb
+++ b/spec/core/basicobject/instance_eval_spec.rb
@@ -303,7 +303,7 @@ describe "BasicObject#instance_eval" do
       def source_code.to_str() :symbol end
 
       a = BasicObject.new
-      -> { a.instance_eval(source_code) }.should raise_error(TypeError, /can't convert Object to String/)
+      -> { a.instance_eval(source_code) }.should raise_consistent_error(TypeError, /can't convert Object to String/)
     end
   end
 
@@ -326,7 +326,7 @@ describe "BasicObject#instance_eval" do
       filename = Object.new
       def filename.to_str() :symbol end
 
-      -> { Object.new.instance_eval("raise", filename) }.should raise_error(TypeError, /can't convert Object to String/)
+      -> { Object.new.instance_eval("raise", filename) }.should raise_consistent_error(TypeError, /can't convert Object to String/)
     end
   end
 
@@ -349,7 +349,7 @@ describe "BasicObject#instance_eval" do
       lineno = Object.new
       def lineno.to_int() :symbol end
 
-      -> { Object.new.instance_eval("raise", "file.rb", lineno) }.should raise_error(TypeError, /can't convert Object to Integer/)
+      -> { Object.new.instance_eval("raise", "file.rb", lineno) }.should raise_consistent_error(TypeError, /can't convert Object to Integer/)
     end
   end
 end

--- a/spec/core/hash/try_convert_spec.rb
+++ b/spec/core/hash/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "Hash.try_convert" do
   it "sends #to_hash to the argument and raises TypeError if it's not a kind of Hash" do
     obj = mock("to_hash")
     obj.should_receive(:to_hash).and_return(Object.new)
-    -> { Hash.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to Hash (MockObject#to_hash gives Object)")
+    -> { Hash.try_convert obj }.should raise_consistent_error(TypeError, "can't convert MockObject to Hash (MockObject#to_hash gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_hash" do

--- a/spec/core/integer/try_convert_spec.rb
+++ b/spec/core/integer/try_convert_spec.rb
@@ -29,7 +29,7 @@ describe "Integer.try_convert" do
     obj.should_receive(:to_int).and_return(Object.new)
     -> {
       Integer.try_convert obj
-    }.should raise_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives Object)")
+    }.should raise_consistent_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives Object)")
   end
 
   it "responds with a different error message when it raises a TypeError, depending on the type of the non-Integer object :to_int returns" do
@@ -37,7 +37,7 @@ describe "Integer.try_convert" do
     obj.should_receive(:to_int).and_return("A String")
     -> {
       Integer.try_convert obj
-    }.should raise_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives String)")
+    }.should raise_consistent_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives String)")
   end
 
   it "does not rescue exceptions raised by #to_int" do

--- a/spec/core/io/lineno_spec.rb
+++ b/spec/core/io/lineno_spec.rb
@@ -100,7 +100,7 @@ describe "IO#lineno=" do
 
   it "raises TypeError if cannot convert argument to Integer implicitly" do
     -> { @io.lineno = "1" }.should raise_error(TypeError, 'no implicit conversion of String into Integer')
-    -> { @io.lineno = nil }.should raise_error(TypeError, 'no implicit conversion from nil to integer')
+    -> { @io.lineno = nil }.should raise_consistent_error(TypeError, 'no implicit conversion from nil to integer')
   end
 
   it "does not accept Integers that don't fit in a C int" do

--- a/spec/core/io/try_convert_spec.rb
+++ b/spec/core/io/try_convert_spec.rb
@@ -38,7 +38,7 @@ describe "IO.try_convert" do
   it "raises a TypeError if the object does not return an IO from #to_io" do
     obj = mock("io")
     obj.should_receive(:to_io).and_return("io")
-    -> { IO.try_convert(obj) }.should raise_error(TypeError, "can't convert MockObject to IO (MockObject#to_io gives String)")
+    -> { IO.try_convert(obj) }.should raise_consistent_error(TypeError, "can't convert MockObject to IO (MockObject#to_io gives String)")
   end
 
   it "propagates an exception raised by #to_io" do

--- a/spec/core/kernel/Rational_spec.rb
+++ b/spec/core/kernel/Rational_spec.rb
@@ -140,7 +140,7 @@ describe "Kernel.Rational" do
         obj = Object.new
         def obj.to_r; []; end
 
-        -> { Rational(obj) }.should raise_error(TypeError, "can't convert Object to Rational (Object#to_r gives Array)")
+        -> { Rational(obj) }.should raise_consistent_error(TypeError, "can't convert Object to Rational (Object#to_r gives Array)")
       end
     end
   end

--- a/spec/core/kernel/shared/sprintf.rb
+++ b/spec/core/kernel/shared/sprintf.rb
@@ -308,13 +308,13 @@ describe :kernel_sprintf, shared: true do
       it "raises TypeError if argument is not String or Integer and cannot be converted to them" do
         -> {
           @method.call("%c", [])
-        }.should raise_error(TypeError, /no implicit conversion of Array into Integer/)
+        }.should raise_consistent_error(TypeError, /no implicit conversion of Array into Integer/)
       end
 
       it "raises TypeError if argument is nil" do
         -> {
           @method.call("%c", nil)
-        }.should raise_error(TypeError, /no implicit conversion from nil to integer/)
+        }.should raise_consistent_error(TypeError, /no implicit conversion from nil to integer/)
       end
 
       it "tries to convert argument to String with to_str" do
@@ -343,7 +343,7 @@ describe :kernel_sprintf, shared: true do
 
         -> {
           @method.call("%c", obj)
-        }.should raise_error(TypeError, /can't convert BasicObject to String/)
+        }.should raise_consistent_error(TypeError, /can't convert BasicObject to String/)
       end
 
       it "raises TypeError if converting to Integer with to_int returns non-Integer" do
@@ -354,7 +354,7 @@ describe :kernel_sprintf, shared: true do
 
         -> {
           @method.call("%c", obj)
-        }.should raise_error(TypeError, /can't convert BasicObject to Integer/)
+        }.should raise_consistent_error(TypeError, /can't convert BasicObject to Integer/)
       end
     end
 

--- a/spec/core/module/instance_method_spec.rb
+++ b/spec/core/module/instance_method_spec.rb
@@ -79,7 +79,7 @@ describe "Module#instance_method" do
     obj = Object.new
     def obj.to_str() [] end
 
-    -> { ModuleSpecs::InstanceMeth.instance_method(obj) }.should raise_error(TypeError, /can't convert Object to String/)
+    -> { ModuleSpecs::InstanceMeth.instance_method(obj) }.should raise_consistent_error(TypeError, /can't convert Object to String/)
   end
 
   it "raises a NameError if the method has been undefined" do

--- a/spec/core/queue/initialize_spec.rb
+++ b/spec/core/queue/initialize_spec.rb
@@ -55,6 +55,6 @@ describe "Queue#initialize" do
     enumerable = MockObject.new('mock-enumerable')
     enumerable.should_receive(:to_a).and_return("string")
 
-    -> { Queue.new(enumerable) }.should raise_error(TypeError, "can't convert MockObject to Array (MockObject#to_a gives String)")
+    -> { Queue.new(enumerable) }.should raise_consistent_error(TypeError, "can't convert MockObject to Array (MockObject#to_a gives String)")
   end
 end

--- a/spec/core/regexp/shared/new.rb
+++ b/spec/core/regexp/shared/new.rb
@@ -46,7 +46,7 @@ describe :regexp_new_non_string_or_regexp, shared: true do
     obj = Object.new
     def obj.to_str() [] end
 
-    -> { Regexp.send(@method, obj) }.should raise_error(TypeError, /can't convert Object to String/)
+    -> { Regexp.send(@method, obj) }.should raise_consistent_error(TypeError, /can't convert Object to String/)
   end
 end
 

--- a/spec/core/regexp/try_convert_spec.rb
+++ b/spec/core/regexp/try_convert_spec.rb
@@ -22,6 +22,6 @@ describe "Regexp.try_convert" do
   it "raises a TypeError if the object does not return an Regexp from #to_regexp" do
     obj = mock("regexp")
     obj.should_receive(:to_regexp).and_return("string")
-    -> { Regexp.try_convert(obj) }.should raise_error(TypeError, "can't convert MockObject to Regexp (MockObject#to_regexp gives String)")
+    -> { Regexp.try_convert(obj) }.should raise_consistent_error(TypeError, "can't convert MockObject to Regexp (MockObject#to_regexp gives String)")
   end
 end

--- a/spec/core/string/try_convert_spec.rb
+++ b/spec/core/string/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "String.try_convert" do
   it "sends #to_str to the argument and raises TypeError if it's not a kind of String" do
     obj = mock("to_str")
     obj.should_receive(:to_str).and_return(Object.new)
-    -> { String.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to String (MockObject#to_str gives Object)")
+    -> { String.try_convert obj }.should raise_consistent_error(TypeError, "can't convert MockObject to String (MockObject#to_str gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_str" do

--- a/spec/core/struct/deconstruct_keys_spec.rb
+++ b/spec/core/struct/deconstruct_keys_spec.rb
@@ -101,7 +101,7 @@ describe "Struct#deconstruct_keys" do
 
     -> {
       s.deconstruct_keys([key])
-    }.should raise_error(TypeError, /can't convert MockObject to Integer/)
+    }.should raise_consistent_error(TypeError, /can't convert MockObject to Integer/)
   end
 
   it "raises TypeError if index is not a String, a Symbol and not convertible to Integer" do

--- a/spec/language/send_spec.rb
+++ b/spec/language/send_spec.rb
@@ -112,7 +112,7 @@ describe "Invoking a method" do
 
       -> {
         specs.makeproc(&o)
-      }.should raise_error(TypeError, "can't convert LangSendSpecs::RawToProc to Proc (LangSendSpecs::RawToProc#to_proc gives Integer)")
+      }.should raise_consistent_error(TypeError, "can't convert LangSendSpecs::RawToProc to Proc (LangSendSpecs::RawToProc#to_proc gives Integer)")
     end
 
     it "raises TypeError if block object isn't a Proc and doesn't respond to `to_proc`" do

--- a/spec/shared/queue/deque.rb
+++ b/spec/shared/queue/deque.rb
@@ -105,11 +105,11 @@ describe :queue_deq, shared: true do
       q = @object.call
       -> {
         q.send(@method, timeout: "1")
-      }.should raise_error(TypeError, "no implicit conversion to float from string")
+      }.should raise_consistent_error(TypeError, "no implicit conversion to float from string")
 
       -> {
         q.send(@method, timeout: false)
-      }.should raise_error(TypeError, "no implicit conversion to float from false")
+      }.should raise_consistent_error(TypeError, "no implicit conversion to float from false")
     end
 
     it "raise ArgumentError if non_block = true is passed too" do

--- a/spec/shared/types/rb_num2dbl_fails.rb
+++ b/spec/shared/types/rb_num2dbl_fails.rb
@@ -7,11 +7,11 @@
 
 describe :rb_num2dbl_fails, shared: true do
   it "fails if string is provided" do
-    -> { @object.call("123") }.should raise_error(TypeError, "no implicit conversion to float from string")
+    -> { @object.call("123") }.should raise_consistent_error(TypeError, "no implicit conversion to float from string")
   end
 
   it "fails if boolean is provided" do
-    -> { @object.call(true) }.should raise_error(TypeError, "no implicit conversion to float from true")
-    -> { @object.call(false) }.should raise_error(TypeError, "no implicit conversion to float from false")
+    -> { @object.call(true) }.should raise_consistent_error(TypeError, "no implicit conversion to float from true")
+    -> { @object.call(false) }.should raise_consistent_error(TypeError, "no implicit conversion to float from false")
   end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1522,6 +1522,10 @@ class Object
     RaiseErrorExpectation.new(klass, message, &block)
   end
 
+  def raise_consistent_error(klass = Exception, message = nil, &block)
+    RaiseErrorExpectation.new(klass, message, &block)
+  end
+
   def complain(message = nil, kwargs = {}, verbose: false)
     ComplainExpectation.new(message, kwargs, verbose: verbose)
   end


### PR DESCRIPTION
A very small helper that will unblock some nightly spec failures to be actual failures, not just a missing spec helper.