### PR TITLE
IClass

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -20,6 +20,7 @@
 #include "natalie/binding_object.hpp"
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"
+#include "natalie/iclass_object.hpp"
 #include "natalie/complex_object.hpp"
 #include "natalie/constant.hpp"
 #include "natalie/dir_object.hpp"

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -20,10 +20,10 @@
 #include "natalie/binding_object.hpp"
 #include "natalie/block.hpp"
 #include "natalie/class_object.hpp"
-#include "natalie/iclass_object.hpp"
 #include "natalie/complex_object.hpp"
 #include "natalie/constant.hpp"
 #include "natalie/dir_object.hpp"
+#include "natalie/iclass_object.hpp"
 
 #include "natalie/encoding/ascii_8bit_encoding_object.hpp"
 #include "natalie/encoding/big5_encoding_object.hpp"

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -63,6 +63,13 @@ public:
     bool is_singleton() const { return m_is_singleton; }
     void set_is_singleton(bool is_singleton) { m_is_singleton = is_singleton; }
 
+    // Set on the first prepend into this class. Points at the origin iclass that
+    // holds the class's own methods so prepended modules' `super` finds them.
+    ClassObject *origin() const { return m_origin; }
+    void set_origin(ClassObject *origin) { m_origin = origin; }
+
+    virtual void visit_children(Visitor &) const override;
+
     virtual String backtrace_name() const override final;
 
     virtual TM::String dbg_inspect(int indent = 0) const override {
@@ -87,6 +94,7 @@ private:
     bool m_is_singleton { false };
     bool m_is_initialized { false };
     AllocFunc m_alloc_func { nullptr };
+    ClassObject *m_origin { nullptr };
 };
 
 }

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -29,7 +29,11 @@ public:
     ClassObject *superclass(Env *env) override {
         if (!m_is_initialized)
             env->raise("TypeError", "uninitialized class");
-        return m_superclass;
+        // m_superclass may point at iclass nodes that are internal-only.
+        // The user-visible superclass skips past them.
+        ClassObject *s = m_superclass;
+        while (s && s->is_iclass()) s = s->m_superclass;
+        return s;
     }
 
     ClassObject *subclass(Env *env, const char *name) {
@@ -63,13 +67,6 @@ public:
     bool is_singleton() const { return m_is_singleton; }
     void set_is_singleton(bool is_singleton) { m_is_singleton = is_singleton; }
 
-    // Set on the first prepend into this class. Points at the origin iclass that
-    // holds the class's own methods so prepended modules' `super` finds them.
-    ClassObject *origin() const { return m_origin; }
-    void set_origin(ClassObject *origin) { m_origin = origin; }
-
-    virtual void visit_children(Visitor &) const override;
-
     virtual String backtrace_name() const override final;
 
     virtual TM::String dbg_inspect(int indent = 0) const override {
@@ -94,7 +91,6 @@ private:
     bool m_is_singleton { false };
     bool m_is_initialized { false };
     AllocFunc m_alloc_func { nullptr };
-    ClassObject *m_origin { nullptr };
 };
 
 }

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -67,6 +67,14 @@ public:
     bool is_singleton() const { return m_is_singleton; }
     void set_is_singleton(bool is_singleton) { m_is_singleton = is_singleton; }
 
+    // For a singleton class, the object/class/module it is the singleton of.
+    // Cvars assigned inside `class << foo` blocks belong on the attached object,
+    // matching Ruby's lexical-scope semantics for class variables.
+    Object *attached_object() const { return m_attached_object; }
+    void set_attached_object(Object *obj) { m_attached_object = obj; }
+
+    virtual void visit_children(Visitor &) const override;
+
     virtual String backtrace_name() const override final;
 
     virtual TM::String dbg_inspect(int indent = 0) const override {
@@ -91,6 +99,7 @@ private:
     bool m_is_singleton { false };
     bool m_is_initialized { false };
     AllocFunc m_alloc_func { nullptr };
+    Object *m_attached_object { nullptr };
 };
 
 }

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -32,7 +32,8 @@ public:
         // m_superclass may point at iclass nodes that are internal-only.
         // The user-visible superclass skips past them.
         ClassObject *s = m_superclass;
-        while (s && s->is_iclass()) s = s->m_superclass;
+        while (s && s->is_iclass())
+            s = s->m_superclass;
         return s;
     }
 

--- a/include/natalie/forward.hpp
+++ b/include/natalie/forward.hpp
@@ -32,6 +32,7 @@ class FileStatObject;
 class FloatObject;
 class GlobalEnv;
 class HashObject;
+class IClassObject;
 class IoBufferObject;
 class IoObject;
 class KernelModule;

--- a/include/natalie/iclass_object.hpp
+++ b/include/natalie/iclass_object.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "natalie/class_object.hpp"
+#include "natalie/forward.hpp"
+
+namespace Natalie {
+
+// IClassObject is a thin proxy node spliced into a class's superclass chain
+// when a module is `include`d, `prepend`ed, or `extend`ed. It shares the
+// wrapped module's method, constant, and class-variable tables so that later
+// `def`s on the module are visible to every including class. IClasses are an
+// internal implementation detail and must never leak to user-visible code:
+// `defined_class()` always reports the wrapped module instead.
+class IClassObject : public ClassObject {
+public:
+    static IClassObject *create(ModuleObject *wrapped, ClassObject *super);
+
+    bool is_iclass() const override { return true; }
+
+    ModuleObject *wrapped_module() const { return m_wrapped_module; }
+    ModuleObject *defined_class() override { return m_wrapped_module; }
+
+    // The origin iclass for prepend wraps a real class (the class whose own
+    // methods got displaced by the prepend). All other iclasses wrap a Module.
+    bool is_origin_iclass() const {
+        return m_wrapped_module && m_wrapped_module->type() == Object::Type::Class;
+    }
+
+    TM::Hashmap<SymbolObject *, MethodInfo> &methods_table() override;
+    const TM::Hashmap<SymbolObject *, MethodInfo> &methods_table() const override;
+    TM::Hashmap<SymbolObject *, Constant *> &constants_table() override;
+    const TM::Hashmap<SymbolObject *, Constant *> &constants_table() const override;
+    TM::Hashmap<SymbolObject *, Optional<Value>> &class_vars_table() override;
+    const TM::Hashmap<SymbolObject *, Optional<Value>> &class_vars_table() const override;
+
+    void visit_children(Visitor &) const override;
+
+    TM::String dbg_inspect(int indent = 0) const override;
+
+    IClassObject(const IClassObject &) = delete;
+    IClassObject &operator=(const IClassObject &) = delete;
+
+private:
+    IClassObject(ModuleObject *wrapped, ClassObject *super);
+
+    ModuleObject *m_wrapped_module { nullptr };
+};
+
+}

--- a/include/natalie/iclass_object.hpp
+++ b/include/natalie/iclass_object.hpp
@@ -20,6 +20,11 @@ public:
     ModuleObject *wrapped_module() const { return m_wrapped_module; }
     ModuleObject *defined_class() override { return m_wrapped_module; }
 
+    // The class or module whose super chain contains this iclass. Used to
+    // propagate late includes/prepends back into includers.
+    ModuleObject *includer() const { return m_includer; }
+    void set_includer(ModuleObject *includer) { m_includer = includer; }
+
     // The origin iclass for prepend wraps a real class (the class whose own
     // methods got displaced by the prepend). All other iclasses wrap a Module.
     bool is_origin_iclass() const {
@@ -44,6 +49,7 @@ private:
     IClassObject(ModuleObject *wrapped, ClassObject *super);
 
     ModuleObject *m_wrapped_module { nullptr };
+    ModuleObject *m_includer { nullptr };
 };
 
 }

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -98,6 +98,7 @@ public:
     static bool respond_to_method(Env *, Value, Value, Optional<Value>);
     static bool respond_to_method(Env *, Value, Value, bool);
     static Value send(Env *, Value, Args &&, Block *);
+    static Value singleton_methods(Env *env, Value self, Optional<Value> recur);
     static Value tap(Env *env, Value self, Block *block);
 };
 

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -238,6 +238,8 @@ private:
 
     void cache_method(SymbolObject *, MethodInfo, Env *);
 
+    void splice_module_chain(ModuleObject *source, ModuleObject *insertion, bool search_super);
+
 protected:
     ModuleObject();
     ModuleObject(const char *);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -140,7 +140,6 @@ public:
 
     void included_modules(Env *, ArrayObject *);
     Value included_modules(Env *);
-    const Vector<ModuleObject *> &included_modules() { return m_included_modules; }
     bool does_include_module(Env *, Value);
 
     virtual Optional<Value> cvar_get_maybe(Env *, SymbolObject *) override;
@@ -253,11 +252,7 @@ protected:
         , m_superclass { other.m_superclass }
         , m_owner { other.m_owner }
         , m_methods { other.m_methods }
-        , m_class_vars { other.m_class_vars } {
-        for (ModuleObject *module : const_cast<ModuleObject &>(other).m_included_modules) {
-            m_included_modules.push(module);
-        }
-    }
+        , m_class_vars { other.m_class_vars } { }
 
     TM::Hashmap<SymbolObject *, Constant *> m_constants {};
     Optional<String> m_name {};
@@ -268,7 +263,6 @@ protected:
     int m_method_cache_version { 0 };
     TM::Hashmap<SymbolObject *, MethodInfo> m_methods {};
     TM::Hashmap<SymbolObject *, Optional<Value>> m_class_vars {};
-    Vector<ModuleObject *> m_included_modules {};
     MethodVisibility m_method_visibility { MethodVisibility::Public };
     bool m_module_function { false };
 };

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -265,6 +265,11 @@ protected:
     int m_method_cache_version { 0 };
     TM::Hashmap<SymbolObject *, MethodInfo> m_methods {};
     TM::Hashmap<SymbolObject *, Optional<Value>> m_class_vars {};
+    // Every iclass currently wrapping this module in some other class's super chain.
+    // Used to propagate late includes/prepends back into already-including classes.
+    // Strong-references each iclass and (transitively) its includer class — a class
+    // that includes a module is kept alive as long as the module is.
+    Vector<IClassObject *> m_iclasses {};
     MethodVisibility m_method_visibility { MethodVisibility::Public };
     bool m_module_function { false };
 };

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -65,11 +65,27 @@ public:
     Optional<Value> handle_missing_constant(Env *, Value, ConstLookupFailureMode);
 
     Constant *get_constant(SymbolObject *name, ModuleObject **found_in_module) {
-        auto constant = m_constants.get(name);
+        auto constant = constants_table().get(name);
         if (found_in_module && constant)
-            *found_in_module = this;
+            *found_in_module = defined_class();
         return constant;
     }
+
+    // Virtual accessors that an IClassObject overrides to forward to its wrapped module.
+    // For all non-iclass modules these return the module's own storage.
+    virtual TM::Hashmap<SymbolObject *, MethodInfo> &methods_table() { return m_methods; }
+    virtual const TM::Hashmap<SymbolObject *, MethodInfo> &methods_table() const { return m_methods; }
+    virtual TM::Hashmap<SymbolObject *, Constant *> &constants_table() { return m_constants; }
+    virtual const TM::Hashmap<SymbolObject *, Constant *> &constants_table() const { return m_constants; }
+    virtual TM::Hashmap<SymbolObject *, Optional<Value>> &class_vars_table() { return m_class_vars; }
+    virtual const TM::Hashmap<SymbolObject *, Optional<Value>> &class_vars_table() const { return m_class_vars; }
+
+    // For iclasses, returns the wrapped module; otherwise returns `this`. Use this
+    // when reporting the owner of a method or constant to user code so that iclasses
+    // never leak.
+    virtual ModuleObject *defined_class() { return this; }
+
+    virtual bool is_iclass() const { return false; }
     Constant *find_constant_in_modules(Env *, SymbolObject *, ConstLookupSearchMode, ModuleObject **);
     Constant *find_constant_in_class_hierarchy(Env *, SymbolObject *, ConstLookupSearchMode, bool, ModuleObject **);
 
@@ -198,7 +214,7 @@ public:
     Value gte(Env *, Value);
     Value cmp(Env *, Value);
 
-    virtual void visit_children(Visitor &) const override final;
+    virtual void visit_children(Visitor &) const override;
 
     virtual TM::String dbg_inspect(int indent = 0) const override {
         return TM::String::format("<ModuleObject {h} name=\"{}\">", this, m_name.value_or("none"));

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -132,6 +132,10 @@ public:
     ClassObject *origin() const { return m_origin; }
     void set_origin(ClassObject *origin) { m_origin = origin; }
 
+    // True for a class that has been prepended into and is now a "hollow" wrapper
+    // — chain walks should skip it and read from the origin iclass instead.
+    bool is_origin_hollow() const;
+
     ModuleObject *owner() const { return m_owner; }
 
     void included_modules(Env *, ArrayObject *);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -144,6 +144,10 @@ public:
 
     virtual Optional<Value> cvar_get_maybe(Env *, SymbolObject *) override;
     virtual Value cvar_set(Env *, SymbolObject *, Value) override;
+
+    // For a singleton class of a class/module, returns the attached object so
+    // class variables track the lexical scope rather than landing on the singleton.
+    ModuleObject *cvar_scope_target();
     bool class_variable_defined(Env *, Value);
     Value class_variable_get(Env *, Value);
     Value class_variable_set(Env *, Value, Value);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -122,6 +122,16 @@ public:
     virtual ClassObject *superclass(Env *) { return m_superclass; }
     void set_superclass_DANGEROUSLY(ClassObject *superclass) { m_superclass = superclass; }
 
+    // Raw next-node pointer for walks that need to traverse iclass nodes (find_method,
+    // ancestors, etc.). Differs from `superclass()` which skips iclasses.
+    ClassObject *chain_super() const { return m_superclass; }
+    void set_chain_super(ClassObject *s) { m_superclass = s; }
+
+    // Set on the first prepend into this module/class. Points at the origin iclass
+    // that holds the original method table so prepended modules' `super` calls find it.
+    ClassObject *origin() const { return m_origin; }
+    void set_origin(ClassObject *origin) { m_origin = origin; }
+
     ModuleObject *owner() const { return m_owner; }
 
     void included_modules(Env *, ArrayObject *);
@@ -248,6 +258,7 @@ protected:
     TM::Hashmap<SymbolObject *, Constant *> m_constants {};
     Optional<String> m_name {};
     ClassObject *m_superclass { nullptr };
+    ClassObject *m_origin { nullptr };
     ModuleObject *m_owner { nullptr };
     TM::Hashmap<SymbolObject *, MethodInfo> m_method_cache {};
     int m_method_cache_version { 0 };

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -1090,6 +1090,7 @@ gen.static_binding_as_instance_method('Kernel', 'protected_methods', 'KernelModu
 gen.static_binding_as_instance_method('Kernel', 'public_methods', 'KernelModule', 'public_methods', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_instance_method('Kernel', 'remove_instance_variable', 'KernelModule', 'remove_instance_variable', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_instance_method('Kernel', 'singleton_class', 'Object', 'singleton_class', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
+gen.static_binding_as_instance_method('Kernel', 'singleton_methods', 'KernelModule', 'singleton_methods', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_instance_method('Kernel', 'tap', 'KernelModule', 'tap', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.static_binding_as_instance_method('Kernel', 'to_s', 'KernelModule', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.static_binding_as_instance_method('Kernel', 'send', 'KernelModule', 'send', argc: 1.., pass_env: true, pass_block: true, return_type: :Value)

--- a/spec/core/kernel/clone_spec.rb
+++ b/spec/core/kernel/clone_spec.rb
@@ -159,21 +159,19 @@ describe "Kernel#clone" do
 
     cloned = object.clone
 
-    NATFIXME 'Implement Kernel#singleton_methods', exception: NoMethodError, message: "undefined method 'singleton_methods'" do
-      cloned.singleton_methods.should == [:bar]
+    cloned.singleton_methods.should == [:bar]
 
-      # bar should replace previous one
-      cloned.define_singleton_method(:bar) do
-        ['c', *super()]
-      end
-      cloned.bar.should == ['c', 'a']
-
-      # bar should be removed and call through to superclass
-      cloned.singleton_class.class_eval do
-        remove_method :bar
-      end
-
-      cloned.bar.should == ['a']
+    # bar should replace previous one
+    cloned.define_singleton_method(:bar) do
+      ['c', *super()]
     end
+    cloned.bar.should == ['c', 'a']
+
+    # bar should be removed and call through to superclass
+    cloned.singleton_class.class_eval do
+      remove_method :bar
+    end
+
+    cloned.bar.should == ['a']
   end
 end

--- a/spec/core/kernel/singleton_methods_spec.rb
+++ b/spec/core/kernel/singleton_methods_spec.rb
@@ -1,0 +1,192 @@
+require_relative '../../spec_helper'
+require_relative '../../fixtures/reflection'
+require_relative 'fixtures/classes'
+
+describe :kernel_singleton_methods, shared: true do
+  it "returns an empty Array for an object with no singleton methods" do
+    ReflectSpecs.o.singleton_methods(*@object).should == []
+  end
+
+  it "returns the names of module methods for a module" do
+    ReflectSpecs::M.singleton_methods(*@object).should include(:ms_pro, :ms_pub)
+  end
+
+  it "does not return private module methods for a module" do
+    ReflectSpecs::M.singleton_methods(*@object).should_not include(:ms_pri)
+  end
+
+  it "returns the names of class methods for a class" do
+    ReflectSpecs::A.singleton_methods(*@object).should include(:as_pro, :as_pub)
+  end
+
+  it "does not return private class methods for a class" do
+    ReflectSpecs::A.singleton_methods(*@object).should_not include(:as_pri)
+  end
+
+  it "returns the names of singleton methods for an object" do
+    ReflectSpecs.os.singleton_methods(*@object).should include(:os_pro, :os_pub)
+  end
+end
+
+describe :kernel_singleton_methods_modules, shared: true do
+  it "does not return any included methods for a module including a module" do
+    ReflectSpecs::N.singleton_methods(*@object).should include(:ns_pro, :ns_pub)
+  end
+
+  it "does not return any included methods for a class including a module" do
+    ReflectSpecs::D.singleton_methods(*@object).should include(:ds_pro, :ds_pub)
+  end
+
+  it "for a module does not return methods in a module prepended to Module itself" do
+    require_relative 'fixtures/singleton_methods'
+    mod = SingletonMethodsSpecs::SelfExtending
+    mod.method(:mspec_test_kernel_singleton_methods).owner.should == SingletonMethodsSpecs::Prepended
+
+    ancestors = mod.singleton_class.ancestors
+    ancestors[0...2].should == [ mod.singleton_class, mod ]
+    ancestors.should include(SingletonMethodsSpecs::Prepended)
+
+    # Do not search prepended modules of `Module`, as that's a non-singleton class
+    mod.singleton_methods.should == []
+  end
+end
+
+describe :kernel_singleton_methods_supers, shared: true do
+  it "returns the names of singleton methods for an object extended with a module" do
+    ReflectSpecs.oe.singleton_methods(*@object).should include(:m_pro, :m_pub)
+  end
+
+  it "returns a unique list for an object extended with a module" do
+    m = ReflectSpecs.oed.singleton_methods(*@object)
+    r = m.select { |x| x == :pub or x == :pro }.sort
+    r.should == [:pro, :pub]
+  end
+
+  it "returns the names of singleton methods for an object extended with two modules" do
+    ReflectSpecs.oee.singleton_methods(*@object).should include(:m_pro, :m_pub, :n_pro, :n_pub)
+  end
+
+  it "returns the names of singleton methods for an object extended with a module including a module" do
+    ReflectSpecs.oei.singleton_methods(*@object).should include(:n_pro, :n_pub, :m_pro, :m_pub)
+  end
+
+  it "returns the names of inherited singleton methods for a subclass" do
+    ReflectSpecs::B.singleton_methods(*@object).should include(:as_pro, :as_pub, :bs_pro, :bs_pub)
+  end
+
+  it "returns a unique list for a subclass" do
+    m = ReflectSpecs::B.singleton_methods(*@object)
+    r = m.select { |x| x == :pub or x == :pro }.sort
+    r.should == [:pro, :pub]
+  end
+
+  it "returns the names of inherited singleton methods for a subclass including a module" do
+    ReflectSpecs::C.singleton_methods(*@object).should include(:as_pro, :as_pub, :cs_pro, :cs_pub)
+  end
+
+  it "returns a unique list for a subclass including a module" do
+    m = ReflectSpecs::C.singleton_methods(*@object)
+    r = m.select { |x| x == :pub or x == :pro }.sort
+    r.should == [:pro, :pub]
+  end
+
+  it "returns the names of inherited singleton methods for a subclass of a class including a module" do
+    ReflectSpecs::E.singleton_methods(*@object).should include(:ds_pro, :ds_pub, :es_pro, :es_pub)
+  end
+
+  it "returns the names of inherited singleton methods for a subclass of a class that includes a module, where the subclass also includes a module" do
+    ReflectSpecs::F.singleton_methods(*@object).should include(:ds_pro, :ds_pub, :fs_pro, :fs_pub)
+  end
+
+  it "returns the names of inherited singleton methods for a class extended with a module" do
+    ReflectSpecs::P.singleton_methods(*@object).should include(:m_pro, :m_pub)
+  end
+end
+
+describe :kernel_singleton_methods_private_supers, shared: true do
+  it "does not return private singleton methods for an object extended with a module" do
+    ReflectSpecs.oe.singleton_methods(*@object).should_not include(:m_pri)
+  end
+
+  it "does not return private singleton methods for an object extended with two modules" do
+    ReflectSpecs.oee.singleton_methods(*@object).should_not include(:m_pri)
+  end
+
+  it "does not return private singleton methods for an object extended with a module including a module" do
+    ReflectSpecs.oei.singleton_methods(*@object).should_not include(:n_pri, :m_pri)
+  end
+
+  it "does not return private singleton methods for a class extended with a module" do
+    ReflectSpecs::P.singleton_methods(*@object).should_not include(:m_pri)
+  end
+
+  it "does not return private inherited singleton methods for a module including a module" do
+    ReflectSpecs::N.singleton_methods(*@object).should_not include(:ns_pri)
+  end
+
+  it "does not return private inherited singleton methods for a class including a module" do
+    ReflectSpecs::D.singleton_methods(*@object).should_not include(:ds_pri)
+  end
+
+  it "does not return private inherited singleton methods for a subclass" do
+    ReflectSpecs::B.singleton_methods(*@object).should_not include(:as_pri, :bs_pri)
+  end
+
+  it "does not return private inherited singleton methods for a subclass including a module" do
+    ReflectSpecs::C.singleton_methods(*@object).should_not include(:as_pri, :cs_pri)
+  end
+
+  it "does not return private inherited singleton methods for a subclass of a class including a module" do
+    ReflectSpecs::E.singleton_methods(*@object).should_not include(:ds_pri, :es_pri)
+  end
+
+  it "does not return private inherited singleton methods for a subclass of a class that includes a module, where the subclass also includes a module" do
+    ReflectSpecs::F.singleton_methods(*@object).should_not include(:ds_pri, :fs_pri)
+  end
+end
+
+describe "Kernel#singleton_methods" do
+  describe "when not passed an argument" do
+    it_behaves_like :kernel_singleton_methods, nil, []
+    it_behaves_like :kernel_singleton_methods_supers, nil, []
+    it_behaves_like :kernel_singleton_methods_modules, nil, []
+    it_behaves_like :kernel_singleton_methods_private_supers, nil, []
+  end
+
+  describe "when passed true" do
+    it_behaves_like :kernel_singleton_methods, nil, true
+    it_behaves_like :kernel_singleton_methods_supers, nil, true
+    it_behaves_like :kernel_singleton_methods_modules, nil, true
+    it_behaves_like :kernel_singleton_methods_private_supers, nil, true
+  end
+
+  describe "when passed false" do
+    it_behaves_like :kernel_singleton_methods, nil, false
+    it_behaves_like :kernel_singleton_methods_modules, nil, false
+    it_behaves_like :kernel_singleton_methods_private_supers, nil, false
+
+    it "returns an empty Array for an object extended with a module" do
+      ReflectSpecs.oe.singleton_methods(false).should == []
+    end
+
+    it "returns an empty Array for an object extended with two modules" do
+      ReflectSpecs.oee.singleton_methods(false).should == []
+    end
+
+    it "returns an empty Array for an object extended with a module including a module" do
+      ReflectSpecs.oei.singleton_methods(false).should == []
+    end
+
+    it "returns the names of singleton methods of the subclass" do
+      ReflectSpecs::B.singleton_methods(false).should include(:bs_pro, :bs_pub)
+    end
+
+    it "does not return names of inherited singleton methods for a subclass" do
+      ReflectSpecs::B.singleton_methods(false).should_not include(:as_pro, :as_pub)
+    end
+
+    it "does not return the names of inherited singleton methods for a class extended with a module" do
+      ReflectSpecs::P.singleton_methods(false).should_not include(:m_pro, :m_pub)
+    end
+  end
+end

--- a/spec/core/module/ancestors_spec.rb
+++ b/spec/core/module/ancestors_spec.rb
@@ -36,9 +36,7 @@ describe "Module#ancestors" do
     end
     m2.include m1 # should be after m3 includes m2
 
-    NATFIXME 'it returns a module that is included later into a nested module as well', exception: SpecFailedException do
-      m3.ancestors.should == [m3, m2, m1]
-    end
+    m3.ancestors.should == [m3, m2, m1]
   end
 
   describe "when called on a singleton class" do

--- a/spec/core/module/ancestors_spec.rb
+++ b/spec/core/module/ancestors_spec.rb
@@ -15,10 +15,8 @@ describe "Module#ancestors" do
     else
       ModuleSpecs.without_test_modules(ModuleSpecs::Parent.ancestors).should ==
         [ModuleSpecs::Parent, Object, Kernel, BasicObject]
-      NATFIXME 'it returns a list of modules included in self (including self)', exception: SpecFailedException do
-        ModuleSpecs.without_test_modules(ModuleSpecs::Child.ancestors).should ==
-          [ModuleSpecs::Child, ModuleSpecs::Super, ModuleSpecs::Basic, ModuleSpecs::Parent, Object, Kernel, BasicObject]
-      end
+      ModuleSpecs.without_test_modules(ModuleSpecs::Child.ancestors).should ==
+        [ModuleSpecs::Child, ModuleSpecs::Super, ModuleSpecs::Basic, ModuleSpecs::Parent, Object, Kernel, BasicObject]
     end
   end
 

--- a/spec/core/module/case_compare_spec.rb
+++ b/spec/core/module/case_compare_spec.rb
@@ -14,17 +14,15 @@ describe "Module#===" do
   end
 
   it "returns true when the given Object's class includes self or when the given Object is extended by self" do
-    NATFIXME 'transitive module inclusion lookup', exception: SpecFailedException do
-      (ModuleSpecs::Basic === ModuleSpecs::Child.new).should == true
-      (ModuleSpecs::Super === ModuleSpecs::Child.new).should == true
-      (ModuleSpecs::Basic === mock('x').extend(ModuleSpecs::Super)).should == true
-      (ModuleSpecs::Super === mock('y').extend(ModuleSpecs::Super)).should == true
+    (ModuleSpecs::Basic === ModuleSpecs::Child.new).should == true
+    (ModuleSpecs::Super === ModuleSpecs::Child.new).should == true
+    (ModuleSpecs::Basic === mock('x').extend(ModuleSpecs::Super)).should == true
+    (ModuleSpecs::Super === mock('y').extend(ModuleSpecs::Super)).should == true
 
-      (ModuleSpecs::Basic === ModuleSpecs::Parent.new).should == false
-      (ModuleSpecs::Super === ModuleSpecs::Parent.new).should == false
-      (ModuleSpecs::Basic === mock('z')).should == false
-      (ModuleSpecs::Super === mock('a')).should == false
-    end
+    (ModuleSpecs::Basic === ModuleSpecs::Parent.new).should == false
+    (ModuleSpecs::Super === ModuleSpecs::Parent.new).should == false
+    (ModuleSpecs::Basic === mock('z')).should == false
+    (ModuleSpecs::Super === mock('a')).should == false
   end
 
   it "does not let a module singleton class interfere when its on the RHS" do

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -77,9 +77,4 @@ String ClassObject::backtrace_name() const {
     return String::format("<class:{}>", m_name.value());
 }
 
-void ClassObject::visit_children(Visitor &visitor) const {
-    ModuleObject::visit_children(visitor);
-    visitor.visit(m_origin);
-}
-
 }

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -77,4 +77,9 @@ String ClassObject::backtrace_name() const {
     return String::format("<class:{}>", m_name.value());
 }
 
+void ClassObject::visit_children(Visitor &visitor) const {
+    ModuleObject::visit_children(visitor);
+    visitor.visit(m_origin);
+}
+
 }

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -77,4 +77,9 @@ String ClassObject::backtrace_name() const {
     return String::format("<class:{}>", m_name.value());
 }
 
+void ClassObject::visit_children(Visitor &visitor) const {
+    ModuleObject::visit_children(visitor);
+    visitor.visit(m_attached_object);
+}
+
 }

--- a/src/iclass_object.cpp
+++ b/src/iclass_object.cpp
@@ -1,0 +1,54 @@
+#include "natalie.hpp"
+
+namespace Natalie {
+
+IClassObject::IClassObject(ModuleObject *wrapped, ClassObject *super)
+    : ClassObject { reinterpret_cast<ClassObject *>(-1) }
+    , m_wrapped_module { wrapped } {
+    // We avoid going through GlobalEnv::the()->Class() because iclasses can be
+    // allocated during early bootstrap before Class is wired up. The bogus -1
+    // klass marker is replaced below if Class is available.
+    m_klass = GlobalEnv::the() ? GlobalEnv::the()->Class() : nullptr;
+    set_superclass_DANGEROUSLY(super);
+}
+
+IClassObject *IClassObject::create(ModuleObject *wrapped, ClassObject *super) {
+    std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
+    return new IClassObject(wrapped, super);
+}
+
+TM::Hashmap<SymbolObject *, MethodInfo> &IClassObject::methods_table() {
+    return m_wrapped_module->methods_table();
+}
+
+const TM::Hashmap<SymbolObject *, MethodInfo> &IClassObject::methods_table() const {
+    return m_wrapped_module->methods_table();
+}
+
+TM::Hashmap<SymbolObject *, Constant *> &IClassObject::constants_table() {
+    return m_wrapped_module->constants_table();
+}
+
+const TM::Hashmap<SymbolObject *, Constant *> &IClassObject::constants_table() const {
+    return m_wrapped_module->constants_table();
+}
+
+TM::Hashmap<SymbolObject *, Optional<Value>> &IClassObject::class_vars_table() {
+    return m_wrapped_module->class_vars_table();
+}
+
+const TM::Hashmap<SymbolObject *, Optional<Value>> &IClassObject::class_vars_table() const {
+    return m_wrapped_module->class_vars_table();
+}
+
+void IClassObject::visit_children(Visitor &visitor) const {
+    ClassObject::visit_children(visitor);
+    visitor.visit(m_wrapped_module);
+}
+
+TM::String IClassObject::dbg_inspect(int) const {
+    auto wrapped_name = m_wrapped_module ? m_wrapped_module->name().value_or("none") : "<null>";
+    return TM::String::format("<IClassObject {h} wrapping=\"{}\">", this, wrapped_name);
+}
+
+}

--- a/src/iclass_object.cpp
+++ b/src/iclass_object.cpp
@@ -44,6 +44,7 @@ const TM::Hashmap<SymbolObject *, Optional<Value>> &IClassObject::class_vars_tab
 void IClassObject::visit_children(Visitor &visitor) const {
     ClassObject::visit_children(visitor);
     visitor.visit(m_wrapped_module);
+    visitor.visit(m_includer);
 }
 
 TM::String IClassObject::dbg_inspect(int) const {

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -1209,6 +1209,25 @@ Value KernelModule::send(Env *env, Value self, Args &&args, Block *block) {
     return self.send(env->caller(), name, args.copy(), block);
 }
 
+Value KernelModule::singleton_methods(Env *env, Value self, Optional<Value> recur_val) {
+    bool recur = recur_val ? recur_val->is_truthy() : true;
+    auto result = ArrayObject::create();
+    ClassObject *klass = self->singleton_class();
+    if (!klass) return result;
+    do {
+        for (auto pair : klass->methods_table()) {
+            auto vis = pair.second.visibility();
+            if (vis == MethodVisibility::Public || vis == MethodVisibility::Protected) {
+                if (!result->include(env, pair.first))
+                    result->push(pair.first);
+            }
+        }
+        if (!recur) break;
+        klass = klass->chain_super();
+    } while (klass && (klass->is_singleton() || klass->is_iclass()));
+    return result;
+}
+
 Value KernelModule::tap(Env *env, Value self, Block *block) {
     Value args[] = { self };
     if (!block)

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -185,30 +185,34 @@ Value ModuleObject::const_fetch(SymbolObject *name) const {
 }
 
 Constant *ModuleObject::find_constant_in_modules(Env *env, SymbolObject *name, ConstLookupSearchMode search_mode, ModuleObject **found_in_module) {
-    Constant *constant = nullptr;
-    if (m_included_modules.is_empty()) {
-        constant = this->get_constant(name, found_in_module);
-    } else {
-        for (auto module : m_included_modules) {
-            if (search_mode == ConstLookupSearchMode::StrictPrivate || module == this)
-                constant = this->get_constant(name, found_in_module);
-            else
-                constant = module->find_constant_in_modules(env, name, search_mode, found_in_module);
-            if (constant)
-                break;
-        }
+    if (search_mode == ConstLookupSearchMode::StrictPrivate)
+        return this->get_constant(name, found_in_module);
+
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p->is_origin_hollow()) continue;
+        // Stop at the first real class above `this` — class-hierarchy traversal is the caller's job.
+        if (!p->is_iclass() && p != this) break;
+        if (auto constant = p->get_constant(name, found_in_module))
+            return constant;
     }
-    return constant;
+    return nullptr;
 }
 
 Constant *ModuleObject::find_constant_in_class_hierarchy(Env *env, SymbolObject *name, ConstLookupSearchMode search_mode, bool include_object, ModuleObject **found_in_module) {
     if (!include_object && (this == GlobalEnv::the()->Object() || this == GlobalEnv::the()->BasicObject()))
         return nullptr;
 
-    auto constant = find_constant_in_modules(env, name, search_mode, found_in_module);
-    if (!constant && m_superclass)
-        constant = m_superclass->find_constant_in_class_hierarchy(env, name, search_mode, include_object, found_in_module);
-    return constant;
+    if (auto constant = find_constant_in_modules(env, name, search_mode, found_in_module))
+        return constant;
+
+    // Skip iclasses (already searched by find_constant_in_modules) to reach the next real class.
+    // Hollow wrappers must NOT be skipped — their constants live on the wrapper itself, reached
+    // via the recursive call below.
+    ClassObject *parent = m_superclass;
+    while (parent && parent->is_iclass())
+        parent = parent->chain_super();
+    if (parent) return parent->find_constant_in_class_hierarchy(env, name, search_mode, include_object, found_in_module);
+    return nullptr;
 }
 
 Value ModuleObject::is_autoload(Env *env, Value name) const {
@@ -530,66 +534,33 @@ MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, Module
 
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    MethodInfo method_info;
     if (!after_method && m_method_cache_version == GlobalEnv::the()->method_cache_version()) {
-        method_info = m_method_cache.get(method_name, env);
-        if (method_info)
+        auto cached = m_method_cache.get(method_name, env);
+        if (cached) return cached;
+    }
+
+    bool should_return_match = !after_method || *after_method_found;
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p->is_origin_hollow()) continue;
+        auto method_info = p->methods_table().get(method_name, env);
+        if (!method_info) continue;
+        if (!method_info.is_defined()) {
+            if (!after_method) cache_method(method_name, method_info, env);
             return method_info;
-    }
-
-    if (m_included_modules.is_empty()) {
-        // no included modules, just search the class/module
-        // note: if there are included modules, then the module chain will include this class/module
-        method_info = methods_table().get(method_name, env);
-        if (method_info) {
-            if (!method_info.is_defined()) {
-                if (!after_method)
-                    cache_method(method_name, method_info, env);
-                return method_info;
-            }
-            auto method = method_info.method();
-            if (method == after_method) {
-                *after_method_found = true;
-            } else if (!after_method || *after_method_found) {
-                if (matching_class_or_module) *matching_class_or_module = m_klass;
-                if (!after_method)
-                    cache_method(method_name, method_info, env);
-                return method_info;
-            }
+        }
+        if (method_info.method() == after_method) {
+            *after_method_found = true;
+            should_return_match = true;
+            continue;
+        }
+        if (should_return_match) {
+            if (matching_class_or_module) *matching_class_or_module = p->defined_class();
+            if (!after_method) cache_method(method_name, method_info, env);
+            return method_info;
         }
     }
 
-    for (ModuleObject *module : m_included_modules) {
-        if (module == this) {
-            method_info = module->methods_table().get(method_name, env);
-        } else {
-            method_info = module->find_method(env, method_name, matching_class_or_module, after_method, after_method_found);
-        }
-        if (method_info) {
-            if (!method_info.is_defined()) {
-                if (!after_method)
-                    cache_method(method_name, method_info, env);
-                return method_info;
-            }
-            auto method = method_info.method();
-            if (method == after_method) {
-                *after_method_found = true;
-            } else if (!after_method || *after_method_found) {
-                if (matching_class_or_module) *matching_class_or_module = module;
-                if (!after_method)
-                    cache_method(method_name, method_info, env);
-                return method_info;
-            }
-        }
-    }
-
-    if (!m_superclass)
-        return {};
-
-    method_info = m_superclass->find_method(env, method_name, matching_class_or_module, after_method, after_method_found);
-    if (!after_method)
-        cache_method(method_name, method_info, env);
-    return method_info;
+    return {};
 }
 
 MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, const Method *after_method) {

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -45,15 +45,19 @@ Value ModuleObject::include(Env *env, Args &&args) {
     return this;
 }
 
+bool ModuleObject::is_origin_hollow() const {
+    return m_origin && m_origin != this;
+}
+
 // Walk a module's iclass-aware super chain and collect each visible module
 // in MRI's ancestor order (skipping hollow class wrappers and unwrapping iclasses).
 // Stops at the first non-iclass node that isn't `start` itself, so we don't
 // leak the parent class hierarchy of a class into an include's splice.
 static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObject *> &out) {
     for (ModuleObject *p = start; p; p = p->chain_super()) {
-        if (p->origin() && p->origin() != p) continue; // hollow wrapper
+        if (p->is_origin_hollow()) continue;
         if (p->is_iclass()) {
-            out.push(static_cast<IClassObject *>(p)->wrapped_module());
+            out.push(p->defined_class());
         } else if (p == start) {
             out.push(p);
         } else {
@@ -294,13 +298,14 @@ Value ModuleObject::remove_const(Env *env, Value name) {
 
 Value ModuleObject::constants(Env *env, Optional<Value> inherit) const {
     auto ary = ArrayObject::create();
-    for (auto pair : m_constants)
+    for (auto pair : constants_table())
         ary->push(pair.first);
     if (!inherit || inherit->is_truthy()) {
-        for (ModuleObject *module : m_included_modules) {
-            if (module != this) {
-                ary->concat(*module->constants(env, inherit).as_array());
-            }
+        for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
+            if (p == GlobalEnv::the()->Object()) break;
+            if (p->is_origin_hollow()) continue;
+            for (auto pair : p->constants_table())
+                ary->push(pair.first);
         }
     }
     return ary;
@@ -344,25 +349,15 @@ Optional<Value> ModuleObject::cvar_get_maybe(Env *env, SymbolObject *name) {
 
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    ModuleObject *module = this;
-    Optional<Value> val;
-    while (module) {
-        val = module->class_vars_table().get(name, env);
-        if (val)
-            return val;
-        module = module->m_superclass;
-    }
-
-    for (auto *m : m_included_modules) {
-        val = m->class_vars_table().get(name, env);
-        if (val)
-            return val;
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p->is_origin_hollow()) continue;
+        auto val = p->class_vars_table().get(name, env);
+        if (val) return val;
     }
 
     if (singleton_class()) {
-        val = singleton_class()->class_vars_table().get(name, env);
-        if (val)
-            return val;
+        auto val = singleton_class()->class_vars_table().get(name, env);
+        if (val) return val;
     }
 
     return {};
@@ -375,16 +370,13 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 
         std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-        ModuleObject *current = module;
-
-        Optional<Value> exists;
-        while (current) {
-            exists = current->class_vars_table().get(name, env);
+        for (ModuleObject *current = module; current; current = current->m_superclass) {
+            if (current->is_origin_hollow()) continue;
+            auto exists = current->class_vars_table().get(name, env);
             if (exists) {
                 current->class_vars_table().put(name, val, env);
                 return val;
             }
-            current = current->m_superclass;
         }
         module->class_vars_table().put(name, val, env);
         return val;
@@ -435,8 +427,17 @@ ArrayObject *ModuleObject::class_variables(Optional<Value> inherit) const {
         for (auto [cvar, _] : singleton_class()->class_vars_table())
             result->push(cvar);
     }
-    if (inherit && inherit->is_truthy() && m_superclass)
-        result->concat(*m_superclass->class_variables(inherit));
+    if (inherit && inherit->is_truthy()) {
+        for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
+            if (p->is_origin_hollow()) continue;
+            for (auto [cvar, _] : p->class_vars_table())
+                result->push(cvar);
+            if (!p->is_iclass() && p->singleton_class()) {
+                for (auto [cvar, _] : p->singleton_class()->class_vars_table())
+                    result->push(cvar);
+            }
+        }
+    }
     return result;
 }
 
@@ -505,18 +506,14 @@ void ModuleObject::methods(Env *env, ArrayObject *array, bool include_super) {
             continue;
         array->push(pair.first);
     }
-    if (!include_super) {
-        return;
-    }
-    for (ModuleObject *module : m_included_modules) {
-        for (auto pair : module->methods_table()) {
+    if (!include_super) return;
+    for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
+        if (p->is_origin_hollow()) continue;
+        for (auto pair : p->methods_table()) {
             if (array->include(env, pair.first))
                 continue;
             array->push(pair.first);
         }
-    }
-    if (m_superclass) {
-        m_superclass->methods(env, array);
     }
 }
 
@@ -680,11 +677,8 @@ ArrayObject *ModuleObject::ancestors(Env *env) {
 
     ArrayObject *ancestors = ArrayObject::create();
     for (ModuleObject *p = this; p; p = p->m_superclass) {
-        if (p->m_origin && p->m_origin != p) continue; // hollow class wrapper
-        if (p->is_iclass())
-            ancestors->push(static_cast<IClassObject *>(p)->wrapped_module());
-        else
-            ancestors->push(p);
+        if (p->is_origin_hollow()) continue;
+        ancestors->push(p->defined_class());
     }
     return ancestors;
 }
@@ -693,9 +687,8 @@ bool ModuleObject::ancestors_includes(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     for (ModuleObject *p = this; p; p = p->m_superclass) {
-        if (p->m_origin && p->m_origin != p) continue;
-        ModuleObject *visible = p->is_iclass() ? static_cast<IClassObject *>(p)->wrapped_module() : p;
-        if (visible == module) return true;
+        if (p->is_origin_hollow()) continue;
+        if (p->defined_class() == module) return true;
     }
     return false;
 }
@@ -752,25 +745,11 @@ Value ModuleObject::cmp(Env *env, Value other) {
 bool ModuleObject::is_subclass_of(ModuleObject *other) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    if (other == this) {
-        return false;
+    if (other == this) return false;
+    for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
+        if (p->is_origin_hollow()) continue;
+        if (p->defined_class() == other) return true;
     }
-    ModuleObject *klass = this;
-    do {
-        if (other == klass->m_superclass) {
-            return true;
-        }
-        for (ModuleObject *m : klass->included_modules()) {
-            if (m == klass) continue;
-            if (other == m) {
-                return true;
-            }
-            if (m->is_subclass_of(other)) {
-                return true;
-            }
-        }
-        klass = klass->m_superclass;
-    } while (klass);
     return false;
 }
 
@@ -906,14 +885,13 @@ ArrayObject *ModuleObject::attr_accessor(Env *env, Args &&args) {
 void ModuleObject::included_modules(Env *env, ArrayObject *modules) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    for (ModuleObject *m : included_modules()) {
-        if (m == this || modules->include(env, m))
-            continue;
-        modules->push(m);
-        m->included_modules(env, modules);
-    }
-    if (m_superclass) {
-        m_superclass->included_modules(env, modules);
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p == this) continue;
+        if (p->is_origin_hollow()) continue;
+        ModuleObject *visible = p->defined_class();
+        if (visible->type() == Type::Class) continue;
+        if (modules->include(env, visible)) continue;
+        modules->push(visible);
     }
 }
 
@@ -927,16 +905,14 @@ bool ModuleObject::does_include_module(Env *env, Value module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     module.assert_type(env, Object::Type::Module, "Module");
-    for (ModuleObject *m : included_modules()) {
-        if (this == m)
-            continue;
-        if (module == m)
-            return true;
-        if (m->does_include_module(env, module))
-            return true;
+    auto target = module.as_module();
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p == this) continue;
+        if (p->is_origin_hollow()) continue;
+        ModuleObject *visible = p->defined_class();
+        if (visible->type() == Type::Class) continue;
+        if (visible == target) return true;
     }
-    if (m_superclass && m_superclass->does_include_module(env, module))
-        return true;
     return false;
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -45,23 +45,57 @@ Value ModuleObject::include(Env *env, Args &&args) {
     return this;
 }
 
+// Walk a module's iclass-aware super chain and collect each visible module
+// in MRI's ancestor order (skipping hollow class wrappers and unwrapping iclasses).
+// Stops at the first non-iclass node that isn't `start` itself, so we don't
+// leak the parent class hierarchy of a class into an include's splice.
+static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObject *> &out) {
+    for (ModuleObject *p = start; p; p = p->chain_super()) {
+        if (p->origin() && p->origin() != p) continue; // hollow wrapper
+        if (p->is_iclass()) {
+            out.push(static_cast<IClassObject *>(p)->wrapped_module());
+        } else if (p == start) {
+            out.push(p);
+        } else {
+            break; // hit a real class above the module being included
+        }
+    }
+}
+
 void ModuleObject::include_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
+    // Update the legacy flat list.
     if (m_included_modules.is_empty()) {
         m_included_modules.push(this);
         m_included_modules.push(module);
     } else {
         ssize_t this_index = -1;
+        bool already_present = false;
         for (size_t i = 0; i < m_included_modules.size(); ++i) {
             if (m_included_modules[i] == this)
                 this_index = i;
             if (m_included_modules[i] == module)
-                return;
+                already_present = true;
         }
+        if (already_present) return;
         assert(this_index != -1);
         m_included_modules.insert(this_index + 1, module);
     }
+
+    // Build the iclass-augmented super chain. Splice an iclass for `module` and each
+    // module in its ancestor chain into self, preserving MRI's ordering.
+    TM::Vector<ModuleObject *> to_splice;
+    collect_modules_for_splice(module, to_splice);
+
+    ModuleObject *insertion = m_origin ? static_cast<ModuleObject *>(m_origin) : this;
+    for (ModuleObject *m : to_splice) {
+        if (m != module && ancestors_includes(env, m)) continue;
+        IClassObject *iclass = IClassObject::create(m, insertion->m_superclass);
+        insertion->m_superclass = iclass;
+        insertion = iclass;
+    }
+
     GlobalEnv::the()->increment_method_cache_version();
     if (module->respond_to(env, "included"_s))
         module->send(env, "included"_s, { this });
@@ -77,6 +111,7 @@ Value ModuleObject::prepend(Env *env, Args &&args) {
 void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
+    // Update the legacy flat list.
     if (m_included_modules.is_empty()) {
         m_included_modules.push(module);
         m_included_modules.push(this);
@@ -87,6 +122,28 @@ void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
         }
         m_included_modules.push_front(module);
     }
+
+    // Lazily create the origin iclass on first prepend. The origin wraps `this` so
+    // that prepended modules' `super` calls land back on the original method table.
+    if (!m_origin) {
+        IClassObject *origin = IClassObject::create(this, m_superclass);
+        m_superclass = origin;
+        m_origin = origin;
+    }
+
+    // Splice prepended modules between `this` and `m_origin` (or above whatever was
+    // most-recently prepended). New iclasses are inserted right after `this`.
+    TM::Vector<ModuleObject *> to_splice;
+    collect_modules_for_splice(module, to_splice);
+
+    ModuleObject *insertion = this;
+    for (ModuleObject *m : to_splice) {
+        if (m != module && ancestors_includes(env, m)) continue;
+        IClassObject *iclass = IClassObject::create(m, insertion->m_superclass);
+        insertion->m_superclass = iclass;
+        insertion = iclass;
+    }
+
     GlobalEnv::the()->increment_method_cache_version();
 }
 
@@ -621,39 +678,25 @@ Value ModuleObject::public_instance_methods(Env *env, Optional<Value> include_su
 ArrayObject *ModuleObject::ancestors(Env *env) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    ModuleObject *klass = this;
     ArrayObject *ancestors = ArrayObject::create();
-    do {
-        if (klass->included_modules().is_empty()) {
-            // note: if there are included modules, then they will include this klass
-            ancestors->push(klass);
-        }
-        for (ModuleObject *m : klass->included_modules()) {
-            ancestors->push(m);
-        }
-        klass = klass->m_superclass;
-    } while (klass);
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p->m_origin && p->m_origin != p) continue; // hollow class wrapper
+        if (p->is_iclass())
+            ancestors->push(static_cast<IClassObject *>(p)->wrapped_module());
+        else
+            ancestors->push(p);
+    }
     return ancestors;
 }
 
 bool ModuleObject::ancestors_includes(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    ModuleObject *klass = this;
-    do {
-        if (klass->included_modules().is_empty()) {
-            // note: if there are included modules, then they will include this klass
-            if (klass == module) {
-                return true;
-            }
-        }
-        for (ModuleObject *m : klass->included_modules()) {
-            if (m == module) {
-                return true;
-            }
-        }
-        klass = klass->m_superclass;
-    } while (klass);
+    for (ModuleObject *p = this; p; p = p->m_superclass) {
+        if (p->m_origin && p->m_origin != p) continue;
+        ModuleObject *visible = p->is_iclass() ? static_cast<IClassObject *>(p)->wrapped_module() : p;
+        if (visible == module) return true;
+    }
     return false;
 }
 
@@ -1146,6 +1189,7 @@ Value ModuleObject::ruby2_keywords(Env *env, Value name) {
 void ModuleObject::visit_children(Visitor &visitor) const {
     Object::visit_children(visitor);
     visitor.visit(m_superclass);
+    visitor.visit(m_origin);
     visitor.visit(m_owner);
     for (auto pair : m_constants) {
         visitor.visit(pair.first);

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -290,20 +290,20 @@ Optional<Value> ModuleObject::cvar_get_maybe(Env *env, SymbolObject *name) {
     ModuleObject *module = this;
     Optional<Value> val;
     while (module) {
-        val = module->m_class_vars.get(name, env);
+        val = module->class_vars_table().get(name, env);
         if (val)
             return val;
         module = module->m_superclass;
     }
 
     for (auto *m : m_included_modules) {
-        val = m->m_class_vars.get(name, env);
+        val = m->class_vars_table().get(name, env);
         if (val)
             return val;
     }
 
     if (singleton_class()) {
-        val = singleton_class()->m_class_vars.get(name, env);
+        val = singleton_class()->class_vars_table().get(name, env);
         if (val)
             return val;
     }
@@ -322,14 +322,14 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
 
         Optional<Value> exists;
         while (current) {
-            exists = current->m_class_vars.get(name, env);
+            exists = current->class_vars_table().get(name, env);
             if (exists) {
-                current->m_class_vars.put(name, val, env);
+                current->class_vars_table().put(name, val, env);
                 return val;
             }
             current = current->m_superclass;
         }
-        module->m_class_vars.put(name, val, env);
+        module->class_vars_table().put(name, val, env);
         return val;
     };
 
@@ -372,10 +372,10 @@ ArrayObject *ModuleObject::class_variables(Optional<Value> inherit) const {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
     auto result = ArrayObject::create();
-    for (auto [cvar, _] : m_class_vars)
+    for (auto [cvar, _] : class_vars_table())
         result->push(cvar);
     if (singleton_class()) {
-        for (auto [cvar, _] : singleton_class()->m_class_vars)
+        for (auto [cvar, _] : singleton_class()->class_vars_table())
             result->push(cvar);
     }
     if (inherit && inherit->is_truthy() && m_superclass)
@@ -443,7 +443,7 @@ SymbolObject *ModuleObject::undefine_method(Env *env, SymbolObject *name) {
 
 // supply an empty array and it will be populated with the method names as symbols
 void ModuleObject::methods(Env *env, ArrayObject *array, bool include_super) {
-    for (auto pair : m_methods) {
+    for (auto pair : methods_table()) {
         if (array->include(env, pair.first))
             continue;
         array->push(pair.first);
@@ -452,7 +452,7 @@ void ModuleObject::methods(Env *env, ArrayObject *array, bool include_super) {
         return;
     }
     for (ModuleObject *module : m_included_modules) {
-        for (auto pair : module->m_methods) {
+        for (auto pair : module->methods_table()) {
             if (array->include(env, pair.first))
                 continue;
             array->push(pair.first);
@@ -486,7 +486,7 @@ MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, Module
     if (m_included_modules.is_empty()) {
         // no included modules, just search the class/module
         // note: if there are included modules, then the module chain will include this class/module
-        method_info = m_methods.get(method_name, env);
+        method_info = methods_table().get(method_name, env);
         if (method_info) {
             if (!method_info.is_defined()) {
                 if (!after_method)
@@ -507,7 +507,7 @@ MethodInfo ModuleObject::find_method(Env *env, SymbolObject *method_name, Module
 
     for (ModuleObject *module : m_included_modules) {
         if (module == this) {
-            method_info = module->m_methods.get(method_name, env);
+            method_info = module->methods_table().get(method_name, env);
         } else {
             method_info = module->find_method(env, method_name, matching_class_or_module, after_method, after_method_found);
         }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -50,7 +50,7 @@ bool ModuleObject::is_origin_hollow() const {
 }
 
 // Walk a module's iclass-aware super chain and collect each visible module
-// in MRI's ancestor order (skipping hollow class wrappers and unwrapping iclasses).
+// in ancestor order (skipping hollow class wrappers and unwrapping iclasses).
 // Stops at the first non-iclass node that isn't `start` itself, so we don't
 // leak the parent class hierarchy of a class into an include's splice.
 static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObject *> &out) {
@@ -69,26 +69,10 @@ static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObj
 void ModuleObject::include_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    // Update the legacy flat list.
-    if (m_included_modules.is_empty()) {
-        m_included_modules.push(this);
-        m_included_modules.push(module);
-    } else {
-        ssize_t this_index = -1;
-        bool already_present = false;
-        for (size_t i = 0; i < m_included_modules.size(); ++i) {
-            if (m_included_modules[i] == this)
-                this_index = i;
-            if (m_included_modules[i] == module)
-                already_present = true;
-        }
-        if (already_present) return;
-        assert(this_index != -1);
-        m_included_modules.insert(this_index + 1, module);
-    }
+    if (ancestors_includes(env, module)) return;
 
-    // Build the iclass-augmented super chain. Splice an iclass for `module` and each
-    // module in its ancestor chain into self, preserving MRI's ordering.
+    // Splice an iclass for `module` and each module in its ancestor chain into
+    // self's super chain.
     TM::Vector<ModuleObject *> to_splice;
     collect_modules_for_splice(module, to_splice);
 
@@ -115,17 +99,7 @@ Value ModuleObject::prepend(Env *env, Args &&args) {
 void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    // Update the legacy flat list.
-    if (m_included_modules.is_empty()) {
-        m_included_modules.push(module);
-        m_included_modules.push(this);
-    } else {
-        for (auto m : m_included_modules) {
-            if (m == module)
-                return;
-        }
-        m_included_modules.push_front(module);
-    }
+    if (ancestors_includes(env, module)) return;
 
     // Lazily create the origin iclass on first prepend. The origin wraps `this` so
     // that prepended modules' `super` calls land back on the original method table.
@@ -1154,9 +1128,6 @@ void ModuleObject::visit_children(Visitor &visitor) const {
         visitor.visit(pair.first);
         if (pair.second)
             visitor.visit(pair.second.value());
-    }
-    for (auto module : m_included_modules) {
-        visitor.visit(module);
     }
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -49,19 +49,41 @@ bool ModuleObject::is_origin_hollow() const {
     return m_origin && m_origin != this;
 }
 
-// Walk a module's iclass-aware super chain and collect each visible module
-// in ancestor order (skipping hollow class wrappers and unwrapping iclasses).
-// Stops at the first non-iclass node that isn't `start` itself, so we don't
-// leak the parent class hierarchy of a class into an include's splice.
-static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObject *> &out) {
-    for (ModuleObject *p = start; p; p = p->chain_super()) {
-        if (p->is_origin_hollow()) continue;
-        if (p->is_iclass()) {
-            out.push(p->defined_class());
-        } else if (p == start) {
-            out.push(p);
-        } else {
-            break; // hit a real class above the module being included
+// Splice each module in `source`'s chain into self's super chain, advancing
+// `insertion` to maintain proper relative order when duplicates are encountered:
+// when an iclass for the same module already exists above any non-iclass boundary,
+// `insertion` moves there so later splices stay in source order.
+//
+// `search_super` walks the entire super chain (include) or stops at `m_origin`
+// (prepend, so dedup checks only the prepended region).
+void ModuleObject::splice_module_chain(ModuleObject *source, ModuleObject *insertion, bool search_super) {
+    for (ModuleObject *cur = source; cur; cur = cur->chain_super()) {
+        if (cur != source && !cur->is_iclass() && !cur->is_origin_hollow()) break;
+
+        ModuleObject *to_splice = cur->defined_class();
+
+        bool insertion_seen = false;
+        bool real_class_seen = false;
+        ClassObject *existing = nullptr;
+        for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
+            if (!search_super && m_origin == p) break;
+            if (p == insertion) insertion_seen = true;
+            if (p->is_iclass()) {
+                if (p->defined_class() == to_splice) {
+                    existing = p;
+                    break;
+                }
+            } else {
+                real_class_seen = true;
+            }
+        }
+
+        if (existing && insertion_seen && !real_class_seen) {
+            insertion = existing;
+        } else if (!existing) {
+            IClassObject *iclass = IClassObject::create(to_splice, insertion->m_superclass);
+            insertion->m_superclass = iclass;
+            insertion = iclass;
         }
     }
 }
@@ -69,20 +91,8 @@ static void collect_modules_for_splice(ModuleObject *start, TM::Vector<ModuleObj
 void ModuleObject::include_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    if (ancestors_includes(env, module)) return;
-
-    // Splice an iclass for `module` and each module in its ancestor chain into
-    // self's super chain.
-    TM::Vector<ModuleObject *> to_splice;
-    collect_modules_for_splice(module, to_splice);
-
     ModuleObject *insertion = m_origin ? static_cast<ModuleObject *>(m_origin) : this;
-    for (ModuleObject *m : to_splice) {
-        if (m != module && ancestors_includes(env, m)) continue;
-        IClassObject *iclass = IClassObject::create(m, insertion->m_superclass);
-        insertion->m_superclass = iclass;
-        insertion = iclass;
-    }
+    splice_module_chain(module, insertion, /*search_super=*/true);
 
     GlobalEnv::the()->increment_method_cache_version();
     if (module->respond_to(env, "included"_s))
@@ -99,8 +109,6 @@ Value ModuleObject::prepend(Env *env, Args &&args) {
 void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    if (ancestors_includes(env, module)) return;
-
     // Lazily create the origin iclass on first prepend. The origin wraps `this` so
     // that prepended modules' `super` calls land back on the original method table.
     if (!m_origin) {
@@ -109,18 +117,7 @@ void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
         m_origin = origin;
     }
 
-    // Splice prepended modules between `this` and `m_origin` (or above whatever was
-    // most-recently prepended). New iclasses are inserted right after `this`.
-    TM::Vector<ModuleObject *> to_splice;
-    collect_modules_for_splice(module, to_splice);
-
-    ModuleObject *insertion = this;
-    for (ModuleObject *m : to_splice) {
-        if (m != module && ancestors_includes(env, m)) continue;
-        IClassObject *iclass = IClassObject::create(m, insertion->m_superclass);
-        insertion->m_superclass = iclass;
-        insertion = iclass;
-    }
+    splice_module_chain(module, this, /*search_super=*/false);
 
     GlobalEnv::the()->increment_method_cache_version();
 }

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -342,20 +342,30 @@ Value ModuleObject::eval_body(Env *env, Value (*fn)(Env *, Value)) {
     return result;
 }
 
+ModuleObject *ModuleObject::cvar_scope_target() {
+    // `class << foo; @@x = ...; end` should land on `foo`, not on its singleton
+    // class — class variables follow the lexical class/module, skipping past
+    // singleton wrappers.
+    if (type() == Type::Class) {
+        ClassObject *self_class = static_cast<ClassObject *>(this);
+        if (self_class->is_singleton()) {
+            Object *attached = self_class->attached_object();
+            if (attached && Value(attached).is_module())
+                return static_cast<ModuleObject *>(attached);
+        }
+    }
+    return this;
+}
+
 Optional<Value> ModuleObject::cvar_get_maybe(Env *env, SymbolObject *name) {
     if (!name->is_cvar_name())
         env->raise_name_error(name, "`{}' is not allowed as a class variable name", name->string());
 
     std::lock_guard<std::recursive_mutex> lock(g_gc_recursive_mutex);
 
-    for (ModuleObject *p = this; p; p = p->m_superclass) {
+    for (ModuleObject *p = cvar_scope_target(); p; p = p->m_superclass) {
         if (p->is_origin_hollow()) continue;
         auto val = p->class_vars_table().get(name, env);
-        if (val) return val;
-    }
-
-    if (singleton_class()) {
-        auto val = singleton_class()->class_vars_table().get(name, env);
         if (val) return val;
     }
 
@@ -382,7 +392,6 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
     };
 
     if (GlobalEnv::the()->instance_evaling()) {
-        // Set class variable in block definition scope
         auto context = GlobalEnv::the()->current_instance_eval_context();
         if (context.block_original_self.is_module()) {
             return set_cvar_in(context.block_original_self.as_module());
@@ -391,7 +400,7 @@ Value ModuleObject::cvar_set(Env *env, SymbolObject *name, Value val) {
         }
     }
 
-    return set_cvar_in(this);
+    return set_cvar_in(cvar_scope_target());
 }
 
 bool ModuleObject::class_variable_defined(Env *env, Value name) {
@@ -422,19 +431,11 @@ ArrayObject *ModuleObject::class_variables(Optional<Value> inherit) const {
     auto result = ArrayObject::create();
     for (auto [cvar, _] : class_vars_table())
         result->push(cvar);
-    if (singleton_class()) {
-        for (auto [cvar, _] : singleton_class()->class_vars_table())
-            result->push(cvar);
-    }
     if (inherit && inherit->is_truthy()) {
         for (ClassObject *p = m_superclass; p; p = p->chain_super()) {
             if (p->is_origin_hollow()) continue;
             for (auto [cvar, _] : p->class_vars_table())
                 result->push(cvar);
-            if (!p->is_iclass() && p->singleton_class()) {
-                for (auto [cvar, _] : p->singleton_class()->class_vars_table())
-                    result->push(cvar);
-            }
         }
     }
     return result;

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -82,6 +82,8 @@ void ModuleObject::splice_module_chain(ModuleObject *source, ModuleObject *inser
             insertion = existing;
         } else if (!existing) {
             IClassObject *iclass = IClassObject::create(to_splice, insertion->m_superclass);
+            iclass->set_includer(this);
+            to_splice->m_iclasses.push(iclass);
             insertion->m_superclass = iclass;
             insertion = iclass;
         }
@@ -93,6 +95,15 @@ void ModuleObject::include_once(Env *env, ModuleObject *module) {
 
     ModuleObject *insertion = m_origin ? static_cast<ModuleObject *>(m_origin) : this;
     splice_module_chain(module, insertion, /*search_super=*/true);
+
+    // Propagate to any class/module that already includes self: insert the new
+    // modules right after each iclass-wrapping-self, so they appear in those
+    // includers' ancestors too.
+    for (IClassObject *iclass_self : m_iclasses) {
+        ModuleObject *includer = iclass_self->includer();
+        assert(includer);
+        includer->splice_module_chain(module, iclass_self, /*search_super=*/true);
+    }
 
     GlobalEnv::the()->increment_method_cache_version();
     if (module->respond_to(env, "included"_s))
@@ -118,6 +129,19 @@ void ModuleObject::prepend_once(Env *env, ModuleObject *module) {
     }
 
     splice_module_chain(module, this, /*search_super=*/false);
+
+    // Propagate to any class/module that already includes self: prepended modules
+    // must appear *before* each iclass-wrapping-self, so we splice into the node
+    // that points at the iclass.
+    for (IClassObject *iclass_self : m_iclasses) {
+        ModuleObject *includer = iclass_self->includer();
+        assert(includer);
+        ModuleObject *prev = includer;
+        while (prev && prev->chain_super() != iclass_self)
+            prev = prev->chain_super();
+        assert(prev);
+        includer->splice_module_chain(module, prev, /*search_super=*/true);
+    }
 
     GlobalEnv::the()->increment_method_cache_version();
 }
@@ -1125,6 +1149,9 @@ void ModuleObject::visit_children(Visitor &visitor) const {
         visitor.visit(pair.first);
         if (pair.second)
             visitor.visit(pair.second.value());
+    }
+    for (auto iclass : m_iclasses) {
+        visitor.visit(iclass);
     }
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -212,6 +212,7 @@ SymbolObject *Object::to_instance_variable_name(Env *env, Value name) {
 
 void Object::set_singleton_class(ClassObject *klass) {
     klass->set_is_singleton(true);
+    klass->set_attached_object(this);
     m_singleton_class = klass;
 }
 


### PR DESCRIPTION
This is a bit of a bigger change, and is a matter of taste, so we can definitely _not_ do this if preferred.

Basically, the way MRI does module inclusion is that it inserts something called an iclass (I'm assuming inserted class?) into the ancestor chain above the current singleton. prepend puts it below. Method lookup/ancestry lookup is then a straight walk through the chain. Natalie has a separate list of included modules, which means method lookup/ancestry lookup needs to look in two places. Not a bad thing necessarily, but it does make the logic (IMO) a little more complex.

This PR migrates over to the iclass approach that MRI uses. As a bonus, it also implements `singleton_methods`, which was actually the impetus. That's now a straight walk through an ancestor chain.