### PR TITLE
Match upstream mspec matchers

### DIFF
--- a/spec/core/data/eql_spec.rb
+++ b/spec/core/data/eql_spec.rb
@@ -10,7 +10,9 @@ describe "Data#eql?" do
   it "returns true if the other has all the same fields" do
     a = DataSpecs::Measure.new(42, "km")
     b = DataSpecs::Measure.new(42, "km")
-    a.should.eql?(b)
+    NATFIXME 'Data#eql? should be true for equal fields', exception: SpecFailedException do
+      a.should.eql?(b)
+    end
   end
 
   it "returns false if the other is a different object or has different fields" do
@@ -47,7 +49,9 @@ describe "Data#eql?" do
       b = DataSpecs::Measure.allocate
       b.send(:initialize, amount: 42, unit: b)
 
-      a.should.eql?(b)
+      NATFIXME 'Data#eql? should be true for equal fields', exception: SpecFailedException do
+        a.should.eql?(b)
+      end
     end
 
     it "returns false if any corresponding elements are not equal with #eql?" do

--- a/spec/core/env/element_reference_spec.rb
+++ b/spec/core/env/element_reference_spec.rb
@@ -17,7 +17,9 @@ describe "ENV.[]" do
 
   it "returns only frozen values" do
     ENV[@variable] = "a non-frozen string"
-    ENV[@variable].should.frozen?
+    NATFIXME 'ENV values should be frozen', exception: SpecFailedException do
+      ENV[@variable].should.frozen?
+    end
   end
 
   it "coerces a non-string name with #to_str" do

--- a/spec/core/false/to_s_spec.rb
+++ b/spec/core/false/to_s_spec.rb
@@ -6,7 +6,9 @@ describe "FalseClass#to_s" do
   end
 
   it "returns a frozen string" do
-    false.to_s.should.frozen?
+    NATFIXME 'FalseClass#to_s should return a frozen string', exception: SpecFailedException do
+      false.to_s.should.frozen?
+    end
   end
 
   it "always returns the same string" do

--- a/spec/core/file/lutime_spec.rb
+++ b/spec/core/file/lutime_spec.rb
@@ -24,7 +24,9 @@ platform_is_not :windows do
       File.lutime(@atime, @mtime, @file)
       stat = File.stat(@file)
       stat.atime.should == @atime
-      stat.mtime.should === @mtime
+      NATFIXME 'File.lutime mtime should === the given time', exception: SpecFailedException do
+        stat.mtime.should === @mtime
+      end
     end
 
     it "sets the access and modification time for a symlink" do
@@ -33,7 +35,9 @@ platform_is_not :windows do
       File.lutime(@atime, @mtime, @symlink)
       stat = File.lstat(@symlink)
       stat.atime.should == @atime
-      stat.mtime.should === @mtime
+      NATFIXME 'File.lutime mtime should === the given time', exception: SpecFailedException do
+        stat.mtime.should === @mtime
+      end
 
       file = File.stat(@file)
       file.atime.should == original.atime

--- a/spec/core/hash/shared/store.rb
+++ b/spec/core/hash/shared/store.rb
@@ -50,7 +50,9 @@ describe :hash_store, shared: true do
     key << "bar"
 
     h.should == { "foo" => 0 }
-    h.keys[0].should.frozen?
+    NATFIXME 'duplicated string keys should be frozen', exception: SpecFailedException do
+      h.keys[0].should.frozen?
+    end
   end
 
   it "doesn't duplicate and freeze already frozen string keys" do

--- a/spec/core/integer/shared/integer_ceil_precision.rb
+++ b/spec/core/integer/shared/integer_ceil_precision.rb
@@ -57,7 +57,9 @@ describe :integer_ceil_precision, shared: true do
 
     # Bug #20654
     it "returns 10**precision.abs when precision.abs has more digits than self" do
-      NATFIXME 'Implement precision argument', condition: @method == :Rational, exception: ArgumentError, message: 'wrong number of arguments' do
+      # Rational raises ArgumentError (precision arg unimplemented); Integer/Float
+      # currently overflow int64 instead of returning a Bignum, so eql? fails.
+      NATFIXME 'precision argument / Bignum result' do
         send(@method, 123).ceil(-20).should.eql?(100000000000000000000)
         send(@method, 123).ceil(-50).should.eql?(100000000000000000000000000000000000000000000000000)
       end

--- a/spec/core/integer/shared/integer_floor_precision.rb
+++ b/spec/core/integer/shared/integer_floor_precision.rb
@@ -9,11 +9,15 @@ describe :integer_floor_precision, shared: true do
 
   context "precision is positive" do
     it "returns self" do
-      send(@method, 0).floor(1).should.eql?(send(@method, 0))
-      send(@method, 0).floor(10).should.eql?(send(@method, 0))
+      # Rational#floor(positive) currently returns an Integer, not a Rational,
+      # so eql? (type-strict) fails.
+      NATFIXME 'Rational#floor(precision) should return a Rational', condition: @method == :Rational, exception: SpecFailedException do
+        send(@method, 0).floor(1).should.eql?(send(@method, 0))
+        send(@method, 0).floor(10).should.eql?(send(@method, 0))
 
-      send(@method, 123).floor(10).should.eql?(send(@method, 123))
-      send(@method, -123).floor(10).should.eql?(send(@method, -123))
+        send(@method, 123).floor(10).should.eql?(send(@method, 123))
+        send(@method, -123).floor(10).should.eql?(send(@method, -123))
+      end
     end
   end
 
@@ -35,8 +39,12 @@ describe :integer_floor_precision, shared: true do
 
     # Bug #20654
     it "returns -(10**precision.abs) when self is negative and precision.abs is larger than the number digits of self" do
-      send(@method, -123).floor(-20).should.eql?(-100000000000000000000)
-      send(@method, -123).floor(-50).should.eql?(-100000000000000000000000000000000000000000000000000)
+      # Integer/Float overflow int64 instead of returning a Bignum; Rational
+      # returns the wrong type. eql? catches all of these.
+      NATFIXME 'floor(negative) should return a Bignum result' do
+        send(@method, -123).floor(-20).should.eql?(-100000000000000000000)
+        send(@method, -123).floor(-50).should.eql?(-100000000000000000000000000000000000000000000000000)
+      end
     end
   end
 end

--- a/spec/core/kernel/clone_spec.rb
+++ b/spec/core/kernel/clone_spec.rb
@@ -67,7 +67,9 @@ describe "Kernel#clone" do
     end
 
     it 'freezes the copy even if the original was not frozen' do
-      @obj.clone(freeze: true).should.frozen?
+      NATFIXME 'clone(freeze: true) should freeze the copy', exception: SpecFailedException do
+        @obj.clone(freeze: true).should.frozen?
+      end
     end
 
     it "calls #initialize_clone with kwargs freeze: true" do

--- a/spec/core/marshal/shared/load.rb
+++ b/spec/core/marshal/shared/load.rb
@@ -775,7 +775,9 @@ describe :marshal_load, shared: true do
       dumped = "\x04\bS:#MarshalSpec::DataSpec::Measure\a:\vamountii:\tunit\"\akm"
       Marshal.dump(obj).should == dumped
 
-      Marshal.send(@method, dumped).should.frozen?
+      NATFIXME 'Marshal-loaded frozen Data object should be frozen', exception: SpecFailedException do
+        Marshal.send(@method, dumped).should.frozen?
+      end
     end
   end
 

--- a/spec/core/matchdata/string_spec.rb
+++ b/spec/core/matchdata/string_spec.rb
@@ -9,7 +9,9 @@ describe "MatchData#string" do
   it "returns a frozen copy of the match string" do
     str = /(.)(.)(\d+)(\d)/.match("THX1138.").string
     str.should == "THX1138."
-    str.should.frozen?
+    NATFIXME 'MatchData#string should return a frozen copy', exception: SpecFailedException do
+      str.should.frozen?
+    end
   end
 
   it "returns the same frozen string for every call" do
@@ -21,6 +23,8 @@ describe "MatchData#string" do
     s = +'he[[o'
     s.gsub!('[', ']')
     $~.string.should == 'he[[o'
-    $~.string.should.frozen?
+    NATFIXME 'MatchData#string should return a frozen copy', exception: SpecFailedException do
+      $~.string.should.frozen?
+    end
   end
 end

--- a/spec/core/nil/to_s_spec.rb
+++ b/spec/core/nil/to_s_spec.rb
@@ -6,7 +6,9 @@ describe "NilClass#to_s" do
   end
 
   it "returns a frozen string" do
-    nil.to_s.should.frozen?
+    NATFIXME 'NilClass#to_s should return a frozen string', exception: SpecFailedException do
+      nil.to_s.should.frozen?
+    end
   end
 
   it "always returns the same string" do

--- a/spec/core/range/frozen_spec.rb
+++ b/spec/core/range/frozen_spec.rb
@@ -16,7 +16,9 @@ describe "Range#frozen?" do
 
   it "is false for instances of a subclass of Range" do
     sub_range = Class.new(Range).new(1, 2)
-    sub_range.should_not.frozen?
+    NATFIXME 'instances of a Range subclass should not be frozen', exception: SpecFailedException do
+      sub_range.should_not.frozen?
+    end
   end
 
   it "is false for Range.allocate" do

--- a/spec/core/range/new_spec.rb
+++ b/spec/core/range/new_spec.rb
@@ -71,7 +71,9 @@ describe "Range.new" do
     end
 
     it "does not create a frozen range if the class is not Range.class" do
-      Class.new(Range).new(1, 2).should_not.frozen?
+      NATFIXME 'a Range subclass instance should not be frozen', exception: SpecFailedException do
+        Class.new(Range).new(1, 2).should_not.frozen?
+      end
     end
   end
 end

--- a/spec/core/struct/keyword_init_spec.rb
+++ b/spec/core/struct/keyword_init_spec.rb
@@ -39,7 +39,9 @@ describe "StructClass#keyword_init?" do
 
   context "class inheriting Struct" do
     it "isn't available in a subclass" do
-      StructClasses::StructSubclass.should_not.respond_to?(:keyword_init?)
+      NATFIXME 'keyword_init? should not be available in a Struct subclass', exception: SpecFailedException do
+        StructClasses::StructSubclass.should_not.respond_to?(:keyword_init?)
+      end
     end
   end
 end

--- a/spec/core/true/to_s_spec.rb
+++ b/spec/core/true/to_s_spec.rb
@@ -6,7 +6,9 @@ describe "TrueClass#to_s" do
   end
 
   it "returns a frozen string" do
-    true.to_s.should.frozen?
+    NATFIXME 'TrueClass#to_s should return a frozen string', exception: SpecFailedException do
+      true.to_s.should.frozen?
+    end
   end
 
   it "always returns the same string" do

--- a/spec/language/hash_spec.rb
+++ b/spec/language/hash_spec.rb
@@ -38,7 +38,9 @@ describe "Hash literal" do
     key.reverse!
     h["foo"].should == "bar"
     h.keys.first.should == "foo"
-    h.keys.first.should.frozen?
+    NATFIXME 'string keys should be frozen on initialization', exception: SpecFailedException do
+      h.keys.first.should.frozen?
+    end
     key.should == "oof"
   end
 

--- a/spec/language/predefined_spec.rb
+++ b/spec/language/predefined_spec.rb
@@ -701,18 +701,24 @@ describe "Predefined global $/" do
       str = string_subclass.new("abc")
       str.instance_variable_set(:@ivar, 1)
       $/ = str
-      $/.should.frozen?
+      NATFIXME 'assigning $/ should make a new frozen String', exception: SpecFailedException do
+        $/.should.frozen?
+      end
       NATFIXME 'it makes a new frozen String from the assigned String', exception: SpecFailedException do
         $/.should be_an_instance_of(String)
       end
-      $/.should_not.instance_variable_defined?(:@ivar)
+      NATFIXME 'the new String should not carry over instance variables', exception: SpecFailedException do
+        $/.should_not.instance_variable_defined?(:@ivar)
+      end
       $/.should == str
     end
 
     it "makes a new frozen String if it's not frozen" do
       str = +"abc"
       $/ = str
-      $/.should.frozen?
+      NATFIXME 'assigning $/ should make a new frozen String', exception: SpecFailedException do
+        $/.should.frozen?
+      end
       $/.should == str
     end
 
@@ -785,18 +791,24 @@ describe "Predefined global $-0" do
       str = string_subclass.new("abc")
       str.instance_variable_set(:@ivar, 1)
       $-0 = str
-      $-0.should.frozen?
+      NATFIXME 'assigning $-0 should make a new frozen String', exception: SpecFailedException do
+        $-0.should.frozen?
+      end
       NATFIXME 'it makes a new frozen String from the assigned String', exception: SpecFailedException do
         $-0.should be_an_instance_of(String)
       end
-      $-0.should_not.instance_variable_defined?(:@ivar)
+      NATFIXME 'the new String should not carry over instance variables', exception: SpecFailedException do
+        $-0.should_not.instance_variable_defined?(:@ivar)
+      end
       $-0.should == str
     end
 
     it "makes a new frozen String if it's not frozen" do
       str = +"abc"
       $-0 = str
-      $-0.should.frozen?
+      NATFIXME 'assigning $-0 should make a new frozen String', exception: SpecFailedException do
+        $-0.should.frozen?
+      end
       $-0.should == str
     end
 
@@ -1084,7 +1096,7 @@ describe "Execution variable $:" do
   end
 
   it "can be changed via <<" do
-    NATFIXME 'Implement $:', exception: LoadError, message: "Cannot manipulate $: at runtime (spec/language/predefined_spec.rb#1088)" do
+    NATFIXME 'Implement $:', exception: LoadError, message: "Cannot manipulate $: at runtime (spec/language/predefined_spec.rb#1100)" do
       $: << "foo"
       $:.should include("foo")
     ensure

--- a/test/natalie/pathname_test.rb
+++ b/test/natalie/pathname_test.rb
@@ -4,7 +4,9 @@ require 'pathname'
 describe 'Pathname.pwd' do
   it 'returns the current working directory' do
     Pathname.pwd.should == Pathname.getwd
-    Pathname.pwd.should.eql?(Dir.getwd)
+    NATFIXME 'Pathname#eql? with a String argument', exception: SpecFailedException do
+      Pathname.pwd.should.eql?(Dir.getwd)
+    end
   end
 end
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -474,8 +474,8 @@ module SpecOperatorMatcherHelpers
   def __eq(other)
     if @subject != other
       if @subject.is_a?(::String) && other.is_a?(::String) &&
-          (@subject.size >= MIN_STRING_SIZE_TO_RUN_DIFF || other.size >= MIN_STRING_SIZE_TO_RUN_DIFF) &&
-          $natfixme_depth == 0
+           (@subject.size >= MIN_STRING_SIZE_TO_RUN_DIFF || other.size >= MIN_STRING_SIZE_TO_RUN_DIFF) &&
+           $natfixme_depth == 0
         __diff(other, @subject)
         ::Kernel.raise ::SpecFailedException, 'two strings should match'
       elsif @subject.is_a?(::Array) && other.is_a?(::Array) &&
@@ -490,7 +490,9 @@ module SpecOperatorMatcherHelpers
   end
 
   def __neq(other)
-    ::Kernel.raise ::SpecFailedException, @subject.inspect + ' should not (!) be == to ' + other.inspect if @subject == other
+    if @subject == other
+      ::Kernel.raise ::SpecFailedException, @subject.inspect + ' should not (!) be == to ' + other.inspect
+    end
   end
 
   def __diff(actual, expected)

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -461,102 +461,128 @@ def flunk
   raise SpecFailedException
 end
 
-class Matcher
-  def initialize(subject, inverted, args)
-    @subject = subject
-    @inverted = inverted
-    @args = args
-    match_expectation(@args.first) if @args.any?
-  end
-
-  def ==(other)
-    @inverted ? neq(other) : eq(other)
-  end
-
+# mspec offers two assertion forms:
+#
+#   obj.should some_matcher       # a matcher object (be_nil, raise_error(...), ...)
+#   obj.should.respond_to?(:x)    # predicate matchers like obj.should.predicate?
+#
+# Shared comparison logic lives in this module.
+module SpecOperatorMatcherHelpers
   MIN_STRING_SIZE_TO_RUN_DIFF = 100
   MIN_ARRAY_SIZE_TO_RUN_DIFF = 2
 
-  def eq(other)
+  def __eq(other)
     if @subject != other
-      if @subject.is_a?(String) && other.is_a?(String) &&
-           (@subject.size >= MIN_STRING_SIZE_TO_RUN_DIFF || other.size >= MIN_STRING_SIZE_TO_RUN_DIFF) &&
-           $natfixme_depth == 0
-        diff(other, @subject)
-        raise SpecFailedException, 'two strings should match'
-      elsif @subject.is_a?(Array) && other.is_a?(Array) &&
+      if @subject.is_a?(::String) && other.is_a?(::String) &&
+          (@subject.size >= MIN_STRING_SIZE_TO_RUN_DIFF || other.size >= MIN_STRING_SIZE_TO_RUN_DIFF) &&
+          $natfixme_depth == 0
+        __diff(other, @subject)
+        ::Kernel.raise ::SpecFailedException, 'two strings should match'
+      elsif @subject.is_a?(::Array) && other.is_a?(::Array) &&
             (@subject.size >= MIN_ARRAY_SIZE_TO_RUN_DIFF || other.size >= MIN_ARRAY_SIZE_TO_RUN_DIFF) &&
             $natfixme_depth == 0
-        diff("[\n" + other.map(&:inspect).join("\n") + "\n]", "[\n" + @subject.map(&:inspect).join("\n") + "\n]")
-        raise SpecFailedException, @subject.inspect + ' should be == to ' + other.inspect
+        __diff("[\n" + other.map(&:inspect).join("\n") + "\n]", "[\n" + @subject.map(&:inspect).join("\n") + "\n]")
+        ::Kernel.raise ::SpecFailedException, @subject.inspect + ' should be == to ' + other.inspect
       else
-        raise SpecFailedException, @subject.inspect + ' should be == to ' + other.inspect
+        ::Kernel.raise ::SpecFailedException, @subject.inspect + ' should be == to ' + other.inspect
       end
     end
   end
 
-  def diff(actual, expected)
-    return if ENV['CI']
+  def __neq(other)
+    ::Kernel.raise ::SpecFailedException, @subject.inspect + ' should not (!) be == to ' + other.inspect if @subject == other
+  end
 
-    actual_file = Tempfile.create('actual')
+  def __diff(actual, expected)
+    return if ::ENV['CI']
+
+    actual_file = ::Tempfile.create('actual')
     actual_file.write(actual)
     actual_file.close
-    expected_file = Tempfile.create('expected')
+    expected_file = ::Tempfile.create('expected')
     expected_file.write(expected)
     expected_file.close
-    puts `diff #{expected_file.path} #{actual_file.path}`
-    File.unlink(actual_file.path)
-    File.unlink(expected_file.path)
+    ::Kernel.system('diff', expected_file.path, actual_file.path)
+    ::File.unlink(actual_file.path)
+    ::File.unlink(expected_file.path)
+  end
+
+  def __predicate_target(method, args)
+    if args.any?
+      case method
+      when :<, :<=, :>, :>=
+        "be #{method} than #{args.first.inspect}"
+      else
+        "#{method} #{args.first.inspect}"
+      end
+    else
+      "be #{method}"
+    end
+  end
+end
+
+class SpecPositiveOperatorMatcher < BasicObject
+  include ::SpecOperatorMatcherHelpers
+
+  def initialize(subject)
+    @subject = subject
+  end
+
+  # Only ==, !=, and equal? need overriding here -- BasicObject defines those,
+  # so without these they would compare the proxy itself instead of reaching
+  # method_missing. raise must be intercepted so it asserts rather than raises.
+  # Everything else (=~, predicates, ...) is forwarded by method_missing.
+  def ==(other)
+    __eq(other)
   end
 
   def !=(other)
-    @inverted ? eq(other) : neq(other)
+    __neq(other)
   end
 
-  def neq(other)
-    raise SpecFailedException, @subject.inspect + ' should not (!) be == to ' + other.inspect if @subject == other
+  def equal?(other)
+    ::EqualExpectation.new(other).match(@subject)
   end
 
-  def =~(pattern)
-    @inverted ? not_regex_match(pattern) : regex_match(pattern)
+  def raise(exception = ::Exception, message = nil, &block)
+    ::RaiseErrorExpectation.new(exception, message, &block).match(@subject)
   end
 
-  def regex_match(pattern)
-    raise SpecFailedException, @subject.inspect + ' should match ' + pattern.inspect if @subject !~ pattern
+  def method_missing(method, *args, &block)
+    result = @subject.__send__(method, *args, &block)
+    ::Kernel.raise ::SpecFailedException, "#{@subject.inspect} should #{__predicate_target(method, args)}" unless result
+    result
+  end
+end
+
+class SpecNegativeOperatorMatcher < BasicObject
+  include ::SpecOperatorMatcherHelpers
+
+  def initialize(subject)
+    @subject = subject
   end
 
-  def !~(pattern)
-    @inverted ? regex_match(pattern) : not_regex_match(pattern)
+  def ==(other)
+    __neq(other)
   end
 
-  def not_regex_match(pattern)
-    raise SpecFailedException, @subject.inspect + ' should not (!) match ' + pattern.inspect if @subject =~ pattern
+  def !=(other)
+    __eq(other)
   end
 
-  def match_expectation(expectation)
-    @inverted ? expectation.inverted_match(@subject) : expectation.match(@subject)
+  def equal?(other)
+    ::EqualExpectation.new(other).inverted_match(@subject)
   end
 
-  def method_missing(method, *args)
-    target =
-      if args.any?
-        case method
-        when :<, :<=, :>, :>=
-          "be #{method} than #{args.first.inspect}"
-        else
-          "#{method} #{args.first.inspect}"
-        end
-      else
-        "be #{method.to_s}"
-      end
-    send = Kernel.instance_method(:send)
-    if !@inverted
-      raise SpecFailedException, "#{@subject.inspect} should #{target}" if !send.bind_call(@subject, method, *args)
-    else
-      raise SpecFailedException, "#{@subject.inspect} should not #{target}" if send.bind_call(@subject, method, *args)
-    end
+  def raise(exception = ::Exception, message = nil, &block)
+    ::RaiseErrorExpectation.new(exception, message, &block).inverted_match(@subject)
   end
 
-  undef_method :equal?
+  def method_missing(method, *args, &block)
+    result = @subject.__send__(method, *args, &block)
+    ::Kernel.raise ::SpecFailedException, "#{@subject.inspect} should not #{__predicate_target(method, args)}" if result
+    result
+  end
 end
 
 class BeNilExpectation
@@ -1503,12 +1529,25 @@ class RespondToExpectation
 end
 
 class Object
-  def should(*args)
-    Matcher.new(self, false, args)
+  NO_MATCHER_GIVEN = ::Object.new
+
+  # With a matcher argument (`obj.should be_nil`) the matcher object does the
+  # work directly; with no argument (`obj.should == x`, `obj.should.foo?`) we
+  # return a BasicObject proxy that asserts via its operators / method_missing.
+  def should(matcher = NO_MATCHER_GIVEN, &block)
+    if NO_MATCHER_GIVEN.equal?(matcher)
+      SpecPositiveOperatorMatcher.new(self)
+    else
+      matcher.match(self)
+    end
   end
 
-  def should_not(*args)
-    Matcher.new(self, true, args)
+  def should_not(matcher = NO_MATCHER_GIVEN, &block)
+    if NO_MATCHER_GIVEN.equal?(matcher)
+      SpecNegativeOperatorMatcher.new(self)
+    else
+      matcher.inverted_match(self)
+    end
   end
 
   def be_nil


### PR DESCRIPTION
.should should return a proxy if no arguments are given to it. That proxy can then be used to make assertions.

When this is implemented properly, it means a bunch more assertions are now firing, which means we need to NATFIXME a bunch of stuff because otherwise it just silently fails.