### PR TITLE
Platform guard imported from upstream

### DIFF
--- a/test/support/platform_guard.rb
+++ b/test/support/platform_guard.rb
@@ -6,6 +6,10 @@ class PlatformGuard
     false
   end
 
+  def self.standard?
+    implementation? :ruby
+  end
+
   def self.windows?
     false
   end


### PR DESCRIPTION
This won't get any specs passing, but it will make it so that they fail with an actual failure as opposed to missing a guard.