### PR TITLE
Thread.handle_interrupt and async exceptions

### DIFF
--- a/include/natalie/thread_object.hpp
+++ b/include/natalie/thread_object.hpp
@@ -93,8 +93,11 @@ public:
     Value status(Env *env);
     String status();
 
-    void set_exception(ExceptionObject *exception) { m_exception = exception; }
-    ExceptionObject *exception() { return m_exception; }
+    // The exception that terminated this thread (read by Thread#join /
+    // #value / #status). The slot doubles as the "kill is pending" channel
+    // between Thread#kill and the target's next checkpoint.
+    void set_terminal_exception(ExceptionObject *exception) { m_terminal_exception = exception; }
+    ExceptionObject *terminal_exception() { return m_terminal_exception; }
 
     ArrayObject *args() { return ArrayObject::create(m_args.size(), m_args.data()); }
     Block *block() { return m_block; }
@@ -188,7 +191,28 @@ public:
         return m_report_on_exception;
     }
 
-    void check_exception(Env *);
+    enum class InterruptTiming {
+        Immediate,
+        OnBlocking,
+        Never,
+    };
+
+    // Where in the thread's execution we're checking for pending exceptions.
+    // Blocking checkpoints fire :immediate AND :on_blocking; NonBlocking
+    // checkpoints (e.g. Thread.pass) fire only :immediate.
+    enum class CheckpointKind {
+        Blocking,
+        NonBlocking,
+    };
+
+    // Deliver a pending async exception (if any) by throwing. Returns nil if
+    // nothing was deliverable. ThreadKillError parked in m_terminal_exception
+    // bypasses the mask regardless of CheckpointKind.
+    Value deliver_pending(Env *env, CheckpointKind kind);
+
+    Value push_interrupt_mask(Env *, Value mask);
+    Value pop_interrupt_mask(Env *);
+    bool has_pending_interrupt(Env *, Optional<Value> error_class = {});
 
     ucontext_t *get_context() const { return m_context; }
 
@@ -249,7 +273,9 @@ public:
         return s_abort_on_exception;
     }
 
-    static void check_current_exception(Env *env);
+    static void deliver_current_pending(Env *env, CheckpointKind kind) {
+        current()->deliver_pending(env, kind);
+    }
 
     static void setup_wake_pipe(Env *env);
     static int wake_pipe_read_fileno() { return s_wake_pipe_read_fileno; }
@@ -293,7 +319,11 @@ private:
 #ifdef __APPLE__
     thread_t m_mach_thread_port { MACH_PORT_NULL };
 #endif
-    std::atomic<ExceptionObject *> m_exception { nullptr };
+    // The exception that killed this thread, if any. Written once at thread
+    // exit (or to a ThreadKillError between Thread#kill and target wakeup).
+    // Read by Thread#join / #value / #status. See thread_object.cpp comment
+    // block above interrupt_timing_for_class.
+    std::atomic<ExceptionObject *> m_terminal_exception { nullptr };
     Optional<Value> m_value {};
     HashObject *m_thread_variables { nullptr };
     FiberObject *m_main_fiber { nullptr };
@@ -318,6 +348,14 @@ private:
     bool m_sleeping { false };
 
     TM::Hashmap<Thread::MutexObject *> m_mutexes {};
+
+    // Top of stack is the end of the vector; each entry is a frozen Hash
+    // mapping {Module/Class => Symbol}.
+    TM::Vector<HashObject *> m_interrupt_mask_stack {};
+    // Async exceptions awaiting delivery at the next checkpoint. FIFO; mask
+    // resolution is recomputed at drain time, not enqueue time.
+    TM::Vector<ExceptionObject *> m_pending_exceptions {};
+    std::mutex m_interrupt_lock;
 
     Value m_fiber_scheduler { Value::nil() };
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1508,6 +1508,7 @@ gen.binding('Thread', 'keys', 'ThreadObject', 'keys', argc: 0, pass_env: true, p
 gen.binding('Thread', 'kill', 'ThreadObject', 'kill', argc: 0, pass_env: true, pass_block: false, aliases: %w[exit terminate], return_type: :Value)
 gen.binding('Thread', 'name', 'ThreadObject', 'name', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Thread', 'name=', 'ThreadObject', 'set_name', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Thread', 'pending_interrupt?', 'ThreadObject', 'has_pending_interrupt', argc: 0..1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Thread', 'priority', 'ThreadObject', 'priority', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Thread', 'priority=', 'ThreadObject', 'set_priority', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Thread', 'raise', 'ThreadObject', 'raise', argc: :any, pass_env: true, pass_block: false, return_type: :Value)

--- a/lib/socket.cpp
+++ b/lib/socket.cpp
@@ -583,7 +583,9 @@ static ssize_t blocking_recvfrom(Env *env, IoObject *io, void *buf, size_t len, 
         if (result >= 0)
             return result;
         if (errno == EINTR) {
-            ThreadObject::check_current_exception(env);
+            // recvfrom is a blocking primitive; deliver :on_blocking
+            // interrupts here in addition to :immediate.
+            ThreadObject::deliver_current_pending(env, ThreadObject::CheckpointKind::Blocking);
             continue;
         }
         if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/spec/core/thread/handle_interrupt_spec.rb
+++ b/spec/core/thread/handle_interrupt_spec.rb
@@ -1,0 +1,125 @@
+require_relative '../../spec_helper'
+
+describe "Thread.handle_interrupt" do
+  def make_handle_interrupt_thread(interrupt_config, blocking = true)
+    interrupt_class = Class.new(RuntimeError)
+
+    ScratchPad.record []
+
+    in_handle_interrupt = Queue.new
+    can_continue = Queue.new
+
+    thread = Thread.new do
+      begin
+        Thread.handle_interrupt(interrupt_config) do
+          begin
+            in_handle_interrupt << true
+            if blocking
+              Thread.pass # Make it clearer the other thread needs to wait for this one to be in #pop
+              can_continue.pop
+            else
+              begin
+                can_continue.pop(true)
+              rescue ThreadError
+                Thread.pass
+                retry
+              end
+            end
+          rescue interrupt_class
+            ScratchPad << :interrupted
+          end
+        end
+      rescue interrupt_class
+        ScratchPad << :deferred
+      end
+    end
+
+    in_handle_interrupt.pop
+    if blocking
+      # Ensure the thread is inside Thread#pop, as if thread.raise is done before it would be deferred
+      Thread.pass until thread.stop?
+    end
+    thread.raise interrupt_class, "interrupt"
+    can_continue << true
+    thread.join
+
+    ScratchPad.recorded
+  end
+
+  before :each do
+    Thread.pending_interrupt?.should == false # sanity check
+  end
+
+  it "with :never defers interrupts until exiting the handle_interrupt block" do
+    make_handle_interrupt_thread(RuntimeError => :never).should == [:deferred]
+  end
+
+  it "with :on_blocking defers interrupts until the next blocking call" do
+    make_handle_interrupt_thread(RuntimeError => :on_blocking).should == [:interrupted]
+    make_handle_interrupt_thread({ RuntimeError => :on_blocking }, false).should == [:deferred]
+  end
+
+  it "with :immediate handles interrupts immediately" do
+    make_handle_interrupt_thread(RuntimeError => :immediate).should == [:interrupted]
+  end
+
+  it "with :immediate immediately runs pending interrupts, before the block" do
+    Thread.handle_interrupt(RuntimeError => :never) do
+      current = Thread.current
+      Thread.new {
+        current.raise "interrupt immediate"
+      }.join
+
+      Thread.pending_interrupt?.should == true
+      -> {
+        Thread.handle_interrupt(RuntimeError => :immediate) {
+          flunk "not reached"
+        }
+      }.should raise_error(RuntimeError, "interrupt immediate")
+      Thread.pending_interrupt?.should == false
+    end
+  end
+
+  it "also works with suspended Fibers and does not duplicate interrupts" do
+    fiber = Fiber.new { Fiber.yield }
+    fiber.resume
+
+    Thread.handle_interrupt(RuntimeError => :never) do
+      current = Thread.current
+      Thread.new {
+        current.raise "interrupt with fibers"
+      }.join
+
+      Thread.pending_interrupt?.should == true
+      -> {
+        Thread.handle_interrupt(RuntimeError => :immediate) {
+          flunk "not reached"
+        }
+      }.should raise_error(RuntimeError, "interrupt with fibers")
+      Thread.pending_interrupt?.should == false
+    end
+
+    fiber.resume
+  end
+
+  it "runs pending interrupts at the end of the block, even if there was an exception raised in the block" do
+    executed = false
+    -> {
+      Thread.handle_interrupt(RuntimeError => :never) do
+        current = Thread.current
+        Thread.new {
+          current.raise "interrupt exception"
+        }.join
+
+        Thread.pending_interrupt?.should == true
+        executed = true
+        raise "regular exception"
+      end
+    }.should raise_error(RuntimeError, "interrupt exception")
+    executed.should == true
+  end
+
+  it "supports multiple pairs in the Hash" do
+    make_handle_interrupt_thread(ArgumentError => :never, RuntimeError => :never).should == [:deferred]
+  end
+end

--- a/spec/core/thread/pending_interrupt_spec.rb
+++ b/spec/core/thread/pending_interrupt_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+
+describe "Thread.pending_interrupt?" do
+  it "returns false if there are no pending interrupts, e.g., outside any Thread.handle_interrupt block" do
+    Thread.pending_interrupt?.should == false
+  end
+
+  it "returns true if there are pending interrupts, e.g., Thread#raise inside Thread.handle_interrupt" do
+    executed = false
+    -> {
+      Thread.handle_interrupt(RuntimeError => :never) do
+        Thread.pending_interrupt?.should == false
+
+        current = Thread.current
+        Thread.new {
+          current.raise "interrupt"
+        }.join
+
+        Thread.pending_interrupt?.should == true
+        executed = true
+      end
+    }.should raise_error(RuntimeError, "interrupt")
+    executed.should == true
+    Thread.pending_interrupt?.should == false
+  end
+end
+
+describe "Thread#pending_interrupt?" do
+  it "returns whether the given threads has pending interrupts" do
+    Thread.current.pending_interrupt?.should == false
+  end
+end

--- a/spec/library/timeout/timeout_spec.rb
+++ b/spec/library/timeout/timeout_spec.rb
@@ -3,13 +3,11 @@ require 'timeout'
 
 describe "Timeout.timeout" do
   it "raises Timeout::Error when it times out with no specified error type" do
-    NATFIXME 'Timeout.timeout needs Thread.handle_interrupt', exception: SpecFailedException do
-      -> {
-        Timeout.timeout(1) do
-          sleep
-        end
-      }.should raise_error(Timeout::Error)
-    end
+    -> {
+      Timeout.timeout(1) do
+        sleep
+      end
+    }.should raise_error(Timeout::Error)
   end
 
   it "raises specified error type when it times out" do
@@ -21,31 +19,25 @@ describe "Timeout.timeout" do
   end
 
   it "raises specified error type with specified message when it times out" do
-    NATFIXME 'Timeout.timeout needs Thread.handle_interrupt', exception: SpecFailedException do
-      -> do
-        Timeout.timeout(1, StandardError, "foobar") do
-          sleep
-        end
-      end.should raise_error(StandardError, "foobar")
-    end
+    -> do
+      Timeout.timeout(1, StandardError, "foobar") do
+        sleep
+      end
+    end.should raise_error(StandardError, "foobar")
   end
 
   it "raises specified error type with a default message when it times out if message is nil" do
-    NATFIXME 'Timeout.timeout needs Thread.handle_interrupt', exception: SpecFailedException do
-      -> do
-        Timeout.timeout(1, StandardError, nil) do
-          sleep
-        end
-      end.should raise_error(StandardError, "execution expired")
-    end
+    -> do
+      Timeout.timeout(1, StandardError, nil) do
+        sleep
+      end
+    end.should raise_error(StandardError, "execution expired")
   end
 
   it "returns back the last value in the block" do
-    NATFIXME 'Timeout.timeout needs Thread.handle_interrupt', exception: NoMethodError, message: /handle_interrupt/ do
-      Timeout.timeout(1) do
-        42
-      end.should == 42
-    end
+    Timeout.timeout(1) do
+      42
+    end.should == 42
   end
 
   ruby_version_is "3.4" do

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -1214,9 +1214,10 @@ Value IoObject::select(Env *env, Value read_ios, Optional<Value> write_ios, Opti
             break;
         } else if (FD_ISSET(wake_pipe_fileno, &read_fds)) {
             // Interrupted by our thread file descriptor.
-            // This thread may need to raise or exit.
+            // This thread may need to raise or exit. select() is a blocking
+            // primitive, so deliver :on_blocking interrupts here too.
             ThreadObject::clear_wake_pipe();
-            ThreadObject::check_current_exception(env);
+            ThreadObject::deliver_current_pending(env, ThreadObject::CheckpointKind::Blocking);
             if (any_closed(read_ios_ary) || any_closed(write_ios_ary) || any_closed(error_ios_ary))
                 env->raise("IOError", "closed stream");
         } else {
@@ -1278,8 +1279,10 @@ void IoObject::select_read(Env *env, timeval *timeout) const {
         }
 
         if (FD_ISSET(wake_pipe_fileno, &readfds)) {
+            // Blocking IO read; fire :on_blocking interrupts when our wake
+            // fd was poked.
             ThreadObject::clear_wake_pipe();
-            ThreadObject::check_current_exception(env);
+            ThreadObject::deliver_current_pending(env, ThreadObject::CheckpointKind::Blocking);
             if (m_closed)
                 env->raise("IOError", "closed stream");
         }

--- a/src/thread.rb
+++ b/src/thread.rb
@@ -1,0 +1,37 @@
+require 'natalie/inline'
+
+class Thread
+  # Run +block+ with an interrupt-mask in effect. The mask is a
+  # +{Module/Class => :immediate|:on_blocking|:never}+ Hash that controls
+  # what happens when this thread is the target of +Thread#raise+:
+  #
+  # * +:immediate+ -- deliver right away (the default with no mask).
+  # * +:on_blocking+ -- queue the exception, deliver at the next blocking
+  #   primitive (Mutex#sleep, Queue#pop, etc).
+  # * +:never+ -- queue the exception until the mask frame ends. When the
+  #   block returns and the frame is popped, any item the now-outer mask
+  #   resolves to :immediate is delivered, which is why a deferred raise
+  #   can fire *after* the user block.
+  #
+  # Items deferred while the user block runs are walked again on pop. If
+  # the block also raised, the deferred interrupt replaces it (Ruby's
+  # ensure-replaces-exception semantics, which is why the drain has to be
+  # in a Ruby +ensure+ rather than a C++ destructor).
+  def self.handle_interrupt(mask)
+    raise ArgumentError, 'block is needed.' unless block_given?
+    __inline__ 'ThreadObject::current()->push_interrupt_mask(env, mask_var);'
+    begin
+      # Drain inside +begin+ so a delivered :immediate exception still
+      # triggers the +ensure+ that pops the mask we just pushed; if we
+      # drained before the begin, an exception there would leak the frame.
+      __inline__ 'ThreadObject::current()->deliver_pending(env, ThreadObject::CheckpointKind::Blocking);'
+      yield
+    ensure
+      __inline__ 'ThreadObject::current()->pop_interrupt_mask(env);'
+    end
+  end
+
+  def self.pending_interrupt?(*args)
+    Thread.current.pending_interrupt?(*args)
+  end
+end

--- a/src/thread/mutex_object.cpp
+++ b/src/thread/mutex_object.cpp
@@ -13,7 +13,9 @@ Value MutexObject::lock(Env *env) {
             ThreadObject::set_current_sleeping(true);
             struct timespec request = { 0, 100000 };
             while (!m_mutex.try_lock()) {
-                ThreadObject::check_current_exception(env);
+                // Mutex#lock is a blocking primitive; deliver :on_blocking
+                // interrupts here in addition to :immediate.
+                ThreadObject::deliver_current_pending(env, ThreadObject::CheckpointKind::Blocking);
                 nanosleep(&request, nullptr);
             }
         }

--- a/src/thread/queue.rb
+++ b/src/thread/queue.rb
@@ -93,15 +93,23 @@ class Thread
         raise ClosedQueueError, 'queue closed' if @closed
 
         @queue.push(obj)
-        if (thread = @waiting.pop)
-          Thread.pass until thread.status == 'sleep'
-          thread.wakeup
-        end
+        wake_waiter(@waiting.pop)
       end
       self
     end
     alias << push
     alias enq push
+
+    private
+
+    # The popped thread may have been raised on while inside pop and be
+    # unwinding rather than sleeping; spin only while it could still reach
+    # sleep (i.e. is alive), and skip wakeup once it isn't.
+    def wake_waiter(thread)
+      return unless thread
+      Thread.pass while thread.alive? && thread.status != 'sleep'
+      thread.wakeup if thread.alive?
+    end
   end
 end
 

--- a/src/thread/sizedqueue.rb
+++ b/src/thread/sizedqueue.rb
@@ -17,7 +17,7 @@ class Thread
         @max = new_max
         threads = @push_waiters.shift(diff) if diff > 0
       end
-      threads.each { |t| wake_thread(t) }
+      threads.each { |t| wake_waiter(t) }
       max
     end
 
@@ -58,10 +58,7 @@ class Thread
         end
 
         @queue.push(obj)
-        if (thread = @waiting.pop)
-          Thread.pass until thread.status == 'sleep'
-          thread.wakeup
-        end
+        wake_waiter(@waiting.pop)
       end
       self
     end
@@ -135,21 +132,14 @@ class Thread
         threads = @push_waiters
         @push_waiters = []
       end
-      threads.each { |t| wake_thread(t) }
+      threads.each { |t| wake_waiter(t) }
     end
 
     def wake_push_waiter
       return if @push_waiters.empty?
       thread = nil
       @mutex.synchronize { thread = @push_waiters.shift }
-      wake_thread(thread) if thread
-    end
-
-    def wake_thread(thread)
-      Thread.pass until thread.status == 'sleep' || thread.status == false || thread.status.nil?
-      thread.wakeup
-    rescue ThreadError
-      nil
+      wake_waiter(thread)
     end
   end
 end

--- a/src/thread_object.cpp
+++ b/src/thread_object.cpp
@@ -64,12 +64,13 @@ static void *nat_create_thread(void *thread_object) {
         // the user code that does what we came here to do.
         auto return_value = block->run((&e), std::move(args), nullptr);
 
-        // If we got here and the thread has an exception,
-        // this is our last chance to raise it. The catch directly below
-        // will catch this exception and do the right thing.
-        auto exception = thread->exception();
-        if (exception)
-            e.raise_exception(exception);
+        // If Thread#kill was called but the thread completed before any
+        // checkpoint fired the kill, drop it -- an undelivered kill is not
+        // propagated to the joiner.
+        if (auto term = thread->terminal_exception()) {
+            if (term->klass() == Natalie::ThreadObject::thread_kill_class())
+                thread->set_terminal_exception(nullptr);
+        }
 
         // Store the value and exit the thread!
         // The cleanup handler does some additional housekeeping
@@ -94,17 +95,16 @@ static void *nat_create_thread(void *thread_object) {
             // abort the program. Saved by the bell!
             auto pending_exception = exception->cause();
             if (pending_exception) {
-                // Calling Thread#value and Thread#join need to raise this pending exception,
-                // so we need to store it on the thread for later use.
-                thread->set_exception(pending_exception);
+                // Thread#value and Thread#join need to raise this exception
+                // in the joining thread, so park it in the terminal slot.
+                thread->set_terminal_exception(pending_exception);
 
                 // Now we can print it or handle SystemExit.
                 Natalie::handle_top_level_exception(&e, pending_exception, false);
             } else {
-                // ThreadKillError shouldn't be visible to user code,
-                // which means it cannot be returned from Thread#value or Thread#join,
-                // so we set this back to null.
-                thread->set_exception(nullptr);
+                // ThreadKillError shouldn't be visible to user code, so make
+                // sure it isn't what join/value sees.
+                thread->set_terminal_exception(nullptr);
             }
 
             // OK, all good. Now we can exit the thread and let the
@@ -112,9 +112,9 @@ static void *nat_create_thread(void *thread_object) {
             pthread_exit(exception);
 
         } else {
-            // Calling Thread#value and Thread#join need to raise this exception,
-            // so we need to store it on the thread for later use.
-            thread->set_exception(exception);
+            // Thread#value and Thread#join need to raise this exception in
+            // the joining thread, so park it in the terminal slot.
+            thread->set_terminal_exception(exception);
 
             // This is a regular Ruby Exception.
             // We need to potentially print it and/or handle SystemExit.
@@ -139,6 +139,40 @@ namespace Natalie {
 
 thread_local ThreadObject *tl_current_thread = nullptr;
 
+// ===== Lock-ordering enforcement =====
+//
+// m_interrupt_lock and m_sleep_lock must never be held simultaneously by the
+// same thread. sleep() holds sleep_lock and briefly nests interrupt_lock (via
+// deliver_pending); raise() takes them in separate scopes. Any other ordering
+// -- in particular, taking interrupt_lock then sleep_lock -- can deadlock
+// against sleep().
+//
+// In debug builds we maintain a per-thread depth counter via the guard type
+// below, and assert at every sleep_lock acquisition that the counter is zero.
+// Release builds elide the depth tracking and the assertion, leaving
+// InterruptLockGuard equivalent to std::lock_guard.
+#ifndef NDEBUG
+static thread_local int tl_interrupt_lock_depth = 0;
+static void assert_no_interrupt_lock() { assert(tl_interrupt_lock_depth == 0); }
+#else
+static inline void assert_no_interrupt_lock() { }
+#endif
+
+struct InterruptLockGuard {
+    std::lock_guard<std::mutex> guard;
+    InterruptLockGuard(std::mutex &m)
+        : guard(m) {
+#ifndef NDEBUG
+        tl_interrupt_lock_depth++;
+#endif
+    }
+    ~InterruptLockGuard() {
+#ifndef NDEBUG
+        tl_interrupt_lock_depth--;
+#endif
+    }
+};
+
 static Value validate_key(Env *env, Value key) {
     if (key.is_string() || key.respond_to(env, "to_str"_s))
         key = key.to_str(env)->to_sym(env);
@@ -148,7 +182,7 @@ static Value validate_key(Env *env, Value key) {
 }
 
 Value ThreadObject::pass(Env *env) {
-    check_current_exception(env);
+    deliver_current_pending(env, CheckpointKind::NonBlocking);
 
     sched_yield();
 
@@ -280,7 +314,7 @@ Value ThreadObject::to_s(Env *env) {
 Value ThreadObject::status(Env *env) {
     auto status_string = status();
     if (m_status == Status::Dead) {
-        if (m_exception)
+        if (m_terminal_exception)
             return Value::nil();
         return Value::False();
     }
@@ -326,8 +360,8 @@ Value ThreadObject::join(Env *env) {
 
     m_joined = true;
 
-    if (m_exception)
-        env->raise_exception(m_exception);
+    if (m_terminal_exception)
+        env->raise_exception(m_terminal_exception);
 
     return this;
 }
@@ -347,22 +381,119 @@ Value ThreadObject::kill(Env *env) {
 
     auto exception = ExceptionObject::create(thread_kill_class(env));
 
-    if (m_exception) {
-        // An pending exception was already raised on this thread,
-        // and we might need to print it out. We'll store it in the "cause"
-        // slot for now, but this might need a dedicated holder in the future.
-        exception->set_cause(m_exception);
+    // Chain the most recent pending exception (if any) as cause for
+    // diagnostics, then clear the queue -- the thread is dying, so any queued
+    // raises that hadn't fired yet are moot.
+    {
+        InterruptLockGuard lock(m_interrupt_lock);
+        if (!m_pending_exceptions.is_empty()) {
+            exception->set_cause(m_pending_exceptions.last());
+            m_pending_exceptions.clear();
+        }
     }
 
     if (is_current()) {
         env->raise_exception(exception);
     } else {
-        m_exception = exception;
+        // Park in the terminal slot; deliver_pending() preempts anything else
+        // when it sees a ThreadKillError there.
+        m_terminal_exception = exception;
         wakeup(env);
         ThreadObject::wake_all();
     }
 
     return this;
+}
+
+// ===== Thread.handle_interrupt machinery =====
+//
+// Thread.handle_interrupt lets a thread say "if someone Thread#raises me right
+// now, hold the exception until X". X is one of three timings:
+//
+//   :immediate    -- deliver right away (also the no-mask default).
+//   :on_blocking  -- queue, deliver at the next blocking primitive
+//                    (Mutex#sleep, Queue#pop, IO read, etc).
+//   :never        -- queue, hold until the masking frame ends.
+//
+// State per thread (all under m_interrupt_lock):
+//
+//   m_interrupt_mask_stack  -- LIFO of frozen {Module/Class => Symbol} hashes.
+//                              Innermost match wins; no match => :immediate.
+//   m_pending_exceptions    -- FIFO of every async raise awaiting delivery,
+//                              regardless of timing. Mask resolution is
+//                              recomputed at drain time so mask changes
+//                              between push and drain are honored.
+//
+// Separately, m_terminal_exception (atomic, no lock) holds:
+//
+//   - between Thread#kill and the target's next checkpoint, the ThreadKillError
+//     that should preempt the queue
+//   - after thread death, the unhandled exception that killed it (read by
+//     Thread#join / #value / #status)
+//
+// The main flow:
+//
+//   Thread#raise (cross-thread or self-deferred)
+//     -> push exception onto m_pending_exceptions under the lock
+//     -> notify m_sleep_cond and wake_all() so a sleeping target hits its next
+//        checkpoint promptly
+//   Thread.current.raise with no mask (or :immediate match)
+//     -> short-circuit: throw synchronously, no queue traversal
+//
+//   Checkpoints (current thread): deliver_pending(env, kind)
+//     -> if a ThreadKillError is parked in m_terminal_exception, throw it
+//        unconditionally (kill bypasses masks)
+//     -> drain the first item in m_pending_exceptions whose mask resolution
+//        is :immediate (always) or :on_blocking (only at Blocking)
+//     -> throw it
+//
+//   Pass CheckpointKind::Blocking at real blocking primitives (sleep,
+//   queue pop, IO read, mutex acquire, mask pop). Pass NonBlocking at
+//   non-blocking yield points (Thread.pass) so yielding the scheduler
+//   doesn't trip :on_blocking and collapse the timing distinction.
+//
+// Lock ordering invariant:
+//   raise() takes m_interrupt_lock and m_sleep_lock in separate scopes -- it
+//   never holds both at once. sleep() holds m_sleep_lock and briefly takes
+//   m_interrupt_lock inside deliver_pending(); cond.wait() releases
+//   m_sleep_lock before blocking, so this is safe.
+
+static Optional<ThreadObject::InterruptTiming> interrupt_timing_from_symbol(SymbolObject *sym) {
+    if (sym == "immediate"_s) return ThreadObject::InterruptTiming::Immediate;
+    if (sym == "on_blocking"_s) return ThreadObject::InterruptTiming::OnBlocking;
+    if (sym == "never"_s) return ThreadObject::InterruptTiming::Never;
+    return {};
+}
+
+// Walk the mask stack innermost-first; first matching entry wins. No match
+// (including an empty stack) means :immediate -- the no-mask default.
+// Caller must hold m_interrupt_lock; the stack may otherwise be mutated
+// mid-walk.
+//
+// For each mask (innermost first), walk the exception class's ancestor
+// chain and look up each ancestor as an exact key. The most-specific
+// ancestor present in the mask wins -- not the first hash entry in
+// insertion order. This matches the behavior of `rescue`: a more
+// specific class always takes precedence over a less specific one
+// when both are listed.
+static ThreadObject::InterruptTiming interrupt_timing_for_class(Env *env, const TM::Vector<HashObject *> &stack, ClassObject *exception_class) {
+    using Timing = ThreadObject::InterruptTiming;
+    if (stack.is_empty()) return Timing::Immediate;
+
+    auto ancestors = exception_class->ancestors(env);
+
+    for (size_t i = stack.size(); i > 0; --i) {
+        auto mask = stack[i - 1];
+        for (auto ancestor : *ancestors) {
+            auto val = mask->get(env, ancestor);
+            if (!val) continue;
+            // val is guaranteed to be a Symbol resolvable to a timing by
+            // push_interrupt_mask's up-front validation; value_or is purely
+            // defensive.
+            return interrupt_timing_from_symbol(val.value().as_symbol()).value_or(Timing::Immediate);
+        }
+    }
+    return Timing::Immediate;
 }
 
 Value ThreadObject::raise(Env *env, Args &&args) {
@@ -371,22 +502,141 @@ Value ThreadObject::raise(Env *env, Args &&args) {
 
     auto exception = ExceptionObject::create_for_raise(env, std::move(args), nullptr);
 
-    if (is_current())
-        env->raise_exception(exception);
+    // Self-raise with an :immediate-resolving mask: throw at the call site.
+    // Anything else (cross-thread, or self with :on_blocking/:never)
+    // queues for delivery at the target's next checkpoint.
+    if (is_current()) {
+        bool synchronous = false;
+        {
+            InterruptLockGuard lock(m_interrupt_lock);
+            auto timing = interrupt_timing_for_class(env, m_interrupt_mask_stack, exception->klass());
+            if (timing == InterruptTiming::Immediate) {
+                synchronous = true;
+            } else {
+                m_pending_exceptions.push(exception);
+            }
+        }
+        if (synchronous)
+            env->raise_exception(exception);
+        return Value::nil();
+    }
 
-    m_exception = exception;
+    // Cross-thread: queue + notify. The lock is dropped before we touch
+    // m_sleep_lock -- never hold both at once (see lock-ordering note).
+    {
+        InterruptLockGuard lock(m_interrupt_lock);
+        m_pending_exceptions.push(exception);
+    }
 
-    // Wake up the thread in case it is sleeping.
+    assert_no_interrupt_lock();
     {
         std::unique_lock sleep_lock { m_sleep_lock };
         m_sleep_cond.notify_one();
     }
 
-    // In case this thread is blocking on read/select/whatever,
-    // we may need to interrupt it (and all other threads, incidentally).
+    // For threads blocked on read/select/etc, an extra global poke is needed
+    // (this also nudges every other thread, harmlessly).
     ThreadObject::wake_all();
 
     return Value::nil();
+}
+
+Value ThreadObject::push_interrupt_mask(Env *env, Value mask_val) {
+    // Coerce via to_hash (raises TypeError if not coercible). Then validate
+    // each entry's value is one of :immediate / :on_blocking / :never. Keys
+    // are not validated -- non-Module keys never match an exception's
+    // ancestor chain and are silently no-op, matching Ruby semantics.
+    //
+    // Validation runs before any state mutation: if we raised mid-mutation
+    // a partial frame would be visible to a concurrent raise() and ensure
+    // (in src/thread.rb) would pop a frame we never pushed.
+    auto mask = mask_val.to_hash(env);
+
+    for (auto &entry : *mask) {
+        if (!entry.val.is_symbol() || !interrupt_timing_from_symbol(entry.val.as_symbol()))
+            env->raise("ArgumentError", "unknown mask signature");
+    }
+
+    // Defensive copy + freeze: callers are free to mutate their original hash
+    // afterward, but the mask we're using for raise() decisions is fixed.
+    auto frozen_mask = HashObject::create(env, *mask);
+    frozen_mask->freeze();
+
+    {
+        InterruptLockGuard lock(m_interrupt_lock);
+        m_interrupt_mask_stack.push(frozen_mask);
+    }
+    return Value::nil();
+}
+
+Value ThreadObject::pop_interrupt_mask(Env *env) {
+    {
+        InterruptLockGuard lock(m_interrupt_lock);
+        if (m_interrupt_mask_stack.is_empty()) return Value::nil();
+        m_interrupt_mask_stack.pop();
+    }
+
+    // Popping a :never frame may have just made one or more queued exceptions
+    // deliverable under the new outer mask -- deliver them now, including
+    // possibly throwing out of this call (Ruby ensure semantics).
+    deliver_pending(env, CheckpointKind::Blocking);
+    return Value::nil();
+}
+
+bool ThreadObject::has_pending_interrupt(Env *env, Optional<Value> error_class) {
+    InterruptLockGuard lock(m_interrupt_lock);
+    if (m_pending_exceptions.is_empty()) return false;
+    if (!error_class) return true;
+    auto klass_val = error_class.value();
+    if (!klass_val.is_module())
+        env->raise("TypeError", "class or module required");
+    auto klass = klass_val.as_module();
+    for (auto exc : m_pending_exceptions) {
+        if (exc->klass()->ancestors_includes(env, klass))
+            return true;
+    }
+    return false;
+}
+
+// Throws a queued/terminal exception or returns Value::nil() if nothing was
+// deliverable. Callers in throw paths can ignore the return value.
+Value ThreadObject::deliver_pending(Env *env, CheckpointKind kind) {
+    // Kill bypasses the mask and the queue: if a ThreadKillError is parked
+    // in the terminal slot (set by Thread#kill on a non-current target),
+    // throw it before considering anything else. Atomic load is enough --
+    // only Thread#kill writes here pre-mortem, and after the thread is Dead
+    // it returns from raise()/kill() before touching this slot.
+    if (auto term = m_terminal_exception.load()) {
+        if (term->klass() == s_thread_kill_class) {
+            m_terminal_exception = nullptr;
+            env->raise_exception(term);
+        }
+    }
+
+    // Drain a single eligible item from the pending queue. Any leftover
+    // items wait for the next checkpoint.
+    ExceptionObject *to_throw = nullptr;
+    {
+        InterruptLockGuard lock(m_interrupt_lock);
+        for (size_t i = 0; i < m_pending_exceptions.size(); ++i) {
+            auto exc = m_pending_exceptions[i];
+            auto timing = interrupt_timing_for_class(env, m_interrupt_mask_stack, exc->klass());
+            bool deliverable = (timing == InterruptTiming::Immediate)
+                || (kind == CheckpointKind::Blocking && timing == InterruptTiming::OnBlocking);
+            if (!deliverable) continue;
+            to_throw = exc;
+            m_pending_exceptions.remove(i);
+            break;
+        }
+    }
+    if (!to_throw) return Value::nil();
+
+    // .exception() may run user Ruby; must happen outside the lock. Skip it
+    // for ThreadKillError because it is an internal sentinel that user code
+    // never sees and shouldn't get a chance to override via #exception.
+    if (to_throw->klass() != s_thread_kill_class)
+        to_throw = Value(to_throw).send(env, "exception"_s, {}).as_exception_or_raise(env);
+    env->raise_exception(to_throw);
 }
 
 Value ThreadObject::run(Env *env) {
@@ -400,6 +650,7 @@ Value ThreadObject::wakeup(Env *env) {
 
     wait_until_running();
 
+    assert_no_interrupt_lock();
     {
         std::unique_lock sleep_lock { m_sleep_lock };
         m_wakeup = true;
@@ -428,10 +679,19 @@ Value ThreadObject::sleep(Env *env, float timeout, Thread::MutexObject *mutex_to
         mutex_to_unlock->unlock(env);
 
     if (timeout < 0.0) {
+        assert_no_interrupt_lock();
         {
             std::unique_lock sleep_lock { m_sleep_lock };
 
-            check_exception(env);
+            // The pre-wait drain MUST happen while holding sleep_lock,
+            // otherwise a concurrent raise() could push to the deferred queue
+            // and notify before we enter cond.wait, and the notification would
+            // land with no waiter and be lost.
+            //
+            // This briefly nests m_interrupt_lock inside m_sleep_lock; that's
+            // safe only because raise() never takes the two together (see
+            // lock-ordering note above ::raise).
+            deliver_pending(env, CheckpointKind::Blocking);
 
             if (!m_wakeup) {
                 Defer done_sleeping([] { ThreadObject::set_current_sleeping(false); });
@@ -442,16 +702,19 @@ Value ThreadObject::sleep(Env *env, float timeout, Thread::MutexObject *mutex_to
             m_wakeup = false;
         }
 
-        check_exception(env);
+        // Post-wake drain after sleep_lock is released so deliver_pending
+        // can throw (and unwind through the user's frames) freely.
+        deliver_pending(env, CheckpointKind::Blocking);
 
         return calculate_elapsed();
     }
 
     const auto wait = std::chrono::nanoseconds(static_cast<int64_t>(timeout * 1000 * 1000 * 1000));
+    assert_no_interrupt_lock();
     {
         std::unique_lock sleep_lock { m_sleep_lock };
 
-        check_exception(env);
+        deliver_pending(env, CheckpointKind::Blocking);
 
         if (!m_wakeup) {
             Defer done_sleeping([] { ThreadObject::set_current_sleeping(false); });
@@ -462,7 +725,7 @@ Value ThreadObject::sleep(Env *env, float timeout, Thread::MutexObject *mutex_to
         m_wakeup = false;
     }
 
-    check_exception(env);
+    deliver_pending(env, CheckpointKind::Blocking);
 
     return calculate_elapsed();
 }
@@ -648,7 +911,7 @@ void ThreadObject::visit_children(Visitor &visitor) const {
     for (auto arg : m_args)
         visitor.visit(arg);
     visitor.visit(m_block);
-    visitor.visit(m_exception);
+    visitor.visit(m_terminal_exception);
     if (m_value)
         visitor.visit(m_value.value());
     visitor.visit(m_thread_variables);
@@ -657,6 +920,10 @@ void ThreadObject::visit_children(Visitor &visitor) const {
     visitor.visit(m_fiber_scheduler);
     visitor.visit(s_thread_kill_class);
     visitor.visit(m_group);
+    for (auto mask : m_interrupt_mask_stack)
+        visitor.visit(mask);
+    for (auto exc : m_pending_exceptions)
+        visitor.visit(exc);
 
     visitor.visit(m_current_fiber);
     visitor.visit(m_main_fiber);
@@ -727,26 +994,6 @@ bool ThreadObject::all_running() {
             return false;
     }
     return true;
-}
-
-void ThreadObject::check_current_exception(Env *env) {
-    current()->check_exception(env);
-}
-
-void ThreadObject::check_exception(Env *env) {
-    if (!m_exception)
-        return;
-
-    auto exception = m_exception.load();
-
-    if (exception->klass() == s_thread_kill_class) {
-        m_exception = nullptr;
-        env->raise_exception(exception);
-    }
-
-    exception = Value(exception).send(env, "exception"_s, {}).as_exception_or_raise(env);
-    m_exception = nullptr;
-    env->raise_exception(exception);
 }
 
 void ThreadObject::detach_all() {

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -168,4 +168,185 @@ describe 'Thread' do
       end
     end
   end
+
+  describe '#raise' do
+    # Two raises queued under :never must both arrive in FIFO order as the
+    # worker hits successive checkpoints. Pre-refactor, the second raise
+    # overwrote the first (single-slot delivery channel), so only one was
+    # ever observed.
+    it 'queues multiple async raises in FIFO order' do
+      seen = []
+      ready = Queue.new
+      proceed = Queue.new
+
+      t =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          begin
+            Thread.handle_interrupt(RuntimeError => :never) do
+              ready << true
+              proceed.pop
+            end
+          rescue RuntimeError => e
+            seen << e.message
+          end
+
+          # The second queued raise drains at the next blocking checkpoint.
+          # If we didn't run another checkpoint here, leftover queue items
+          # would be silently dropped at thread exit.
+          begin
+            sleep 0
+          rescue RuntimeError => e
+            seen << e.message
+          end
+        end
+
+      ready.pop
+      t.raise RuntimeError, 'first'
+      t.raise RuntimeError, 'second'
+      proceed << true
+      t.join
+
+      seen.should == %w[first second]
+    end
+  end
+
+  describe '.handle_interrupt' do
+    it 'raises ArgumentError when called without a block' do
+      -> { Thread.handle_interrupt(RuntimeError => :immediate) }.should raise_error(ArgumentError)
+    end
+
+    it 'coerces the mask via to_hash' do
+      coerced = Class.new do
+        def to_hash
+          { RuntimeError => :immediate }
+        end
+      end.new
+
+      ran = false
+      caught = nil
+      t =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          begin
+            Thread.handle_interrupt(coerced) do
+              sleep 0.5
+              ran = true
+            end
+          rescue => e
+            caught = e.message
+          end
+        end
+      sleep 0.05
+      t.raise RuntimeError, 'x'
+      t.join
+
+      ran.should == false
+      caught.should == 'x'
+    end
+
+    it 'silently ignores non-Module keys in the mask' do
+      ran = false
+      t =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          # MRI permits any key here; the lookup just never matches and
+          # falls through to the default :immediate timing.
+          Thread.handle_interrupt('not_a_class' => :never) do
+            ran = true
+          end
+        end
+      t.join
+
+      ran.should == true
+    end
+
+    it 'raises ArgumentError for an unknown timing symbol' do
+      -> { Thread.handle_interrupt(RuntimeError => :sometime) {} }.should raise_error(ArgumentError)
+    end
+  end
+
+  describe '#kill' do
+    # Race: kill is set while the worker is in Mutex#lock spin; main then
+    # releases the mutex; the worker's next try_lock succeeds and the spin
+    # exits without re-running the deliver_pending checkpoint, so the
+    # thread completes normally past the kill. The undelivered kill must
+    # not propagate to join (MRI behaviour: an undelivered kill is dropped).
+    it 'does not leak ThreadKillError to the joiner when the kill never fires' do
+      m = Mutex.new
+      m.lock
+
+      th =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          m.synchronize { :ok }
+        end
+
+      Thread.pass while th.status == 'run' && !th.stop?
+      th.kill
+      m.unlock
+
+      -> { th.join }.should_not raise_error
+    end
+
+    # When a single mask names both a parent class and a more specific
+    # subclass, the timing of the most-specific match in the exception's
+    # ancestor chain wins -- regardless of hash insertion order.
+    it 'prefers the most-specific class match within a mask' do
+      ran = false
+      caught = nil
+
+      t =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          begin
+            # StandardError appears first in the hash but RuntimeError is a
+            # more-specific match for the raised exception, so :immediate
+            # wins -- the sleep should be interrupted, not deferred.
+            Thread.handle_interrupt(StandardError => :never, RuntimeError => :immediate) do
+              sleep 0.5
+              ran = true
+            end
+          rescue RuntimeError => e
+            caught = e.message
+          end
+        end
+
+      sleep 0.05
+      t.raise RuntimeError, 'specific'
+      t.join
+
+      ran.should == false
+      caught.should == 'specific'
+    end
+
+    # Symmetrically: subclass listed first, raised with the parent. Only the
+    # parent entry can match, so we get its timing.
+    it 'falls back to a less-specific class when the more-specific one does not match' do
+      ran = false
+      caught = nil
+
+      t =
+        Thread.new do
+          Thread.current.report_on_exception = false
+          begin
+            Thread.handle_interrupt(RuntimeError => :immediate, StandardError => :never) do
+              sleep 0.5
+              ran = true
+            end
+          rescue ArgumentError => e
+            caught = e.message
+          end
+        end
+
+      sleep 0.05
+      t.raise ArgumentError, 'general'
+      t.join
+
+      # ArgumentError is a StandardError but not a RuntimeError, so :never
+      # applies and the sleep completes; the deferred raise fires at frame pop.
+      ran.should == true
+      caught.should == 'general'
+    end
+  end
 end

--- a/test/natalie/thread_test.rb
+++ b/test/natalie/thread_test.rb
@@ -217,11 +217,14 @@ describe 'Thread' do
     end
 
     it 'coerces the mask via to_hash' do
-      coerced = Class.new do
-        def to_hash
-          { RuntimeError => :immediate }
-        end
-      end.new
+      coerced =
+        Class
+          .new do
+            def to_hash
+              { RuntimeError => :immediate }
+            end
+          end
+          .new
 
       ran = false
       caught = nil
@@ -252,9 +255,7 @@ describe 'Thread' do
           Thread.current.report_on_exception = false
           # MRI permits any key here; the lookup just never matches and
           # falls through to the default :immediate timing.
-          Thread.handle_interrupt('not_a_class' => :never) do
-            ran = true
-          end
+          Thread.handle_interrupt('not_a_class' => :never) { ran = true }
         end
       t.join
 


### PR DESCRIPTION
Adds Thread.handle_interrupt / Thread.pending_interrupt? and replaces m_exception with a queue of pending exceptions to raise.

Lots of comments in this commit because it is somewhat tricky to describe/implement. Basically a cross-thread exception can be deferred with thread APIs to raise either when the next blocking thing would happen (usually an IO or sleep) or they can be hidden entirely.