### PR TITLE
Propagate last match through to calling block

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -194,7 +194,14 @@ public:
 
     Optional<Value> match() { return m_match; }
     void set_match(Optional<Value> match) { m_match = match; }
-    void clear_match() { m_match = Optional<Value>(); }
+    void clear_match() { non_block_env()->m_match = Optional<Value>(); }
+
+    // Make our enclosing method's $~ visible to whoever called that method.
+    void propagate_last_match_to_caller() {
+        auto src = non_block_env();
+        if (auto dst = src->caller())
+            dst->set_last_match(src->has_last_match() ? src->last_match().as_match_data() : nullptr);
+    }
 
     Value exception_object();
     ExceptionObject *exception();

--- a/spec/core/enumerable/grep_spec.rb
+++ b/spec/core/enumerable/grep_spec.rb
@@ -26,24 +26,18 @@ describe "Enumerable#grep" do
 
   it "can use $~ in the block when used with a Regexp" do
     ary = ["aba", "aba"]
-    NATFIXME 'nth ref inside block', exception: SpecFailedException do
-      ary.grep(/a(b)a/) { $1 }.should == ["b", "b"]
-    end
+    ary.grep(/a(b)a/) { $1 }.should == ["b", "b"]
   end
 
   it "sets $~ in the block" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].grep(/b/) { |e|
       e.should == "abc"
-      NATFIXME 'nth ref inside block', exception: SpecFailedException do
-        $&.should == "b"
-      end
+      $&.should == "b"
     }
 
     # Set by the failed match of "def"
-    NATFIXME 'nth ref inside block', exception: SpecFailedException do
-      $~.should == nil
-    end
+    $~.should == nil
   end
 
   it "does not set $~ when given no block" do

--- a/spec/core/enumerable/grep_v_spec.rb
+++ b/spec/core/enumerable/grep_v_spec.rb
@@ -13,15 +13,11 @@ describe "Enumerable#grep_v" do
     "z" =~ /z/ # Reset $~
     ["abc", "def"].grep_v(/e/) { |e|
       e.should == "abc"
-      NATFIXME 'reset back ref inside block somehow (not sure how)', exception: SpecFailedException do
-        $~.should == nil
-      end
+      $~.should == nil
     }
 
     # Set by the match of "def"
-    NATFIXME 'reset back ref inside block somehow (not sure how)', exception: SpecFailedException do
-      $&.should == "e"
-    end
+    $&.should == "e"
   end
 
   it "does not set $~ when given no block" do

--- a/spec/core/matchdata/regexp_spec.rb
+++ b/spec/core/matchdata/regexp_spec.rb
@@ -19,8 +19,6 @@ describe "MatchData#regexp" do
 
   it "returns a Regexp for the result of gsub(String)" do
     'he[[o'.gsub('[', ']')
-    NATFIXME 'Set $~ in String#gsub', exception: NoMethodError, message: "undefined method 'regexp' for nil" do
-      $~.regexp.should == /\[/
-    end
+    $~.regexp.should == /\[/
   end
 end

--- a/spec/core/matchdata/string_spec.rb
+++ b/spec/core/matchdata/string_spec.rb
@@ -20,9 +20,7 @@ describe "MatchData#string" do
   it "returns a frozen copy of the matched string for gsub!(String)" do
     s = +'he[[o'
     s.gsub!('[', ']')
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method 'string' for nil" do
-      $~.string.should == 'he[[o'
-      $~.string.should.frozen?
-    end
+    $~.string.should == 'he[[o'
+    $~.string.should.frozen?
   end
 end

--- a/spec/core/string/gsub_spec.rb
+++ b/spec/core/string/gsub_spec.rb
@@ -204,18 +204,16 @@ describe "String#gsub with pattern and replacement" do
 
   it "sets $~ to MatchData of last match and nil when there's none" do
     'hello.'.gsub('hello', 'x')
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method '[]' for nil" do
-      $~[0].should == 'hello'
+    $~[0].should == 'hello'
 
-      'hello.'.gsub('not', 'x')
-      $~.should == nil
+    'hello.'.gsub('not', 'x')
+    $~.should == nil
 
-      'hello.'.gsub(/.(.)/, 'x')
-      $~[0].should == 'o.'
+    'hello.'.gsub(/.(.)/, 'x')
+    $~[0].should == 'o.'
 
-      'hello.'.gsub(/not/, 'x')
-      $~.should == nil
-    end
+    'hello.'.gsub(/not/, 'x')
+    $~.should == nil
   end
 
   it "handles a pattern in a superset encoding" do
@@ -278,20 +276,18 @@ describe "String#gsub with pattern and Hash" do
   end
 
   it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
-    NATFIXME 'Support hash argument', exception: SpecFailedException do
-      'hello.'.gsub('l', 'l' => 'L')
-      $~.begin(0).should == 3
-      $~[0].should == 'l'
+    'hello.'.gsub('l', 'l' => 'L')
+    $~.begin(0).should == 3
+    $~[0].should == 'l'
 
-      'hello.'.gsub('not', 'ot' => 'to')
-      $~.should == nil
+    'hello.'.gsub('not', 'ot' => 'to')
+    $~.should == nil
 
-      'hello.'.gsub(/.(.)/, 'o' => ' hole')
-      $~[0].should == 'o.'
+    'hello.'.gsub(/.(.)/, 'o' => ' hole')
+    $~[0].should == 'o.'
 
-      'hello.'.gsub(/not/, 'z' => 'glark')
-      $~.should == nil
-    end
+    'hello.'.gsub(/not/, 'z' => 'glark')
+    $~.should == nil
   end
 
   it "doesn't interpolate special sequences like \\1 for the block's return value" do
@@ -348,20 +344,18 @@ describe "String#gsub! with pattern and Hash" do
   end
 
   it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
-    NATFIXME 'Support hash argument', exception: SpecFailedException do
-      'hello.'.gsub!('l', 'l' => 'L')
-      $~.begin(0).should == 3
-      $~[0].should == 'l'
+    'hello.'.gsub!('l', 'l' => 'L')
+    $~.begin(0).should == 3
+    $~[0].should == 'l'
 
-      'hello.'.gsub!('not', 'ot' => 'to')
-      $~.should == nil
+    'hello.'.gsub!('not', 'ot' => 'to')
+    $~.should == nil
 
-      'hello.'.gsub!(/.(.)/, 'o' => ' hole')
-      $~[0].should == 'o.'
+    'hello.'.gsub!(/.(.)/, 'o' => ' hole')
+    $~[0].should == 'o.'
 
-      'hello.'.gsub!(/not/, 'z' => 'glark')
-      $~.should == nil
-    end
+    'hello.'.gsub!(/not/, 'z' => 'glark')
+    $~.should == nil
   end
 
   it "doesn't interpolate special sequences like \\1 for the block's return value" do
@@ -418,19 +412,17 @@ describe "String#gsub with pattern and block" do
 
   it "sets $~ to MatchData of last match and nil when there's none for access from outside" do
     'hello.'.gsub('l') { 'x' }
-    NATFIXME 'Implement $~', exception: NoMethodError, message: "undefined method 'begin' for nil" do
-      $~.begin(0).should == 3
-      $~[0].should == 'l'
+    $~.begin(0).should == 3
+    $~[0].should == 'l'
 
-      'hello.'.gsub('not') { 'x' }
-      $~.should == nil
+    'hello.'.gsub('not') { 'x' }
+    $~.should == nil
 
-      'hello.'.gsub(/.(.)/) { 'x' }
-      $~[0].should == 'o.'
+    'hello.'.gsub(/.(.)/) { 'x' }
+    $~[0].should == 'o.'
 
-      'hello.'.gsub(/not/) { 'x' }
-      $~.should == nil
-    end
+    'hello.'.gsub(/not/) { 'x' }
+    $~.should == nil
   end
 
   it "doesn't interpolate special sequences like \\1 for the block's return value" do

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -356,9 +356,13 @@ Value ArrayObject::refeq(Env *env, Value index_obj, Value size, Optional<Value> 
 Value ArrayObject::any(Env *env, Args &&args, Block *block) {
     // FIXME: delegating to Enumerable#any? like this does not have the same semantics as MRI,
     // i.e. one can override Enumerable#any? in MRI and it won't affect Array#any?.
+    bool regexp_pattern = args.size() > 0 && args[0].is_regexp();
     auto Enumerable = GlobalEnv::the()->Object()->const_fetch("Enumerable"_s).as_module();
     auto method_info = Enumerable->find_method(env, "any?"_s);
-    return method_info.method()->call(env, this, std::move(args), block);
+    auto result = method_info.method()->call(env, this, std::move(args), block);
+    if (regexp_pattern)
+        env->propagate_last_match_to_caller();
+    return result;
 }
 
 bool ArrayObject::eq(Env *env, Value other) {
@@ -1779,17 +1783,25 @@ Value ArrayObject::find_index(Env *env, Optional<Value> object, Block *block, bo
 Value ArrayObject::none(Env *env, Args &&args, Block *block) {
     // FIXME: delegating to Enumerable#none? like this does not have the same semantics as MRI,
     // i.e. one can override Enumerable#none? in MRI and it won't affect Array#none?.
+    bool regexp_pattern = args.size() > 0 && args[0].is_regexp();
     auto Enumerable = GlobalEnv::the()->Object()->const_fetch("Enumerable"_s).as_module();
     auto method_info = Enumerable->find_method(env, "none?"_s);
-    return method_info.method()->call(env, this, std::move(args), block);
+    auto result = method_info.method()->call(env, this, std::move(args), block);
+    if (regexp_pattern)
+        env->propagate_last_match_to_caller();
+    return result;
 }
 
 Value ArrayObject::one(Env *env, Args &&args, Block *block) {
     // FIXME: delegating to Enumerable#one? like this does not have the same semantics as MRI,
     // i.e. one can override Enumerable#one? in MRI and it won't affect Array#one?.
+    bool regexp_pattern = args.size() > 0 && args[0].is_regexp();
     auto Enumerable = GlobalEnv::the()->Object()->const_fetch("Enumerable"_s).as_module();
     auto method_info = Enumerable->find_method(env, "one?"_s);
-    return method_info.method()->call(env, this, std::move(args), block);
+    auto result = method_info.method()->call(env, this, std::move(args), block);
+    if (regexp_pattern)
+        env->propagate_last_match_to_caller();
+    return result;
 }
 
 Value ArrayObject::product(Env *env, Args &&args, Block *block) {

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -1,9 +1,16 @@
+require 'natalie/inline'
+
 module Enumerable
   def all?(pattern = nil)
     gather = ->(item) { item.size <= 1 ? item.first : item }
     if pattern
       warn('warning: given block not used') if block_given?
-      each { |*item| return false unless pattern === gather.(item) }
+      regexp = Regexp === pattern
+      each do |*item|
+        result = pattern === gather.(item)
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        return false unless result
+      end
       true
     elsif block_given?
       each { |*item| return false unless yield(*item) }
@@ -18,7 +25,12 @@ module Enumerable
     gather = ->(item) { item.size <= 1 ? item.first : item }
     if pattern
       warn('warning: given block not used') if block_given?
-      each { |*item| return true if pattern === gather.(item) }
+      regexp = Regexp === pattern
+      each do |*item|
+        result = pattern === gather.(item)
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        return true if result
+      end
       false
     elsif block_given?
       each { |*item| return true if yield(*item) }
@@ -39,7 +51,12 @@ module Enumerable
     gather = ->(item) { item.size <= 1 ? item.first : item }
     if pattern
       warn('warning: given block not used') if block_given?
-      each { |*item| return false if pattern === gather.(item) }
+      regexp = Regexp === pattern
+      each do |*item|
+        matched = pattern === gather.(item)
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        return false if matched
+      end
     elsif block_given?
       each { |*item| return false if yield(*item) }
     else
@@ -53,8 +70,11 @@ module Enumerable
     result = false
     if pattern
       warn('warning: given block not used') if block_given?
+      regexp = Regexp === pattern
       each do |*item|
-        if pattern === gather.(item)
+        matched = pattern === gather.(item)
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        if matched
           return false if result
           result = true
         end
@@ -306,9 +326,12 @@ module Enumerable
   def grep(pattern)
     if block_given?
       ary = []
+      regexp = Regexp === pattern
       each do |*item|
         item = item.size > 1 ? item : item[0]
-        ary << yield(item) if pattern === item
+        matched = pattern === item
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        ary << yield(item) if matched
       end
       ary
     else
@@ -319,9 +342,12 @@ module Enumerable
   def grep_v(pattern)
     if block_given?
       ary = []
+      regexp = Regexp === pattern
       each do |*item|
         item = item.size > 1 ? item : item[0]
-        ary << yield(item) if !(pattern === item)
+        matched = pattern === item
+        __inline__ 'env->propagate_last_match_to_caller();' if regexp
+        ary << yield(item) unless matched
       end
       ary
     else

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -2827,6 +2827,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
         env->raise("TypeError", "wrong argument type {} (expected Regexp)", find.klass()->inspect_module());
 
     MatchDataObject *match = nullptr;
+    MatchDataObject *last_match = nullptr;
     StringObject *expanded_replacement = nullptr;
     size_t byte_index = 0;
     String out;
@@ -2845,6 +2846,7 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
             result = negotiate_result_encoding(env, result, expanded_replacement->encoding(), expanded_replacement->is_ascii_only());
 
         if (match) {
+            last_match = match;
             byte_index = match->end_byte_index(0);
             if (match->is_empty()) {
                 if (byte_index < m_string.size()) {
@@ -2862,6 +2864,8 @@ Value StringObject::gsub(Env *env, Value find, Optional<Value> replacement_value
             }
         }
     } while (match);
+
+    env->caller()->set_last_match(last_match);
 
     return StringObject::create(out, result.first);
 }


### PR DESCRIPTION
We need to propagate the last match to the frame of the caller, which is difficult in a Ruby-implemented method. To solve this we use the __inline__ macro and a new env method.

Side note: I think this is the last thing we need before net/http.